### PR TITLE
ci: skip tests for docs-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,18 @@ name: Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - '.github/**/*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - '.github/**/*.md'
 
 jobs:
   unit:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to GitHub Actions test workflow
- Skips unit tests, E2E tests, and build checks when only docs are changed (`*.md`, `docs/`, `.github/*.md`)

## Test plan
- [ ] Verify docs-only PR does not trigger CI
- [ ] Verify code changes still trigger CI normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)