### PR TITLE
fix: prevent mobile status badge text wrapping and service name truncation

### DIFF
--- a/src/components/StatusPill.jsx
+++ b/src/components/StatusPill.jsx
@@ -17,7 +17,7 @@ export default function StatusPill({ status = 'operational' }) {
   return (
     <span
       role="status"
-      className={`inline-flex items-center mono font-medium uppercase text-[9px] tracking-[0.06em] ${cls}`}
+      className={`inline-flex items-center mono font-medium uppercase text-[9px] tracking-[0.06em] whitespace-nowrap shrink-0 ${cls}`}
       style={{ padding: '3px 7px', borderRadius: '4px' }}
     >
       {t(`status.${status}`)}

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -109,18 +109,18 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
       {/* ── Mobile compact layout ── */}
       <div className="md:hidden" style={{ padding: '10px 12px' }}>
         <div className="flex justify-between items-center" style={{ marginBottom: '4px' }}>
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="text-[13px] font-medium text-[var(--text0)] truncate">{service.name}</span>
-            <span className="mono text-[10px] text-[var(--text2)] shrink-0">
-              <span className={uptimeColor}>{uptimeStr}</span>
-              {incidentCount > 0 && <>{' · '}<span className="text-[var(--red)]">{incidentCount}{t('overview.card.incidents.compact')}</span></>}
-              {scoreStr && <>{' · '}{scoreStr}</>}
-            </span>
-          </div>
+          <span className="text-[13px] font-medium text-[var(--text0)] truncate min-w-0">{service.name}</span>
           <div className="flex items-center gap-1.5">
             {isRecovered && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
             <StatusPill status={service.status} />
           </div>
+        </div>
+        <div className="flex items-center justify-between" style={{ marginBottom: '4px' }}>
+          <span className="mono text-[10px] text-[var(--text2)]">
+            <span className={uptimeColor}>{uptimeStr}</span>
+            {incidentCount > 0 && <>{' · '}<span className="text-[var(--red)]">{incidentCount}{t('overview.card.incidents.compact')}</span></>}
+            {scoreStr && <>{' · '}{scoreStr}</>}
+          </span>
         </div>
         <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact)} compact />
       </div>


### PR DESCRIPTION
## Summary
- StatusPill: add `whitespace-nowrap` + `shrink-0` to prevent badge text ("PARTIAL OUTAGE") from wrapping to new line
- Overview mobile layout: separate service name + badge (row 1) from stats (row 2) so names like "OpenAI API" display fully instead of being truncated to "Open..."

## Test plan
- [x] Build passes (`npm run build`)
- [x] Mobile viewport: verify status badges stay on single line
- [x] Mobile viewport: verify long service names (OpenAI API, GitHub Copilot) are not over-truncated
- [x] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)