### PR TITLE
feat: replace status page latency with probe RTT (#123)

### DIFF
--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -529,6 +529,8 @@ function usePollingInternal() {
     error: null,
     lastUpdated: null,
     latency24h: [],
+    probe24h: [],
+    probeServiceIds: [],
     aiAnalysis: {},
     recentlyRecovered: [],
   })
@@ -594,6 +596,19 @@ function usePollingInternal() {
       // Status/incident alerts handled server-side (Worker detectAndAlertIncidents)
       // to avoid duplicate alerts when both browser and Worker are running
 
+      // Overlay probe RTT onto service.latency (replaces status page timing with real API RTT)
+      // Non-probe API services keep status page latency with different label in UI
+      const probeSnapshots = data.probe24h ?? []
+      let probeServiceIds = []
+      if (probeSnapshots.length > 0) {
+        const latestProbe = probeSnapshots[probeSnapshots.length - 1].data ?? {}
+        probeServiceIds = Object.keys(latestProbe)
+        merged.forEach((svc) => {
+          const p = latestProbe[svc.id]
+          if (p?.rtt > 0) svc.latency = p.rtt
+        })
+      }
+
       hasDataRef.current = true
       refreshingRef.current = false
       if (!cancelledRef.current) {
@@ -604,6 +619,8 @@ function usePollingInternal() {
           error: null,
           lastUpdated: new Date(data.lastUpdated),
           latency24h: data.latency24h ?? [],
+          probe24h: probeSnapshots,
+          probeServiceIds,
           aiAnalysis: data.aiAnalysis ?? {},
           recentlyRecovered: data.recentlyRecovered ?? [],
         })
@@ -658,6 +675,9 @@ function usePollingInternal() {
             refreshing: false,
             error: null,
             lastUpdated: new Date(),
+            latency24h: [],
+            probe24h: [],
+            probeServiceIds: [],
             aiAnalysis: MOCK_AI_ANALYSIS,
             recentlyRecovered: MOCK_RECENTLY_RECOVERED,
           })
@@ -669,6 +689,9 @@ function usePollingInternal() {
             refreshing: false,
             error: err || new Error('Failed to fetch'),
             lastUpdated: null,
+            latency24h: [],
+            probe24h: [],
+            probeServiceIds: [],
           })
         }
       }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -86,7 +86,7 @@ const en = {
 
   // Latency
   'latency.rankings': 'Current Rankings',
-  'latency.disclaimer': 'Measures each service\'s official status page response time.',
+  'latency.disclaimer': 'Measures direct API endpoint response time (RTT). Services without a public endpoint show status page timing.',
   'latency.fastest': 'Fastest',
   'latency.average': 'Average',
   'latency.slowest': 'Slowest',
@@ -138,7 +138,8 @@ const en = {
   'uptime.collecting': 'Collecting data',
 
   // Service Details
-  'svc.latency': 'Status Page Latency',
+  'svc.latency': 'API Response Time',
+  'svc.latency.statusPage': 'Status Page Latency',
   'svc.uptime30d': '30-Day Uptime',
   'uptime.label.official': 'Official Uptime',
   'uptime.sub.official': 'Official status page',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -86,7 +86,7 @@ const ko = {
 
   // Latency
   'latency.rankings': '현재 순위',
-  'latency.disclaimer': '각 서비스의 공식 상태 페이지 응답 시간을 측정합니다.',
+  'latency.disclaimer': 'API 엔드포인트 응답 시간(RTT)을 직접 측정합니다. 공개 엔드포인트가 없는 서비스는 상태 페이지 응답 시간을 표시합니다.',
   'latency.fastest': '가장 빠름',
   'latency.average': '평균',
   'latency.slowest': '가장 느림',
@@ -138,7 +138,8 @@ const ko = {
   'uptime.collecting': '데이터 수집 중',
 
   // Service Details
-  'svc.latency': '상태 페이지 레이턴시',
+  'svc.latency': 'API 응답 시간',
+  'svc.latency.statusPage': '상태 페이지 레이턴시',
   'svc.uptime30d': '30일 업타임',
   'uptime.label.official': '공식 Uptime',
   'uptime.sub.official': '공식 status page 기준',

--- a/src/pages/Latency.jsx
+++ b/src/pages/Latency.jsx
@@ -7,12 +7,13 @@ import { usePolling } from '../hooks/usePolling'
 import { LatencySkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
 import { ensureChart } from '../utils/chartLoader'
+import { filterLast24h } from '../utils/time'
 
 // ── Constants ────────────────────────────────────────────────
 
 // Latency thresholds for bar color coding
-const FAST_MS   = 300  // ≤ 300ms → green
-const NORMAL_MS = 500  // 301–500ms → amber  /  > 500ms → red
+const FAST_MS   = 500  // ≤ 500ms → green
+const NORMAL_MS = 800  // 501–800ms → amber  /  > 800ms → red
 
 // Per-service chart line colors (visualization palette — not design tokens).
 // Canvas-based charts cannot use CSS custom properties directly.
@@ -30,6 +31,10 @@ const SERVICE_COLOR = {
   elevenlabs:  '#6be5e2',
   xai:         '#e0e0e0',
   deepseek:    '#ff6b6b',
+  openrouter:  '#ffa657',
+  stability:   '#c9d1d9',
+  assemblyai:  '#79dfc1',
+  deepgram:    '#a5b4fc',
 }
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -65,14 +70,25 @@ function LatencyTrendSection({ services, t, hourlyData }) {
       return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
     })
 
-    const apiServices = services.filter((s) => s.category === 'api' && s.latency != null)
+    // Detect data format: probe snapshots have { status, rtt } objects, latency snapshots have plain numbers
+    const isProbeData = hourlyData.length > 0 && typeof Object.values(hourlyData[0].data ?? {})[0] === 'object'
+    // For probe data, show only services present in probe snapshots
+    const probeServiceIds = isProbeData ? Object.keys(hourlyData[hourlyData.length - 1]?.data ?? {}) : null
+    const apiServices = probeServiceIds
+      ? services.filter((s) => probeServiceIds.includes(s.id))
+      : services.filter((s) => s.category === 'api' && s.latency != null)
     const styles = getComputedStyle(document.documentElement)
     const textMuted = styles.getPropertyValue('--text2').trim() || '#6b7280'
     const borderClr = styles.getPropertyValue('--border').trim() || 'rgba(107,114,128,0.1)'
 
     const datasets = apiServices.map((svc) => ({
       label: svc.name,
-      data: hourlyData.map((s) => s.data[svc.id] ?? null),
+      data: hourlyData.map((s) => {
+        const val = s.data[svc.id]
+        if (val == null) return null
+        if (typeof val === 'object') return val.rtt > 0 ? val.rtt : null
+        return val
+      }),
       borderColor: SERVICE_COLOR[svc.id] ?? '#8b949e',
       borderWidth: 1.5,
       pointRadius: 1.5,
@@ -185,7 +201,7 @@ function RankingBar({ service, maxLatency, rank }) {
 
 export default function Latency() {
   const { t } = useLang()
-  const { services: rawServices, loading, error, latency24h, refresh } = usePolling()
+  const { services: rawServices, loading, error, probe24h, latency24h, probeServiceIds, refresh } = usePolling()
 
   // Defensive default — handles transient undefined state
   const services = rawServices ?? []
@@ -194,13 +210,17 @@ export default function Latency() {
   if (!loading && services.length === 0 && error) return <EmptyState type="offline" onAction={refresh} />
   if (error)   return <EmptyState type="error" onAction={() => window.location.reload()} />
 
-  // Only include services with latency data (exclude web apps and coding agents)
+  // Split services: probe RTT (ranked) vs status page only (separate section)
+  // When no probe data (mock/dev mode), show all services in ranked list
+  const hasProbeData = probeServiceIds.length > 0
   const withLatency = services.filter((s) => s.latency != null)
-  const sorted = [...withLatency].sort((a, b) => a.latency - b.latency)
+  const probeServices = hasProbeData ? withLatency.filter((s) => probeServiceIds.includes(s.id)) : withLatency
+  const statusPageOnly = hasProbeData ? withLatency.filter((s) => !probeServiceIds.includes(s.id)) : []
+  const sorted = [...probeServices].sort((a, b) => a.latency - b.latency)
   const fastest = sorted[0]
   const slowest = sorted[sorted.length - 1]
-  const avg = withLatency.length
-    ? Math.round(withLatency.reduce((s, v) => s + v.latency, 0) / withLatency.length)
+  const avg = probeServices.length
+    ? Math.round(probeServices.reduce((s, v) => s + v.latency, 0) / probeServices.length)
     : 0
   const maxLatency = slowest?.latency ?? 1
 
@@ -222,7 +242,7 @@ export default function Latency() {
       {/* ── Summary Cards ── */}
       <div className="grid grid-cols-1 md:grid-cols-3" style={{ gap: '10px' }}>
         <SummaryCard label={t('latency.fastest')} value={fastest?.latency ?? '—'} sub={fastest?.name ?? ''} colorClass="text-[var(--green)]" />
-        <SummaryCard label={t('latency.average')} value={avg}                      sub={`${services.length} ${t('latency.avg.services')}`}  colorClass="text-[var(--blue)]" />
+        <SummaryCard label={t('latency.average')} value={avg}                      sub={`${probeServices.length} ${t('latency.avg.services')}`}  colorClass="text-[var(--blue)]" />
         <SummaryCard label={t('latency.slowest')} value={slowest?.latency ?? '—'} sub={slowest?.name ?? ''} colorClass="text-[var(--red)]" />
       </div>
 
@@ -242,13 +262,23 @@ export default function Latency() {
             {sorted.map((svc, i) => (
               <RankingBar key={svc.id} service={svc} maxLatency={maxLatency} rank={i + 1} />
             ))}
+            {statusPageOnly.length > 0 && (
+              <>
+                <div className="mono text-[9px] text-[var(--text2)] uppercase" style={{ marginTop: '8px', letterSpacing: '0.08em' }}>
+                  {t('svc.latency.statusPage')}
+                </div>
+                {[...statusPageOnly].sort((a, b) => a.latency - b.latency).map((svc) => (
+                  <RankingBar key={svc.id} service={svc} maxLatency={maxLatency} rank="—" />
+                ))}
+              </>
+            )}
           </div>
         )}
         </div>
       </section>
 
       {/* ── 24h Trend — shows badges + chart when hourly KV data exists ── */}
-      <LatencyTrendSection services={sorted} t={t} hourlyData={latency24h} />
+      <LatencyTrendSection services={sorted} t={t} hourlyData={probe24h.length > 0 ? filterLast24h(probe24h) : latency24h} />
 
     </div>
   )

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -90,8 +90,8 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
   const hasUptime = service.uptime30d != null
   const uptimeColor = !hasUptime ? 'text-[var(--text2)]' : service.uptime30d >= 99 ? 'text-[var(--green)]' : service.uptime30d >= 97 ? 'text-[var(--amber)]' : 'text-[var(--red)]'
   const latencyColor = service.latency == null ? 'text-[var(--text2)]'
-    : service.latency < 200 ? 'text-[var(--green)]'
-    : service.latency < 500 ? 'text-[var(--amber)]'
+    : service.latency < 500 ? 'text-[var(--green)]'
+    : service.latency < 800 ? 'text-[var(--amber)]'
     : 'text-[var(--red)]'
   const uptimeStr = hasUptime ? `${service.uptime30d.toFixed(2)}%` : t('uptime.unavailable.short')
   const scoreStr = service.aiwatchScore != null ? `${service.aiwatchScore} ${service.scoreGrade}` : null
@@ -265,8 +265,8 @@ function IncidentItem({ incident, lang, t }) {
 // Latency bar with colored fill per speed tier
 function LatencyBar({ service, maxLatency }) {
   const widthPct = maxLatency > 0 ? Math.round((service.latency / maxLatency) * 100) : 0
-  const fillCls = service.latency < 200 ? 'bg-[var(--green)]' : service.latency < 400 ? 'bg-[var(--amber)]' : 'bg-[var(--red)]'
-  const valColor = service.latency < 200 ? '' : service.latency < 400 ? 'text-[var(--amber)]' : 'text-[var(--red)]'
+  const fillCls = service.latency < 500 ? 'bg-[var(--green)]' : service.latency < 800 ? 'bg-[var(--amber)]' : 'bg-[var(--red)]'
+  const valColor = service.latency < 500 ? '' : service.latency < 800 ? 'text-[var(--amber)]' : 'text-[var(--red)]'
   return (
     <div className="flex items-center" style={{ gap: '10px' }}>
       <span className="mono text-[10px] text-[var(--text1)] shrink-0 whitespace-nowrap truncate" style={{ width: '90px' }}>{service.name}</span>

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -15,6 +15,7 @@ import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
 import StatusPill from '../components/StatusPill'
 import { ensureChart } from '../utils/chartLoader'
+import { filterLast24h } from '../utils/time'
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -130,7 +131,12 @@ function ServiceLatencyTrend({ service, t, hourlyData }) {
       const d = new Date(s.t)
       return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
     })
-    const values = hourlyData.map((s) => s.data[service.id] ?? null)
+    const values = hourlyData.map((s) => {
+      const val = s.data[service.id]
+      if (val == null) return null
+      if (typeof val === 'object') return val.rtt > 0 ? val.rtt : null
+      return val
+    })
     const color = SERVICE_COLOR[service.id] ?? '#8b949e'
 
     const styles = getComputedStyle(document.documentElement)
@@ -550,7 +556,7 @@ function BadgeCode({ serviceId, serviceName, t }) {
 export default function ServiceDetails({ serviceId }) {
   const { t, lang } = useLang()
   const { setPage } = usePage()
-  const { services: rawServices, loading, error, latency24h, refresh, recentlyRecovered } = usePolling()
+  const { services: rawServices, loading, error, probe24h, latency24h, probeServiceIds, refresh, recentlyRecovered } = usePolling()
   const services = rawServices ?? []
 
   // useMemo must be called before any early returns (Rules of Hooks)
@@ -640,7 +646,7 @@ export default function ServiceDetails({ serviceId }) {
       {/* ── Metric Cards ── */}
       <div className="grid grid-cols-2 md:grid-cols-4" style={{ gap: '10px' }}>
         <MetricCard
-          label={t('svc.latency')}
+          label={probeServiceIds.includes(service.id) ? t('svc.latency') : t('svc.latency.statusPage')}
           value={service.latency != null ? `${service.latency} ms` : '—'}
           sub={service.latency != null ? t('svc.latency.sub') : t('uptime.collecting')}
           colorClass="text-[var(--blue)]"
@@ -717,7 +723,7 @@ export default function ServiceDetails({ serviceId }) {
       )}
 
       {/* ── 24h Latency Trend — shows chart when hourly KV data exists ── */}
-      {service.category === 'api' && <ServiceLatencyTrend service={service} t={t} hourlyData={latency24h} />}
+      {service.category === 'api' && <ServiceLatencyTrend service={service} t={t} hourlyData={probe24h.length > 0 ? filterLast24h(probe24h) : latency24h} />}
 
       {/* ── Regional Availability (only for services with defined regions) ── */}
       {SERVICE_REGIONS[service.id] && <RegionalAvailability service={service} t={t} />}

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -23,3 +23,8 @@ export function formatDate(date, lang) {
     timeZoneName: 'short',
   }).format(new Date(date))
 }
+
+export function filterLast24h(snapshots) {
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000
+  return snapshots.filter((s) => new Date(s.t).getTime() >= cutoff)
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1048,6 +1048,7 @@ export default {
         const aiAnalysis: Record<string, AIAnalysisResult[]> = {}
         const recentlyRecovered: string[] = []
         const latencyPromise = env.STATUS_CACHE!.get('latency:24h').catch(() => null)
+        const probePromise = env.STATUS_CACHE!.get('probe:24h').catch(() => null)
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
         const withActiveInc = cached.services.filter(s =>
           (s.incidents ?? []).some(i => i.status !== 'resolved')
@@ -1080,9 +1081,14 @@ export default {
           })
         ))
         let latency24h: Array<{ t: string; data: Record<string, number> }> = []
+        let probe24h: ProbeSnapshot[] = []
         const latRaw = await latencyPromise
+        const probeRaw = await probePromise
         if (latRaw) {
           try { latency24h = JSON.parse(latRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached latency24h parse failed:', err instanceof Error ? err.message : err) }
+        }
+        if (probeRaw) {
+          try { probe24h = JSON.parse(probeRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached probe24h parse failed:', err instanceof Error ? err.message : err) }
         }
 
         // Calculate scores for cached services (same as /api/status)
@@ -1096,6 +1102,7 @@ export default {
           lastUpdated: cached.cachedAt,
           cached: true,
           latency24h,
+          ...(probe24h.length > 0 ? { probe24h } : {}),
           ...(Object.keys(aiAnalysis).length > 0 ? { aiAnalysis } : {}),
           ...(recentlyRecovered.length > 0 ? { recentlyRecovered } : {}),
         }), {


### PR DESCRIPTION
## Summary
- Switch dashboard latency from status page fetch timing to direct API endpoint RTT (probe)
- 17 probe-covered services show real API response time; 3 non-probe services (Bedrock, Azure OpenAI, Pinecone) show status page latency with distinct label
- Add probe24h to `/api/status/cached`, split rankings into probe (ranked) vs status-page-only (unranked), adjust color thresholds, update i18n

## Test plan
- [x] `npm run build` — frontend builds
- [x] `npm run test:worker` — 424 unit tests pass
- [x] `npm test` — 53 E2E tests pass
- [x] `npx wrangler deploy --dry-run` — Worker builds
- [x] Local verify: Latency page shows probe RTT values, rankings split correctly, ServiceDetails shows conditional labels

refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)