### PR TITLE
feat: probe spike Detection Lead (#123)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -545,6 +545,13 @@ export default {
             const existing = await env.STATUS_CACHE.get(alertKey).catch(() => null)
             if (existing) continue
             await kvPut(env.STATUS_CACHE, alertKey, '1', { expirationTtl: 3600 })
+            // Record probe spike as earliest detection (Detection Lead feature)
+            // Probe often detects issues before official status page updates
+            const detectKey = `detected:${spike.serviceId}`
+            const existingDetect = await env.STATUS_CACHE.get(detectKey).catch(() => null)
+            if (!existingDetect || new Date(spike.since).getTime() < new Date(existingDetect).getTime()) {
+              await kvPut(env.STATUS_CACHE, detectKey, spike.since, { expirationTtl: 604800 })
+            }
             const svcName = spike.serviceId
             await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
               title: `📡 ${svcName} — Probe RTT Spike Detected`,


### PR DESCRIPTION
## Summary
- Record probe RTT spike timestamp to `detected:{svcId}` KV when consecutive spikes detected
- If probe spike is earlier than existing status page detection, overwrite with earlier time
- Frontend Detection Lead badge automatically shows the time advantage (no frontend changes needed)

## How it works
```
Probe spike detected (3+ consecutive) → spike.since = "2026-04-03T10:15:00Z"
Status page detects degraded          → detected:{svcId} already has earlier probe time
Official incident announced           → incident.startedAt = "2026-04-03T10:25:00Z"
Frontend calculates                   → Detection Lead = 10m
```

## Test plan
- [x] `npm run test:worker` — 424 tests pass
- [x] `npx wrangler deploy --dry-run` — Worker builds
- [ ] Production verification: next real incident with probe spike → Detection Lead badge shows on ServiceDetails

refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)