### PR TITLE
feat: probe history API + monthly report templates (#145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
     npm run deploy:worker
     ```
   - Verify the output says `Uploaded aiwatch-worker` (not `aiwatch`)
-  - Endpoints: `GET /api/status`, `GET /api/status/cached` (KV-only, includes probe24h, for SSR + initial load), `GET /api/uptime?days=30`, `POST /api/alert`, `GET /badge/:serviceId`, `GET /api/og` (dynamic OG image PNG), `GET /api/v1/status`
+  - Endpoints: `GET /api/status`, `GET /api/status/cached` (KV-only, includes probe24h, for SSR + initial load), `GET /api/uptime?days=30`, `GET /api/probe/history?days=30` (daily probe RTT summaries, 90d max), `POST /api/alert`, `GET /badge/:serviceId`, `GET /api/og` (dynamic OG image PNG), `GET /api/v1/status`
   - **Cron Trigger**: `*/5 * * * *` — alert detection runs every 5 minutes via scheduled handler (not per-request). Uses KV ID-based dedup (`alerted:new/res:` keys 7d TTL, `alerted:down/degraded/recovered:` keys 2h TTL). Fallback recommendations only included when service status is degraded/down (not operational). AI analysis runs inline with 8s timeout (merged into incident embed), results stored in `ai:analysis:{svcId}:{incId}` (1h TTL, per-incident). Daily alert counts tracked in `alert:count:{date}` for Daily Summary
 - **Frontend deployment**: Vercel, domain ai-watch.dev — `git push origin main` triggers auto-deploy. `npm run build` is local only; changes are not live until pushed
 - **PWA**: `public/manifest.json` + `public/sw.js` (stale-while-revalidate). CACHE_NAME in `sw.js` must be bumped manually when static assets change. SW excludes `/is-*` (Edge SSR) and `/api/*` (real-time data) from caching

--- a/worker/src/__tests__/probe-history.test.ts
+++ b/worker/src/__tests__/probe-history.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readProbeHistory } from '../index'
+
+function mockKV(store: Record<string, string> = {}) {
+  return {
+    get: vi.fn(async (key: string) => store[key] ?? null),
+    put: vi.fn(),
+  } as unknown as KVNamespace
+}
+
+describe('readProbeHistory', () => {
+  it('reads probe:daily keys for the requested number of days', async () => {
+    const store: Record<string, string> = {
+      'probe:daily:2026-04-02': JSON.stringify({ claude: { p50: 25, p75: 30, p95: 45, min: 20, max: 50, count: 288, spikes: 0 } }),
+      'probe:daily:2026-04-01': JSON.stringify({ claude: { p50: 28, p75: 32, p95: 48, min: 22, max: 55, count: 280, spikes: 1 } }),
+    }
+    const kv = mockKV(store)
+    const history = await readProbeHistory(kv, 3)
+
+    // Should have called get for 3 days (today + 2 past)
+    expect(kv.get).toHaveBeenCalledTimes(3)
+    // Should contain the 2 days that have data
+    const dates = Object.keys(history)
+    expect(dates).toContain('2026-04-02')
+    expect(dates).toContain('2026-04-01')
+    expect(history['2026-04-02'].claude.p75).toBe(30)
+    expect(history['2026-04-01'].claude.spikes).toBe(1)
+  })
+
+  it('returns empty object when no probe data exists', async () => {
+    const kv = mockKV({})
+    const history = await readProbeHistory(kv, 7)
+    expect(history).toEqual({})
+    expect(kv.get).toHaveBeenCalledTimes(7)
+  })
+
+  it('works with the maximum day count of 90', async () => {
+    const kv = mockKV({})
+    const history = await readProbeHistory(kv, 90)
+    expect(history).toEqual({})
+    expect(kv.get).toHaveBeenCalledTimes(90)
+  })
+
+  it('skips entries with invalid JSON gracefully', async () => {
+    const store: Record<string, string> = {
+      'probe:daily:2026-04-02': '{ invalid json',
+      'probe:daily:2026-04-01': JSON.stringify({ openai: { p50: 100, p75: 150, p95: 200, min: 80, max: 300, count: 288, spikes: 2 } }),
+    }
+    const kv = mockKV(store)
+    const history = await readProbeHistory(kv, 3)
+
+    // Invalid JSON day should be skipped
+    expect(history['2026-04-02']).toBeUndefined()
+    expect(history['2026-04-01'].openai.p75).toBe(150)
+  })
+
+  it('handles KV get failures gracefully', async () => {
+    const kv = {
+      get: vi.fn(async (key: string) => {
+        if (key.includes('04-02')) throw new Error('KV error')
+        return null
+      }),
+      put: vi.fn(),
+    } as unknown as KVNamespace
+
+    const history = await readProbeHistory(kv, 3)
+    expect(history).toEqual({})
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -197,6 +197,24 @@ export async function readUptimeHistory(kv: KVNamespace, days: number): Promise<
   return history
 }
 
+// Read probe RTT daily history for last N days
+export async function readProbeHistory(kv: KVNamespace, days: number): Promise<Record<string, ProbeDailyData>> {
+  const history: Record<string, ProbeDailyData> = {}
+  const today = new Date()
+  const keyPairs = Array.from({ length: days }, (_, i) => {
+    const dateStr = new Date(today.getTime() - i * 86_400_000).toISOString().split('T')[0]
+    return { dateStr, key: `probe:daily:${dateStr}` }
+  })
+
+  const results = await Promise.all(keyPairs.map(({ key }) => kv.get(key).catch(() => null)))
+  results.forEach((raw, i) => {
+    if (raw) {
+      try { history[keyPairs[i].dateStr] = JSON.parse(raw) } catch (err) { console.warn('[kv] probe history parse failed:', keyPairs[i].dateStr, err instanceof Error ? err.message : err) }
+    }
+  })
+  return history
+}
+
 // Calculate per-service uptime% from accumulated daily counters
 function computeUptime(history: Record<string, DailyCounters>): Record<string, number> {
   const totals: Record<string, { ok: number; total: number }> = {}
@@ -522,7 +540,7 @@ import { generateOgSvg } from './og'
 import { detectRedditPosts, formatRedditAlert, isPromotable } from './reddit'
 import { buildDailySummary } from './daily-summary'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
-import { archiveProbeDaily } from './probe-archival'
+import { archiveProbeDaily, type ProbeDailyData } from './probe-archival'
 
 export default {
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
@@ -1124,6 +1142,17 @@ export default {
       })
     }
 
+    // GET /api/probe/history — return daily probe RTT history
+    if (url.pathname === '/api/probe/history') {
+      const rawDays = Number(url.searchParams.get('days') ?? 30)
+      const days = Math.max(1, Math.min(Number.isNaN(rawDays) ? 30 : rawDays, 90))
+      const history = env.STATUS_CACHE ? await readProbeHistory(env.STATUS_CACHE, days) : {}
+      return new Response(JSON.stringify({ history, days }), {
+        status: 200,
+        headers: { ...cors, 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },
+      })
+    }
+
     // GET /api/uptime — return daily uptime history
     if (url.pathname === '/api/uptime') {
       const rawDays = Number(url.searchParams.get('days') ?? 30)
@@ -1135,7 +1164,7 @@ export default {
       })
     }
 
-    if (request.method !== 'GET' || (url.pathname !== '/api/status' && url.pathname !== '/api/uptime')) {
+    if (request.method !== 'GET' || (url.pathname !== '/api/status' && url.pathname !== '/api/uptime' && url.pathname !== '/api/probe/history')) {
       return new Response(JSON.stringify({ error: 'Not Found' }), {
         status: 404,
         headers: { ...cors, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Add `GET /api/probe/history?days=30` endpoint — reads `probe:daily:{date}` KV keys for up to 90 days, returns per-service p50/p75/p95/min/max/spikes
- Add monthly report template sections: **API Response Time (Monthly p75)** rankings table + **Detection Lead** summary table
- 5 unit tests for `readProbeHistory()` (normal, empty, max days, invalid JSON, KV errors)

refs #145

## Test plan
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — Worker builds
- [x] `npm run test:worker` — 439 tests pass
- [x] `npm run build` — frontend builds
- [x] Local verify: `curl /api/probe/history?days=3` returns `{"history":{},"days":3}` (no data yet — archival starts after UTC 09:00 today)
- [ ] Verify Vercel preview
- [ ] After UTC 09:00: verify `probe:daily:2026-04-03` populates and `/api/probe/history` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)