### PR TITLE
fix: BetterStack RSS incident grouping — use guid instead of homepage link (#152)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -170,6 +170,173 @@ describe('parseRssIncidents', () => {
     expect(result[0].status).toBe('resolved')
   })
 
+  it('separates incidents when link is homepage URL (Fireworks/Together/HuggingFace pattern)', () => {
+    // BetterStack RSS: all <link> tags point to homepage, guid hash is per-incident
+    const xml = `
+      <item>
+        <guid>https://status.fireworks.ai/#aaa111</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Service A went down</title>
+        <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#aaa111</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Service A recovered</title>
+        <pubDate>Sat, 01 Mar 2026 10:30:00 GMT</pubDate>
+        <description>Back up</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#bbb222</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Service B went down</title>
+        <pubDate>Sat, 01 Mar 2026 12:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#bbb222</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Service B recovered</title>
+        <pubDate>Sat, 01 Mar 2026 12:15:00 GMT</pubDate>
+        <description>Back up</description>
+      </item>
+    `
+    const result = parseRssIncidents(xml)
+    expect(result).toHaveLength(2)
+    expect(result[0].title).toContain('Service A')
+    expect(result[0].status).toBe('resolved')
+    expect(result[1].title).toContain('Service B')
+    expect(result[1].status).toBe('resolved')
+  })
+
+  it('groups by link when link is a unique incident URL (Modal pattern)', () => {
+    // Modal RSS: <link> has unique incident URLs, guid hash varies per update
+    const xml = `
+      <item>
+        <guid>https://status.modal.com/incident/100#hash1</guid>
+        <link>https://status.modal.com/incident/100</link>
+        <title>Web endpoint degradation</title>
+        <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+        <description>Degraded</description>
+      </item>
+      <item>
+        <guid>https://status.modal.com/incident/100#hash2</guid>
+        <link>https://status.modal.com/incident/100</link>
+        <title>Web endpoint degradation</title>
+        <pubDate>Sat, 01 Mar 2026 10:30:00 GMT</pubDate>
+        <description>Recovered</description>
+      </item>
+      <item>
+        <guid>https://status.modal.com/incident/200#hash3</guid>
+        <link>https://status.modal.com/incident/200</link>
+        <title>API latency spike</title>
+        <pubDate>Sat, 01 Mar 2026 14:00:00 GMT</pubDate>
+        <description>Spike detected</description>
+      </item>
+    `
+    const result = parseRssIncidents(xml)
+    expect(result).toHaveLength(2)
+    expect(result[0].title).toContain('Web endpoint')
+    expect(result[0].status).toBe('resolved')
+    expect(result[1].title).toContain('API latency')
+    expect(result[1].status).toBe('investigating')
+  })
+
+  it('does not merge different incidents into mega-incident when all links are homepage', () => {
+    // Regression test: the actual bug — resolved + unresolved incidents from different dates
+    // were merged into one 1712h mega-incident, causing false degraded status
+    const xml = `
+      <item>
+        <guid>https://status.fireworks.ai/#old111</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Llama API went down</title>
+        <pubDate>Thu, 12 Mar 2026 18:02:55 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#old111</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Llama API recovered</title>
+        <pubDate>Thu, 12 Mar 2026 18:08:55 GMT</pubDate>
+        <description>Back up</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#new222</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Embed API went down</title>
+        <pubDate>Tue, 01 Apr 2026 03:05:14 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.fireworks.ai/#new222</guid>
+        <link>https://status.fireworks.ai/</link>
+        <title>Embed API recovered</title>
+        <pubDate>Tue, 01 Apr 2026 03:08:03 GMT</pubDate>
+        <description>Back up</description>
+      </item>
+    `
+    const result = parseRssIncidents(xml)
+    expect(result).toHaveLength(2)
+    // Each incident has correct short duration, not a merged 1712h duration
+    expect(result[0].duration).toBe('6m')
+    expect(result[1].duration).toBe('3m')
+    expect(result.every(i => i.status === 'resolved')).toBe(true)
+  })
+
+  it('unresolved incident with homepage link does not infect resolved ones', () => {
+    // An active "went down" should be its own incident, not merge with recovered ones
+    const xml = `
+      <item>
+        <guid>https://status.together.ai/#resolved1</guid>
+        <link>https://status.together.ai/</link>
+        <title>Service X went down</title>
+        <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.together.ai/#resolved1</guid>
+        <link>https://status.together.ai/</link>
+        <title>Service X recovered</title>
+        <pubDate>Sat, 01 Mar 2026 10:30:00 GMT</pubDate>
+        <description>Back up</description>
+      </item>
+      <item>
+        <guid>https://status.together.ai/#active2</guid>
+        <link>https://status.together.ai/</link>
+        <title>Service Y went down</title>
+        <pubDate>Mon, 06 Apr 2026 12:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+    `
+    const result = parseRssIncidents(xml)
+    expect(result).toHaveLength(2)
+    expect(result[0].status).toBe('resolved')
+    expect(result[1].status).toBe('investigating')
+    expect(result[1].title).toContain('Service Y')
+  })
+
+  it('handles homepage link without trailing slash', () => {
+    const xml = `
+      <item>
+        <guid>https://status.example.com/#inc1</guid>
+        <link>https://status.example.com</link>
+        <title>API went down</title>
+        <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+      <item>
+        <guid>https://status.example.com/#inc2</guid>
+        <link>https://status.example.com</link>
+        <title>DB went down</title>
+        <pubDate>Sat, 01 Mar 2026 12:00:00 GMT</pubDate>
+        <description>Down</description>
+      </item>
+    `
+    const result = parseRssIncidents(xml)
+    expect(result).toHaveLength(2)
+  })
+
   it('returns empty for no items', () => {
     expect(parseRssIncidents('<rss></rss>')).toEqual([])
   })

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -1,4 +1,4 @@
-// Better Stack RSS Feed Parser — for HuggingFace, Together, xAI
+// Better Stack RSS Feed Parser — for HuggingFace, Together, Fireworks, Modal, xAI
 
 import type { TimelineEntry, Incident, DailyImpactLevel } from '../types'
 import { formatDuration } from '../utils'
@@ -18,14 +18,18 @@ export function parseRssIncidents(xml: string): Incident[] {
   const items = xml.match(/<item>([\s\S]*?)<\/item>/g)
   if (!items) return []
 
-  // Group by incident key: use <link> if available (stable per incident),
-  // fall back to guid prefix before '#' (Modal uses per-update hashes in guid)
+  // Group by incident key:
+  // - Modal: <link> has unique incident URL (/incident/ID) → use link
+  // - Together/HuggingFace/Fireworks: <link> is just homepage, guid hash is per-incident → use full guid
+  // - Modal guid has per-update hashes (incident/ID#updateHash) → split('#')[0] groups correctly
   const groups = new Map<string, Array<{ title: string; date: string; desc: string }>>()
   for (const item of items) {
     const guid = item.match(/<guid[^>]*>(.*?)<\/guid>/)?.[1]
     if (!guid) continue // skip items without guid
     const link = item.match(/<link>(.*?)<\/link>/)?.[1]
-    const groupKey = link || guid.split('#')[0] || guid
+    // Only use <link> if it points to a specific incident (has path beyond /)
+    const linkIsIncident = link ? !/^https?:\/\/[^/]+\/?$/.test(link) : false
+    const groupKey = linkIsIncident ? link! : guid
     const date = item.match(/<pubDate>(.*?)<\/pubDate>/)?.[1] ?? ''
     if (!isValidDate(date)) continue // skip malformed dates
     const title = decodeXmlEntities(item.match(/<title>(.*?)<\/title>/)?.[1] ?? '')


### PR DESCRIPTION
## Summary
- BetterStack RSS feeds (Fireworks, Together, HuggingFace) return identical homepage URLs in `<link>` tags, causing all incidents to merge into one mega-incident (e.g., `duration: 1712h 30m`)
- Detect homepage-only links via regex and fall back to full guid as grouping key
- Modal's unique incident URLs (`/incident/ID`) preserved with existing link-based grouping

## Test plan
- [x] Worker tests pass (458 tests) — `npm run test:worker`
- [x] 5 new test cases: homepage link separation, Modal pattern, mega-incident regression, unresolved isolation, no-trailing-slash
- [x] Local Worker dev server verified: Fireworks/Together/HuggingFace/Modal all show correct individual incidents
- [ ] Deploy worker and verify production Fireworks status

closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)