### PR TITLE
fix: prevent OpenAI API incidents from cross-contaminating ChatGPT (#156)

### DIFF
--- a/worker/src/__tests__/filter-incidents.test.ts
+++ b/worker/src/__tests__/filter-incidents.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { filterIncidents, includeUntaggedIncidents } from '../services'
+import type { Incident, ServiceConfig } from '../types'
+
+function mockIncident(overrides: Partial<Incident> = {}): Incident {
+  return {
+    id: 'inc-1',
+    title: 'Test incident',
+    status: 'investigating',
+    impact: 'major',
+    startedAt: '2026-04-06T10:00:00Z',
+    resolvedAt: null,
+    duration: null,
+    timeline: [],
+    ...overrides,
+  }
+}
+
+function mockConfig(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
+  return {
+    id: 'test',
+    name: 'Test',
+    provider: 'Test',
+    category: 'api',
+    statusUrl: 'https://example.com',
+    apiUrl: null,
+    ...overrides,
+  }
+}
+
+describe('filterIncidents', () => {
+  it('returns all incidents when no keywords or excludes', () => {
+    const incidents = [mockIncident({ title: 'API Error' })]
+    expect(filterIncidents(incidents, mockConfig())).toHaveLength(1)
+  })
+
+  it('excludes by incidentExclude keywords', () => {
+    const incidents = [mockIncident({ title: 'ChatGPT login issues' })]
+    const config = mockConfig({ incidentExclude: ['chatgpt'] })
+    expect(filterIncidents(incidents, config)).toHaveLength(0)
+  })
+
+  it('includes only matching incidentKeywords', () => {
+    const incidents = [
+      mockIncident({ id: '1', title: 'API latency spike' }),
+      mockIncident({ id: '2', title: 'Dashboard outage' }),
+    ]
+    const config = mockConfig({ incidentKeywords: ['api'] })
+    const result = filterIncidents(incidents, config)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+
+  it('matches keywords against componentNames', () => {
+    const incidents = [mockIncident({ title: 'Service issue', componentNames: ['API Gateway'] })]
+    const config = mockConfig({ incidentKeywords: ['api'] })
+    expect(filterIncidents(incidents, config)).toHaveLength(1)
+  })
+
+  it('exclude takes precedence over keywords', () => {
+    const incidents = [mockIncident({ title: 'ChatGPT API error' })]
+    const config = mockConfig({ incidentKeywords: ['api'], incidentExclude: ['chatgpt'] })
+    expect(filterIncidents(incidents, config)).toHaveLength(0)
+  })
+})
+
+describe('includeUntaggedIncidents', () => {
+  const apiIncident = mockIncident({
+    id: 'api-inc',
+    title: 'GET /v1/responses endpoint is down',
+    componentNames: [],
+  })
+  const chatgptIncident = mockIncident({
+    id: 'chat-inc',
+    title: 'ChatGPT conversation errors',
+    componentNames: ['Conversations'],
+  })
+
+  const components = [
+    { id: 'comp-api', name: 'API', status: 'major_outage' },
+    { id: 'comp-conv', name: 'Conversations', status: 'operational' },
+  ]
+
+  it('skips untagged fallback when component is operational (ChatGPT case)', () => {
+    // ChatGPT has keyword filter, no matching active incidents, but component is operational
+    const config = mockConfig({
+      id: 'chatgpt',
+      incidentKeywords: ['chatgpt', 'conversation'],
+      statusComponentId: 'comp-conv', // Conversations → operational
+    })
+    const filtered: Incident[] = [] // keyword filter excluded the API incident
+    const result = includeUntaggedIncidents(filtered, [apiIncident], config, components, 'major')
+    expect(result).toHaveLength(0) // should NOT include untagged API incident
+  })
+
+  it('includes untagged incidents when no component configured and page is degraded', () => {
+    // Service without statusComponentId — uses overall page status
+    const config = mockConfig({
+      id: 'generic',
+      incidentKeywords: ['something'],
+    })
+    const filtered: Incident[] = []
+    const result = includeUntaggedIncidents(filtered, [apiIncident], config, components, 'major')
+    expect(result).toHaveLength(1) // should include untagged since overall is major
+    expect(result[0].id).toBe('api-inc')
+  })
+
+  it('skips when filtered already has active incidents', () => {
+    const config = mockConfig({ incidentKeywords: ['chatgpt'] })
+    const active = [mockIncident({ id: 'active', status: 'investigating' })]
+    const result = includeUntaggedIncidents(active, [apiIncident], config, components, 'major')
+    expect(result).toEqual(active) // no change — already has active incidents
+  })
+
+  it('skips when no keyword filters configured', () => {
+    const config = mockConfig({}) // no incidentKeywords
+    const result = includeUntaggedIncidents([], [apiIncident], config, components, 'major')
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips when overall status is operational', () => {
+    const config = mockConfig({ incidentKeywords: ['something'] })
+    const result = includeUntaggedIncidents([], [apiIncident], config, [], 'none')
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes untagged incidents matching incidentExclude', () => {
+    const config = mockConfig({
+      incidentKeywords: ['something'],
+      incidentExclude: ['responses'],
+    })
+    const result = includeUntaggedIncidents([], [apiIncident], config, [], 'major')
+    expect(result).toHaveLength(0) // excluded by title match
+  })
+
+  it('skips incidents that have componentNames (not untagged)', () => {
+    const config = mockConfig({ incidentKeywords: ['something'] })
+    const tagged = mockIncident({ id: 'tagged', componentNames: ['API Gateway'] })
+    const result = includeUntaggedIncidents([], [tagged], config, [], 'major')
+    expect(result).toHaveLength(0) // has componentNames → not untagged
+  })
+
+  it('uses statusComponent name match when available', () => {
+    const config = mockConfig({
+      incidentKeywords: ['something'],
+      statusComponent: 'Conversations',
+    })
+    // Conversations component is operational → skip
+    const result = includeUntaggedIncidents([], [apiIncident], config, components, 'major')
+    expect(result).toHaveLength(0)
+  })
+
+  it('includes untagged when component is degraded', () => {
+    const config = mockConfig({
+      incidentKeywords: ['something'],
+      statusComponentId: 'comp-api', // API → major_outage
+    })
+    const result = includeUntaggedIncidents([], [apiIncident], config, components, 'major')
+    expect(result).toHaveLength(1) // component is down, include untagged
+  })
+
+  it('only includes unresolved untagged incidents', () => {
+    const config = mockConfig({ incidentKeywords: ['something'] })
+    const resolved = mockIncident({ id: 'old', status: 'resolved', componentNames: [] })
+    const active = mockIncident({ id: 'new', status: 'investigating', componentNames: [] })
+    const result = includeUntaggedIncidents([], [resolved, active], config, [], 'major')
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('new')
+  })
+})

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -46,7 +46,7 @@ const SERVICES: ServiceConfig[] = [
   // AI Apps
   { id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude.ai', 'across surfaces', 'claude desktop'], statusComponent: 'claude.ai', statusComponentId: 'rwppv331jlwc' },
   { id: 'characterai', name: 'Character.AI', provider: 'Character AI', category: 'app', statusUrl: 'https://status.character.ai', apiUrl: 'https://status.character.ai/api/v2/summary.json', statusComponentId: 'fw8g76r7dqcl' },
-  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG' },
+  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG', statusComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG' },
   // Coding Agents
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
@@ -54,7 +54,7 @@ const SERVICES: ServiceConfig[] = [
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
 ]
 
-function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {
+export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {
   const { incidentKeywords, incidentExclude } = config
   return incidents.filter((inc) => {
     const title = inc.title.toLowerCase()
@@ -69,6 +69,42 @@ function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident
     }
     return true
   })
+}
+
+/**
+ * Include untagged incidents when keyword-filtered service has no active incidents
+ * but the service's status is non-operational. Checks component-specific status when
+ * available to prevent cross-contamination (e.g., API incident on ChatGPT).
+ */
+export function includeUntaggedIncidents(
+  filtered: Incident[],
+  allIncidents: Incident[],
+  config: ServiceConfig,
+  components: Array<{ id: string; name: string; status: string }>,
+  overallIndicator: string,
+): Incident[] {
+  if (filtered.some((i) => i.status !== 'resolved')) return filtered
+  if (!config.incidentKeywords || config.incidentKeywords.length === 0) return filtered
+
+  // Use component-specific status when available, otherwise overall page status
+  const comp = config.statusComponent
+    ? components?.find((c) => c.name.startsWith(config.statusComponent!))
+    : config.statusComponentId
+      ? components?.find((c) => c.id === config.statusComponentId)
+      : null
+  const svcStatus = comp
+    ? normalizeStatus(comp.status)
+    : normalizeStatus(overallIndicator)
+  if (svcStatus === 'operational') return filtered
+
+  const untagged = allIncidents.filter((inc) =>
+    inc.status !== 'resolved' &&
+    (inc.componentNames ?? []).length === 0 &&
+    !config.incidentExclude?.some((kw) => inc.title.toLowerCase().includes(kw.toLowerCase()))
+  )
+  return [...filtered, ...untagged].sort((a, b) =>
+    new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+  )
 }
 
 // Retry once on failure to reduce false-positive 'down' from transient network issues
@@ -166,21 +202,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
       }
 
       let filtered = filterIncidents(incidents, config)
-      // If service has keyword filters, is degraded/down, but no ongoing incidents matched,
-      // include untagged incidents (provider didn't tag components on the incident)
-      if (filtered.filter((i) => i.status !== 'resolved').length === 0 && config.incidentKeywords) {
-        const svcStatus = normalizeStatus(summaryData.status?.indicator ?? 'none')
-        if (svcStatus !== 'operational') {
-          const untagged = incidents.filter((inc) =>
-            inc.status !== 'resolved' &&
-            (inc.componentNames ?? []).length === 0 &&
-            !config.incidentExclude?.some((kw) => inc.title.toLowerCase().includes(kw.toLowerCase()))
-          )
-          filtered = [...filtered, ...untagged].sort((a, b) =>
-            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
-          )
-        }
-      }
+      filtered = includeUntaggedIncidents(filtered, incidents, config, summaryData.components ?? [], summaryData.status?.indicator ?? 'none')
       if (config.incidentIoBaseUrl) {
         filtered = await enrichIncidentIoText(filtered, config.incidentIoBaseUrl, pageUrls, kv)
       }


### PR DESCRIPTION
## Summary
- OpenAI API incidents with no component association were incorrectly shown on ChatGPT
- Untagged fallback now checks component-specific status before including incidents
- Added `statusComponentId` to ChatGPT config (Conversations component)

## Root Cause
Untagged fallback used overall page status → API incident on degraded page → force-included on ChatGPT despite keyword filter excluding it.

## Test plan
- [x] 15 unit tests (filterIncidents + includeUntaggedIncidents)
- [x] `npm run test:worker` — 481 tests pass
- [x] `wrangler deploy --dry-run` — build OK

closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)