### PR TITLE
feat: integrate Mistral probe cross-validation into API pipeline (refs #91)

### DIFF
--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -231,6 +231,79 @@ describe('isCorroboratedByProbe', () => {
   })
 })
 
+describe('Mistral noise filtering pipeline (#91)', () => {
+  // Simulates the filtering logic in /api/status handler:
+  // compute median → filter incidents where isCorroboratedByProbe is false
+  const probeSnapshots: ProbeSnapshot[] = [
+    // Baseline: ~170ms median (20 normal probes)
+    ...Array.from({ length: 20 }, (_, i) => ({
+      t: `2026-04-05T${String(12 + Math.floor(i * 5 / 60)).padStart(2, '0')}:${String((i * 5) % 60).padStart(2, '0')}:00Z`,
+      data: { mistral: { status: 401, rtt: 160 + (i % 5) * 5 } }, // 160-180ms
+    })),
+    // Spike at 13:40 (600ms — real outage)
+    { t: '2026-04-05T13:40:00Z', data: { mistral: { status: 401, rtt: 600 } } },
+    // Normal at 17:55 (170ms — no spike during noise incident)
+    { t: '2026-04-05T17:55:00Z', data: { mistral: { status: 401, rtt: 170 } } },
+    { t: '2026-04-05T18:00:00Z', data: { mistral: { status: 401, rtt: 165 } } },
+  ]
+
+  function filterMistralIncidents(incidents: { id: string; title: string; startedAt: string; resolvedAt: string | null }[]) {
+    const median = computeMedianRtt(probeSnapshots, 'mistral')
+    if (median === null) return incidents
+    return incidents.filter((inc) =>
+      isCorroboratedByProbe(probeSnapshots, 'mistral', inc.startedAt, inc.resolvedAt, median),
+    )
+  }
+
+  it('filters noise incidents with no RTT spike', () => {
+    const incidents = [
+      { id: 'noise-1', title: 'Completion API Degraded', startedAt: '2026-04-05T17:53:00Z', resolvedAt: '2026-04-05T17:56:00Z' },
+    ]
+    expect(filterMistralIncidents(incidents)).toHaveLength(0)
+  })
+
+  it('keeps real incidents with RTT spike', () => {
+    const incidents = [
+      { id: 'real-1', title: 'Audio API Degraded', startedAt: '2026-04-05T13:35:00Z', resolvedAt: '2026-04-05T13:50:00Z' },
+    ]
+    const result = filterMistralIncidents(incidents)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('real-1')
+  })
+
+  it('filters mixed noise and real incidents correctly', () => {
+    const incidents = [
+      { id: 'real-1', title: 'Audio API Degraded', startedAt: '2026-04-05T13:35:00Z', resolvedAt: '2026-04-05T13:50:00Z' },
+      { id: 'noise-1', title: 'Completion API Degraded', startedAt: '2026-04-05T17:53:00Z', resolvedAt: '2026-04-05T17:56:00Z' },
+      { id: 'noise-2', title: 'Audio API TTS Degraded', startedAt: '2026-04-05T17:58:00Z', resolvedAt: '2026-04-05T18:01:00Z' },
+    ]
+    const result = filterMistralIncidents(incidents)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('real-1')
+  })
+
+  it('keeps all incidents when no probe data exists', () => {
+    const emptyProbes: ProbeSnapshot[] = []
+    const median = computeMedianRtt(emptyProbes, 'mistral')
+    expect(median).toBeNull()
+    const incidents = [
+      { id: 'inc-1', title: 'API Degraded', startedAt: '2026-04-05T17:53:00Z', resolvedAt: '2026-04-05T17:56:00Z' },
+    ]
+    // When median is null, all incidents pass through (conservative — no filtering without baseline)
+    const result = incidents.filter((inc) => {
+      if (median === null) return true
+      return isCorroboratedByProbe(emptyProbes, 'mistral', inc.startedAt, inc.resolvedAt, median)
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not affect non-mistral services', () => {
+    // Probe data only has mistral — computing median for other services returns null
+    const otherMedian = computeMedianRtt(probeSnapshots, 'openai')
+    expect(otherMedian).toBeNull()
+  })
+})
+
 describe('detectConsecutiveSpikes', () => {
   it('detects 3+ consecutive spikes at tail', () => {
     // Enough baseline to keep median low (~50ms), so threshold ~150ms

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -127,7 +127,7 @@ async function writeLatencySnapshot(kv: KVNamespace, services: ServiceStatus[]):
 }
 
 // ── Health Check Probing (Phase 2 PoC) ──
-import { type ProbeResult, type ProbeSnapshot, type ProbeSpike, PROBE_TARGETS, computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, detectConsecutiveSpikes } from './probe'
+import { type ProbeResult, type ProbeSnapshot, type ProbeSpike, PROBE_TARGETS, computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, detectConsecutiveSpikes, computeMedianRtt, isCorroboratedByProbe } from './probe'
 
 let lastProbeSlot = ''
 
@@ -1082,11 +1082,37 @@ export default {
     if (request.method === 'GET' && url.pathname === '/api/status/cached') {
       const cached = env.STATUS_CACHE ? await cacheRead(env.STATUS_CACHE) : null
       if (cached) {
-        // Read AI analysis + latency 24h in parallel (per-incident keys)
+        // Read latency + probe data first (needed for Mistral noise filtering before AI analysis)
+        let latency24h: Array<{ t: string; data: Record<string, number> }> = []
+        let probe24h: ProbeSnapshot[] = []
+        const [latRaw, probeRaw] = await Promise.all([
+          env.STATUS_CACHE!.get('latency:24h').catch(() => null),
+          env.STATUS_CACHE!.get('probe:24h').catch(() => null),
+        ])
+        if (latRaw) {
+          try { latency24h = JSON.parse(latRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached latency24h parse failed:', err instanceof Error ? err.message : err) }
+        }
+        if (probeRaw) {
+          try { probe24h = JSON.parse(probeRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached probe24h parse failed:', err instanceof Error ? err.message : err) }
+        }
+
+        // Filter Mistral micro-incident noise via probe cross-validation (#91)
+        // Must run BEFORE AI analysis reads — otherwise filtered incidents still have analysis data
+        if (probe24h.length > 0) {
+          const mistralMedian = computeMedianRtt(probe24h, 'mistral')
+          if (mistralMedian !== null) {
+            for (const svc of cached.services) {
+              if (svc.id !== 'mistral' || !svc.incidents?.length) continue
+              svc.incidents = svc.incidents.filter((inc) =>
+                isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+              )
+            }
+          }
+        }
+
+        // Read AI analysis (per-incident keys) — uses filtered incident list
         const aiAnalysis: Record<string, AIAnalysisResult[]> = {}
         const recentlyRecovered: string[] = []
-        const latencyPromise = env.STATUS_CACHE!.get('latency:24h').catch(() => null)
-        const probePromise = env.STATUS_CACHE!.get('probe:24h').catch(() => null)
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
         const withActiveInc = cached.services.filter(s =>
           (s.incidents ?? []).some(i => i.status !== 'resolved')
@@ -1118,16 +1144,6 @@ export default {
             } catch { /* ignore */ }
           })
         ))
-        let latency24h: Array<{ t: string; data: Record<string, number> }> = []
-        let probe24h: ProbeSnapshot[] = []
-        const latRaw = await latencyPromise
-        const probeRaw = await probePromise
-        if (latRaw) {
-          try { latency24h = JSON.parse(latRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached latency24h parse failed:', err instanceof Error ? err.message : err) }
-        }
-        if (probeRaw) {
-          try { probe24h = JSON.parse(probeRaw).snapshots ?? [] } catch (err) { console.warn('[kv] cached probe24h parse failed:', err instanceof Error ? err.message : err) }
-        }
 
         // Calculate scores for cached services (same as /api/status)
         const scoredCached = cached.services.map((svc) => {
@@ -1206,6 +1222,19 @@ export default {
         }
         if (probeRaw) {
           try { probe24h = JSON.parse(probeRaw).snapshots ?? [] } catch (err) { console.warn('[kv] probe24h parse failed:', err instanceof Error ? err.message : err) }
+        }
+      }
+
+      // Filter Mistral micro-incident noise via probe cross-validation (#91)
+      if (probe24h.length > 0) {
+        const mistralMedian = computeMedianRtt(probe24h, 'mistral')
+        if (mistralMedian !== null) {
+          for (const svc of enriched) {
+            if (svc.id !== 'mistral' || !svc.incidents?.length) continue
+            svc.incidents = svc.incidents.filter((inc) =>
+              isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+            )
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Mistral micro-incident noise filtering via probe RTT cross-validation — incidents without RTT spike (>3× median) are excluded from `/api/status` and `/api/status/cached` responses
- Validated against live production data: 10 incidents → 5 real (RTT 510ms+) + 5 noise (no spike)
- 5 pipeline integration tests added (`probe.test.ts`)

## Changes
- `worker/src/index.ts`: add filtering in both `/api/status` and `/api/status/cached` handlers (cached handler: filter before AI analysis reads to prevent stale analysis data)
- `worker/src/__tests__/probe.test.ts`: 5 new tests — noise filtering, real incident pass-through, mixed filtering, no probe data fallback, non-mistral isolation

## Test plan
- [x] `npm run test:worker` — 486 tests passing
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — build OK
- [x] Local verification: Mistral incidents reduced from 10 → 5 on dashboard
- [ ] Deploy worker and verify production

refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)