### PR TITLE
fix: ignore BetterStack degraded when <10% resources affected (#159)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -433,9 +433,46 @@ describe('parseBetterStackStatus', () => {
     })).toBe('degraded')
   })
 
-  it('returns degraded for "degraded" and "maintenance"', () => {
+  it('returns degraded for "degraded" and "maintenance" without resource data', () => {
     expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'degraded' } } })).toBe('degraded')
     expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'maintenance' } } })).toBe('degraded')
+  })
+
+  it('returns operational for "degraded" when <10% of resources are non-operational (#159)', () => {
+    // Together AI scenario: 1 out of 28 models down → should be operational
+    const resources = Array.from({ length: 28 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'operational' },
+    }))
+    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'degraded' } },
+      included: resources,
+    })).toBe('operational')
+  })
+
+  it('returns degraded for "degraded" when ≥10% of resources are non-operational', () => {
+    // 3 out of 10 down = 30% → genuinely degraded
+    const resources = Array.from({ length: 10 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'operational' },
+    }))
+    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    resources[1] = { type: 'status_page_resource', attributes: { status: 'degraded' } }
+    resources[2] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'degraded' } },
+      included: resources,
+    })).toBe('degraded')
+  })
+
+  it('returns operational for "downtime" when <10% of resources are non-operational (#159)', () => {
+    const resources = Array.from({ length: 20 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'operational' },
+    }))
+    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'downtime' } },
+      included: resources,
+    })).toBe('operational')
   })
 
   it('returns degraded with warning for unknown state', () => {

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -188,12 +188,20 @@ export function parseBetterStackStatus(data: BetterStackIndex): 'operational' | 
   const state = data.data?.attributes?.aggregate_state
   if (!state) return null
   if (state === 'operational') return 'operational'
-  if (state === 'degraded' || state === 'maintenance') return 'degraded'
+
+  // Resource-level threshold: if <10% of resources are non-operational, treat as operational
+  // (e.g., Together AI has 28 model monitors — 1 model down ≠ service-level degradation)
+  const resources = (data.included ?? []).filter(
+    (r) => r.type === 'status_page_resource' && r.attributes?.status
+  )
+  const nonOpCount = resources.filter((r) => r.attributes?.status !== 'operational').length
+
+  if (state === 'degraded' || state === 'maintenance') {
+    if (resources.length > 0 && nonOpCount / resources.length < 0.1) return 'operational'
+    return 'degraded'
+  }
   if (state === 'downtime') {
-    // Check resource-level status: if majority is operational, treat as degraded not down
-    const resources = (data.included ?? []).filter(
-      (r) => r.type === 'status_page_resource' && r.attributes?.status
-    )
+    if (resources.length > 0 && nonOpCount / resources.length < 0.1) return 'operational'
     if (resources.length > 0) {
       const downCount = resources.filter((r) => r.attributes?.status === 'downtime').length
       return downCount > resources.length / 2 ? 'down' : 'degraded'


### PR DESCRIPTION
## Summary

- Add resource-level threshold to `parseBetterStackStatus()` — if <10% of resources are non-operational, treat as `operational` instead of `degraded`/`down`
- Fixes false service-level degradation for Together AI (28 model monitors, 1 model down ≠ service outage)
- Applies consistently to both `degraded` and `downtime` aggregate states

## Test plan

- [x] `npm run test:worker` — 489 tests passed
- [x] `npx wrangler deploy --dry-run` — build check passed
- [ ] Verify on Vercel Preview
- [ ] Deploy worker and confirm Together AI shows operational when single model is down

closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)