### PR TITLE
fix: raise BetterStack resource threshold 10% → 15% (#159)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -438,19 +438,21 @@ describe('parseBetterStackStatus', () => {
     expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'maintenance' } } })).toBe('degraded')
   })
 
-  it('returns operational for "degraded" when <10% of resources are non-operational (#159)', () => {
-    // Together AI scenario: 1 out of 28 models down → should be operational
+  it('returns operational for "degraded" when <15% of resources are non-operational (#159)', () => {
+    // Together AI scenario: 3 out of 28 models down (10.7%) → below 15% threshold
     const resources = Array.from({ length: 28 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
     }))
     resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    resources[1] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    resources[2] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
     expect(parseBetterStackStatus({
       data: { attributes: { aggregate_state: 'degraded' } },
       included: resources,
     })).toBe('operational')
   })
 
-  it('returns degraded for "degraded" when ≥10% of resources are non-operational', () => {
+  it('returns degraded for "degraded" when ≥15% of resources are non-operational', () => {
     // 3 out of 10 down = 30% → genuinely degraded
     const resources = Array.from({ length: 10 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
@@ -464,11 +466,12 @@ describe('parseBetterStackStatus', () => {
     })).toBe('degraded')
   })
 
-  it('returns operational for "downtime" when <10% of resources are non-operational (#159)', () => {
+  it('returns operational for "downtime" when <15% of resources are non-operational (#159)', () => {
     const resources = Array.from({ length: 20 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
     }))
     resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    resources[1] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
     expect(parseBetterStackStatus({
       data: { attributes: { aggregate_state: 'downtime' } },
       included: resources,

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -189,19 +189,19 @@ export function parseBetterStackStatus(data: BetterStackIndex): 'operational' | 
   if (!state) return null
   if (state === 'operational') return 'operational'
 
-  // Resource-level threshold: if <10% of resources are non-operational, treat as operational
-  // (e.g., Together AI has 28 model monitors — 1 model down ≠ service-level degradation)
+  // Resource-level threshold: if <15% of resources are non-operational, treat as operational
+  // (e.g., Together AI has 28 model monitors — individual model churn ≠ service-level degradation)
   const resources = (data.included ?? []).filter(
     (r) => r.type === 'status_page_resource' && r.attributes?.status
   )
   const nonOpCount = resources.filter((r) => r.attributes?.status !== 'operational').length
 
   if (state === 'degraded' || state === 'maintenance') {
-    if (resources.length > 0 && nonOpCount / resources.length < 0.1) return 'operational'
+    if (resources.length > 0 && nonOpCount / resources.length < 0.15) return 'operational'
     return 'degraded'
   }
   if (state === 'downtime') {
-    if (resources.length > 0 && nonOpCount / resources.length < 0.1) return 'operational'
+    if (resources.length > 0 && nonOpCount / resources.length < 0.15) return 'operational'
     if (resources.length > 0) {
       const downCount = resources.filter((r) => r.attributes?.status === 'downtime').length
       return downCount > resources.length / 2 ? 'down' : 'degraded'


### PR DESCRIPTION
## Summary
- Raise BetterStack resource-level threshold from 10% to 15% to suppress individual model churn noise on Together AI (28 monitors)
- 3/28 models down (10.7%) triggered false degraded alert at 01:49 KST, recovered in 5 min — not a service-level issue
- With 15% threshold, requires 5+ simultaneous model failures for degraded status

## Test plan
- [x] 489 worker tests pass (threshold tests updated for 15%)
- [x] `wrangler deploy --dry-run` build check passes
- [ ] Deploy worker and monitor Together AI alerts over next 24h

closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)