### PR TITLE
fix: RSS-first status + raise BetterStack threshold to 30% (#162)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -438,40 +438,36 @@ describe('parseBetterStackStatus', () => {
     expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'maintenance' } } })).toBe('degraded')
   })
 
-  it('returns operational for "degraded" when <15% of resources are non-operational (#159)', () => {
-    // Together AI scenario: 3 out of 28 models down (10.7%) → below 15% threshold
+  it('returns operational for "degraded" when <30% of resources are non-operational (#162)', () => {
+    // Together AI scenario: 7 out of 28 models down (25%) → below 30% threshold
     const resources = Array.from({ length: 28 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
     }))
-    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
-    resources[1] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
-    resources[2] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    for (let i = 0; i < 7; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
     expect(parseBetterStackStatus({
       data: { attributes: { aggregate_state: 'degraded' } },
       included: resources,
     })).toBe('operational')
   })
 
-  it('returns degraded for "degraded" when ≥15% of resources are non-operational', () => {
-    // 3 out of 10 down = 30% → genuinely degraded
+  it('returns degraded for "degraded" when ≥30% of resources are non-operational', () => {
+    // 4 out of 10 down = 40% → genuinely degraded
     const resources = Array.from({ length: 10 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
     }))
-    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
-    resources[1] = { type: 'status_page_resource', attributes: { status: 'degraded' } }
-    resources[2] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    for (let i = 0; i < 4; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
     expect(parseBetterStackStatus({
       data: { attributes: { aggregate_state: 'degraded' } },
       included: resources,
     })).toBe('degraded')
   })
 
-  it('returns operational for "downtime" when <15% of resources are non-operational (#159)', () => {
+  it('returns operational for "downtime" when <30% of resources are non-operational (#162)', () => {
+    // 5 out of 20 down = 25% → below 30% threshold
     const resources = Array.from({ length: 20 }, () => ({
       type: 'status_page_resource', attributes: { status: 'operational' },
     }))
-    resources[0] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
-    resources[1] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    for (let i = 0; i < 5; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
     expect(parseBetterStackStatus({
       data: { attributes: { aggregate_state: 'downtime' } },
       included: resources,

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -189,19 +189,21 @@ export function parseBetterStackStatus(data: BetterStackIndex): 'operational' | 
   if (!state) return null
   if (state === 'operational') return 'operational'
 
-  // Resource-level threshold: if <15% of resources are non-operational, treat as operational
-  // (e.g., Together AI has 28 model monitors — individual model churn ≠ service-level degradation)
+  // Resource-level threshold: if <30% of resources are non-operational, treat as operational
+  // BetterStack services (Together, Fireworks, HuggingFace, Modal) have many individual monitors.
+  // Individual model churn (e.g., 5/28 = 17%) ≠ service-level degradation.
+  // This is a backup signal — RSS incidents take priority in services.ts derivedStatus.
   const resources = (data.included ?? []).filter(
     (r) => r.type === 'status_page_resource' && r.attributes?.status
   )
   const nonOpCount = resources.filter((r) => r.attributes?.status !== 'operational').length
 
   if (state === 'degraded' || state === 'maintenance') {
-    if (resources.length > 0 && nonOpCount / resources.length < 0.15) return 'operational'
+    if (resources.length > 0 && nonOpCount / resources.length < 0.3) return 'operational'
     return 'degraded'
   }
   if (state === 'downtime') {
-    if (resources.length > 0 && nonOpCount / resources.length < 0.15) return 'operational'
+    if (resources.length > 0 && nonOpCount / resources.length < 0.3) return 'operational'
     if (resources.length > 0) {
       const downCount = resources.filter((r) => r.attributes?.status === 'downtime').length
       return downCount > resources.length / 2 ? 'down' : 'degraded'

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -480,11 +480,11 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
       }
 
       const filtered = filterIncidents(incidents, config)
-      // Prefer BetterStack aggregate_state (authoritative platform status),
-      // then fall back to RSS incident check, then HTTP check
+      // RSS incidents first (explicit provider-reported issues), then BetterStack
+      // aggregate_state as backup (resource-level threshold filters model churn noise)
       const hasOngoing = filtered.some((i) => i.status !== 'resolved')
       const httpStatus = res.ok || res.status === 403 ? 'operational' : 'degraded'
-      const derivedStatus = betterStackStat ?? (hasOngoing ? 'degraded' : httpStatus)
+      const derivedStatus = hasOngoing ? 'degraded' : (betterStackStat ?? httpStatus)
 
       // Successful fetch — reset consecutive failure counter
       await resetFetchFailure(kv, config.id)


### PR DESCRIPTION
## Summary
- Flip `derivedStatus` priority: RSS incidents → aggregate_state → HTTP (was: aggregate_state → RSS → HTTP)
- Raise resource threshold from 15% to 30% (backup signal for rapid detection before RSS)
- Together AI: 7/28 model churn (25%) → operational; 9+/28 (30%+) → degraded

## Context
Despite raising threshold from 10% → 15% in #161, Together AI triggered another false degraded alert at 06:29 KST (5+ models simultaneously flapping). Root cause: `aggregate_state` is inherently noisy for multi-model services — individual model churn ≠ service-level degradation.

## Test plan
- [x] 489 worker tests pass (threshold tests updated for 30%)
- [x] `wrangler deploy --dry-run` build check passes
- [ ] Deploy worker and monitor — no false degraded alerts expected

closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)