### PR TITLE
feat: re-trigger AI analysis when estimated recovery time is exceeded (refs #168)

### DIFF
--- a/worker/src/__tests__/ai-analysis.test.ts
+++ b/worker/src/__tests__/ai-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, type KVLike } from '../ai-analysis'
+import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, parseRecoveryHours, type KVLike } from '../ai-analysis'
 import type { Incident, ServiceStatus } from '../types'
 
 const mockIncident = (overrides: Partial<Incident> = {}): Incident => ({
@@ -180,6 +180,24 @@ describe('buildAnalysisPrompt', () => {
     const prompt = buildAnalysisPrompt('Test', { title: 'error', status: 's', startedAt: '2026-01-01T00:00:00Z', impact: null }, longIncidents)
     // History text capped at 1000 chars
     expect(prompt.length).toBeLessThan(2000)
+  })
+
+  it('includes previous prediction context when prevPrediction is provided', () => {
+    const prompt = buildAnalysisPrompt(
+      'Deepgram', { title: 'Voice API Error', status: 'investigating', startedAt: '2026-03-27T03:00:00Z', impact: 'major' },
+      [], { estimatedRecoveryHours: 6, elapsedHours: 14 },
+    )
+    expect(prompt).toContain('Previous Prediction')
+    expect(prompt).toContain('6h')
+    expect(prompt).toContain('14h')
+    expect(prompt).toContain('incorrect')
+  })
+
+  it('omits previous prediction context when prevPrediction is not provided', () => {
+    const prompt = buildAnalysisPrompt(
+      'Deepgram', { title: 'Voice API Error', status: 'investigating', startedAt: '2026-03-27T03:00:00Z', impact: 'major' }, [],
+    )
+    expect(prompt).not.toContain('Previous Prediction')
   })
 })
 
@@ -878,5 +896,149 @@ describe('refreshOrReanalyze', () => {
     expect(store[analysisKey('claudecode', 'inc-shared')]).toBeDefined()
     expect(result.reanalyzed).toContain('claudeai')
     expect(result.reanalyzed).toContain('claudecode')
+  })
+
+  it('re-analyzes when estimated recovery time is exceeded despite unchanged timeline', async () => {
+    const oldAnalysis = {
+      ...mockAnalysis,
+      incidentId: 'inc-1',
+      analyzedAt: '2026-03-27T03:00:00Z',
+      estimatedRecoveryHours: 6, // predicted 6h recovery
+      timelineHash: '2026-03-27T03:00:00Z',
+    }
+    const store: Record<string, string> = { [analysisKey('deepgram', 'inc-1')]: JSON.stringify(oldAnalysis) }
+    const kv = mockKV(store)
+    const svc = mockService('deepgram', [{
+      id: 'inc-1',
+      status: 'investigating',
+      startedAt: '2026-03-27T02:00:00Z', // incident started 1h before analysis
+      timeline: [{ stage: 'investigating', text: 'Looking into it', at: '2026-03-27T03:00:00Z' }],
+    }])
+    const updatedAnalysis = { ...mockAnalysis, incidentId: 'inc-1', summary: 'Recovery exceeded re-analysis' }
+    const analyzeFn = vi.fn().mockResolvedValue(updatedAnalysis)
+
+    // 15h since incident start — well beyond 6h estimate
+    const now = new Date('2026-03-27T17:00:00Z').getTime()
+    const result = await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2, now)
+
+    expect(analyzeFn).toHaveBeenCalledOnce()
+    expect(result.reanalyzed).toEqual(['deepgram'])
+    const stored = JSON.parse(store[analysisKey('deepgram', 'inc-1')])
+    expect(stored.summary).toBe('Recovery exceeded re-analysis')
+  })
+
+  it('does not trigger recovery-exceeded re-analysis when within estimated time', async () => {
+    const oldAnalysis = {
+      ...mockAnalysis,
+      incidentId: 'inc-1',
+      analyzedAt: '2026-03-27T03:00:00Z',
+      estimatedRecoveryHours: 6,
+      timelineHash: '2026-03-27T03:00:00Z',
+    }
+    const store: Record<string, string> = { [analysisKey('deepgram', 'inc-1')]: JSON.stringify(oldAnalysis) }
+    const kv = mockKV(store)
+    const svc = mockService('deepgram', [{
+      id: 'inc-1',
+      status: 'investigating',
+      startedAt: '2026-03-27T02:00:00Z',
+      timeline: [{ stage: 'investigating', text: 'Looking into it', at: '2026-03-27T03:00:00Z' }],
+    }])
+    const analyzeFn = vi.fn()
+
+    // 5h since incident start — within 6h estimate
+    const now = new Date('2026-03-27T07:00:00Z').getTime()
+    const result = await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2, now)
+
+    expect(analyzeFn).not.toHaveBeenCalled()
+    expect(result.refreshed).toEqual(['deepgram'])
+  })
+
+  it('passes prevPrediction context to analyzeFn when recovery exceeded', async () => {
+    const oldAnalysis = {
+      ...mockAnalysis,
+      incidentId: 'inc-1',
+      analyzedAt: '2026-03-27T03:00:00Z',
+      estimatedRecoveryHours: 4,
+      timelineHash: '2026-03-27T03:00:00Z',
+    }
+    const store: Record<string, string> = { [analysisKey('deepgram', 'inc-1')]: JSON.stringify(oldAnalysis) }
+    const kv = mockKV(store)
+    const svc = mockService('deepgram', [{
+      id: 'inc-1',
+      status: 'investigating',
+      startedAt: '2026-03-27T02:00:00Z', // incident started 1h before analysis
+      timeline: [{ stage: 'investigating', text: 'Looking into it', at: '2026-03-27T03:00:00Z' }],
+    }])
+    const analyzeFn = vi.fn().mockResolvedValue({ ...mockAnalysis, incidentId: 'inc-1' })
+
+    // 11h since incident start — 2.75× the 4h estimate
+    const now = new Date('2026-03-27T13:00:00Z').getTime()
+    await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2, now)
+
+    // elapsedHours should be incident age (11h), not analysis age (10h)
+    expect(analyzeFn).toHaveBeenCalledWith(
+      'key', expect.any(String), expect.any(Object), expect.any(Array),
+      expect.objectContaining({ estimatedRecoveryHours: 4, elapsedHours: expect.closeTo(11, 0.1) }),
+    )
+  })
+
+  it('re-analyzes on recovery exceeded even when new timeline entries are boilerplate', async () => {
+    const oldAnalysis = {
+      ...mockAnalysis,
+      incidentId: 'inc-1',
+      analyzedAt: '2026-03-27T03:00:00Z',
+      estimatedRecoveryHours: 2,
+      timelineHash: '2026-03-27T03:00:00Z',
+    }
+    const store: Record<string, string> = { [analysisKey('deepgram', 'inc-1')]: JSON.stringify(oldAnalysis) }
+    const kv = mockKV(store)
+    const svc = mockService('deepgram', [{
+      id: 'inc-1',
+      status: 'monitoring',
+      startedAt: '2026-03-27T02:00:00Z',
+      timeline: [
+        { stage: 'investigating', text: 'We are investigating this issue', at: '2026-03-27T03:00:00Z' },
+        { stage: 'monitoring', text: 'We are continuing to monitor', at: '2026-03-27T04:00:00Z' },
+      ],
+    }])
+    const analyzeFn = vi.fn().mockResolvedValue({ ...mockAnalysis, incidentId: 'inc-1' })
+
+    // 9h since incident start — 4.5× the 2h estimate
+    const now = new Date('2026-03-27T11:00:00Z').getTime()
+    const result = await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2, now)
+
+    // Should re-analyze despite boilerplate, because recovery exceeded
+    expect(analyzeFn).toHaveBeenCalledOnce()
+    expect(result.reanalyzed).toEqual(['deepgram'])
+  })
+})
+
+describe('parseRecoveryHours', () => {
+  it('parses range format with hours', () => {
+    expect(parseRecoveryHours('4–6h')).toBe(6)
+    expect(parseRecoveryHours('1–3h')).toBe(3)
+  })
+
+  it('parses range format with mixed units', () => {
+    expect(parseRecoveryHours('30m–1h')).toBe(1)
+    expect(parseRecoveryHours('15m–45m')).toBe(0.75)
+  })
+
+  it('parses single value', () => {
+    expect(parseRecoveryHours('2h')).toBe(2)
+    expect(parseRecoveryHours('30m')).toBe(0.5)
+    expect(parseRecoveryHours('1h 30m')).toBe(1.5)
+  })
+
+  it('returns null for N/A', () => {
+    expect(parseRecoveryHours('N/A')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseRecoveryHours('')).toBeNull()
+  })
+
+  it('handles hyphen as range separator', () => {
+    expect(parseRecoveryHours('2-4h')).toBe(4)
   })
 })

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -35,11 +35,33 @@ export function isBoilerplate(text: string | null | undefined): boolean {
 export interface AIAnalysisResult {
   summary: string
   estimatedRecovery: string
+  estimatedRecoveryHours?: number  // upper bound parsed from estimatedRecovery (e.g., "4–6h" → 6)
   affectedScope: string[]
   analyzedAt: string
   incidentId: string
   resolvedAt?: string
   timelineHash?: string  // latest timeline entry timestamp — used to skip re-analysis when unchanged
+}
+
+/**
+ * Parse estimated recovery string to hours (upper bound).
+ * "4–6h" → 6, "30m–1h" → 1, "2h" → 2, "15–45m" → 0.75, "N/A" → null
+ */
+export function parseRecoveryHours(recovery: string): number | null {
+  if (!recovery || recovery === 'N/A') return null
+  // Split on range separator (–, -, ~) and take the last (upper bound) part
+  const parts = recovery.split(/[–\-~]/).map(s => s.trim()).filter(Boolean)
+  const upper = parts[parts.length - 1]
+  if (!upper) return null
+  const hMatch = upper.match(/(\d+(?:\.\d+)?)\s*h/i)
+  const mMatch = upper.match(/(\d+(?:\.\d+)?)\s*m/i)
+  let hours = 0
+  if (hMatch) hours += parseFloat(hMatch[1])
+  if (mMatch) hours += parseFloat(mMatch[1]) / 60
+  if (hours <= 0) {
+    console.warn(`[ai-analysis] Could not parse recovery hours from: "${recovery}"`)
+  }
+  return hours > 0 ? Math.round(hours * 100) / 100 : null
 }
 
 /** Centralized KV key for per-incident analysis */
@@ -98,6 +120,7 @@ export function buildAnalysisPrompt(
   serviceName: string,
   currentIncident: { title: string; status: string; startedAt: string; impact: string | null; timeline?: Array<{ stage: string; text: string | null; at: string }> },
   similarIncidents: Incident[],
+  prevPrediction?: { estimatedRecoveryHours: number; elapsedHours: number },
 ): string {
   const historyText = similarIncidents.length > 0
     ? similarIncidents.map(i =>
@@ -120,13 +143,17 @@ export function buildAnalysisPrompt(
     timelineText += (timelineText ? '\n' : '') + line
   }
 
+  const prevPredictionText = prevPrediction
+    ? `\nPrevious Prediction: Estimated recovery in ${prevPrediction.estimatedRecoveryHours}h, but ${Math.round(prevPrediction.elapsedHours)}h have elapsed and the incident remains unresolved. The previous prediction was incorrect — re-evaluate with updated context.\n`
+    : ''
+
   return `<incident_data>
 Service: ${safeName}
 Current Incident: "${safeTitle}"
 Status: ${safeStatus}
 Started: ${sanitize(currentIncident.startedAt).slice(0, 30)}
 Impact: ${safeImpact}
-${timelineText ? `\nTimeline Updates:\n${timelineText}\n` : ''}
+${prevPredictionText}${timelineText ? `\nTimeline Updates:\n${timelineText}\n` : ''}
 Historical Data (last 30 days):
 ${historyText}
 </incident_data>`
@@ -140,9 +167,10 @@ export async function analyzeIncident(
   serviceName: string,
   currentIncident: { id: string; title: string; status: string; startedAt: string; impact: string | null; timeline?: Array<{ stage: string; text: string | null; at: string }> },
   allIncidents: Incident[],
+  prevPrediction?: { estimatedRecoveryHours: number; elapsedHours: number },
 ): Promise<AIAnalysisResult | null> {
   const similar = findSimilarIncidents(currentIncident.title, allIncidents)
-  const prompt = buildAnalysisPrompt(serviceName, currentIncident, similar)
+  const prompt = buildAnalysisPrompt(serviceName, currentIncident, similar, prevPrediction)
 
   try {
     const res = await fetch('https://api.anthropic.com/v1/messages', {
@@ -188,9 +216,11 @@ export async function analyzeIncident(
       .replace(/\s*to\s*/g, '–')
     // Store latest timeline entry timestamp to detect new updates on re-analysis
     const latestTimelineAt = currentIncident.timeline?.at(-1)?.at ?? ''
+    const recoveryHours = parseRecoveryHours(recovery)
     return {
       summary: sanitize(parsed.summary ?? 'Analysis unavailable'),
       estimatedRecovery: recovery,
+      ...(recoveryHours != null && { estimatedRecoveryHours: recoveryHours }),
       affectedScope: (parsed.affectedScope ?? []).map(s => sanitize(s)),
       analyzedAt: new Date().toISOString(),
       incidentId: currentIncident.id,
@@ -246,11 +276,18 @@ export async function refreshOrReanalyze(
           // Time-based re-analysis: if 2h+ old, attempt update without deleting old analysis first
           const analysisAge = now - new Date(parsed.analyzedAt).getTime()
           if (analysisAge >= 7_200_000 && apiKey && reAnalysisCount < cap) {
+            // Check if estimated recovery time has been exceeded (relative to incident start, not analysis time)
+            const estHours = typeof parsed.estimatedRecoveryHours === 'number' && parsed.estimatedRecoveryHours > 0
+              ? parsed.estimatedRecoveryHours : null
+            const incidentAge = now - new Date(inc.startedAt).getTime()
+            const recoveryExceeded = estHours != null && incidentAge > estHours * 3_600_000
+
             // Skip re-analysis if timeline hasn't changed since last analysis
+            // UNLESS recovery time has been exceeded (stale prediction must be updated)
             const latestTimelineAt = inc.timeline?.at(-1)?.at ?? ''
             const hashTime = parsed.timelineHash ? new Date(parsed.timelineHash).getTime() : 0
             const latestTime = latestTimelineAt ? new Date(latestTimelineAt).getTime() : 0
-            if (parsed.timelineHash && hashTime === latestTime) {
+            if (parsed.timelineHash && hashTime === latestTime && !recoveryExceeded) {
               // No new timeline updates — just refresh TTL, skip API call
               parsed._lastRefresh = new Date(now).toISOString()
               await kvPut(kv, key, JSON.stringify(parsed), { expirationTtl: 3600 })
@@ -259,7 +296,8 @@ export async function refreshOrReanalyze(
               continue
             }
             // Skip if new timeline entries are all boilerplate (no technical detail)
-            if (parsed.timelineHash) {
+            // UNLESS recovery time has been exceeded
+            if (parsed.timelineHash && !recoveryExceeded) {
               const newEntries = (inc.timeline ?? []).filter(t => new Date(t.at).getTime() > hashTime)
               if (newEntries.length > 0 && newEntries.every(t => isBoilerplate(t.text))) {
                 // Update timelineHash to avoid rechecking, but skip API call
@@ -271,12 +309,17 @@ export async function refreshOrReanalyze(
                 continue
               }
             }
+            // Build previous prediction context for re-analysis prompt
+            const prevPrediction = recoveryExceeded && estHours
+              ? { estimatedRecoveryHours: estHours, elapsedHours: incidentAge / 3_600_000 }
+              : undefined
             reAnalysisCount++
             try {
               const newAnalysis = await analyzeFn(
                 apiKey, svc.name,
                 { id: inc.id, title: inc.title, status: inc.status, startedAt: inc.startedAt, impact: inc.impact, timeline: inc.timeline },
                 svc.incidents ?? [],
+                prevPrediction,
               )
               // Track usage
               const today = new Date(now).toISOString().split('T')[0]


### PR DESCRIPTION
## Summary

- Parse `estimatedRecoveryHours` from AI analysis output and store in KV
- Force re-analysis when incident duration exceeds the predicted recovery time, even if timeline is unchanged or boilerplate-only
- Include "previous prediction was incorrect" context in re-analysis prompt for better updated estimates
- Type-safe KV read guard + warn logging for unparseable recovery formats

## Test plan

- [x] 501 worker tests passing (12 new: parseRecoveryHours 6 + recovery exceeded 4 + buildAnalysisPrompt 2)
- [x] Worker dry-run build passing
- [ ] Verify Vercel Preview

refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)