### PR TITLE
fix: fallback parse for pre-deployment KV data (refs #168)

### DIFF
--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -277,8 +277,10 @@ export async function refreshOrReanalyze(
           const analysisAge = now - new Date(parsed.analyzedAt).getTime()
           if (analysisAge >= 7_200_000 && apiKey && reAnalysisCount < cap) {
             // Check if estimated recovery time has been exceeded (relative to incident start, not analysis time)
+            // Fallback: if estimatedRecoveryHours not stored (pre-deployment data), parse from estimatedRecovery string
             const estHours = typeof parsed.estimatedRecoveryHours === 'number' && parsed.estimatedRecoveryHours > 0
-              ? parsed.estimatedRecoveryHours : null
+              ? parsed.estimatedRecoveryHours
+              : (parsed.estimatedRecovery ? parseRecoveryHours(parsed.estimatedRecovery) : null)
             const incidentAge = now - new Date(inc.startedAt).getTime()
             const recoveryExceeded = estHours != null && incidentAge > estHours * 3_600_000
 


### PR DESCRIPTION
## Summary
- Pre-existing KV analysis entries lack `estimatedRecoveryHours` field (added in #169)
- Falls back to runtime `parseRecoveryHours(estimatedRecovery)` so recovery-exceeded re-analysis triggers for old data

refs #168