### PR TITLE
fix: change Claude API probe endpoint to /v1/models (#171)

### DIFF
--- a/worker/src/probe.ts
+++ b/worker/src/probe.ts
@@ -7,7 +7,7 @@ export interface ProbeTarget { id: string; url: string }
 
 export const PROBE_TARGETS: ProbeTarget[] = [
   // API services — auth not required for RTT measurement (401/403/405 = server alive)
-  { id: 'claude', url: 'https://api.anthropic.com/v1/messages' },
+  { id: 'claude', url: 'https://api.anthropic.com/v1/models' },
   { id: 'openai', url: 'https://api.openai.com/v1/models' },
   { id: 'gemini', url: 'https://generativelanguage.googleapis.com/v1beta/models' },
   { id: 'mistral', url: 'https://api.mistral.ai/v1/models' },


### PR DESCRIPTION
## Summary

- Change Claude API probe endpoint from `/v1/messages` (POST-only, 405) to `/v1/models` (GET, 401) for fair RTT measurement
- `/v1/messages` returned 405 immediately without hitting auth middleware, producing artificially low RTT (~9ms on prod)
- `/v1/models` goes through the same auth path as other services' `/v1/models` endpoints

## Test plan

- [x] `npm run test:worker` — 501 passed
- [x] `npx wrangler deploy --dry-run` — success
- [x] Local curl comparison: `/v1/messages` ~367ms vs `/v1/models` ~579ms (auth middleware adds realistic processing)
- [ ] Deploy worker after merge, verify new p50 values via `wrangler tail`

refs #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)