### PR TITLE
fix: extend vitals daily KV TTL from 2d to 3d

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ When adding a new monitored service, update ALL of the following:
 | `webhook:reg:{sha256hash}` | `{ type, registeredAt }` JSON | 30d | ~1/user/day | Active webhook registration (hashed, refreshed on ping) |
 | `alert:proxy:{YYYY-MM-DD}` | `{ discord, slack, failed }` JSON | 2d | ~1 | User webhook delivery counts (approximate, flushed from in-memory by daily summary cron) |
 | `kv_limit_alert` | `"1"` | 5min | ~1 | KV write limit exceeded cooldown |
-| `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 2d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
+| `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 
 **Free tier budget**: 1,000 writes/day. Estimated total: ~841-951 writes/day + vitals (1 per visit). Monitor if daily visits exceed ~50.

--- a/worker/src/vitals.ts
+++ b/worker/src/vitals.ts
@@ -91,7 +91,7 @@ export async function writeVitalsToKV(kv: KVNamespace, metrics: Partial<Record<V
   await kv.put(key, JSON.stringify({
     count: (existing?.count ?? 0) + 1,
     allValues,
-  }), { expirationTtl: 2 * 86400 })
+  }), { expirationTtl: 3 * 86400 })
 }
 
 /**


### PR DESCRIPTION
## Summary
- `vitals:{date}` KV key TTL: 2 days → 3 days
- Gives extra day buffer for `archiveVitals()` to run before raw data expires
- Prevents vitals data loss when frequent worker deployments cause daily summary to miss UTC 09:00 window
- Updated CLAUDE.md KV schema table

## Root cause
4/6~4/8 사이 워커 10회 배포 → daily summary 미실행 → `archiveVitals()` 미실행 → `vitals:2026-04-06` TTL 2일 만료 → history 키 미생성 → daily report vitals 섹션 미출력

## Test plan
- [x] 510 worker tests pass
- [x] `wrangler deploy --dry-run` build check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)