### PR TITLE
fix: page-specific skeleton fallbacks for lazy chunk loading (#195)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import CookieBanner from './components/CookieBanner'
 import InstallBanner from './components/InstallBanner'
 import { PrivacyContent, TermsContent } from './components/LegalContent'
 import Overview from './pages/Overview'
+import SkeletonUI, { LatencySkeleton, IncidentsSkeleton, UptimeSkeleton, ServiceDetailsSkeleton } from './components/SkeletonUI'
 
 function lazyWithRetry(importFn) {
   return lazy(() =>
@@ -79,13 +80,13 @@ function pageToHash(page) {
 function resolvePage(page) {
   switch (page.name) {
     case 'overview':  return <Overview />
-    case 'latency':   return <Latency />
-    case 'incidents': return <Incidents />
-    case 'uptime':    return <Uptime />
-    case 'service':   return <ServiceDetails serviceId={page.serviceId} />
-    case 'settings':  return <Settings />
-    case 'about-score': return <AboutScore />
-    case 'ranking':     return <Ranking />
+    case 'latency':   return <Suspense fallback={<LatencySkeleton />}><Latency /></Suspense>
+    case 'incidents': return <Suspense fallback={<IncidentsSkeleton />}><Incidents /></Suspense>
+    case 'uptime':    return <Suspense fallback={<UptimeSkeleton />}><Uptime /></Suspense>
+    case 'service':   return <Suspense fallback={<ServiceDetailsSkeleton />}><ServiceDetails serviceId={page.serviceId} /></Suspense>
+    case 'settings':  return <Suspense fallback={<SkeletonUI />}><Settings /></Suspense>
+    case 'about-score': return <Suspense fallback={<SkeletonUI />}><AboutScore /></Suspense>
+    case 'ranking':     return <Suspense fallback={<SkeletonUI />}><Ranking /></Suspense>
     default:          return <Overview />
   }
 }
@@ -188,9 +189,7 @@ function AppInner() {
         onSidebarClose={() => setSidebarOpen(false)}
       >
         <ChunkErrorBoundary>
-          <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center' }}><span className="text-[var(--text2)] mono text-[12px]">Loading…</span></div>}>
-            {resolvePage(page)}
-          </Suspense>
+          {resolvePage(page)}
         </ChunkErrorBoundary>
       </Layout>
 

--- a/tests/uptime.spec.js
+++ b/tests/uptime.spec.js
@@ -23,7 +23,6 @@ test.describe('Uptime page', () => {
   test('renders uptime matrix', async ({ page }) => {
     const main = page.locator('main')
     // Matrix section should show service names in a grid
-    const serviceCount = await main.getByText(/API|Cloud|AI|Copilot|Cursor|Windsurf/).count()
-    expect(serviceCount).toBeGreaterThan(0)
+    await expect(main.getByText(/API|Cloud|AI|Copilot|Cursor|Windsurf/).first()).toBeVisible({ timeout: 10000 })
   })
 })


### PR DESCRIPTION
## Summary
- Move `<Suspense>` from single outer wrapper into `resolvePage()` with page-specific skeleton fallbacks
- Each lazy-loaded page now shows its matching skeleton UI during chunk download instead of generic "Loading…" text
- `Overview` (statically imported) correctly has no Suspense wrapper

closes #195

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (54/55, 1 pre-existing flaky)
- [x] Verified on mobile (iOS + Android) — skeleton shows during page transitions
- [x] Desktop: page transitions show skeleton, not "Loading…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)