### PR TITLE
fix: update Cursor statusComponentId after status page migration (#199)

### DIFF
--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -52,7 +52,7 @@ export const SERVICES: ServiceConfig[] = [
   // Coding Agents
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
-  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: '92rkl6jnscl8' },
+  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
 ]
 


### PR DESCRIPTION
closes #199

## Summary
- Cursor restructured their status page components — old ID `92rkl6jnscl8` no longer exists
- Updated `statusComponentId` to `rflc60xp5fp2` → new **IDE** component (`rflc60xp5jp2`)
- Stops repeated "Component ID Mismatch" Discord alerts

## Test plan
- [x] Worker dry-run build passes
- [x] Worker unit tests pass (602/602)
- [x] Playwright E2E tests pass (55/55)
- [x] Local Worker returns Cursor as `operational` with correct incident data
- [x] Local browser verification confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)