### PR TITLE
fix: optimize Latency 24h Trend chart density on mobile (#201)

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -91,6 +91,7 @@ const en = {
   'latency.average': 'Average',
   'latency.slowest': 'Slowest',
   'latency.trend': '24h Trend',
+  'latency.top8': 'Top 8 by Score',
   'latency.excludeNote': '* AI Apps (claude.ai, ChatGPT, etc.) and Coding Agents are excluded — no public API endpoint to measure.',
   'latency.dummy': 'Collecting data (switches to real data after 24h)',
   'latency.avg.services': 'services',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -91,6 +91,7 @@ const ko = {
   'latency.average': '평균',
   'latency.slowest': '가장 느림',
   'latency.trend': '24시간 추세',
+  'latency.top8': 'Score 상위 8개',
   'latency.excludeNote': '* AI Apps(claude.ai, ChatGPT 등)와 Coding Agent는 API 엔드포인트가 없어 측정 대상에서 제외됩니다.',
   'latency.dummy': '데이터 수집 중 (24시간 후 실데이터로 전환)',
   'latency.avg.services': '개 서비스',

--- a/src/pages/Latency.jsx
+++ b/src/pages/Latency.jsx
@@ -65,33 +65,68 @@ function LatencyTrendSection({ services, t, hourlyData }) {
       if (cancelled || !canvasRef.current) return
       if (chartRef.current) chartRef.current.destroy()
 
-    const labels = hourlyData.map((s) => {
-      const d = new Date(s.t)
-      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-    })
-
     // Detect data format: probe snapshots have { status, rtt } objects, latency snapshots have plain numbers
     const isProbeData = hourlyData.length > 0 && typeof Object.values(hourlyData[0].data ?? {})[0] === 'object'
     // For probe data, show only services present in probe snapshots
     const probeServiceIds = isProbeData ? Object.keys(hourlyData[hourlyData.length - 1]?.data ?? {}) : null
-    const apiServices = probeServiceIds
+    const isMobile = window.innerWidth < 768
+
+    // Downsample 5-min probe data → 30-min slot averages (:00–:29, :30–:59)
+    const needsDownsample = isProbeData && hourlyData.length > 60
+    let chartData = hourlyData
+    if (needsDownsample) {
+      const slotMap = new Map()
+      for (const s of hourlyData) {
+        const d = new Date(s.t)
+        const h = d.getHours()
+        const half = d.getMinutes() < 30 ? 0 : 30
+        const key = `${h}:${half}`
+        if (!slotMap.has(key)) slotMap.set(key, { points: [], h, half })
+        slotMap.get(key).points.push(s)
+      }
+      chartData = [...slotMap.values()].map(({ points, h, half }) => {
+        const mid = points[Math.floor(points.length / 2)]
+        const merged = {}
+        const svcIds = new Set(points.flatMap((s) => Object.keys(s.data ?? {})))
+        for (const id of svcIds) {
+          const vals = points.map((s) => {
+            const v = s.data?.[id]
+            return v && typeof v === 'object' ? (v.rtt > 0 ? v.rtt : null) : v
+          }).filter((v) => v != null)
+          if (vals.length > 0) merged[id] = { rtt: Math.round(vals.reduce((a, b) => a + b, 0) / vals.length), status: 'ok' }
+        }
+        const hh = String(h).padStart(2, '0')
+        const endHalf = half === 0 ? '30' : '00'
+        const endH = half === 0 ? hh : String((h + 1) % 24).padStart(2, '0')
+        return { t: mid.t, data: merged, _rangeLabel: `${hh}:${String(half).padStart(2, '0')}–${endH}:${endHalf}` }
+      })
+    }
+
+    const labels = chartData.map((s) => {
+      const d = new Date(s.t)
+      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+    })
+    const rangeLabels = needsDownsample ? chartData.map((s) => s._rangeLabel) : null
+
+    let apiServices = probeServiceIds
       ? services.filter((s) => probeServiceIds.includes(s.id))
       : services.filter((s) => s.category === 'api' && s.latency != null)
+    if (isMobile) apiServices = [...apiServices].sort((a, b) => (b.aiwatchScore ?? 0) - (a.aiwatchScore ?? 0)).slice(0, 8)
     const styles = getComputedStyle(document.documentElement)
     const textMuted = styles.getPropertyValue('--text2').trim() || '#6b7280'
     const borderClr = styles.getPropertyValue('--border').trim() || 'rgba(107,114,128,0.1)'
 
     const datasets = apiServices.map((svc) => ({
       label: svc.name,
-      data: hourlyData.map((s) => {
+      data: chartData.map((s) => {
         const val = s.data[svc.id]
         if (val == null) return null
         if (typeof val === 'object') return val.rtt > 0 ? val.rtt : null
         return val
       }),
       borderColor: SERVICE_COLOR[svc.id] ?? '#8b949e',
-      borderWidth: 1.5,
-      pointRadius: 1.5,
+      borderWidth: isMobile ? 1 : 1.5,
+      pointRadius: isMobile ? 0 : 1.5,
       pointHoverRadius: 3,
       tension: 0.3,
       fill: false,
@@ -107,17 +142,26 @@ function LatencyTrendSection({ services, t, hourlyData }) {
         interaction: { mode: 'index', intersect: false },
         plugins: {
           legend: {
-            display: true,
+            display: !isMobile,
             position: 'bottom',
             labels: { font: { size: 9, family: 'var(--font-mono)' }, color: textMuted, boxWidth: 8, padding: 8 },
           },
           tooltip: {
-            callbacks: { label: (ctx) => ctx.parsed.y != null ? `${ctx.dataset.label}: ${ctx.parsed.y}ms` : null },
+            filter: (item) => item.parsed.y != null,
+            itemSort: (a, b) => b.parsed.y - a.parsed.y,
+            callbacks: {
+              title: (items) => {
+                if (!items.length) return ''
+                const i = items[0].dataIndex
+                return rangeLabels ? `${rangeLabels[i]} avg` : labels[i]
+              },
+              label: (ctx) => `${ctx.dataset.label}: ${ctx.parsed.y}ms`,
+            },
           },
         },
         scales: {
           x: {
-            ticks: { font: { size: 9, family: 'var(--font-mono)' }, color: textMuted, maxTicksLimit: 12, callback: (_, i) => { const l = labels[i]; return l ? l.slice(0, 3) + '00' : '' } },
+            ticks: { font: { size: 9, family: 'var(--font-mono)' }, color: textMuted, maxTicksLimit: isMobile ? 6 : 12, callback: (_, i) => { const l = labels[i]; return l ? l.slice(0, 3) + '00' : '' } },
             grid: { display: false },
           },
           y: {
@@ -134,15 +178,16 @@ function LatencyTrendSection({ services, t, hourlyData }) {
 
   return (
     <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
-      <div className="border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
+      <div className="border-b border-[var(--border)] flex items-center justify-between" style={{ padding: '12px 16px' }}>
         <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
           <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: 'var(--blue)' }} />
           {t('latency.trend')}
         </div>
+        <span className="md:hidden mono text-[9px] text-[var(--text2)]">{t('latency.top8')}</span>
       </div>
       {hasData ? (
-        <div style={{ padding: '16px' }}>
-          <div style={{ height: '320px' }}>
+        <div className="p-2 md:p-4">
+          <div className="h-[240px] md:h-[320px]">
             <canvas ref={canvasRef} />
           </div>
         </div>

--- a/tests/latency.spec.js
+++ b/tests/latency.spec.js
@@ -22,4 +22,10 @@ test.describe('Latency page', () => {
     await expect(main.getByText('Claude API').first()).toBeVisible()
     await expect(main.getByText('OpenAI API').first()).toBeVisible()
   })
+
+  test('renders 24h trend section', async ({ page }) => {
+    const main = page.locator('main')
+    // Trend section header should be visible (canvas or "Collecting data" depending on data availability)
+    await expect(main.getByText(/trend/i).first()).toBeVisible({ timeout: 10000 })
+  })
 })

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -128,6 +128,13 @@ test.describe('Mobile viewport', () => {
     expect(hasCloseBtn).toBe(false)
   })
 
+  test('latency chart shows Top 8 by Score badge on mobile', async ({ page }) => {
+    // Navigate to Latency page
+    await page.goto('/#latency')
+    const main = page.locator('main')
+    await expect(main.getByText(/Top 8 by Score|Score 상위 8개/)).toBeVisible({ timeout: 10000 })
+  })
+
   test('backdrop click closes sidebar overlay', async ({ page }) => {
     // Open sidebar
     await page.locator('header button').first().click()


### PR DESCRIPTION
refs #201

## Summary
- **Mobile (< 768px)**: show top 8 services by AIWatch Score, hide legend, remove point dots, thinner lines, 240px height, 6 x-axis ticks, "Top 8 by Score" i18n badge
- **Both**: downsample 5-min probe data → 30-min slot averages (:00–:30, :30–:00), tooltip shows range label + latency-sorted items
- Added E2E tests: trend section rendering (desktop), Top 8 badge visibility (mobile)

## Test plan
- [x] `npm run build` passes
- [x] Playwright E2E 57/57 passed
- [x] Worker unit tests 602/602 passed
- [x] Mobile browser verification (LAN)
- [x] Desktop chart unchanged (full services, legend visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)