### PR TITLE
fix: hide AI analysis modal for monitoring-status incidents (#203)

### DIFF
--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -80,7 +80,7 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
             const worstStatus = svcs.some(s => s.status === 'down') ? 'down'
               : svcs.some(s => s.status !== 'operational') ? 'degraded' : 'operational'
             const isAllResolved = svcs.every(s => s.status === 'operational')
-            const hasActiveInc = svcs.some(s => (s.incidents ?? []).some(i => i.status !== 'resolved'))
+            const hasActiveInc = svcs.some(s => (s.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring'))
             const allRecovered = analyses.every(a => !!a.resolvedAt)
 
             return (

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -43,7 +43,7 @@ export default function Topbar({ onMenuToggle }) {
     return arr.some(analysis => {
       if (analysis.resolvedAt) return true
       const svc = services.find(s => s.id === svcId)
-      return svc && (svc.incidents ?? []).some(i => i.status !== 'resolved' && i.id === analysis.incidentId)
+      return svc && (svc.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring' && i.id === analysis.incidentId)
     })
   })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -521,8 +521,9 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
   }
 
   // Refresh TTL on existing AI analyses / re-analyze missing ones (max 2 per cron)
+  // monitoring = "recovery confirmed, verifying" — treat as inactive (no TTL refresh)
   const activeServices = scored.filter(s =>
-    (s.incidents ?? []).some(i => i.status !== 'resolved')
+    (s.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring')
   )
   await refreshOrReanalyze(activeServices, env.STATUS_CACHE, env.ANTHROPIC_API_KEY, analyzeIncident)
 
@@ -1275,11 +1276,12 @@ export default {
         const aiAnalysis: Record<string, AIAnalysisResult[]> = {}
         const recentlyRecovered: string[] = []
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
+        // monitoring = "recovery confirmed" — exclude from active analysis display
         const withActiveInc = cached.services.filter(s =>
-          (s.incidents ?? []).some(i => i.status !== 'resolved')
+          (s.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring')
         )
         await Promise.all(withActiveInc.flatMap(svc =>
-          (svc.incidents ?? []).filter(i => i.status !== 'resolved').map(async (inc) => {
+          (svc.incidents ?? []).filter(i => i.status !== 'resolved' && i.status !== 'monitoring').map(async (inc) => {
             const raw = await env.STATUS_CACHE!.get(analysisKey(svc.id, inc.id)).catch(() => null)
             if (!raw) return
             try {
@@ -1458,11 +1460,12 @@ export default {
       const recentlyRecovered: string[] = []
       if (env.STATUS_CACHE) {
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
+        // monitoring = "recovery confirmed" — exclude from active analysis display
         const withActiveInc = servicesWithScore.filter(s =>
-          (s.incidents ?? []).some(i => i.status !== 'resolved')
+          (s.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring')
         )
         await Promise.all(withActiveInc.flatMap(svc =>
-          (svc.incidents ?? []).filter(i => i.status !== 'resolved').map(async (inc) => {
+          (svc.incidents ?? []).filter(i => i.status !== 'resolved' && i.status !== 'monitoring').map(async (inc) => {
             const raw = await env.STATUS_CACHE!.get(analysisKey(svc.id, inc.id)).catch(() => null)
             if (!raw) return
             try {


### PR DESCRIPTION
refs #203

## Summary
- Treat incident status `monitoring` as inactive (same as `resolved`) for AI analysis display
- `monitoring` = "recovery confirmed, verifying" — showing analysis sends wrong signal that issue persists
- Worker: skip TTL refresh + exclude from active analysis reads in both `/api/status` and `/api/status/cached`
- Frontend: exclude monitoring incidents from Topbar analyze button + AnalysisModal active badge
- Alert detection, incident display, status determination unchanged

## Test plan
- [x] `npm run build` passes
- [x] Worker dry-run passes
- [x] Worker unit tests 604/604
- [x] Playwright E2E 55/55
- [x] Verified Deepgram `monitoring` incident would be excluded from analysis display

🤖 Generated with [Claude Code](https://claude.com/claude-code)