### PR TITLE
feat: automated competitive monitoring — Reddit + GitHub detection (#207)

### DIFF
--- a/worker/src/__tests__/competitive.test.ts
+++ b/worker/src/__tests__/competitive.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { matchesCompetitiveKeywords } from '../reddit'
+import { formatGitHubAlert } from '../competitive'
+
+describe('matchesCompetitiveKeywords', () => {
+  it('matches strong competitive keywords', () => {
+    expect(matchesCompetitiveKeywords('Best AI status monitor tools')).toBe(true)
+    expect(matchesCompetitiveKeywords('New status page aggregator')).toBe(true)
+    expect(matchesCompetitiveKeywords('Uptime dashboard for LLMs')).toBe(true)
+    expect(matchesCompetitiveKeywords('API status tracking service')).toBe(true)
+    expect(matchesCompetitiveKeywords('LLM status monitoring')).toBe(true)
+  })
+
+  it('matches weak competitive keywords (tool names)', () => {
+    expect(matchesCompetitiveKeywords('down detector alternative for AI')).toBe(true)
+    expect(matchesCompetitiveKeywords('statusgator vs isdown for monitoring')).toBe(true)
+    expect(matchesCompetitiveKeywords('Anyone use statuspage for API status?')).toBe(true)
+  })
+
+  it('matches context + AI keywords', () => {
+    expect(matchesCompetitiveKeywords('AI monitoring dashboard with real-time alerts')).toBe(true)
+    expect(matchesCompetitiveKeywords('Track OpenAI API alerts and notifications')).toBe(true)
+  })
+
+  it('rejects unrelated posts', () => {
+    expect(matchesCompetitiveKeywords('How to fine-tune GPT-4')).toBe(false)
+    expect(matchesCompetitiveKeywords('Best GPU for local LLM inference')).toBe(false)
+    expect(matchesCompetitiveKeywords('Python tutorial for beginners')).toBe(false)
+    expect(matchesCompetitiveKeywords('DevOps salary survey 2026')).toBe(false)
+  })
+
+  it('rejects generic monitoring without AI context', () => {
+    expect(matchesCompetitiveKeywords('Server monitoring with Grafana')).toBe(false)
+    expect(matchesCompetitiveKeywords('Kubernetes pod health checks')).toBe(false)
+  })
+})
+
+describe('formatGitHubAlert', () => {
+  it('formats repo alert for Discord', () => {
+    const alert = {
+      key: 'github:seen:user/ai-status-tool',
+      repo: {
+        fullName: 'user/ai-status-tool',
+        description: 'Real-time AI API status monitor',
+        stars: 42,
+        url: 'https://github.com/user/ai-status-tool',
+        createdAt: '2026-04-08T10:00:00Z',
+      },
+    }
+    const result = formatGitHubAlert(alert)
+    expect(result.title).toBe('🔍 New Competitor Repo')
+    expect(result.description).toContain('user/ai-status-tool')
+    expect(result.description).toContain('42')
+    expect(result.description).toContain('2026-04-08')
+    expect(result.color).toBe(0x8b949e)
+    expect(result.url).toBe('https://github.com/user/ai-status-tool')
+  })
+})

--- a/worker/src/competitive.ts
+++ b/worker/src/competitive.ts
@@ -1,0 +1,82 @@
+// GitHub competitive monitoring — detect new repos in AI monitoring space
+// Uses GitHub's public search API (no auth required, 10 req/min limit)
+
+export interface GitHubRepo {
+  fullName: string
+  description: string
+  stars: number
+  url: string
+  createdAt: string
+}
+
+export interface GitHubAlert {
+  key: string  // KV dedup key: github:seen:{owner/repo}
+  repo: GitHubRepo
+}
+
+const SEARCH_TOPICS = ['ai-monitoring', 'llm-status', 'ai-status', 'api-uptime-monitor']
+
+/**
+ * Search GitHub for new repos matching AI monitoring topics.
+ * Returns repos created in the last 7 days with 5+ stars.
+ */
+export async function detectNewRepos(kv: KVNamespace | null): Promise<GitHubAlert[]> {
+  if (!kv) return []
+
+  const alerts: GitHubAlert[] = []
+  const weekAgo = new Date(Date.now() - 7 * 86_400_000).toISOString().split('T')[0]
+
+  const results = await Promise.allSettled(
+    SEARCH_TOPICS.map(async (topic) => {
+      const query = encodeURIComponent(`topic:${topic} created:>${weekAgo} stars:>=5`)
+      const url = `https://api.github.com/search/repositories?q=${query}&sort=stars&order=desc&per_page=5`
+
+      const res = await fetch(url, {
+        headers: {
+          'User-Agent': 'AIWatch/1.0 (ai-watch.dev; competitive monitoring)',
+          'Accept': 'application/vnd.github.v3+json',
+        },
+        signal: AbortSignal.timeout(5000),
+      })
+
+      if (!res.ok) {
+        console.warn(`[competitive] GitHub search failed for ${topic}: HTTP ${res.status}`)
+        res.body?.cancel()
+        return []
+      }
+
+      const data = await res.json() as { items?: Array<Record<string, unknown>> }
+      return (data.items ?? []).map((item): GitHubRepo => ({
+        fullName: String(item.full_name ?? ''),
+        description: String(item.description ?? '').slice(0, 200),
+        stars: Number(item.stargazers_count ?? 0),
+        url: String(item.html_url ?? ''),
+        createdAt: String(item.created_at ?? ''),
+      }))
+    }),
+  )
+
+  for (const result of results) {
+    if (result.status !== 'fulfilled') continue
+    for (const repo of result.value) {
+      const key = `github:seen:${repo.fullName}`
+      const seen = await kv.get(key).catch(() => null)
+      if (seen) continue
+      alerts.push({ key, repo })
+    }
+  }
+
+  return alerts
+}
+
+/**
+ * Format a GitHub repo alert for Discord
+ */
+export function formatGitHubAlert(alert: GitHubAlert): { title: string; description: string; color: number; url: string } {
+  return {
+    title: '🔍 New Competitor Repo',
+    description: `**${alert.repo.fullName}** ⭐ ${alert.repo.stars}\n${alert.repo.description}\nCreated: ${alert.repo.createdAt.split('T')[0]}`,
+    color: 0x8b949e, // gray
+    url: alert.repo.url,
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -580,7 +580,8 @@ function corsHeaders(origin: string, allowedOrigin: string | undefined): Headers
 
 import { generateBadgeSvg } from './badge'
 import { generateOgSvg } from './og'
-import { detectRedditPosts, formatRedditAlert, isPromotable } from './reddit'
+import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, isPromotable } from './reddit'
+import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, type ProbeDailyData } from './probe-archival'
@@ -679,11 +680,14 @@ export default {
     if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCMinutes() < 5) {
       try {
         const redditAlerts = await detectRedditPosts(env.STATUS_CACHE)
+        // Split: service outage alerts vs competitive monitoring
+        const outageAlerts = redditAlerts.filter(a => !a.competitive)
+        const competitiveAlerts = redditAlerts.filter(a => a.competitive)
         // Mark all detected posts as seen (prevents re-checking), but only notify promotable ones
-        for (const alert of redditAlerts.slice(0, 5)) {
+        for (const alert of outageAlerts.slice(0, 5)) {
           await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 86400 })
         }
-        const promotable = redditAlerts.filter(a => isPromotable(a.post.title)).slice(0, 3)
+        const promotable = outageAlerts.filter(a => isPromotable(a.post.title)).slice(0, 3)
         for (const alert of promotable) {
           const formatted = formatRedditAlert(alert)
           await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
@@ -692,8 +696,36 @@ export default {
             color: formatted.color,
           })
         }
+        // Competitive alerts — mark seen + notify (max 2 per hour)
+        for (const alert of competitiveAlerts.slice(0, 2)) {
+          await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 86400 })
+          const formatted = formatCompetitiveAlert(alert)
+          await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+            title: formatted.title,
+            description: `${formatted.description}\n[View Post](${formatted.url})`,
+            color: formatted.color,
+          })
+        }
       } catch (err) {
         console.warn('[cron] Reddit monitoring failed:', err instanceof Error ? err.message : err)
+      }
+    }
+
+    // GitHub competitive monitoring — weekly on Monday UTC 00:00-00:05
+    if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCDay() === 1 && now.getUTCHours() === 0 && now.getUTCMinutes() < 5) {
+      try {
+        const ghAlerts = await detectNewRepos(env.STATUS_CACHE)
+        for (const alert of ghAlerts.slice(0, 3)) {
+          await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 2_592_000 }) // 30d TTL
+          const formatted = formatGitHubAlert(alert)
+          await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+            title: formatted.title,
+            description: `${formatted.description}\n[View Repo](${formatted.url})`,
+            color: formatted.color,
+          })
+        }
+      } catch (err) {
+        console.warn('[cron] GitHub competitive monitoring failed:', err instanceof Error ? err.message : err)
       }
     }
 

--- a/worker/src/reddit.ts
+++ b/worker/src/reddit.ts
@@ -15,10 +15,12 @@ export interface RedditAlert {
   key: string       // KV dedup key: reddit:seen:{postId}
   subreddit: string
   post: RedditPost
+  competitive: boolean  // true = competitive monitoring, false = outage detection
 }
 
 // Subreddit → search keywords mapping
 const REDDIT_TARGETS: Array<{ subreddit: string; service: string }> = [
+  // Service-specific subreddits (outage detection + promotion)
   { subreddit: 'ClaudeAI',        service: 'Claude' },
   { subreddit: 'ClaudeCode',      service: 'Claude Code' },
   { subreddit: 'ChatGPT',         service: 'ChatGPT' },
@@ -26,6 +28,10 @@ const REDDIT_TARGETS: Array<{ subreddit: string; service: string }> = [
   { subreddit: 'cursor',          service: 'Cursor' },
   { subreddit: 'windsurf',        service: 'Windsurf' },
   { subreddit: 'Codeium',         service: 'Windsurf' },
+  // Competitive monitoring — broader AI/DevOps communities
+  { subreddit: 'devops',          service: '_competitive' },
+  { subreddit: 'artificial',      service: '_competitive' },
+  { subreddit: 'LocalLLaMA',      service: '_competitive' },
 ]
 
 // Strong signals: always match. Weak signals (issues/errors/slow): require context words
@@ -85,11 +91,24 @@ export function isPromotable(title: string): boolean {
   return QUESTION_WITH_CONTEXT.test(title) || ANYONE_WITH_OUTAGE.test(title) || SEEKING_HELP.test(title)
 }
 
+// Competitive monitoring keywords — match posts about status monitoring tools
+const COMPETITIVE_STRONG = /\b(status monitor|status page|uptime dashboard|api status|ai status|llm status)\b/i
+const COMPETITIVE_CONTEXT = /\b(monitor|track|alert|notification|dashboard|real.?time)\b/i
+const COMPETITIVE_WEAK = /\b(down.?detector|statuspage|statusgator|isdown)\b/i
+
+export function matchesCompetitiveKeywords(title: string): boolean {
+  if (COMPETITIVE_STRONG.test(title)) return true
+  if (COMPETITIVE_WEAK.test(title)) return true
+  return COMPETITIVE_CONTEXT.test(title) && /\b(ai|llm|api|openai|claude|gpt)\b/i.test(title)
+}
+
 /**
  * Fetch recent posts from a subreddit matching outage keywords
  */
-async function fetchSubreddit(subreddit: string): Promise<RedditPost[]> {
-  const query = encodeURIComponent('down OR "not working" OR outage OR issues OR error')
+async function fetchSubreddit(subreddit: string, competitive = false): Promise<RedditPost[]> {
+  const query = competitive
+    ? encodeURIComponent('"status monitor" OR "uptime dashboard" OR "api status" OR "is down" OR "status page"')
+    : encodeURIComponent('down OR "not working" OR outage OR issues OR error')
   const url = `https://www.reddit.com/r/${subreddit}/search.json?q=${query}&sort=new&restrict_sr=on&t=day&limit=5`
 
   const res = await fetch(url, {
@@ -99,6 +118,7 @@ async function fetchSubreddit(subreddit: string): Promise<RedditPost[]> {
 
   if (!res.ok) {
     console.warn(`[reddit] r/${subreddit} returned HTTP ${res.status}`)
+    res.body?.cancel()
     return []
   }
 
@@ -119,18 +139,19 @@ export async function detectRedditPosts(
   // Fetch all subreddits in parallel
   const results = await Promise.allSettled(
     REDDIT_TARGETS.map(async (target) => {
-      const posts = await fetchSubreddit(target.subreddit)
-      return { target, posts }
+      const isCompetitive = target.service === '_competitive'
+      const posts = await fetchSubreddit(target.subreddit, isCompetitive)
+      return { target, posts, isCompetitive }
     }),
   )
 
   for (const result of results) {
     if (result.status !== 'fulfilled') continue
-    const { target, posts } = result.value
+    const { target, posts, isCompetitive } = result.value
 
     for (const post of posts) {
       // Double-check keywords (Reddit search can be fuzzy)
-      if (!matchesKeywords(post.title)) continue
+      if (isCompetitive ? !matchesCompetitiveKeywords(post.title) : !matchesKeywords(post.title)) continue
 
       // Skip old posts (>6h)
       const age = Date.now() / 1000 - post.createdUtc
@@ -141,7 +162,7 @@ export async function detectRedditPosts(
       const seen = await kv.get(key).catch(() => null)
       if (seen) continue
 
-      alerts.push({ key, subreddit: target.subreddit, post })
+      alerts.push({ key, subreddit: target.subreddit, post, competitive: isCompetitive })
     }
   }
 
@@ -172,6 +193,20 @@ export function formatRedditAlert(alert: RedditAlert): { title: string; descript
     title: `📢 Reddit: r/${alert.subreddit} [🎯 PROMOTE]`,
     description: `"${alert.post.title}"\nby u/${alert.post.author} · ${alert.post.score} upvotes · ${agoText}${shareLink}`,
     color: 0x3fb950, // green
+    url: alert.post.url,
+  }
+}
+
+export function formatCompetitiveAlert(alert: RedditAlert): { title: string; description: string; color: number; url: string } {
+  const ago = Math.floor(Date.now() / 1000 - alert.post.createdUtc)
+  const agoText = ago < 60 ? 'just now'
+    : ago < 3600 ? `${Math.floor(ago / 60)}m ago`
+    : `${Math.floor(ago / 3600)}h ago`
+
+  return {
+    title: `🔍 Competitive: r/${alert.subreddit}`,
+    description: `"${alert.post.title}"\nby u/${alert.post.author} · ${alert.post.score} upvotes · ${agoText}`,
+    color: 0x8b949e, // gray
     url: alert.post.url,
   }
 }


### PR DESCRIPTION
refs #207

## Summary
- **Reddit expansion**: add r/devops, r/artificial, r/LocalLLaMA with competitive keyword matching (status monitor, uptime dashboard, statusgator, etc.)
- **GitHub detection**: weekly scan (Monday UTC 00:00) for new repos with topics `ai-monitoring`, `llm-status`, `ai-status`, `api-uptime-monitor` (5+ stars, last 7d)
- Competitive alerts use gray Discord embeds (🔍), separate from outage alerts (📢)
- `RedditAlert.competitive` flag replaces hardcoded subreddit filtering
- Fixed pre-existing `res.body?.cancel()` miss in `fetchSubreddit`

## KV impact
- Reddit competitive: ~2 writes/hour max = ~48/day
- GitHub: ~3 writes/week (negligible)
- Total budget: ~891-1001/day (within 1,000 limit)

## Test plan
- [x] Worker dry-run passes
- [x] Worker unit tests 610/610 (new: competitive keyword + formatGitHubAlert)
- [x] Playwright E2E 57/57
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)