### PR TITLE
fix: consistent Mistral probe cross-validation in cron alerts (#209)

### DIFF
--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -302,6 +302,29 @@ describe('Mistral noise filtering pipeline (#91)', () => {
     const otherMedian = computeMedianRtt(probeSnapshots, 'openai')
     expect(otherMedian).toBeNull()
   })
+
+  it('cron + API consistency: same filter produces same result (#209)', () => {
+    // Simulates the exact filtering pattern used in both cron alert detection
+    // and /api/status response handler — must produce identical results
+    const incidents = [
+      { id: 'real-1', title: 'Audio API Degraded', startedAt: '2026-04-05T13:35:00Z', resolvedAt: '2026-04-05T13:50:00Z' },
+      { id: 'noise-1', title: 'Files API Degraded', startedAt: '2026-04-05T17:53:00Z', resolvedAt: null }, // ongoing, no spike
+    ]
+    // Cron path filter (same as index.ts cronAlertCheck)
+    const cronMedian = computeMedianRtt(probeSnapshots, 'mistral')
+    const cronFiltered = incidents.filter((inc) =>
+      isCorroboratedByProbe(probeSnapshots, 'mistral', inc.startedAt, inc.resolvedAt, cronMedian!),
+    )
+    // API path filter (same as index.ts /api/status handler)
+    const apiMedian = computeMedianRtt(probeSnapshots, 'mistral')
+    const apiFiltered = incidents.filter((inc) =>
+      isCorroboratedByProbe(probeSnapshots, 'mistral', inc.startedAt, inc.resolvedAt, apiMedian!),
+    )
+    // Both must produce identical results
+    expect(cronFiltered).toEqual(apiFiltered)
+    expect(cronFiltered).toHaveLength(1)
+    expect(cronFiltered[0].id).toBe('real-1')
+  })
 })
 
 describe('detectConsecutiveSpikes', () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -299,10 +299,10 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
   // If cache is stale (>10min) or empty, fetch live data to avoid alert decisions on outdated status.
   // Does NOT write to KV — cache writes are handled exclusively by /api/status handler's cacheWrite()
   // to respect the 10-min KV write throttle and stay within the 1,000 writes/day free tier.
+  let cronProbes: ProbeSnapshot[] = []
   if (stale) {
     try {
       // Read probe data for cross-validation of status page failures
-      let cronProbes: ProbeSnapshot[] = []
       const probeRaw = await env.STATUS_CACHE.get('probe:24h').catch(() => null)
       if (probeRaw) {
         try { cronProbes = JSON.parse(probeRaw).snapshots ?? [] } catch (err) { console.warn('[cron] probe24h parse failed:', err instanceof Error ? err.message : err) }
@@ -323,6 +323,27 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
     const s = calculateAIWatchScore(svc)
     return { ...svc, aiwatchScore: s.score, scoreGrade: s.grade }
   })
+
+  // Mistral probe cross-validation — filter micro-incident noise BEFORE alert detection
+  // Ensures Discord alerts and dashboard display are consistent (#209)
+  // Reuse cronProbes if already fetched (stale path), otherwise read from KV
+  if (cronProbes.length === 0) {
+    const probeRaw = await env.STATUS_CACHE.get('probe:24h').catch(() => null)
+    if (probeRaw) {
+      try { cronProbes = JSON.parse(probeRaw).snapshots ?? [] } catch { /* ignore */ }
+    }
+  }
+  if (cronProbes.length > 0) {
+    const mistralMedian = computeMedianRtt(cronProbes, 'mistral')
+    if (mistralMedian !== null) {
+      for (const svc of scored) {
+        if (svc.id !== 'mistral' || !svc.incidents?.length) continue
+        svc.incidents = svc.incidents.filter((inc) =>
+          isCorroboratedByProbe(cronProbes, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+        )
+      }
+    }
+  }
 
   // Collect previously alerted IDs from KV for dedup context
   const alertedNewIds = new Set<string>()


### PR DESCRIPTION
closes #209

## Summary
- Mistral probe cross-validation was applied in `/api/status` handlers but NOT in cron alert detection
- This caused Discord alerts for incidents that were invisible on the dashboard (e.g., "Files API Degraded")
- Fix: apply the same filtering in cron, after score calculation but before `buildIncidentAlerts`
- Hoisted `cronProbes` variable to reuse probe data and avoid duplicate KV reads

## Test plan
- [x] Worker dry-run passes
- [x] Worker unit tests 604/604
- [x] Playwright E2E 57/57
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)