### PR TITLE
fix: bypass Mistral probe cross-validation for non-probed sub-services (#211)

### DIFF
--- a/worker/src/__tests__/mistral-bypass-e2e.test.ts
+++ b/worker/src/__tests__/mistral-bypass-e2e.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { isMistralProbedEndpoint, isCorroboratedByProbe, computeMedianRtt } from '../probe'
+import type { ProbeSnapshot } from '../probe'
+
+describe('Mistral bypass E2E: live incident titles from 2026-04-12', () => {
+  // Real incident titles from Mistral Instatus page
+  const liveIncidents = [
+    { title: 'Batch API Degraded', startedAt: '2026-04-12T03:29:11.471Z', resolvedAt: null },
+    { title: 'Files API Degraded', startedAt: '2026-04-12T02:41:25.723Z', resolvedAt: null },
+    { title: 'Batch API Degraded', startedAt: '2026-04-12T01:13:49.214Z', resolvedAt: '2026-04-12T01:42:59.144Z' },
+    { title: 'Files API Degraded', startedAt: '2026-04-12T01:11:33.266Z', resolvedAt: '2026-04-12T01:45:49.092Z' },
+    { title: 'Completion API Degraded · Chat Completions API', startedAt: '2026-04-11T08:02:00.353Z', resolvedAt: '2026-04-11T09:15:21.084Z' },
+  ]
+
+  // Simulate real probe data: normal RTT (no spikes) during incident window
+  const probeSnapshots: ProbeSnapshot[] = Array.from({ length: 20 }, (_, i) => ({
+    t: new Date(Date.parse('2026-04-12T02:00:00Z') + i * 300_000).toISOString(),
+    data: { mistral: { status: 200, rtt: 55 + Math.floor(Math.random() * 20) } },
+  }))
+
+  it('Batch API + Files API bypass cross-validation, Completion API gets filtered', () => {
+    const medianRtt = computeMedianRtt(probeSnapshots, 'mistral')
+    expect(medianRtt).not.toBeNull()
+
+    const filtered = liveIncidents.filter((inc) =>
+      !isMistralProbedEndpoint(inc.title) ||
+      isCorroboratedByProbe(probeSnapshots, 'mistral', inc.startedAt, inc.resolvedAt ?? null, medianRtt),
+    )
+
+    // Batch + Files (4) bypass probe check. Completion (1) has no probes in its window
+    // (probes start at 02:00, Completion was 08:02 previous day) → assumed real (conservative)
+    expect(filtered).toHaveLength(5)
+
+    // Now add normal probes during the Completion incident window → it gets filtered
+    const withCompletionProbes: ProbeSnapshot[] = [
+      ...probeSnapshots,
+      { t: '2026-04-11T08:05:00Z', data: { mistral: { status: 200, rtt: 60 } } },
+      { t: '2026-04-11T08:10:00Z', data: { mistral: { status: 200, rtt: 55 } } },
+    ]
+    const median2 = computeMedianRtt(withCompletionProbes, 'mistral')
+    const filtered2 = liveIncidents.filter((inc) =>
+      !isMistralProbedEndpoint(inc.title) ||
+      isCorroboratedByProbe(withCompletionProbes, 'mistral', inc.startedAt, inc.resolvedAt ?? null, median2),
+    )
+    // Completion filtered (normal RTT, no spike), Batch+Files still bypass
+    expect(filtered2).toHaveLength(4)
+    expect(filtered2.every((inc) => /batch|files/i.test(inc.title))).toBe(true)
+  })
+
+  it('with probe spike, Completion API also survives', () => {
+    // Add a spike during the Completion API incident window
+    const spikedProbes: ProbeSnapshot[] = [
+      ...probeSnapshots,
+      { t: '2026-04-11T08:05:00Z', data: { mistral: { status: 200, rtt: 2000 } } },
+    ]
+    const medianRtt = computeMedianRtt(spikedProbes, 'mistral')
+
+    const filtered = liveIncidents.filter((inc) =>
+      !isMistralProbedEndpoint(inc.title) ||
+      isCorroboratedByProbe(spikedProbes, 'mistral', inc.startedAt, inc.resolvedAt ?? null, medianRtt),
+    )
+
+    // All 5 should survive
+    expect(filtered).toHaveLength(5)
+  })
+})

--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, PROBE_TARGETS, computeMedianRtt, isCorroboratedByProbe, detectConsecutiveSpikes, isProbeHealthy } from '../probe'
+import { computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, PROBE_TARGETS, computeMedianRtt, isCorroboratedByProbe, detectConsecutiveSpikes, isProbeHealthy, isMistralProbedEndpoint } from '../probe'
 import type { ProbeSnapshot } from '../probe'
 
 describe('computeProbeSlot', () => {
@@ -510,5 +510,44 @@ describe('isProbeHealthy', () => {
       { t: recentTime(25), data: { claude: { status: 200, rtt: 210 } } },
     ]
     expect(isProbeHealthy(snapshots, 'claude', 900_000)).toBe(false) // 15min max age
+  })
+})
+
+describe('isMistralProbedEndpoint', () => {
+  it('returns true for Chat Completions / Completion API incidents', () => {
+    expect(isMistralProbedEndpoint('Completion API Degraded')).toBe(true)
+    expect(isMistralProbedEndpoint('Chat Completions API Degraded')).toBe(true)
+    expect(isMistralProbedEndpoint('API Latency Issues')).toBe(true)
+    expect(isMistralProbedEndpoint('Elevated Error Rates')).toBe(true)
+  })
+
+  it('returns false for non-probed sub-services (Batch, Files, Audio, etc.)', () => {
+    expect(isMistralProbedEndpoint('Batch API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Files API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('File API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Audio API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Audio API Text-to-Speech Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('OCR API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Embedding API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Fine-tuning API Degraded')).toBe(false)
+    expect(isMistralProbedEndpoint('Fine Tuning Jobs Degraded')).toBe(false)
+  })
+
+  it('bypass ensures non-probed incidents survive cross-validation filter', () => {
+    // Simulate the filter logic used in index.ts:
+    // svc.incidents.filter(inc => !isMistralProbedEndpoint(inc.title) || isCorroboratedByProbe(...))
+    const incidents = [
+      { title: 'Batch API Degraded', startedAt: '2026-04-12T03:29:00Z', resolvedAt: null },
+      { title: 'Files API Degraded', startedAt: '2026-04-12T02:41:00Z', resolvedAt: null },
+      { title: 'Completion API Degraded', startedAt: '2026-04-12T03:00:00Z', resolvedAt: null },
+    ]
+    // Mock: no probe spike → isCorroboratedByProbe returns false for all
+    const mockCorroborated = () => false
+    const filtered = incidents.filter((inc) =>
+      !isMistralProbedEndpoint(inc.title) || mockCorroborated(),
+    )
+    // Batch + Files should survive (bypass), Completion should be filtered
+    expect(filtered).toHaveLength(2)
+    expect(filtered.map((i) => i.title)).toEqual(['Batch API Degraded', 'Files API Degraded'])
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -128,7 +128,7 @@ async function writeLatencySnapshot(kv: KVNamespace, services: ServiceStatus[]):
 }
 
 // ── Health Check Probing (Phase 2 PoC) ──
-import { type ProbeResult, type ProbeSnapshot, type ProbeSpike, PROBE_TARGETS, computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, detectConsecutiveSpikes, computeMedianRtt, isCorroboratedByProbe } from './probe'
+import { type ProbeResult, type ProbeSnapshot, type ProbeSpike, PROBE_TARGETS, computeProbeSlot, slotToTimestamp, trimSnapshots, hasSlot, failedProbe, detectConsecutiveSpikes, computeMedianRtt, isCorroboratedByProbe, isMistralProbedEndpoint } from './probe'
 
 let lastProbeSlot = ''
 
@@ -339,7 +339,7 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
       for (const svc of scored) {
         if (svc.id !== 'mistral' || !svc.incidents?.length) continue
         svc.incidents = svc.incidents.filter((inc) =>
-          isCorroboratedByProbe(cronProbes, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+          !isMistralProbedEndpoint(inc.title) || isCorroboratedByProbe(cronProbes, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
         )
       }
     }
@@ -1319,7 +1319,7 @@ export default {
             for (const svc of cached.services) {
               if (svc.id !== 'mistral' || !svc.incidents?.length) continue
               svc.incidents = svc.incidents.filter((inc) =>
-                isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+                !isMistralProbedEndpoint(inc.title) || isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
               )
             }
           }
@@ -1485,7 +1485,7 @@ export default {
           for (const svc of enriched) {
             if (svc.id !== 'mistral' || !svc.incidents?.length) continue
             svc.incidents = svc.incidents.filter((inc) =>
-              isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
+              !isMistralProbedEndpoint(inc.title) || isCorroboratedByProbe(probe24h, 'mistral', inc.startedAt, inc.resolvedAt ?? null, mistralMedian),
             )
           }
         }

--- a/worker/src/probe.ts
+++ b/worker/src/probe.ts
@@ -173,6 +173,16 @@ export function isCorroboratedByProbe(
 }
 
 /**
+ * Check if a Mistral incident title affects the probed endpoint (/v1/models → Chat Completions).
+ * Non-probed sub-services (Batch API, Files API, Audio API, etc.) bypass cross-validation
+ * because their outages don't cause RTT spikes on the main models endpoint.
+ */
+const MISTRAL_NON_PROBED = /\b(batch|files?|audio|ocr|embedding|fine.?tun)/i
+export function isMistralProbedEndpoint(title: string): boolean {
+  return !MISTRAL_NON_PROBED.test(title)
+}
+
+/**
  * Check if a service's recent probe data indicates it is healthy.
  * Used to cross-validate status page fetch failures — if the API responds normally
  * but the status page is down, the service is likely operational (false positive).


### PR DESCRIPTION
## Summary

- Mistral probe measures `/v1/models` (Chat Completions endpoint) only
- Incidents on Batch API, Files API, Audio API, OCR API, Embedding API were incorrectly filtered by `isCorroboratedByProbe()` because they don't cause RTT spikes on the probed endpoint
- Add `isMistralProbedEndpoint()` to bypass cross-validation for non-probed sub-service incidents
- Applied consistently across all 3 filter sites (cron alerts, cached KV, live fetch)

## Test plan

- [x] `npm run test:worker` — 614 tests pass
- [x] `wrangler deploy --dry-run` — build check pass
- [ ] Deploy Worker and verify Mistral Batch/Files API incidents visible on dashboard

refs #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)