### PR TITLE
feat: weekly Discord briefing with changelog RSS detection (#213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ When adding a new monitored service, update ALL of the following:
 | `alert:proxy:{YYYY-MM-DD}` | `{ discord, slack, failed }` JSON | 2d | ~1 | User webhook delivery counts (approximate, flushed from in-memory by daily summary cron) |
 | `kv_limit_alert` | `"1"` | 5min | ~1 | KV write limit exceeded cooldown |
 | `daily-summary:{YYYY-MM-DD}` | `"1"` | 7d | 1 | Daily summary execution marker (prevents duplicate send + enables catch-up) |
-| `changelog:entries` | `ChangelogEntry[]` JSON | 14d | ~3 | Accumulated changelog entries from RSS/Atom feeds (cleared after weekly briefing) |
+| `changelog:entries` | `ChangelogEntry[]` JSON | 14d | ~3 | Accumulated changelog entries from RSS + HTML sources (cleared after weekly briefing) |
 | `weekly-briefing:{YYYY-MM-DD}` | `"1"` | 7d | 1/week | Weekly briefing execution dedup marker |
 | `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
@@ -267,7 +267,7 @@ worker/
     alerts.ts   # Alert detection logic (buildIncidentAlerts, buildServiceAlerts, formatDetectionLead)
     fallback.ts # Fallback recommendation (getFallbacks, buildFallbackText, buildGroupedFallbackText for multi-category incidents)
     ai-analysis.ts # Claude Sonnet incident analysis (system/user prompt, needsFallback assessment, TTL refresh, re-analysis, incidentId dedup, timeline context, boilerplate filtering)
-    changelog.ts # Changelog RSS/Atom collection (OpenAI blog, Google AI blog, Anthropic SDK releases)
+    changelog.ts # Changelog/news collection (OpenAI blog RSS, Google AI blog RSS, Anthropic /news HTML parsing)
     weekly-briefing.ts # Weekly Discord briefing (changelog + incidents + stability trends)
     daily-summary.ts # Expanded daily Discord report (uptime, latency, AI usage, Reddit, Web Vitals)
     monthly-archive.ts # Monthly reliability archive (uptime, score, incidents, latency per service, permanent KV)
@@ -380,6 +380,8 @@ Cron Trigger (*/5 min)
   → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
+  → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
+  → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed
 
 Web Vitals Pipeline (per-request, 100% collection):
   Browser (web-vitals) → POST /api/vitals → Worker → KV merge (vitals:{date})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,8 @@ When adding a new monitored service, update ALL of the following:
 | `alert:proxy:{YYYY-MM-DD}` | `{ discord, slack, failed }` JSON | 2d | ~1 | User webhook delivery counts (approximate, flushed from in-memory by daily summary cron) |
 | `kv_limit_alert` | `"1"` | 5min | ~1 | KV write limit exceeded cooldown |
 | `daily-summary:{YYYY-MM-DD}` | `"1"` | 7d | 1 | Daily summary execution marker (prevents duplicate send + enables catch-up) |
+| `changelog:entries` | `ChangelogEntry[]` JSON | 14d | ~3 | Accumulated changelog entries from RSS/Atom feeds (cleared after weekly briefing) |
+| `weekly-briefing:{YYYY-MM-DD}` | `"1"` | 7d | 1/week | Weekly briefing execution dedup marker |
 | `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 | `incidents:monthly:{YYYY-MM}` | `MonthlyIncidents` JSON | 60d | 1/day | Monthly incident accumulation (deduped by ID, updated in daily summary cron) |
@@ -233,7 +235,7 @@ When adding a new monitored service, update ALL of the following:
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 
-**Free tier budget**: 1,000 writes/day. Estimated total: ~843-953 writes/day + vitals (1 per visit) + platform status (~1/cycle when changed). Monitor if daily visits exceed ~50.
+**Free tier budget**: 1,000 writes/day. Estimated total: ~843-953 writes/day + changelog (~3/day) + weekly briefing (~1/week) + vitals (1 per visit) + platform status (~1/cycle when changed). Monitor if daily visits exceed ~50.
 
 ### Directory Layout
 ```
@@ -265,6 +267,8 @@ worker/
     alerts.ts   # Alert detection logic (buildIncidentAlerts, buildServiceAlerts, formatDetectionLead)
     fallback.ts # Fallback recommendation (getFallbacks, buildFallbackText, buildGroupedFallbackText for multi-category incidents)
     ai-analysis.ts # Claude Sonnet incident analysis (system/user prompt, needsFallback assessment, TTL refresh, re-analysis, incidentId dedup, timeline context, boilerplate filtering)
+    changelog.ts # Changelog RSS/Atom collection (OpenAI blog, Google AI blog, Anthropic SDK releases)
+    weekly-briefing.ts # Weekly Discord briefing (changelog + incidents + stability trends)
     daily-summary.ts # Expanded daily Discord report (uptime, latency, AI usage, Reddit, Web Vitals)
     monthly-archive.ts # Monthly reliability archive (uptime, score, incidents, latency per service, permanent KV)
     vitals.ts   # Web Vitals aggregation (ingest, KV flush, p75 computation, Discord formatting)

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,7 @@
 - **AI 분석 (Beta)** — 장애 발생 시 Claude Sonnet 자동 분석: 원인 추정, 예상 복구 시간, 영향 범위, 대체 서비스 추천. 인시던트 Discord 알림에 통합(단일 embed), Topbar Analyze 모달, Is X Down AI Insight 카드
 - **랜딩 페이지** — Product Hunt 랜딩 페이지(`/intro`), 대시보드 프리뷰 mock, KO/EN 이중 언어, Flow 애니메이션, GA4 트래킹
 - **Web Vitals 모니터링** — 실사용자 LCP, FCP, TTFB, CLS, INP 수집, p75 집계 및 Discord Daily Report 임계값 알림
+- **주간 브리핑** — 매주 일요일 Discord 다이제스트: AI 서비스 변경 감지(OpenAI, Google, Anthropic), 인시던트 요약, 안정성 트렌드
 - **상태 페이지 교차 검증** — Probe RTT + 플랫폼 쿼럼 + metastatuspage 모니터링으로 상태 페이지 인프라 장애 시 오탐 방지
 
 ## 모니터링 서비스
@@ -311,6 +312,8 @@ worker/
     alerts.ts    # 알림 감지 로직 (인시던트 + 서비스 알림)
     fallback.ts  # 대체 서비스 추천
     ai-analysis.ts # Claude Sonnet 장애 분석
+    changelog.ts # 변경사항/뉴스 수집 (OpenAI RSS, Google RSS, Anthropic HTML)
+    weekly-briefing.ts # 주간 Discord 브리핑 (변경사항 + 인시던트 + 안정성)
     daily-summary.ts # 일일 Discord 리포트 (가동률, 지연시간, AI 사용량)
     monthly-archive.ts # 월간 안정성 아카이브 (영구 KV 보존)
     vitals.ts    # Web Vitals 집계 (p75, Discord 포맷)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Real-time monitoring dashboard for **30 AI services** — track status, latency,
 - **AI Analysis (Beta)** — Claude Sonnet auto-analysis on incidents: cause estimation, recovery time, affected scope, contextual fallback recommendations. Merged into incident Discord alert (single embed), Topbar Analyze modal, Is X Down AI Insight card
 - **Landing page** — Product Hunt landing page (`/intro`) with dashboard preview mock, KO/EN i18n, flow animation, and GA4 tracking
 - **Web Vitals monitoring** — Real user LCP, FCP, TTFB, CLS, INP collection with p75 aggregation and threshold-based alerts in Discord Daily Report
+- **Weekly briefing** — Sunday Discord digest with AI service changelog detection (OpenAI, Google, Anthropic), incident summary, and stability trends
 - **Status page cross-validation** — Probe RTT + platform quorum + metastatuspage monitoring to prevent false positives during status page infrastructure outages
 
 ## Monitored Services
@@ -312,6 +313,8 @@ worker/
     alerts.ts    # Alert detection logic (incident + service alerts)
     fallback.ts  # Fallback recommendation
     ai-analysis.ts # Claude Sonnet incident analysis
+    changelog.ts # Changelog/news collection (OpenAI RSS, Google RSS, Anthropic HTML)
+    weekly-briefing.ts # Weekly Discord briefing (changelog + incidents + stability)
     daily-summary.ts # Daily Discord report (uptime, latency, AI usage)
     monthly-archive.ts # Monthly reliability archive (permanent KV)
     vitals.ts    # Web Vitals aggregation (p75, Discord formatting)

--- a/worker/src/__tests__/changelog.test.ts
+++ b/worker/src/__tests__/changelog.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { parseRssEntries, parseAnthropicNews, isRelevantEntry, formatChangelogSection, CHANGELOG_SOURCES, type ChangelogEntry } from '../changelog'
+
+describe('CHANGELOG_SOURCES', () => {
+  it('has 3 pilot sources', () => {
+    expect(CHANGELOG_SOURCES).toHaveLength(3)
+    expect(CHANGELOG_SOURCES.map((s) => s.id)).toEqual(['openai', 'google', 'anthropic'])
+  })
+
+  it('anthropic source uses html type', () => {
+    const anthropic = CHANGELOG_SOURCES.find((s) => s.id === 'anthropic')!
+    expect(anthropic.type).toBe('html')
+    expect(anthropic.feedUrl).toBe('https://www.anthropic.com/news')
+  })
+})
+
+describe('parseRssEntries', () => {
+  const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>OpenAI News</title>
+    <item>
+      <title>Introducing GPT-5</title>
+      <link>https://openai.com/blog/gpt-5</link>
+      <pubDate>Wed, 09 Apr 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title><![CDATA[New API pricing update]]></title>
+      <link>https://openai.com/blog/pricing</link>
+      <pubDate>Tue, 08 Apr 2026 10:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Team spotlight: safety research</title>
+      <link>https://openai.com/blog/team</link>
+      <pubDate>Mon, 07 Apr 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+  it('parses RSS items with title, link, date', () => {
+    const entries = parseRssEntries(sampleRss, 'openai')
+    expect(entries).toHaveLength(3)
+    expect(entries[0].title).toBe('Introducing GPT-5')
+    expect(entries[0].url).toBe('https://openai.com/blog/gpt-5')
+    expect(entries[0].source).toBe('openai')
+    expect(entries[0].date).toContain('2026-04-09')
+  })
+
+  it('handles CDATA in title', () => {
+    const entries = parseRssEntries(sampleRss, 'openai')
+    expect(entries[1].title).toBe('New API pricing update')
+  })
+
+  it('limits to 50 items', () => {
+    const items = Array.from({ length: 60 }, (_, i) =>
+      `<item><title>Item ${i}</title><link>https://example.com/${i}</link><pubDate>Wed, 09 Apr 2026 12:00:00 GMT</pubDate></item>`,
+    ).join('')
+    const xml = `<rss><channel>${items}</channel></rss>`
+    expect(parseRssEntries(xml, 'test')).toHaveLength(50)
+  })
+
+  it('returns empty for invalid XML', () => {
+    expect(parseRssEntries('not xml', 'test')).toEqual([])
+    expect(parseRssEntries('<rss><channel></channel></rss>', 'test')).toEqual([])
+  })
+
+  it('handles malformed dates gracefully', () => {
+    const xml = `<rss><channel><item><title>Test</title><link>https://example.com</link><pubDate>not-a-date</pubDate></item></channel></rss>`
+    const entries = parseRssEntries(xml, 'test')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].date).toBe('')
+  })
+})
+
+describe('parseAnthropicNews', () => {
+  // Minimal mock of the Next.js SSR payload structure
+  const mockHtml = `<html><script>self.__next_f.push([1,"
+    \\"publishedOn\\":\\"2026-04-07T18:00:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"project-glasswing\\"},\\"subjects\\":[],\\"title\\":\\"Project Glasswing\\"
+    \\"publishedOn\\":\\"2026-02-17T18:00:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"claude-sonnet-4-6\\"},\\"subjects\\":[],\\"title\\":\\"Introducing Claude Sonnet 4.6\\"
+    \\"publishedOn\\":\\"2026-02-05T18:00:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"claude-opus-4-6\\"},\\"subjects\\":[],\\"title\\":\\"Introducing Claude Opus 4.6\\"
+    \\"publishedOn\\":\\"2026-03-12T14:39:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"claude-partner-network\\"},\\"subjects\\":[],\\"title\\":\\"Anthropic invests $100 million into the Claude Partner Network\\"
+    \\"publishedOn\\":\\"2025-12-02T18:00:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"anthropic-acquires-bun\\"},\\"subjects\\":[],\\"title\\":\\"Anthropic acquires Bun as Claude Code reaches $1B milestone\\"
+  "])</script></html>`
+
+  it('extracts news list posts with title, slug, date', () => {
+    const entries = parseAnthropicNews(mockHtml)
+    expect(entries.length).toBeGreaterThanOrEqual(4)
+    const sonnet = entries.find((e) => e.title === 'Introducing Claude Sonnet 4.6')
+    expect(sonnet).toBeDefined()
+    expect(sonnet!.url).toBe('https://www.anthropic.com/news/claude-sonnet-4-6')
+    expect(sonnet!.date).toContain('2026-02-17')
+  })
+
+  it('extracts featured grid items (e.g. Project Glasswing)', () => {
+    const featuredHtml = `<html><script>self.__next_f.push([1,"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-04-07\\",\\"subject\\":\\"Announcements\\",\\"summary\\":\\"A new initiative...\\",\\"title\\":\\"Project Glasswing\\",\\"url\\":\\"/glasswing\\"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-03-18\\",\\"summary\\":\\"We invited Claude.ai users...\\",\\"title\\":\\"What 81,000 people want from AI\\",\\"url\\":\\"/news/what-81000-people-want\\"
+    "])</script></html>`
+    const entries = parseAnthropicNews(featuredHtml)
+    expect(entries.length).toBe(2)
+    const glasswing = entries.find((e) => e.title === 'Project Glasswing')
+    expect(glasswing).toBeDefined()
+    expect(glasswing!.url).toBe('https://www.anthropic.com/glasswing')
+    expect(glasswing!.date).toContain('2026-04-07')
+  })
+
+  it('combines featured + news list and deduplicates', () => {
+    const combinedHtml = `<html><script>self.__next_f.push([1,"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-04-07\\",\\"summary\\":\\"test\\",\\"title\\":\\"Project Glasswing\\",\\"url\\":\\"/glasswing\\"
+      \\"publishedOn\\":\\"2026-02-17T18:00:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"claude-sonnet-4-6\\"},\\"subjects\\":[],\\"title\\":\\"Introducing Claude Sonnet 4.6\\"
+    "])</script></html>`
+    const entries = parseAnthropicNews(combinedHtml)
+    expect(entries.length).toBe(2)
+    expect(entries.map((e) => e.title)).toContain('Project Glasswing')
+    expect(entries.map((e) => e.title)).toContain('Introducing Claude Sonnet 4.6')
+  })
+
+  it('deduplicates by URL', () => {
+    const duped = mockHtml + mockHtml
+    const entries = parseAnthropicNews(duped)
+    const urls = entries.map((e) => e.url)
+    expect(new Set(urls).size).toBe(urls.length)
+  })
+
+  it('returns empty for non-Anthropic HTML', () => {
+    expect(parseAnthropicNews('<html><body>Hello</body></html>')).toEqual([])
+  })
+})
+
+describe('isRelevantEntry', () => {
+  describe('Anthropic news', () => {
+    it('product launches are relevant', () => {
+      expect(isRelevantEntry('Introducing Claude Sonnet 4.6', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Introducing Claude Opus 4.6', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Claude Opus 4.1', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Introducing Claude Haiku 4.5', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Anthropic acquires Bun as Claude Code reaches $1B milestone', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Introducing the Model Context Protocol', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Enabling Claude Code to work more autonomously', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Developing a computer use model', 'anthropic')).toBe(true)
+      // Frontier model / project codenames
+      expect(isRelevantEntry('Project Glasswing', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Claude Mythos Preview', 'anthropic')).toBe(true)
+      expect(isRelevantEntry('Making frontier cybersecurity capabilities available to defenders', 'anthropic')).toBe(true)
+    })
+
+    it('corporate/policy posts are filtered', () => {
+      expect(isRelevantEntry('Australian government and Anthropic sign MOU for AI safety', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Anthropic\'s Responsible Scaling Policy: Version 3.0', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Statement from Dario Amodei on the Paris AI Action Summit', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Where things stand with the Department of War', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Anthropic Education Report: How university students use Claude', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Sydney will become Anthropic\'s fourth office in Asia-Pacific', 'anthropic')).toBe(false)
+      expect(isRelevantEntry('Mariano-Florentino Cuéllar appointed to Anthropic\'s Long-Term Benefit Trust', 'anthropic')).toBe(false)
+    })
+  })
+
+  describe('OpenAI/Google blog', () => {
+    it('API/model posts are relevant', () => {
+      expect(isRelevantEntry('Introducing GPT-5', 'openai')).toBe(true)
+      expect(isRelevantEntry('New API pricing update', 'openai')).toBe(true)
+      expect(isRelevantEntry('Gemini 2.5 Pro release', 'google')).toBe(true)
+      expect(isRelevantEntry('Fine-tuning API updates', 'openai')).toBe(true)
+      expect(isRelevantEntry('Batch API now available', 'openai')).toBe(true)
+      // Real OpenAI product announcements
+      expect(isRelevantEntry('Introducing GPT-5.4 mini and nano', 'openai')).toBe(true)
+      expect(isRelevantEntry('Codex now offers more flexible pricing for teams', 'openai')).toBe(true)
+      expect(isRelevantEntry('Creating with Sora Safely', 'openai')).toBe(true)
+      expect(isRelevantEntry('From model to agent: Equipping the Responses API with a computer environment', 'openai')).toBe(true)
+      // Real Google product announcements
+      expect(isRelevantEntry('New ways to balance cost and reliability in the Gemini API', 'google')).toBe(true)
+      expect(isRelevantEntry('Build with Veo 3.1 Lite, our most cost-effective video generation model', 'google')).toBe(true)
+      expect(isRelevantEntry('Gemini 3.1 Flash Live: Making audio AI more natural and reliable', 'google')).toBe(true)
+    })
+
+    it('noise posts are filtered', () => {
+      expect(isRelevantEntry('Team spotlight: safety research', 'openai')).toBe(false)
+      expect(isRelevantEntry('We are hiring engineers', 'openai')).toBe(false)
+      expect(isRelevantEntry('Using custom GPTs', 'openai')).toBe(false)
+      expect(isRelevantEntry('Creating images with ChatGPT', 'openai')).toBe(false)
+      expect(isRelevantEntry('ChatGPT for marketing teams', 'openai')).toBe(false)
+      expect(isRelevantEntry('Getting started with ChatGPT', 'openai')).toBe(false)
+      // Safety/policy/internal posts
+      expect(isRelevantEntry('Introducing the Child Safety Blueprint', 'openai')).toBe(false)
+      expect(isRelevantEntry('Inside our approach to the Model Spec', 'openai')).toBe(false)
+      expect(isRelevantEntry('Introducing the OpenAI Safety Bug Bounty program', 'openai')).toBe(false)
+      expect(isRelevantEntry('How we monitor internal coding agents for misalignment', 'openai')).toBe(false)
+      expect(isRelevantEntry('Our response to the Axios developer tool compromise', 'openai')).toBe(false)
+    })
+
+    it('generic posts without keywords are filtered', () => {
+      expect(isRelevantEntry('Our thoughts on responsible AI', 'openai')).toBe(false)
+      expect(isRelevantEntry('Partnering with schools in Kenya', 'google')).toBe(false)
+    })
+  })
+})
+
+describe('formatChangelogSection', () => {
+  it('formats entries with date and source', () => {
+    const entries: ChangelogEntry[] = [
+      { source: 'openai', title: 'GPT-5 released', url: 'https://openai.com', date: '2026-04-10T00:00:00Z' },
+      { source: 'anthropic', title: 'Introducing Claude Sonnet 4.6', url: 'https://anthropic.com', date: '2026-04-09T00:00:00Z' },
+    ]
+    const result = formatChangelogSection(entries)
+    expect(result).toContain('OpenAI: GPT-5 released (4/10)')
+    expect(result).toContain('Anthropic: Introducing Claude Sonnet 4.6 (4/9)')
+  })
+
+  it('returns fallback message for empty entries', () => {
+    expect(formatChangelogSection([])).toBe('No service changes detected this week.')
+  })
+
+  it('limits to 8 items and sorts by date descending', () => {
+    const entries: ChangelogEntry[] = Array.from({ length: 12 }, (_, i) => ({
+      source: 'openai', title: `Item ${i}`, url: 'https://example.com', date: `2026-04-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    const lines = formatChangelogSection(entries).split('\n')
+    expect(lines).toHaveLength(8)
+    // First line should be most recent
+    expect(lines[0]).toContain('4/12')
+  })
+})

--- a/worker/src/__tests__/weekly-briefing.test.ts
+++ b/worker/src/__tests__/weekly-briefing.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, type WeeklyBriefingData } from '../weekly-briefing'
+
+describe('getWeekRange', () => {
+  it('returns Mon–Sun for a Wednesday', () => {
+    const { start, end } = getWeekRange(new Date('2026-04-08T12:00:00Z')) // Wednesday
+    expect(start).toBe('2026-04-06')
+    expect(end).toBe('2026-04-12')
+  })
+
+  it('returns Mon–Sun for a Monday', () => {
+    const { start, end } = getWeekRange(new Date('2026-04-06T00:00:00Z')) // Monday
+    expect(start).toBe('2026-04-06')
+    expect(end).toBe('2026-04-12')
+  })
+
+  it('returns Mon–Sun for a Sunday', () => {
+    const { start, end } = getWeekRange(new Date('2026-04-12T23:59:00Z')) // Sunday
+    expect(start).toBe('2026-04-06')
+    expect(end).toBe('2026-04-12')
+  })
+})
+
+describe('buildIncidentSummary', () => {
+  const incidents = [
+    { id: '1', serviceId: 'mistral', serviceName: 'Mistral API', title: 'Files API Degraded', startedAt: '2026-04-07T10:00:00Z', duration: '25m' },
+    { id: '2', serviceId: 'mistral', serviceName: 'Mistral API', title: 'Batch API Degraded', startedAt: '2026-04-08T03:00:00Z', duration: '1h 10m' },
+    { id: '3', serviceId: 'openai', serviceName: 'OpenAI API', title: 'Elevated Error Rates', startedAt: '2026-04-09T15:00:00Z', duration: '45m' },
+    { id: '4', serviceId: 'claude', serviceName: 'Claude API', title: 'Old incident', startedAt: '2026-03-30T10:00:00Z', duration: '30m' },
+  ]
+
+  it('aggregates incidents within the week range', () => {
+    const result = buildIncidentSummary(incidents, '2026-04-06', '2026-04-12')
+    expect(result).toHaveLength(2) // mistral, openai (old claude excluded)
+    expect(result[0].serviceId).toBe('mistral')
+    expect(result[0].count).toBe(2)
+    expect(result[0].totalDurationMin).toBe(95) // 25 + 70
+    expect(result[1].serviceId).toBe('openai')
+    expect(result[1].count).toBe(1)
+  })
+
+  it('returns empty for no incidents in range', () => {
+    expect(buildIncidentSummary(incidents, '2026-04-20', '2026-04-26')).toEqual([])
+  })
+
+  it('handles hours-only duration ("2h")', () => {
+    const incs = [
+      { id: '1', serviceId: 'claude', serviceName: 'Claude API', title: 'Outage', startedAt: '2026-04-07T10:00:00Z', duration: '2h' },
+    ]
+    const result = buildIncidentSummary(incs, '2026-04-06', '2026-04-12')
+    expect(result[0].totalDurationMin).toBe(120)
+  })
+})
+
+describe('buildStabilityChanges', () => {
+  it('reports changes > 0.5%', () => {
+    const thisWeek = { groq: { ok: 998, total: 1000 }, mistral: { ok: 980, total: 1000 } }
+    const prevWeek = { groq: { ok: 990, total: 1000 }, mistral: { ok: 999, total: 1000 } }
+    const names = { groq: 'Groq Cloud', mistral: 'Mistral API' }
+    const result = buildStabilityChanges(thisWeek, prevWeek, names)
+    expect(result).toHaveLength(2)
+    // Sorted by change ascending (declined first)
+    expect(result[0].serviceId).toBe('mistral')
+    expect(result[0].currUptime).toBeCloseTo(98.0)
+    expect(result[1].serviceId).toBe('groq')
+    expect(result[1].currUptime).toBeCloseTo(99.8)
+  })
+
+  it('ignores changes <= 0.5%', () => {
+    const thisWeek = { groq: { ok: 998, total: 1000 } }
+    const prevWeek = { groq: { ok: 995, total: 1000 } }
+    const result = buildStabilityChanges(thisWeek, prevWeek, { groq: 'Groq' })
+    expect(result).toHaveLength(0) // 0.3% change
+  })
+})
+
+describe('buildWeeklyBriefing', () => {
+  it('formats complete briefing with all sections', () => {
+    const data: WeeklyBriefingData = {
+      weekStart: '2026-04-06',
+      weekEnd: '2026-04-12',
+      changelog: [
+        { source: 'openai', title: 'GPT-5 released', url: 'https://openai.com', date: '2026-04-10T00:00:00Z' },
+      ],
+      incidents: [
+        { serviceId: 'mistral', serviceName: 'Mistral API', count: 6, totalDurationMin: 120 },
+        { serviceId: 'openai', serviceName: 'OpenAI API', count: 2, totalDurationMin: 45 },
+      ],
+      stabilityChanges: [
+        { serviceId: 'groq', serviceName: 'Groq Cloud', prevUptime: 99.2, currUptime: 99.8 },
+        { serviceId: 'mistral', serviceName: 'Mistral API', prevUptime: 99.9, currUptime: 98.1 },
+      ],
+    }
+    const result = buildWeeklyBriefing(data)
+    // Title is in embed title now, not description
+    expect(result).not.toContain('Weekly Briefing')
+    expect(result).toContain('Service Changes')
+    expect(result).toContain('GPT-5 released')
+    expect(result).toContain('8 incidents across 2 services')
+    expect(result).toContain('Mistral API (6)')
+    expect(result).toContain('2h 45m')
+    expect(result).toContain('Improved: Groq Cloud')
+    expect(result).toContain('Declined: Mistral API')
+  })
+
+  it('handles empty data gracefully', () => {
+    const data: WeeklyBriefingData = {
+      weekStart: '2026-04-06',
+      weekEnd: '2026-04-12',
+      changelog: [],
+      incidents: [],
+      stabilityChanges: [],
+    }
+    const result = buildWeeklyBriefing(data)
+    expect(result).toContain('No service changes detected')
+    expect(result).toContain('No incidents this week')
+    expect(result).toContain('No significant changes')
+  })
+})

--- a/worker/src/changelog.ts
+++ b/worker/src/changelog.ts
@@ -1,0 +1,212 @@
+// Changelog / News collection — detect new AI service updates
+// Pilot: OpenAI (blog RSS), Google (AI blog RSS), Anthropic (news page HTML)
+
+import { kvPut } from './utils'
+
+export interface ChangelogEntry {
+  source: string    // 'openai' | 'google' | 'anthropic'
+  title: string
+  url: string
+  date: string      // ISO date
+}
+
+export interface ChangelogSource {
+  id: string
+  name: string
+  feedUrl: string
+  type: 'rss' | 'html'
+}
+
+export const CHANGELOG_SOURCES: ChangelogSource[] = [
+  { id: 'openai', name: 'OpenAI', feedUrl: 'https://openai.com/blog/rss.xml', type: 'rss' },
+  { id: 'google', name: 'Google AI', feedUrl: 'https://blog.google/technology/ai/rss/', type: 'rss' },
+  { id: 'anthropic', name: 'Anthropic', feedUrl: 'https://www.anthropic.com/news', type: 'html' },
+]
+
+// OpenAI/Google blog RSS contains non-API content — filter to relevant items
+const RELEVANCE_KEYWORDS = /\b(model|api|gpt|gemini|claude|sdk|release|deprecat|pricing|rate.?limit|token|endpoint|embed|function.?call|tool.?us|vision|voice|image|video|reason|agent|fine.?tun|batch|assistant|codex|sora|dall|whisper|introduc)/i
+const NOISE_KEYWORDS = /\b(hiring|career|team spotlight|company update|policy statement|annual report|getting started|fundamentals|how to use|using .+|chatgpt for \w+|prompting|writing with|research with|analyzing data|creating .+ with chatgpt|healthcare|financial services|safety blueprint|bug bounty|model spec|misalignment|monitor.*agent|our (approach|response)|doesn't include|safe use of ai|responsible)\b/i
+
+// Anthropic news: filter to product/tech announcements
+const ANTHROPIC_RELEVANCE = /\b(introduc|launch|announc|releas|claude|model|api|code|agent|feature|acquir|partner.*claude|computer use|mcp|protocol|project\s+\w+|frontier|preview|mythos|glasswing|capybara|sonnet|opus|haiku)/i
+const ANTHROPIC_NOISE = /\b(statement|policy|safety|responsible|economic|education|office|partnership.*(?:government|university|institute)|signs?\b|MOU|hiring|appoint|advisory|pledge|trust|compliance|election)/i
+
+export function isRelevantEntry(title: string, source: string): boolean {
+  if (source === 'anthropic') {
+    if (ANTHROPIC_NOISE.test(title)) return false
+    return ANTHROPIC_RELEVANCE.test(title)
+  }
+  // Blog posts: require relevance keyword, reject noise
+  if (NOISE_KEYWORDS.test(title)) return false
+  return RELEVANCE_KEYWORDS.test(title)
+}
+
+/**
+ * Parse RSS 2.0 XML into entries (OpenAI, Google)
+ */
+export function parseRssEntries(xml: string, source: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = []
+  const items = xml.match(/<item[\s>][\s\S]*?<\/item>/gi)
+  if (!items) return []
+
+  for (const item of items.slice(0, 50)) {
+    const title = item.match(/<title>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/title>/i)?.[1]?.trim() ?? ''
+    const link = item.match(/<link>([\s\S]*?)<\/link>/i)?.[1]?.trim() ?? ''
+    const pubDate = item.match(/<pubDate>([\s\S]*?)<\/pubDate>/i)?.[1]?.trim() ?? ''
+
+    if (!title || !link) continue
+    const parsed = pubDate ? new Date(pubDate) : null
+    const date = parsed && !isNaN(parsed.getTime()) ? parsed.toISOString() : ''
+
+    entries.push({ source, title, url: link, date })
+  }
+  return entries
+}
+
+/**
+ * Parse Anthropic /news HTML page (Next.js SSR payload).
+ * Extracts from two data structures:
+ * 1. Featured grid items: {"_type":"featuredGridLink","date":"...","title":"...","url":"..."}
+ * 2. News list items: publishedOn + slug + title pattern
+ */
+export function parseAnthropicNews(html: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = []
+  const seen = new Set<string>()
+  // Unescape the JSON (Next.js RSC payload uses escaped quotes)
+  const u = html.replace(/\\"/g, '"')
+
+  // 1. Featured grid items (e.g. Project Glasswing — published at /glasswing, not /news/)
+  const featRe = /"_type":"featuredGridLink","date":"([^"]+)","(?:subject":"[^"]*",")?(summary":"[^"]*",")?title":"([^"]+)","url":"([^"]+)"/g
+  let m
+  while ((m = featRe.exec(u)) !== null) {
+    const date = m[1]
+    const title = m[3]
+    const urlPath = m[4]
+    const parsed = new Date(date)
+    if (isNaN(parsed.getTime())) continue
+    const fullUrl = urlPath.startsWith('http') ? urlPath : `https://www.anthropic.com${urlPath}`
+    if (seen.has(fullUrl)) continue
+    seen.add(fullUrl)
+    entries.push({ source: 'anthropic', title, url: fullUrl, date: parsed.toISOString() })
+  }
+
+  // 2. News list items: publishedOn + slug pairs
+  const slugRe = /"publishedOn":"([^"]+)","slug":\{"_type":"slug","current":"([^"]+)"\}/g
+  while ((m = slugRe.exec(u)) !== null) {
+    const slug = m[2]
+    const fullUrl = `https://www.anthropic.com/news/${slug}`
+    if (seen.has(fullUrl)) continue
+    seen.add(fullUrl)
+
+    // Find title AFTER slug (the JSON structure has: ...slug...subjects...title)
+    const searchStr = `"current":"${slug}"`
+    const pos = u.indexOf(searchStr)
+    if (pos < 0) continue
+    const after = u.substring(pos, pos + 1500)
+    const titleMatch = after.match(/"title":"([^"]{5,300})"/)
+    if (!titleMatch) continue
+
+    const parsed = new Date(m[1])
+    if (isNaN(parsed.getTime())) continue
+
+    entries.push({ source: 'anthropic', title: titleMatch[1], url: fullUrl, date: parsed.toISOString() })
+  }
+  return entries
+}
+
+/**
+ * Fetch and parse a single changelog source.
+ * Returns relevant entries from the last 7 days.
+ */
+async function fetchSource(src: ChangelogSource): Promise<ChangelogEntry[]> {
+  const res = await fetch(src.feedUrl, {
+    headers: { 'User-Agent': 'AIWatch/1.0 (ai-watch.dev; changelog monitoring)' },
+    signal: AbortSignal.timeout(8000),
+  })
+  if (!res.ok) {
+    res.body?.cancel()
+    throw new Error(`${src.id} returned HTTP ${res.status}`)
+  }
+  const text = await res.text()
+  const entries = src.type === 'html'
+    ? parseAnthropicNews(text)
+    : parseRssEntries(text, src.id)
+  if (entries.length === 0 && text.length > 1000) {
+    console.warn(`[changelog] ${src.id}: fetched ${text.length} bytes but parsed 0 entries — possible format change`)
+  }
+
+  // Filter to last 7 days + relevance
+  const weekAgo = Date.now() - 7 * 86_400_000
+  return entries.filter((e) => {
+    if (!e.date) return false
+    const ts = new Date(e.date).getTime()
+    if (isNaN(ts) || ts < weekAgo) return false
+    return isRelevantEntry(e.title, e.source)
+  })
+}
+
+/**
+ * Collect changelog entries from all sources.
+ * Dedup against KV (only return new entries not seen before).
+ */
+export async function collectChangelogs(
+  kv: KVNamespace | null,
+): Promise<ChangelogEntry[]> {
+  if (!kv) return []
+
+  const results = await Promise.allSettled(
+    CHANGELOG_SOURCES.map((src) => fetchSource(src)),
+  )
+
+  // Read previously seen entries
+  const seenRaw = await kv.get('changelog:entries').catch(() => null)
+  const seen: ChangelogEntry[] = seenRaw ? JSON.parse(seenRaw) : []
+  const seenKeys = new Set(seen.map((e) => `${e.source}:${e.title}`))
+
+  const newEntries: ChangelogEntry[] = []
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (result.status === 'rejected') {
+      console.warn(`[changelog] ${CHANGELOG_SOURCES[i].id} fetch failed:`, result.reason instanceof Error ? result.reason.message : result.reason)
+      continue
+    }
+    for (const entry of result.value) {
+      const key = `${entry.source}:${entry.title}`
+      if (seenKeys.has(key)) continue
+      seenKeys.add(key)
+      newEntries.push(entry)
+    }
+  }
+
+  // Persist accumulated entries (append new to existing)
+  if (newEntries.length > 0) {
+    const updated = [...seen, ...newEntries].slice(-50) // keep last 50
+    await kvPut(kv, 'changelog:entries', JSON.stringify(updated), { expirationTtl: 1_209_600 }) // 14d
+  }
+
+  return newEntries
+}
+
+/**
+ * Format changelog entries for Discord embed section
+ */
+export function formatChangelogSection(entries: ChangelogEntry[]): string {
+  if (entries.length === 0) return 'No service changes detected this week.'
+
+  const sourceNames: Record<string, string> = {
+    openai: 'OpenAI',
+    google: 'Google AI',
+    anthropic: 'Anthropic',
+  }
+
+  return entries
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 8) // max 8 items in Discord embed
+    .map((e) => {
+      const date = new Date(e.date)
+      const dateStr = `${date.getMonth() + 1}/${date.getDate()}`
+      const name = sourceNames[e.source] ?? e.source
+      return `• ${name}: ${e.title} (${dateStr})`
+    })
+    .join('\n')
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -604,6 +604,8 @@ import { generateOgSvg } from './og'
 import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, isPromotable } from './reddit'
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
+import { collectChangelogs } from './changelog'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing } from './weekly-briefing'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, type ProbeDailyData } from './probe-archival'
 import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
@@ -747,6 +749,98 @@ export default {
         }
       } catch (err) {
         console.warn('[cron] GitHub competitive monitoring failed:', err instanceof Error ? err.message : err)
+      }
+    }
+
+    // Changelog RSS collection — every hour at :00 (3 sources, write only on new entries)
+    if (env.STATUS_CACHE && now.getUTCMinutes() === 0) {
+      try {
+        const newEntries = await collectChangelogs(env.STATUS_CACHE)
+        if (newEntries.length > 0) {
+          console.log(`[cron] changelog: ${newEntries.length} new entries detected`)
+        }
+      } catch (err) {
+        console.warn('[cron] changelog collection failed:', err instanceof Error ? err.message : err)
+      }
+    }
+
+    // Weekly briefing — Sunday UTC 00:00-00:04 (KST 09:00)
+    if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCDay() === 0 && now.getUTCHours() === 0 && now.getUTCMinutes() < 5) {
+      try {
+        const weeklyKey = `weekly-briefing:${todayUTC()}`
+        const alreadySent = await env.STATUS_CACHE.get(weeklyKey).catch(() => null)
+        if (!alreadySent) {
+          const { start: weekStart, end: weekEnd } = getWeekRange(now)
+
+          // Read changelog entries accumulated this week
+          const changelogRaw = await env.STATUS_CACHE.get('changelog:entries').catch(() => null)
+          let changelog: unknown[] = []
+          if (changelogRaw) { try { changelog = JSON.parse(changelogRaw) } catch { console.warn('[cron] changelog entries parse failed') } }
+
+          // Read monthly incidents for incident summary (check both current and previous month for week spanning month boundary)
+          const allMonthlyIncidents: unknown[] = []
+          const currMonthKey = `incidents:monthly:${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+          const prevMonth = new Date(now); prevMonth.setUTCMonth(prevMonth.getUTCMonth() - 1)
+          const prevMonthKey = `incidents:monthly:${prevMonth.getFullYear()}-${String(prevMonth.getMonth() + 1).padStart(2, '0')}`
+          for (const mk of [currMonthKey, prevMonthKey]) {
+            const mRaw = await env.STATUS_CACHE.get(mk).catch(() => null)
+            if (mRaw) { try { allMonthlyIncidents.push(...(JSON.parse(mRaw).incidents ?? [])) } catch { console.warn(`[cron] ${mk} parse failed`) } }
+          }
+          const incidents = buildIncidentSummary(allMonthlyIncidents as Parameters<typeof buildIncidentSummary>[0], weekStart, weekEnd)
+
+          // Read daily uptime counters for stability comparison
+          const thisWeekCounters: Record<string, { ok: number; total: number }> = {}
+          const prevWeekCounters: Record<string, { ok: number; total: number }> = {}
+          for (let i = 0; i < 7; i++) {
+            const d = new Date(now)
+            d.setUTCDate(d.getUTCDate() - i)
+            const key = `history:${d.toISOString().split('T')[0]}`
+            const raw = await env.STATUS_CACHE.get(key).catch(() => null)
+            if (raw) {
+              try {
+                const data = JSON.parse(raw)
+                for (const [svcId, counts] of Object.entries(data) as [string, { ok: number; total: number }][]) {
+                  const c = thisWeekCounters[svcId] ?? { ok: 0, total: 0 }
+                  c.ok += counts.ok; c.total += counts.total
+                  thisWeekCounters[svcId] = c
+                }
+              } catch { console.warn(`[cron] ${key} parse failed`) }
+            }
+            // Previous week
+            const pd = new Date(now)
+            pd.setUTCDate(pd.getUTCDate() - i - 7)
+            const pkey = `history:${pd.toISOString().split('T')[0]}`
+            const praw = await env.STATUS_CACHE.get(pkey).catch(() => null)
+            if (praw) {
+              try {
+                const pdata = JSON.parse(praw)
+                for (const [svcId, counts] of Object.entries(pdata) as [string, { ok: number; total: number }][]) {
+                  const c = prevWeekCounters[svcId] ?? { ok: 0, total: 0 }
+                  c.ok += counts.ok; c.total += counts.total
+                  prevWeekCounters[svcId] = c
+                }
+              } catch { console.warn(`[cron] ${pkey} parse failed`) }
+            }
+          }
+          const serviceNames: Record<string, string> = {}
+          for (const svc of SERVICES) serviceNames[svc.id] = svc.name
+          const stabilityChanges = buildStabilityChanges(thisWeekCounters, prevWeekCounters, serviceNames)
+
+          const briefing = buildWeeklyBriefing({ weekStart, weekEnd, changelog, incidents, stabilityChanges })
+          await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+            title: `📋 Weekly Briefing (${weekStart} ~ ${weekEnd})`,
+            description: briefing,
+            color: 0x58a6ff, // blue
+          })
+          await kvPut(env.STATUS_CACHE, weeklyKey, '1', { expirationTtl: 604_800 }) // 7d dedup
+
+          // Clear accumulated changelog entries after sending
+          await env.STATUS_CACHE.delete('changelog:entries').catch((err) =>
+            console.warn('[cron] changelog entries cleanup failed:', err instanceof Error ? err.message : err),
+          )
+        }
+      } catch (err) {
+        console.error('[cron] weekly briefing failed:', err instanceof Error ? err.message : err)
       }
     }
 

--- a/worker/src/weekly-briefing.ts
+++ b/worker/src/weekly-briefing.ts
@@ -1,0 +1,161 @@
+// Weekly Briefing — Discord summary every Sunday UTC 00:00 (KST 09:00)
+// Combines changelog RSS detection + incident summary + stability trends
+
+import type { ChangelogEntry } from './changelog'
+import { formatChangelogSection } from './changelog'
+
+export interface WeeklyIncidentSummary {
+  serviceId: string
+  serviceName: string
+  count: number
+  totalDurationMin: number
+}
+
+export interface WeeklyStabilityChange {
+  serviceId: string
+  serviceName: string
+  prevUptime: number
+  currUptime: number
+}
+
+export interface WeeklyBriefingData {
+  weekStart: string // ISO date (Mon)
+  weekEnd: string   // ISO date (Sun)
+  changelog: ChangelogEntry[]
+  incidents: WeeklyIncidentSummary[]
+  stabilityChanges: WeeklyStabilityChange[]
+}
+
+/**
+ * Compute week date range (Mon–Sun) for a given date.
+ */
+export function getWeekRange(date: Date): { start: string; end: string } {
+  const d = new Date(date)
+  const day = d.getUTCDay()
+  // Monday = start of week (day 0=Sun → offset 6, day 1=Mon → offset 0, ...)
+  const diffToMon = day === 0 ? 6 : day - 1
+  const mon = new Date(d)
+  mon.setUTCDate(d.getUTCDate() - diffToMon)
+  const sun = new Date(mon)
+  sun.setUTCDate(mon.getUTCDate() + 6)
+
+  return {
+    start: mon.toISOString().split('T')[0],
+    end: sun.toISOString().split('T')[0],
+  }
+}
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start)
+  const e = new Date(end)
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[s.getUTCMonth()]} ${s.getUTCDate()} – ${months[e.getUTCMonth()]} ${e.getUTCDate()}`
+}
+
+/**
+ * Build incident summary from incidents:monthly KV data.
+ * Filters to incidents that started within the week range.
+ */
+export function buildIncidentSummary(
+  monthlyIncidents: Array<{ id: string; serviceId: string; serviceName: string; title: string; startedAt: string; duration: string | null }>,
+  weekStart: string,
+  weekEnd: string,
+): WeeklyIncidentSummary[] {
+  const startMs = new Date(weekStart).getTime()
+  const endMs = new Date(weekEnd + 'T23:59:59Z').getTime()
+
+  const byService = new Map<string, { name: string; count: number; totalMin: number }>()
+  for (const inc of monthlyIncidents) {
+    const ts = new Date(inc.startedAt).getTime()
+    if (ts < startMs || ts > endMs) continue
+    const entry = byService.get(inc.serviceId) ?? { name: inc.serviceName, count: 0, totalMin: 0 }
+    entry.count++
+    if (inc.duration) {
+      const match = inc.duration.match(/(?:(\d+)h\s*)?(?:(\d+)m)?/)
+      if (match && (match[1] || match[2])) entry.totalMin += (parseInt(match[1] ?? '0') * 60) + parseInt(match[2] ?? '0')
+    }
+    byService.set(inc.serviceId, entry)
+  }
+
+  return Array.from(byService.entries())
+    .map(([id, v]) => ({ serviceId: id, serviceName: v.name, count: v.count, totalDurationMin: v.totalMin }))
+    .sort((a, b) => b.count - a.count)
+}
+
+/**
+ * Build stability changes from daily uptime counters.
+ * Compares this week's uptime vs previous week.
+ */
+export function buildStabilityChanges(
+  thisWeek: Record<string, { ok: number; total: number }>,
+  prevWeek: Record<string, { ok: number; total: number }>,
+  serviceNames: Record<string, string>,
+): WeeklyStabilityChange[] {
+  const changes: WeeklyStabilityChange[] = []
+  for (const [id, curr] of Object.entries(thisWeek)) {
+    const prev = prevWeek[id]
+    if (!prev || prev.total === 0 || curr.total === 0) continue
+    const currUptime = (curr.ok / curr.total) * 100
+    const prevUptime = (prev.ok / prev.total) * 100
+    const diff = currUptime - prevUptime
+    // Only report changes > 0.5%
+    if (Math.abs(diff) > 0.5) {
+      changes.push({
+        serviceId: id,
+        serviceName: serviceNames[id] ?? id,
+        prevUptime,
+        currUptime,
+      })
+    }
+  }
+  return changes.sort((a, b) => (a.currUptime - a.prevUptime) - (b.currUptime - b.prevUptime))
+}
+
+/**
+ * Format the weekly briefing as a Discord embed description.
+ */
+export function buildWeeklyBriefing(data: WeeklyBriefingData): string {
+  const lines: string[] = []
+  const dateRange = formatDateRange(data.weekStart, data.weekEnd)
+
+  // Section 1: Changelog
+  lines.push(`\n🔄 **Service Changes**`)
+  lines.push(formatChangelogSection(data.changelog))
+
+  // Section 2: Incident Summary
+  lines.push(`\n⚠️ **Incident Summary**`)
+  if (data.incidents.length === 0) {
+    lines.push('No incidents this week.')
+  } else {
+    const totalInc = data.incidents.reduce((s, i) => s + i.count, 0)
+    const totalMin = data.incidents.reduce((s, i) => s + i.totalDurationMin, 0)
+    const svcCount = data.incidents.length
+    lines.push(`${totalInc} incidents across ${svcCount} services`)
+    const top3 = data.incidents.slice(0, 3).map((i) => `${i.serviceName} (${i.count})`).join(', ')
+    lines.push(`Most affected: ${top3}`)
+    if (totalMin > 0) {
+      const h = Math.floor(totalMin / 60)
+      const m = totalMin % 60
+      lines.push(`Total downtime: ${h > 0 && m > 0 ? `${h}h ${m}m` : h > 0 ? `${h}h` : `${m}m`}`)
+    }
+  }
+
+  // Section 3: Stability Trend
+  lines.push(`\n📊 **Stability Trend**`)
+  if (data.stabilityChanges.length === 0) {
+    lines.push('No significant changes.')
+  } else {
+    const improved = data.stabilityChanges.filter((c) => c.currUptime > c.prevUptime)
+    const declined = data.stabilityChanges.filter((c) => c.currUptime < c.prevUptime)
+    if (improved.length > 0) {
+      const list = improved.slice(0, 3).map((c) => `${c.serviceName} (${c.prevUptime.toFixed(1)}% → ${c.currUptime.toFixed(1)}%)`).join(', ')
+      lines.push(`Improved: ${list}`)
+    }
+    if (declined.length > 0) {
+      const list = declined.slice(0, 3).map((c) => `${c.serviceName} (${c.prevUptime.toFixed(1)}% → ${c.currUptime.toFixed(1)}%)`).join(', ')
+      lines.push(`Declined: ${list}`)
+    }
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

- Weekly Discord briefing every Sunday UTC 00:00 (KST 09:00)
- Changelog collection from 3 sources: OpenAI blog RSS, Google AI blog RSS, Anthropic /news HTML
- Keyword relevance filtering (product launches, model releases) + noise filtering (policy, hiring, guides)
- Anthropic featured grid parsing for non-/news paths (e.g. Project Glasswing at /glasswing)
- Combines with existing monitoring data: incident summary + stability trends

## Changes

| File | Description |
|------|-------------|
| `worker/src/changelog.ts` | RSS/HTML parser, keyword filters, KV dedup |
| `worker/src/weekly-briefing.ts` | Incident summary, stability changes, briefing formatter |
| `worker/src/index.ts` | Hourly changelog cron + Sunday weekly briefing cron |
| `CLAUDE.md` | KV schema + directory layout updates |
| `worker/src/__tests__/changelog.test.ts` | 20 tests for parsers + filters |
| `worker/src/__tests__/weekly-briefing.test.ts` | 8 tests for briefing logic |

## Test plan

- [x] `npm run test:worker` — 646 tests pass
- [x] `wrangler deploy --dry-run` — build check pass
- [x] Local E2E: fetched real RSS from all 3 sources, verified filtering
- [x] Discord test send: Project Glasswing + OpenAI entries detected and sent
- [ ] Deploy Worker and verify Sunday cron execution

refs #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)