### PR TITLE
feat: AI service security incident monitoring (refs #215)

### DIFF
--- a/worker/src/__tests__/reddit.test.ts
+++ b/worker/src/__tests__/reddit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseRedditResponse, matchesKeywords, isPromotable, formatRedditAlert } from '../reddit'
+import { parseRedditResponse, matchesKeywords, matchesSecurityKeywords, isPromotable, formatRedditAlert, formatSecurityAlert } from '../reddit'
 import type { RedditAlert } from '../reddit'
 
 describe('parseRedditResponse', () => {
@@ -88,6 +88,71 @@ describe('matchesKeywords', () => {
   })
 })
 
+describe('matchesSecurityKeywords', () => {
+  it('matches AI service security incidents', () => {
+    expect(matchesSecurityKeywords('OpenAI data breach exposes user emails')).toBe(true)
+    expect(matchesSecurityKeywords('Claude Code RCE vulnerability CVE-2025-59536')).toBe(true)
+    expect(matchesSecurityKeywords('Anthropic API key leak found on GitHub')).toBe(true)
+    expect(matchesSecurityKeywords('HuggingFace credentials leaked in breach')).toBe(true)
+    expect(matchesSecurityKeywords('DeepSeek database compromised with unauthorized access')).toBe(true)
+    expect(matchesSecurityKeywords('Gemini prompt injection exploit discovered')).toBe(true)
+    expect(matchesSecurityKeywords('xAI Grok hacked — data exfiltration confirmed')).toBe(true)
+  })
+
+  it('matches strong security signals with AI-adjacent keywords', () => {
+    expect(matchesSecurityKeywords('Major breach at AI cloud provider')).toBe(true)
+    expect(matchesSecurityKeywords('CVE-2025-12345 remote code execution in LLM API')).toBe(true)
+    expect(matchesSecurityKeywords('Data leak exposes GPT model weights')).toBe(true)
+  })
+
+  it('does not match strong security signals without AI context', () => {
+    expect(matchesSecurityKeywords('Major breach at cloud provider')).toBe(false)
+    expect(matchesSecurityKeywords('CVE-2025-12345 remote code execution in Linux kernel')).toBe(false)
+    expect(matchesSecurityKeywords('Data leak exposes millions of records')).toBe(false)
+  })
+
+  it('matches security context + AI service', () => {
+    expect(matchesSecurityKeywords('OpenAI security vulnerability patched')).toBe(true)
+    expect(matchesSecurityKeywords('Anthropic disclosure of exploit')).toBe(true)
+    expect(matchesSecurityKeywords('Copilot malicious injection attack')).toBe(true)
+  })
+
+  it('does not match unrelated posts', () => {
+    expect(matchesSecurityKeywords('How to use Claude for coding')).toBe(false)
+    expect(matchesSecurityKeywords('Best security practices for web apps')).toBe(false)
+    expect(matchesSecurityKeywords('New feature announcement from Google')).toBe(false)
+    expect(matchesSecurityKeywords('Pricing comparison of AI services')).toBe(false)
+  })
+
+  it('is case insensitive', () => {
+    expect(matchesSecurityKeywords('OPENAI BREACH CONFIRMED')).toBe(true)
+    expect(matchesSecurityKeywords('Claude vulnerability DISCLOSURE')).toBe(true)
+  })
+})
+
+describe('formatSecurityAlert', () => {
+  it('formats Reddit security alert with red color and lock icon', () => {
+    const alert: RedditAlert = {
+      key: 'reddit:seen:sec123',
+      subreddit: 'netsec',
+      post: {
+        id: 'sec123',
+        title: 'OpenAI API key leak discovered',
+        author: 'secresearcher',
+        subreddit: 'netsec',
+        score: 42,
+        url: 'https://www.reddit.com/r/netsec/comments/sec123/',
+        createdUtc: Math.floor(Date.now() / 1000) - 300,
+      },
+      type: 'security',
+    }
+    const formatted = formatSecurityAlert(alert)
+    expect(formatted.title).toBe('🔒 Security: r/netsec')
+    expect(formatted.description).toContain('OpenAI API key leak')
+    expect(formatted.color).toBe(0xf85149) // red
+  })
+})
+
 describe('isPromotable', () => {
   it('detects question-style posts as promotable', () => {
     expect(isPromotable('Is Claude down right now?')).toBe(true)
@@ -124,6 +189,7 @@ describe('formatRedditAlert', () => {
     const alert: RedditAlert = {
       key: 'reddit:seen:abc123',
       subreddit: 'ClaudeAI',
+      type: 'outage',
       post: {
         id: 'abc123',
         title: 'Is Claude down?',
@@ -144,9 +210,9 @@ describe('formatRedditAlert', () => {
 
   it('filters promotable alerts from mixed list (integration)', () => {
     const alerts: RedditAlert[] = [
-      { key: 'k1', subreddit: 'ClaudeAI', post: { id: '1', title: 'Is Claude down?', author: 'a', subreddit: 'ClaudeAI', score: 5, url: '', createdUtc: 0 } },
-      { key: 'k2', subreddit: 'OpenAI', post: { id: '2', title: 'OpenAI outage lasted 3 hours', author: 'b', subreddit: 'OpenAI', score: 20, url: '', createdUtc: 0 } },
-      { key: 'k3', subreddit: 'ChatGPT', post: { id: '3', title: 'Anyone having issues with ChatGPT?', author: 'c', subreddit: 'ChatGPT', score: 8, url: '', createdUtc: 0 } },
+      { key: 'k1', subreddit: 'ClaudeAI', type: 'outage' as const, post: { id: '1', title: 'Is Claude down?', author: 'a', subreddit: 'ClaudeAI', score: 5, url: '', createdUtc: 0 } },
+      { key: 'k2', subreddit: 'OpenAI', type: 'outage' as const, post: { id: '2', title: 'OpenAI outage lasted 3 hours', author: 'b', subreddit: 'OpenAI', score: 20, url: '', createdUtc: 0 } },
+      { key: 'k3', subreddit: 'ChatGPT', type: 'outage' as const, post: { id: '3', title: 'Anyone having issues with ChatGPT?', author: 'c', subreddit: 'ChatGPT', score: 8, url: '', createdUtc: 0 } },
     ]
     const promotable = alerts.filter(a => isPromotable(a.post.title))
     expect(promotable).toHaveLength(2)
@@ -158,6 +224,7 @@ describe('formatRedditAlert', () => {
     const alert: RedditAlert = {
       key: 'reddit:seen:xyz',
       subreddit: 'UnknownSub',
+      type: 'outage',
       post: {
         id: 'xyz',
         title: 'Is this service down?',

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { mapOSVSeverity, detectSecurityAlerts, formatSecurityDigest } from '../security-monitor'
+import type { SecurityAlert } from '../security-monitor'
+
+describe('mapOSVSeverity', () => {
+  it('maps critical (>= 9.0)', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '9.0' }] })).toBe('critical')
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '10.0' }] })).toBe('critical')
+  })
+
+  it('maps high (>= 7.0, < 9.0)', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '7.0' }] })).toBe('high')
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '8.9' }] })).toBe('high')
+  })
+
+  it('maps medium (>= 4.0, < 7.0)', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '4.0' }] })).toBe('medium')
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '6.9' }] })).toBe('medium')
+  })
+
+  it('maps low (< 4.0)', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '3.9' }] })).toBe('low')
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [{ type: 'CVSS_V3', score: '0.1' }] })).toBe('low')
+  })
+
+  it('handles CVSS vector strings by falling back to database_specific.severity', () => {
+    expect(mapOSVSeverity({
+      id: 'X', modified: '',
+      severity: [{ type: 'CVSS_V4', score: 'CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N' }],
+      database_specific: { severity: 'MODERATE' },
+    })).toBe('medium')
+
+    expect(mapOSVSeverity({
+      id: 'X', modified: '',
+      severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' }],
+      database_specific: { severity: 'CRITICAL' },
+    })).toBe('critical')
+  })
+
+  it('defaults to medium when no severity data at all', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '' })).toBe('medium')
+    expect(mapOSVSeverity({ id: 'X', modified: '', severity: [] })).toBe('medium')
+  })
+
+  it('uses database_specific.severity text when no numeric score', () => {
+    expect(mapOSVSeverity({ id: 'X', modified: '', database_specific: { severity: 'HIGH' } })).toBe('high')
+    expect(mapOSVSeverity({ id: 'X', modified: '', database_specific: { severity: 'LOW' } })).toBe('low')
+    expect(mapOSVSeverity({ id: 'X', modified: '', database_specific: { severity: 'CRITICAL' } })).toBe('critical')
+  })
+
+  it('prefers numeric CVSS score over database_specific text', () => {
+    expect(mapOSVSeverity({
+      id: 'X', modified: '',
+      severity: [{ type: 'CVSS_V3', score: '3.9' }],
+      database_specific: { severity: 'CRITICAL' },
+    })).toBe('low')
+  })
+})
+
+describe('detectSecurityAlerts', () => {
+  it('returns empty when kv is null', async () => {
+    const result = await detectSecurityAlerts(null)
+    expect(result).toEqual([])
+  })
+})
+
+describe('formatSecurityDigest', () => {
+  it('formats single OSV alert with remediation', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'osv',
+      id: 'GHSA-abc-123',
+      title: 'RCE in openai package',
+      url: 'https://osv.dev/vulnerability/GHSA-abc-123',
+      severity: 'critical',
+      kvKey: 'security:seen:osv:GHSA-abc-123',
+      affectedPackage: 'PyPI/openai',
+      affectedRange: '>= 1.0.0',
+      fixedVersion: '1.0.1',
+      patchUrl: 'https://github.com/openai/openai-python/commit/abc',
+    }]
+    const digest = formatSecurityDigest(alerts)
+    expect(digest.title).toBe('🔒 Security Alert — 1 new finding')
+    expect(digest.description).toContain('SDK Vulnerabilities (1)')
+    expect(digest.description).toContain('GHSA-abc-123')
+    expect(digest.description).toContain('pip install openai>=1.0.1')
+    expect(digest.color).toBe(0xf85149) // critical → red
+  })
+
+  it('formats single HN alert', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'hackernews',
+      id: '99999',
+      title: 'OpenAI data breach',
+      url: 'https://example.com/breach',
+      kvKey: 'security:seen:hn:99999',
+    }]
+    const digest = formatSecurityDigest(alerts)
+    expect(digest.title).toBe('🔒 Security Alert — 1 new finding')
+    expect(digest.description).toContain('Security News (1)')
+    expect(digest.description).toContain('OpenAI data breach')
+    expect(digest.description).toContain('[HN]')
+    expect(digest.description).toContain('[Source]')
+  })
+
+  it('groups mixed OSV + HN alerts into sections', () => {
+    const alerts: SecurityAlert[] = [
+      {
+        source: 'osv', id: 'GHSA-1', title: 'Vuln A', url: 'https://osv.dev/1',
+        severity: 'high', kvKey: 'k1', affectedPackage: 'PyPI/anthropic', fixedVersion: '2.0.0',
+      },
+      {
+        source: 'osv', id: 'GHSA-2', title: 'Vuln B', url: 'https://osv.dev/2',
+        severity: 'medium', kvKey: 'k2', affectedPackage: 'npm/@anthropic-ai/sdk',
+      },
+      {
+        source: 'hackernews', id: '111', title: 'Claude security news',
+        url: 'https://news.ycombinator.com/item?id=111', kvKey: 'k3',
+      },
+    ]
+    const digest = formatSecurityDigest(alerts)
+    expect(digest.title).toBe('🔒 Security Alert — 3 new findings')
+    expect(digest.description).toContain('SDK Vulnerabilities (2)')
+    expect(digest.description).toContain('Security News (1)')
+    expect(digest.description).toContain('GHSA-1')
+    expect(digest.description).toContain('GHSA-2')
+    expect(digest.color).toBe(0xd29922) // highest is high → yellow
+  })
+
+  it('formats npm package with npm install command', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'osv', id: 'GHSA-npm', title: 'Path traversal',
+      url: 'https://osv.dev/npm', severity: 'medium', kvKey: 'k',
+      affectedPackage: 'npm/@anthropic-ai/sdk', fixedVersion: '0.81.0',
+    }]
+    const digest = formatSecurityDigest(alerts)
+    expect(digest.description).toContain('npm install @anthropic-ai/sdk@0.81.0')
+  })
+
+  it('uses gray color when all alerts are medium/low', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'osv', id: 'X', title: 'Minor', url: 'u',
+      severity: 'low', kvKey: 'k', affectedPackage: 'PyPI/x',
+    }]
+    expect(formatSecurityDigest(alerts).color).toBe(0x8b949e)
+  })
+})

--- a/worker/src/daily-summary.ts
+++ b/worker/src/daily-summary.ts
@@ -15,6 +15,7 @@ export interface DailySummaryData {
   webhookCounts?: { discord: number; slack: number }
   deliveryCounts?: { discord: number; slack: number; failed: number } | null
   redditCount: number
+  securityCount?: number
   vitals?: VitalsDaily | null
   probeSnapshots?: ProbeSnapshot[]
 }
@@ -128,6 +129,7 @@ export function buildDailySummary(data: DailySummaryData): string {
     }
   }
   if (redditCount > 0) lines.push(`📢 **Reddit**: ${redditCount} posts detected`)
+  if (data.securityCount && data.securityCount > 0) lines.push(`🔒 **Security**: ${data.securityCount} alerts detected`)
 
   // Section: Web Vitals
   if (vitals && vitals.count > 0) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -601,7 +601,8 @@ function corsHeaders(origin: string, allowedOrigin: string | undefined): Headers
 
 import { generateBadgeSvg } from './badge'
 import { generateOgSvg } from './og'
-import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, isPromotable } from './reddit'
+import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, formatSecurityAlert as formatRedditSecurityAlert, isPromotable } from './reddit'
+import { detectSecurityAlerts, formatSecurityDigest } from './security-monitor'
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
@@ -701,9 +702,10 @@ export default {
     if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCMinutes() < 5) {
       try {
         const redditAlerts = await detectRedditPosts(env.STATUS_CACHE)
-        // Split: service outage alerts vs competitive monitoring
-        const outageAlerts = redditAlerts.filter(a => !a.competitive)
-        const competitiveAlerts = redditAlerts.filter(a => a.competitive)
+        // Split: service outage alerts vs competitive vs security monitoring
+        const outageAlerts = redditAlerts.filter(a => a.type === 'outage')
+        const competitiveAlerts = redditAlerts.filter(a => a.type === 'competitive')
+        const redditSecurityAlerts = redditAlerts.filter(a => a.type === 'security')
         // Mark all detected posts as seen (prevents re-checking), but only notify promotable ones
         for (const alert of outageAlerts.slice(0, 5)) {
           await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 86400 })
@@ -727,8 +729,48 @@ export default {
             color: formatted.color,
           })
         }
+        // Security alerts from Reddit — notify first, then mark seen (max 5 per hour)
+        const secReddit = redditSecurityAlerts.slice(0, 5)
+        if (secReddit.length > 0) {
+          const secLines = secReddit.map(a => {
+            const formatted = formatRedditSecurityAlert(a)
+            return `${formatted.description}\n[View Post](${formatted.url})`
+          })
+          await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+            title: `🔒 Reddit Security — ${secReddit.length} post${secReddit.length > 1 ? 's' : ''}`,
+            description: secLines.join('\n\n'),
+            color: 0xf85149,
+          })
+          for (const alert of secReddit) {
+            await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 86400 }).catch(err => {
+              console.error('[cron] Failed to mark Reddit security alert as seen:', alert.key, err instanceof Error ? err.message : err)
+            })
+          }
+        }
       } catch (err) {
-        console.warn('[cron] Reddit monitoring failed:', err instanceof Error ? err.message : err)
+        console.error('[cron] Reddit monitoring failed:', err instanceof Error ? err.message : err)
+      }
+
+      // HN + OSV security monitoring (independent of Reddit — separate try/catch)
+      try {
+        const securityAlerts = await detectSecurityAlerts(env.STATUS_CACHE)
+        if (securityAlerts.length > 0) {
+          // Send notification first — duplicate is better than lost alert
+          const digest = formatSecurityDigest(securityAlerts)
+          await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+            title: digest.title,
+            description: digest.description,
+            color: digest.color,
+          })
+          // Then mark as seen
+          for (const alert of securityAlerts) {
+            await kvPut(env.STATUS_CACHE, alert.kvKey, '1', { expirationTtl: 86400 }).catch(err => {
+              console.error('[cron] Failed to mark security alert as seen:', alert.kvKey, err instanceof Error ? err.message : err)
+            })
+          }
+        }
+      } catch (err) {
+        console.error('[cron] Security monitoring (HN/OSV) failed:', err instanceof Error ? err.message : err)
       }
     }
 
@@ -860,6 +902,15 @@ export default {
             console.warn('[daily-summary] Failed to list reddit keys:', err instanceof Error ? err.message : err)
           }
 
+          // Count security alerts seen today (HN + OSV)
+          let securityCount = 0
+          try {
+            const listed = await env.STATUS_CACHE.list({ prefix: 'security:seen:' })
+            securityCount = listed.keys.length
+          } catch (err) {
+            console.warn('[daily-summary] Failed to list security keys:', err instanceof Error ? err.message : err)
+          }
+
           // Read daily alert counter
           let alertCounts = null
           try {
@@ -920,6 +971,7 @@ export default {
             webhookCounts,
             deliveryCounts,
             redditCount,
+            securityCount,
             vitals: vitalsSummary,
             probeSnapshots,
           })

--- a/worker/src/reddit.ts
+++ b/worker/src/reddit.ts
@@ -11,11 +11,13 @@ export interface RedditPost {
   createdUtc: number
 }
 
+export type RedditAlertType = 'outage' | 'competitive' | 'security'
+
 export interface RedditAlert {
   key: string       // KV dedup key: reddit:seen:{postId}
   subreddit: string
   post: RedditPost
-  competitive: boolean  // true = competitive monitoring, false = outage detection
+  type: RedditAlertType
 }
 
 // Subreddit → search keywords mapping
@@ -32,6 +34,9 @@ const REDDIT_TARGETS: Array<{ subreddit: string; service: string }> = [
   { subreddit: 'devops',          service: '_competitive' },
   { subreddit: 'artificial',      service: '_competitive' },
   { subreddit: 'LocalLLaMA',      service: '_competitive' },
+  // Security monitoring — security communities for AI service breach/vulnerability chatter
+  { subreddit: 'netsec',          service: '_security' },
+  { subreddit: 'cybersecurity',   service: '_security' },
 ]
 
 // Strong signals: always match. Weak signals (issues/errors/slow): require context words
@@ -102,12 +107,30 @@ export function matchesCompetitiveKeywords(title: string): boolean {
   return COMPETITIVE_CONTEXT.test(title) && /\b(ai|llm|api|openai|claude|gpt)\b/i.test(title)
 }
 
+// Security monitoring keywords — match posts about AI service security incidents
+const AI_SERVICE = /\b(openai|claude|anthropic|gemini|google ai|mistral|cohere|deepseek|hugging\s?face|replicate|elevenlabs|cursor|copilot|windsurf|xai|grok)\b/i
+const SECURITY_STRONG = /\b(breach|data leak|hacked|compromised|unauthorized access|CVE-\d{4}|credentials? (leak|expos)|API key (leak|expos)|RCE|remote code execution)\b/i
+const SECURITY_CONTEXT = /\b(security|vulnerab|exploit|injection|exfiltrat|malicious|patch|disclosure)\b/i
+
+const AI_ADJACENT = /\b(ai|llm|model|api|gpt|chatbot|machine learning)\b/i
+
+export function matchesSecurityKeywords(title: string): boolean {
+  // Strong security signal + AI service mention = always match
+  if (SECURITY_STRONG.test(title) && AI_SERVICE.test(title)) return true
+  // Security context + AI service mention = match
+  if (SECURITY_CONTEXT.test(title) && AI_SERVICE.test(title)) return true
+  // Strong security signal + broader AI-adjacent keyword = match (reduces noise from non-AI posts)
+  return SECURITY_STRONG.test(title) && AI_ADJACENT.test(title)
+}
+
 /**
  * Fetch recent posts from a subreddit matching outage keywords
  */
-async function fetchSubreddit(subreddit: string, competitive = false): Promise<RedditPost[]> {
-  const query = competitive
+async function fetchSubreddit(subreddit: string, mode: 'outage' | 'competitive' | 'security' = 'outage'): Promise<RedditPost[]> {
+  const query = mode === 'competitive'
     ? encodeURIComponent('"status monitor" OR "uptime dashboard" OR "api status" OR "is down" OR "status page"')
+    : mode === 'security'
+    ? encodeURIComponent('breach OR leak OR hacked OR vulnerability OR CVE OR "unauthorized access" OR exploit OR "security incident"')
     : encodeURIComponent('down OR "not working" OR outage OR issues OR error')
   const url = `https://www.reddit.com/r/${subreddit}/search.json?q=${query}&sort=new&restrict_sr=on&t=day&limit=5`
 
@@ -139,19 +162,26 @@ export async function detectRedditPosts(
   // Fetch all subreddits in parallel
   const results = await Promise.allSettled(
     REDDIT_TARGETS.map(async (target) => {
-      const isCompetitive = target.service === '_competitive'
-      const posts = await fetchSubreddit(target.subreddit, isCompetitive)
-      return { target, posts, isCompetitive }
+      const mode: RedditAlertType = target.service === '_competitive' ? 'competitive'
+        : target.service === '_security' ? 'security' : 'outage'
+      const posts = await fetchSubreddit(target.subreddit, mode)
+      return { target, posts, mode }
     }),
   )
 
   for (const result of results) {
-    if (result.status !== 'fulfilled') continue
-    const { target, posts, isCompetitive } = result.value
+    if (result.status === 'rejected') {
+      console.error('[reddit] Subreddit fetch failed:', result.reason instanceof Error ? result.reason.message : result.reason)
+      continue
+    }
+    const { target, posts, mode } = result.value
 
     for (const post of posts) {
       // Double-check keywords (Reddit search can be fuzzy)
-      if (isCompetitive ? !matchesCompetitiveKeywords(post.title) : !matchesKeywords(post.title)) continue
+      const matched = mode === 'competitive' ? matchesCompetitiveKeywords(post.title)
+        : mode === 'security' ? matchesSecurityKeywords(post.title)
+        : matchesKeywords(post.title)
+      if (!matched) continue
 
       // Skip old posts (>6h)
       const age = Date.now() / 1000 - post.createdUtc
@@ -159,10 +189,13 @@ export async function detectRedditPosts(
 
       // KV dedup
       const key = `reddit:seen:${post.id}`
-      const seen = await kv.get(key).catch(() => null)
+      const seen = await kv.get(key).catch((err) => {
+        console.error('[reddit] KV dedup read failed:', key, err instanceof Error ? err.message : err)
+        return null  // favor sending potential duplicate over silently dropping alert
+      })
       if (seen) continue
 
-      alerts.push({ key, subreddit: target.subreddit, post, competitive: isCompetitive })
+      alerts.push({ key, subreddit: target.subreddit, post, type: mode })
     }
   }
 
@@ -207,6 +240,20 @@ export function formatCompetitiveAlert(alert: RedditAlert): { title: string; des
     title: `🔍 Competitive: r/${alert.subreddit}`,
     description: `"${alert.post.title}"\nby u/${alert.post.author} · ${alert.post.score} upvotes · ${agoText}`,
     color: 0x8b949e, // gray
+    url: alert.post.url,
+  }
+}
+
+export function formatSecurityAlert(alert: RedditAlert): { title: string; description: string; color: number; url: string } {
+  const ago = Math.floor(Date.now() / 1000 - alert.post.createdUtc)
+  const agoText = ago < 60 ? 'just now'
+    : ago < 3600 ? `${Math.floor(ago / 60)}m ago`
+    : `${Math.floor(ago / 3600)}h ago`
+
+  return {
+    title: `🔒 Security: r/${alert.subreddit}`,
+    description: `"${alert.post.title}"\nby u/${alert.post.author} · ${alert.post.score} upvotes · ${agoText}`,
+    color: 0xf85149, // red — security alerts are high-priority
     url: alert.post.url,
   }
 }

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -1,0 +1,310 @@
+// Security incident monitoring for AI services
+// Sources: Hacker News Algolia API, OSV.dev vulnerability database
+// Runs hourly alongside Reddit security monitoring
+
+// ---------- Types ----------
+
+export interface SecurityAlert {
+  source: 'hackernews' | 'osv'
+  id: string             // HN story ID or OSV vuln ID
+  title: string
+  url: string
+  severity?: 'critical' | 'high' | 'medium' | 'low'
+  kvKey: string          // KV dedup key
+  // OSV-specific remediation info
+  affectedPackage?: string   // e.g. "PyPI/anthropic"
+  affectedRange?: string     // e.g. ">= 0.86.0"
+  fixedVersion?: string      // e.g. "0.87.0"
+  patchUrl?: string          // commit or release URL
+  cweIds?: string[]          // e.g. ["CWE-276"]
+}
+
+// ---------- Hacker News Algolia ----------
+
+const HN_AI_KEYWORDS = [
+  'openai', 'anthropic', 'claude', 'chatgpt', 'gemini', 'mistral',
+  'cohere', 'deepseek', 'huggingface', 'hugging face', 'replicate',
+  'elevenlabs', 'cursor', 'copilot', 'windsurf', 'xai', 'grok',
+]
+
+const HN_SECURITY_KEYWORDS = [
+  'breach', 'leak', 'hacked', 'vulnerability', 'CVE', 'exploit',
+  'unauthorized', 'security incident', 'data exposure', 'compromised',
+  'RCE', 'injection', 'exfiltration',
+]
+
+function buildHNQuery(): string {
+  // "(openai OR anthropic OR claude OR ...) AND (breach OR leak OR ...)"
+  const ai = HN_AI_KEYWORDS.map(k => `"${k}"`).join(' OR ')
+  const sec = HN_SECURITY_KEYWORDS.map(k => `"${k}"`).join(' OR ')
+  return `(${ai}) AND (${sec})`
+}
+
+interface HNHit {
+  objectID: string
+  title: string
+  url: string | null
+  points: number
+  created_at_i: number
+}
+
+export async function fetchHNSecurityPosts(): Promise<SecurityAlert[]> {
+  const oneDayAgo = Math.floor(Date.now() / 1000) - 86400
+  const query = buildHNQuery()
+  const params = new URLSearchParams({
+    query,
+    tags: 'story',
+    numericFilters: `created_at_i>${oneDayAgo}`,
+    hitsPerPage: '10',
+  })
+
+  const res = await fetch(`https://hn.algolia.com/api/v1/search?${params}`, {
+    headers: { 'User-Agent': 'AIWatch/1.0 (ai-watch.dev; security monitoring)' },
+    signal: AbortSignal.timeout(5000),
+  })
+
+  if (!res.ok) {
+    console.error(`[security] HN Algolia returned HTTP ${res.status}`)
+    res.body?.cancel()
+    return []
+  }
+
+  const json = await res.json() as { hits?: HNHit[] }
+  if (!json.hits) return []
+
+  return json.hits
+    .filter(hit => hit.title && hit.objectID)
+    .map(hit => ({
+      source: 'hackernews' as const,
+      id: hit.objectID,
+      title: hit.title,
+      url: hit.url || `https://news.ycombinator.com/item?id=${hit.objectID}`,
+      kvKey: `security:seen:hn:${hit.objectID}`,
+    }))
+}
+
+// ---------- OSV.dev (AI SDK vulnerabilities) ----------
+
+const OSV_PACKAGES = [
+  { name: 'openai', ecosystem: 'PyPI' },
+  { name: 'anthropic', ecosystem: 'PyPI' },
+  { name: 'google-generativeai', ecosystem: 'PyPI' },
+  { name: 'cohere', ecosystem: 'PyPI' },
+  { name: 'mistralai', ecosystem: 'PyPI' },
+  { name: 'langchain', ecosystem: 'PyPI' },
+  { name: 'transformers', ecosystem: 'PyPI' },
+  { name: 'openai', ecosystem: 'npm' },
+  { name: '@anthropic-ai/sdk', ecosystem: 'npm' },
+  { name: '@google/generative-ai', ecosystem: 'npm' },
+]
+
+interface OSVVuln {
+  id: string
+  summary?: string
+  details?: string
+  severity?: Array<{ type: string; score: string }>
+  references?: Array<{ type: string; url: string }>
+  affected?: Array<{
+    package?: { name: string; ecosystem: string }
+    ranges?: Array<{
+      type: string
+      events: Array<{ introduced?: string; fixed?: string }>
+    }>
+  }>
+  database_specific?: { severity?: string; cwe_ids?: string[] }
+  modified: string
+}
+
+// Map OSV severity text label to our severity level
+const SEVERITY_TEXT_MAP: Record<string, SecurityAlert['severity']> = {
+  CRITICAL: 'critical', HIGH: 'high', MODERATE: 'medium', MEDIUM: 'medium', LOW: 'low',
+}
+
+export function mapOSVSeverity(vuln: OSVVuln): SecurityAlert['severity'] {
+  // 1. Try numeric CVSS score (some entries use plain number)
+  for (const s of vuln.severity ?? []) {
+    const numeric = parseFloat(s.score)
+    if (!Number.isNaN(numeric)) {
+      if (numeric >= 9.0) return 'critical'
+      if (numeric >= 7.0) return 'high'
+      if (numeric >= 4.0) return 'medium'
+      return 'low'
+    }
+  }
+  // 2. Fall back to database_specific.severity text (e.g. "MODERATE", "CRITICAL")
+  const textSeverity = vuln.database_specific?.severity?.toUpperCase()
+  if (textSeverity && textSeverity in SEVERITY_TEXT_MAP) {
+    return SEVERITY_TEXT_MAP[textSeverity]!
+  }
+  return 'medium'
+}
+
+export async function fetchOSVAlerts(): Promise<SecurityAlert[]> {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 86400 * 1000).toISOString()
+
+  // Use batch endpoint — single request for all packages
+  const queries = OSV_PACKAGES.map(pkg => ({ package: { name: pkg.name, ecosystem: pkg.ecosystem } }))
+
+  const res = await fetch('https://api.osv.dev/v1/querybatch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'AIWatch/1.0 (ai-watch.dev; security monitoring)' },
+    body: JSON.stringify({ queries }),
+    signal: AbortSignal.timeout(8000),
+  })
+
+  if (!res.ok) {
+    console.error(`[security] OSV.dev returned HTTP ${res.status}`)
+    res.body?.cancel()
+    return []
+  }
+
+  const json = await res.json() as { results?: Array<{ vulns?: OSVVuln[] }> }
+  if (!json.results) return []
+
+  const alerts: SecurityAlert[] = []
+  for (let i = 0; i < json.results.length; i++) {
+    const vulns = json.results[i]?.vulns
+    if (!vulns) continue
+    const pkg = OSV_PACKAGES[i]
+
+    for (const v of vulns) {
+      if (v.modified < sevenDaysAgo) continue
+
+      // Extract remediation info from affected ranges
+      const aff = v.affected?.[0]
+      const range = aff?.ranges?.[0]
+      const introduced = range?.events?.find(e => e.introduced)?.introduced
+      const fixed = range?.events?.find(e => e.fixed)?.fixed
+      const patchUrl = v.references?.find(r =>
+        r.url.includes('/commit/') || r.url.includes('/releases/tag/'),
+      )?.url
+
+      alerts.push({
+        source: 'osv' as const,
+        id: v.id,
+        title: v.summary || `${v.id}: ${pkg.ecosystem}/${pkg.name}`,
+        url: v.references?.find(r => r.type === 'WEB' || r.type === 'ADVISORY')?.url
+          || `https://osv.dev/vulnerability/${v.id}`,
+        severity: mapOSVSeverity(v),
+        kvKey: `security:seen:osv:${v.id}`,
+        affectedPackage: `${pkg.ecosystem}/${pkg.name}`,
+        affectedRange: introduced ? `>= ${introduced}` : undefined,
+        fixedVersion: fixed,
+        patchUrl,
+        cweIds: v.database_specific?.cwe_ids,
+      })
+    }
+  }
+
+  return alerts
+}
+
+// ---------- Orchestrator ----------
+
+export async function detectSecurityAlerts(
+  kv: KVNamespace | null,
+): Promise<SecurityAlert[]> {
+  if (!kv) return []
+
+  const [hnAlerts, osvAlerts] = await Promise.allSettled([
+    fetchHNSecurityPosts(),
+    fetchOSVAlerts(),
+  ])
+
+  if (hnAlerts.status === 'rejected') {
+    console.error('[security] HN Algolia fetch failed:', hnAlerts.reason instanceof Error ? hnAlerts.reason.message : hnAlerts.reason)
+  }
+  if (osvAlerts.status === 'rejected') {
+    console.error('[security] OSV.dev fetch failed:', osvAlerts.reason instanceof Error ? osvAlerts.reason.message : osvAlerts.reason)
+  }
+
+  const allAlerts = [
+    ...(hnAlerts.status === 'fulfilled' ? hnAlerts.value : []),
+    ...(osvAlerts.status === 'fulfilled' ? osvAlerts.value : []),
+  ]
+
+  // KV dedup
+  const newAlerts: SecurityAlert[] = []
+  for (const alert of allAlerts) {
+    const seen = await kv.get(alert.kvKey).catch((err) => {
+      console.error('[security] KV dedup read failed:', alert.kvKey, err instanceof Error ? err.message : err)
+      return null
+    })
+    if (seen) continue
+    newAlerts.push(alert)
+  }
+
+  return newAlerts
+}
+
+// ---------- Discord formatting ----------
+
+const SEVERITY_EMOJI: Record<string, string> = {
+  critical: '🔴',
+  high: '🟠',
+  medium: '🟡',
+  low: '🟢',
+}
+
+function formatOSVLine(alert: SecurityAlert): string {
+  const emoji = SEVERITY_EMOJI[alert.severity || 'medium']
+  const parts = [`${emoji} **${alert.id}** · ${alert.affectedPackage || 'unknown'}`]
+  parts.push(alert.title)
+  if (alert.fixedVersion) {
+    const cmd = alert.affectedPackage?.startsWith('npm/')
+      ? `npm install ${alert.affectedPackage.slice(4)}@${alert.fixedVersion}`
+      : `pip install ${alert.affectedPackage?.split('/')[1] || 'package'}>=${alert.fixedVersion}`
+    parts.push(`→ \`${cmd}\``)
+  } else if (alert.affectedRange) {
+    parts.push(`Affected: ${alert.affectedRange}`)
+  }
+  parts.push(`[Details](${alert.url})`)
+  return parts.join('\n')
+}
+
+function formatHNLine(alert: SecurityAlert): string {
+  const hnUrl = `https://news.ycombinator.com/item?id=${alert.id}`
+  const sourceLink = alert.url !== hnUrl ? ` · [Source](${alert.url})` : ''
+  return `• ${alert.title}\n  [HN](${hnUrl})${sourceLink}`
+}
+
+/**
+ * Format all security alerts into a single Discord embed.
+ * Groups OSV vulnerabilities and HN news into sections.
+ */
+export function formatSecurityDigest(alerts: SecurityAlert[]): {
+  title: string
+  description: string
+  color: number
+} {
+  const osvAlerts = alerts.filter(a => a.source === 'osv')
+  const hnAlerts = alerts.filter(a => a.source === 'hackernews')
+
+  const sections: string[] = []
+
+  if (osvAlerts.length > 0) {
+    sections.push(`**SDK Vulnerabilities (${osvAlerts.length})**`)
+    for (const alert of osvAlerts) {
+      sections.push(formatOSVLine(alert))
+    }
+  }
+
+  if (hnAlerts.length > 0) {
+    if (sections.length > 0) sections.push('')
+    sections.push(`**Security News (${hnAlerts.length})**`)
+    for (const alert of hnAlerts) {
+      sections.push(formatHNLine(alert))
+    }
+  }
+
+  // Color: highest severity wins
+  const hasCritical = osvAlerts.some(a => a.severity === 'critical')
+  const hasHigh = osvAlerts.some(a => a.severity === 'high')
+  const color = hasCritical ? 0xf85149 : hasHigh ? 0xd29922 : 0x8b949e
+
+  return {
+    title: `🔒 Security Alert — ${alerts.length} new finding${alerts.length > 1 ? 's' : ''}`,
+    description: sections.join('\n'),
+    color,
+  }
+}


### PR DESCRIPTION
## Summary

- Add security incident monitoring for AI services via Reddit (r/netsec, r/cybersecurity), HN Algolia, and OSV.dev batch API
- Detect SDK vulnerabilities (PyPI/npm) with remediation info: upgrade commands, patch URLs, affected version ranges
- Send single digest embed to Discord (not individual alerts) with severity-based color coding
- Notify-first ordering: Discord alert sent before KV dedup marking to prevent silent alert loss

## Changes

**New files:**
- `worker/src/security-monitor.ts` — HN Algolia + OSV.dev batch query, CVSS severity mapping (numeric + vector string fallback), digest formatting
- `worker/src/__tests__/security-monitor.test.ts` — mapOSVSeverity boundary tests, formatSecurityDigest tests

**Modified:**
- `worker/src/reddit.ts` — security subreddits, `matchesSecurityKeywords` with AI-adjacent filter, `RedditAlertType` union replacing boolean
- `worker/src/index.ts` — separate try/catch for Reddit vs HN/OSV, digest-style alerts, daily summary security count
- `worker/src/daily-summary.ts` — `securityCount` field
- `worker/src/__tests__/reddit.test.ts` — security keyword + format tests

## Test plan

- [x] `npm run test:worker` — 637 tests passing
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — build OK
- [x] Local API integration test: HN Algolia (200), OSV.dev batch (200), Reddit r/netsec + r/cybersecurity (200)
- [x] Discord digest embed verified locally — single embed with grouped OSV vulnerabilities + HN news
- [ ] Verify Vercel Preview deployment

refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)