### PR TITLE
fix: global internal error detection — silent catch + service count drop (#221)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ When adding a new monitored service, update ALL of the following:
 | `fetch-fail:{svcId}` | counter string | 30min | ~0 (spikes on outage) | RSS fetch consecutive failure counter (3+ → degraded, capped writes) |
 | `component-missing:{svcId}` | counter string | 30min | ~0 (spikes on migration) | Component ID consecutive miss counter (3+ → Discord alert) |
 | `alerted:component-missing:{svcId}` | `"1"` | 24h | ~0 | Component ID mismatch alert dedup |
+| `alerted:service-drop` | `"1"` | 2h | ~0 | Service count drop alert dedup (< 80% of expected) |
 | `alert:count:{YYYY-MM-DD}` | `{ incidents, resolved, down, degraded, recovered }` JSON | 2d | ~1-5 | Daily alert count aggregated in Daily Summary |
 | `webhook:reg:{sha256hash}` | `{ type, registeredAt }` JSON | 30d | ~1/user/day | Active webhook registration (hashed, refreshed on ping) |
 | `alert:proxy:{YYYY-MM-DD}` | `{ discord, slack, failed }` JSON | 2d | ~1 | User webhook delivery counts (approximate, flushed from in-memory by daily summary cron) |

--- a/worker/src/__tests__/service-count-drop.test.ts
+++ b/worker/src/__tests__/service-count-drop.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { detectServiceCountDrop } from '../alerts'
+
+const CONFIGS = Array.from({ length: 30 }, (_, i) => ({ id: `svc${i}` }))
+
+describe('detectServiceCountDrop (#221)', () => {
+  it('returns not dropped when all services present', () => {
+    const ids = CONFIGS.map(c => c.id)
+    const result = detectServiceCountDrop(ids, CONFIGS)
+    expect(result.dropped).toBe(false)
+    expect(result.missing).toEqual([])
+  })
+
+  it('returns not dropped at 80% threshold (24/30)', () => {
+    const ids = CONFIGS.slice(0, 24).map(c => c.id)
+    const result = detectServiceCountDrop(ids, CONFIGS)
+    expect(result.dropped).toBe(false)
+  })
+
+  it('returns dropped below 80% threshold (23/30)', () => {
+    const ids = CONFIGS.slice(0, 23).map(c => c.id)
+    const result = detectServiceCountDrop(ids, CONFIGS)
+    expect(result.dropped).toBe(true)
+    expect(result.missing).toHaveLength(7)
+    expect(result.missing).toContain('svc23')
+    expect(result.missing).toContain('svc29')
+  })
+
+  it('returns dropped for 13/30 services (actual incident scenario)', () => {
+    const ids = CONFIGS.slice(0, 13).map(c => c.id)
+    const result = detectServiceCountDrop(ids, CONFIGS)
+    expect(result.dropped).toBe(true)
+    expect(result.missing).toHaveLength(17)
+  })
+
+  it('returns dropped for 0 services', () => {
+    const result = detectServiceCountDrop([], CONFIGS)
+    expect(result.dropped).toBe(true)
+    expect(result.missing).toHaveLength(30)
+  })
+
+  it('identifies correct missing service IDs', () => {
+    const ids = ['svc0', 'svc5', 'svc10']
+    const result = detectServiceCountDrop(ids, CONFIGS)
+    expect(result.dropped).toBe(true)
+    expect(result.missing).not.toContain('svc0')
+    expect(result.missing).not.toContain('svc5')
+    expect(result.missing).not.toContain('svc10')
+    expect(result.missing).toContain('svc1')
+    expect(result.missing).toContain('svc29')
+  })
+
+  it('supports custom threshold ratio', () => {
+    const ids = CONFIGS.slice(0, 15).map(c => c.id) // 50%
+    // Default 0.8 → dropped
+    expect(detectServiceCountDrop(ids, CONFIGS).dropped).toBe(true)
+    // Custom 0.5 → not dropped (15 >= floor(30*0.5)=15)
+    expect(detectServiceCountDrop(ids, CONFIGS, 0.5).dropped).toBe(false)
+    // Custom 0.5 with 14 → dropped
+    const ids14 = CONFIGS.slice(0, 14).map(c => c.id)
+    expect(detectServiceCountDrop(ids14, CONFIGS, 0.5).dropped).toBe(true)
+  })
+})

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -202,3 +202,16 @@ export function formatDetectionLead(detectedAt: string | null, incidentStartedAt
   if (mins < 1 || mins >= 60) return ''
   return `⚡ **Detection Lead: ${mins}m** — AIWatch detected this before the official report`
 }
+
+/** Detect service count drop — returns missing service IDs if below threshold */
+export function detectServiceCountDrop(
+  returnedIds: string[],
+  expectedConfigs: Array<{ id: string }>,
+  thresholdRatio = 0.8,
+): { dropped: boolean; missing: string[] } {
+  const threshold = Math.floor(expectedConfigs.length * thresholdRatio)
+  if (returnedIds.length >= threshold) return { dropped: false, missing: [] }
+  const returnedSet = new Set(returnedIds)
+  const missing = expectedConfigs.filter(c => !returnedSet.has(c.id)).map(c => c.id)
+  return { dropped: true, missing }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type ServiceStatus } from './services'
 import { calculateAIWatchScore } from './score'
-import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead } from './alerts'
+import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop } from './alerts'
 import { analyzeIncident, refreshOrReanalyze, analysisKey, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
@@ -317,6 +317,29 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
     }
   }
   if (services.length === 0) return empty
+
+  // Service count drop detection (#221) — alert when significantly fewer services than expected
+  const { dropped, missing } = detectServiceCountDrop(services.map(s => s.id), SERVICES)
+  if (dropped) {
+    const dropKey = 'alerted:service-drop'
+    const alreadyAlerted = await env.STATUS_CACHE.get(dropKey).catch(() => null)
+    if (!alreadyAlerted) {
+      try {
+        await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
+          title: `⚠️ Service Count Drop: ${services.length}/${SERVICES.length}`,
+          description: `Only ${services.length} of ${SERVICES.length} services returned.\n\n**Missing (${missing.length}):** ${missing.join(', ')}`,
+          color: 0xFF6600,
+        })
+      } catch (err) {
+        console.error('[cron] service count drop alert failed:', err instanceof Error ? err.message : err)
+      }
+      await kvPut(env.STATUS_CACHE, dropKey, '1', { expirationTtl: 7200 }) // 2h dedup
+    }
+  } else {
+    // Recovery: clear dedup key only if it exists (avoid unnecessary KV writes)
+    const existing = await env.STATUS_CACHE.get('alerted:service-drop').catch(() => null)
+    if (existing) await kvDel(env.STATUS_CACHE, 'alerted:service-drop')
+  }
 
   // Calculate scores for fallback recommendations
   const scored = services.map((svc) => {

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -2,7 +2,7 @@
 
 import type { Incident, ServiceStatus, ServiceConfig, DailyImpactLevel } from './types'
 export type { ServiceStatus } from './types'
-import { fetchWithTimeout, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss } from './utils'
+import { fetchWithTimeout, formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss } from './utils'
 import { isProbeHealthy, type ProbeSnapshot } from './probe'
 import { platformStatusKey, type PlatformStatus } from './platform-monitor'
 import { type StatuspageResponse, normalizeStatus, parseIncidents, parseUptimeData } from './parsers/statuspage'
@@ -147,6 +147,7 @@ interface PrefetchedData {
 
 async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, kv?: KVNamespace): Promise<ServiceStatus> {
   const now = new Date().toISOString()
+  let parseErrors = 0 // Track internal parse/fetch failures — prevents resetFetchFailure from masking repeated errors
   const base: ServiceStatus = {
     id: config.id,
     name: config.name,
@@ -175,7 +176,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         const start = Date.now()
         const [summaryRes, incidentsRes] = await Promise.all([
           fetchWithRetry(config.apiUrl),
-          fetchWithRetry(`${baseUrl}/incidents.json`).catch((err) => { console.warn(`[fetchService] ${config.id} incidents.json failed:`, err.message); return null }),
+          fetchWithRetry(`${baseUrl}/incidents.json`).catch((err) => { console.warn(`[fetchService] ${config.id} incidents.json failed:`, err.message); parseErrors++; return null }),
         ])
         latency = Date.now() - start
         if (!summaryRes.ok) {
@@ -293,8 +294,13 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         }
       }
 
-      // Successful fetch — reset consecutive failure counter
-      await resetFetchFailure(kv, config.id)
+      // Successful fetch — reset or track based on parse errors
+      if (parseErrors > 0) {
+        console.warn(`[fetchService] ${config.id} completed with ${parseErrors} parse error(s)`)
+        await trackFetchFailure(kv, config.id)
+      } else {
+        await resetFetchFailure(kv, config.id)
+      }
 
       return {
         ...base,
@@ -410,12 +416,14 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         scrapeUrl
           ? fetchWithTimeout(scrapeUrl).catch((err) => {
               console.warn(`[fetchService] ${config.id} scrape failed:`, err instanceof Error ? err.message : err)
+              parseErrors++
               return null
             })
           : Promise.resolve(null),
         config.betterStackUrl
           ? fetchWithTimeout(`${config.betterStackUrl}/index.json`, 5000).catch((err) => {
               console.warn(`[fetchService] ${config.id} BetterStack uptime fetch failed:`, err instanceof Error ? err.message : err)
+              parseErrors++
               return null
             })
           : Promise.resolve(null),
@@ -498,6 +506,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
           }
         } catch (err) {
           console.warn(`[fetchService] ${config.id} BetterStack parse failed:`, err instanceof Error ? err.message : err)
+          parseErrors++
         }
       }
 
@@ -511,8 +520,13 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         ? (betterStackStat ?? httpStatus)
         : (hasOngoing ? 'degraded' : httpStatus)
 
-      // Successful fetch — reset consecutive failure counter
-      await resetFetchFailure(kv, config.id)
+      // Successful fetch — reset or track based on parse errors
+      if (parseErrors > 0) {
+        console.warn(`[fetchService] ${config.id} completed with ${parseErrors} parse error(s)`)
+        await trackFetchFailure(kv, config.id)
+      } else {
+        await resetFetchFailure(kv, config.id)
+      }
 
       return {
         ...base,


### PR DESCRIPTION
## Summary
- Add `parseErrors` counter to `fetchService` — internal catch blocks increment counter, success path calls `trackFetchFailure` instead of `resetFetchFailure` when parse errors occurred (prevents masking repeated failures)
- Fix missing `formatDuration` import in `services.ts` (caused runtime `ReferenceError` in BetterStack parse path)
- Add service count drop detection in `cronAlertCheck` — Discord alert when <80% of expected services returned, with KV dedup (2h TTL)
- Add `detectServiceCountDrop` pure function in `alerts.ts` with 7 unit tests

closes #221

## Test plan
- [x] `npx wrangler deploy --dry-run` build passes
- [x] 33 test files, 623 tests all pass (vitest)
- [x] New `service-count-drop.test.ts` covers threshold boundary, real-world scenario (13/30), custom ratio
- [x] PR review: critical (sendDiscordAlert try-catch), important (kvDel every cycle, incidents.json parseErrors) — all fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)