### PR TITLE
fix: security alert dedup TTL 24h→7d + service name in Discord (refs #215)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,8 +238,8 @@ When adding a new monitored service, update ALL of the following:
 | `pending:degraded:{svcId}` | `"1"` | 10min | ~5 | Anti-flapping: 2-cycle consecutive detection |
 | `detected:{svcId}` | ISO timestamp | 7d | ~5 | Detection Lead: earliest detection time (probe spike or status page, whichever is earlier) |
 | `reddit:seen:{postId}` | `"1"` | 24h | ~120 | Reddit post dedup (hourly scan, max 5/hour) |
-| `security:seen:hn:{objectId}` | `"1"` | 24h | ~0 | HN security post dedup |
-| `security:seen:osv:{vulnId}` | `"1"` | 24h | ~0 | OSV.dev vulnerability dedup |
+| `security:seen:hn:{objectId}` | `"1"` | 7d | ~0 | HN security post dedup |
+| `security:seen:osv:{vulnId}` | `"1"` | 7d | ~0 | OSV.dev vulnerability dedup |
 | `ai:analysis:{svcId}:{incId}` | `AIAnalysisResult` JSON | 1h (active) / 2h (resolved) | ~5 per incident | Claude Sonnet per-incident analysis result (TTL refreshed while active; on recovery, `resolvedAt` added instead of deleting — kept 2h for "Recently Resolved" UI) |
 | `ai:reanalysis-skip:{svcId}:{incId}` | `"1"` | 30min | ~2 per incident | Per-incident re-analysis failure cooldown |
 | `ai:usage:{YYYY-MM-DD}` | `{ calls, success, failed }` JSON | 2d | ~5 | Daily AI analysis usage counter (includes re-analysis) |

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -143,4 +143,27 @@ describe('formatSecurityDigest', () => {
     }]
     expect(formatSecurityDigest(alerts).color).toBe(0x8b949e)
   })
+
+  it('includes service name tag in OSV alert format', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'osv', id: 'GHSA-test', title: 'Vuln in transformers',
+      url: 'https://osv.dev/test', severity: 'medium', kvKey: 'k',
+      service: 'Hugging Face', affectedPackage: 'PyPI/transformers',
+    }]
+    const digest = formatSecurityDigest(alerts)
+    expect(digest.description).toContain('[Hugging Face]')
+    expect(digest.description).toContain('GHSA-test')
+  })
+
+  it('omits service tag when service is undefined', () => {
+    const alerts: SecurityAlert[] = [{
+      source: 'osv', id: 'GHSA-noservice', title: 'Generic vuln',
+      url: 'https://osv.dev/x', severity: 'low', kvKey: 'k',
+      affectedPackage: 'PyPI/unknown',
+    }]
+    const digest = formatSecurityDigest(alerts)
+    // Should not contain a service tag like [Hugging Face], but [Details]/[HN] links are expected
+    expect(digest.description).not.toMatch(/\[(?!Details|HN|Source)[A-Z][a-zA-Z ]+\]/)
+    expect(digest.description).toContain('GHSA-noservice')
+  })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -767,7 +767,7 @@ export default {
             color: 0xf85149,
           })
           for (const alert of secReddit) {
-            await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 86400 }).catch(err => {
+            await kvPut(env.STATUS_CACHE, alert.key, '1', { expirationTtl: 604800 }).catch(err => { // 7d dedup
               console.error('[cron] Failed to mark Reddit security alert as seen:', alert.key, err instanceof Error ? err.message : err)
             })
           }
@@ -789,7 +789,7 @@ export default {
           })
           // Then mark as seen
           for (const alert of securityAlerts) {
-            await kvPut(env.STATUS_CACHE, alert.kvKey, '1', { expirationTtl: 86400 }).catch(err => {
+            await kvPut(env.STATUS_CACHE, alert.kvKey, '1', { expirationTtl: 604800 }).catch(err => { // 7d dedup
               console.error('[cron] Failed to mark security alert as seen:', alert.kvKey, err instanceof Error ? err.message : err)
             })
           }

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -12,6 +12,7 @@ export interface SecurityAlert {
   severity?: 'critical' | 'high' | 'medium' | 'low'
   kvKey: string          // KV dedup key
   // OSV-specific remediation info
+  service?: string            // e.g. "Hugging Face" — mapped AIWatch service name
   affectedPackage?: string   // e.g. "PyPI/anthropic"
   affectedRange?: string     // e.g. ">= 0.86.0"
   fixedVersion?: string      // e.g. "0.87.0"
@@ -86,16 +87,16 @@ export async function fetchHNSecurityPosts(): Promise<SecurityAlert[]> {
 // ---------- OSV.dev (AI SDK vulnerabilities) ----------
 
 const OSV_PACKAGES = [
-  { name: 'openai', ecosystem: 'PyPI' },
-  { name: 'anthropic', ecosystem: 'PyPI' },
-  { name: 'google-generativeai', ecosystem: 'PyPI' },
-  { name: 'cohere', ecosystem: 'PyPI' },
-  { name: 'mistralai', ecosystem: 'PyPI' },
-  { name: 'langchain', ecosystem: 'PyPI' },
-  { name: 'transformers', ecosystem: 'PyPI' },
-  { name: 'openai', ecosystem: 'npm' },
-  { name: '@anthropic-ai/sdk', ecosystem: 'npm' },
-  { name: '@google/generative-ai', ecosystem: 'npm' },
+  { name: 'openai', ecosystem: 'PyPI', service: 'OpenAI' },
+  { name: 'anthropic', ecosystem: 'PyPI', service: 'Anthropic (Claude)' },
+  { name: 'google-generativeai', ecosystem: 'PyPI', service: 'Google (Gemini)' },
+  { name: 'cohere', ecosystem: 'PyPI', service: 'Cohere' },
+  { name: 'mistralai', ecosystem: 'PyPI', service: 'Mistral' },
+  { name: 'langchain', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'transformers', ecosystem: 'PyPI', service: 'Hugging Face' },
+  { name: 'openai', ecosystem: 'npm', service: 'OpenAI' },
+  { name: '@anthropic-ai/sdk', ecosystem: 'npm', service: 'Anthropic (Claude)' },
+  { name: '@google/generative-ai', ecosystem: 'npm', service: 'Google (Gemini)' },
 ]
 
 interface OSVVuln {
@@ -187,6 +188,7 @@ export async function fetchOSVAlerts(): Promise<SecurityAlert[]> {
           || `https://osv.dev/vulnerability/${v.id}`,
         severity: mapOSVSeverity(v),
         kvKey: `security:seen:osv:${v.id}`,
+        service: pkg.service,
         affectedPackage: `${pkg.ecosystem}/${pkg.name}`,
         affectedRange: introduced ? `>= ${introduced}` : undefined,
         fixedVersion: fixed,
@@ -248,7 +250,8 @@ const SEVERITY_EMOJI: Record<string, string> = {
 
 function formatOSVLine(alert: SecurityAlert): string {
   const emoji = SEVERITY_EMOJI[alert.severity || 'medium']
-  const parts = [`${emoji} **${alert.id}** · ${alert.affectedPackage || 'unknown'}`]
+  const serviceTag = alert.service ? `[${alert.service}] ` : ''
+  const parts = [`${emoji} ${serviceTag}**${alert.id}** · ${alert.affectedPackage || 'unknown'}`]
   parts.push(alert.title)
   if (alert.fixedVersion) {
     const cmd = alert.affectedPackage?.startsWith('npm/')


### PR DESCRIPTION
## Summary
- Increase security dedup TTL from 24h to 7d — prevents duplicate Discord alerts for same vulnerability/news the next day
- Add service name mapping to OSV packages (e.g. `transformers` → `Hugging Face`)
- Show `[ServiceName]` tag in Discord security alert format for immediate service identification
- Add unit tests for service tag display (positive + negative cases)

refs #215

## Test plan
- [x] 678 tests pass (vitest)
- [x] Build check passes (wrangler dry-run)
- [x] Code review: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)