### PR TITLE
fix: Recently Resolved banner independent of AI analysis (refs #224)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ When adding a new monitored service, update ALL of the following:
 | `alerted:down:{svcId}` | ISO timestamp | 2h | ~2 | Service down alert dedup + recovery duration |
 | `alerted:degraded:{svcId}` | ISO timestamp | 2h | ~2 | Service degraded alert dedup |
 | `alerted:recovered:{svcId}` | `"1"` | 2h | ~2 | Recovery alert dedup |
+| `recovered:{svcId}:{incId}` | `{ resolvedAt, incidentTitle, duration }` JSON | 2h | ~2 | Independent recovery marker (powers Recently Resolved banner without AI analysis) |
 | `alerted:probe-spike:{svcId}` | `"1"` | 1h | ~2 | Probe RTT spike alert dedup (early detection) |
 | `pending:degraded:{svcId}` | `"1"` | 10min | ~5 | Anti-flapping: 2-cycle consecutive detection |
 | `detected:{svcId}` | ISO timestamp | 7d | ~5 | Detection Lead: earliest detection time (probe spike or status page, whichever is earlier) |
@@ -261,7 +262,7 @@ When adding a new monitored service, update ALL of the following:
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 
-**Free tier budget**: 1,000 writes/day. Estimated total: ~843-953 writes/day + changelog (~3/day) + weekly briefing (~1/week) + vitals (1 per visit) + platform status (~1/cycle when changed). Monitor if daily visits exceed ~50.
+**Free tier budget**: 1,000 writes/day. Estimated total: ~845-958 writes/day + changelog (~3/day) + weekly briefing (~1/week) + vitals (1 per visit) + platform status (~1/cycle when changed) + recovery markers (~2-5/day). Monitor if daily visits exceed ~50.
 
 ### Directory Layout
 ```
@@ -429,7 +430,7 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
   - Dedup: sibling services sharing same incidentId copy analysis from KV (no extra API call)
   - Modal groups services with same incidentId into single card
   - API response: `aiAnalysis: Record<svcId, AIAnalysisResult[]>` — array per service
-  - **Recently Resolved**: on recovery, per-incident analysis keys get `resolvedAt` field (2h TTL instead of deletion). `/api/status` returns `recentlyRecovered[]` for operational services with resolved analysis. Dashboard shows info banner + "Resolved" badge on service cards + Analyze modal remains active
+  - **Recently Resolved**: on recovery, cron writes independent `recovered:{svcId}:{incId}` KV (2h TTL) regardless of AI analysis. Also marks per-incident analysis keys with `resolvedAt` field if they exist. `/api/status` returns `recentlyRecovered: Record<svcId, incId[]>` for operational services with recovery markers. Dashboard shows info banner (service names link to detail page) + "Recently Resolved" badge on specific incidents in ServiceDetails + Analyze modal link only when AI analysis exists. "See details in Analyze" hidden when no AI analysis data
   - **Contextual fallback** (`needsFallback`): AI analysis includes boolean flag assessing if incident warrants switching to alternative. When true, AnalysisModal + Is X Down AI Insight card show Score-based fallback list. Shared `getFallbacks()` utility in `src/utils/constants.js` (used by AnalysisModal + Overview)
   - Grouped fallback: when incident affects multiple categories, Discord alerts + dashboard show per-category alternatives via `buildGroupedFallbackText`
   - **Fallback tier priority** (API services only): same-tier services are recommended first, then adjacent tiers. Within each tier, sorted by AIWatch Score descending. Defined in `worker/src/fallback.ts`, mirrored in `src/utils/constants.js` and `api/is-down.ts`:

--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -506,7 +506,7 @@ const MOCK_AI_ANALYSIS = {
   ],
   together: [{ summary: 'Moonshot Kimi K2.5 model experienced a brief outage affecting inference endpoints. Service has been restored.', estimatedRecovery: 'Resolved', affectedScope: ['Kimi K2.5 inference', 'Model endpoints'], needsFallback: false, analyzedAt: new Date(Date.now() - 30 * 60000).toISOString(), incidentId: 'together-mock-1', resolvedAt: new Date(Date.now() - 10 * 60000).toISOString() }],
 }
-const MOCK_RECENTLY_RECOVERED = ['together']
+const MOCK_RECENTLY_RECOVERED = { together: ['together-mock-1'] }
 
 // ── Merge live Worker data with mock fallback ──
 // Worker provides: id, name, provider, category, status, latency, incidents
@@ -565,7 +565,7 @@ function usePollingInternal() {
     probe24h: [],
     probeServiceIds: [],
     aiAnalysis: {},
-    recentlyRecovered: [],
+    recentlyRecovered: {},
   })
   const cancelledRef = useRef(false)
   const controllerRef = useRef(null)
@@ -655,7 +655,7 @@ function usePollingInternal() {
           probe24h: probeSnapshots,
           probeServiceIds,
           aiAnalysis: data.aiAnalysis ?? {},
-          recentlyRecovered: data.recentlyRecovered ?? [],
+          recentlyRecovered: data.recentlyRecovered ?? {},
         })
       }
     } catch (err) {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -69,7 +69,7 @@ const en = {
   'overview.banner.monitoringCount': 'Monitoring ({n}):',
   'overview.banner.healthy': 'Healthy alternatives:',
   'overview.card.incidents.compact': ' inc',
-  'overview.recovered': 'Resolved',
+  'overview.recovered': 'Recently Resolved',
   'overview.recentlyResolved': 'Recently Resolved',
   'overview.seeAnalysis': 'See details in Analyze',
   'analysis.recoveredAt': 'Recovered',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -69,7 +69,7 @@ const ko = {
   'overview.banner.monitoringCount': '모니터링 ({n}):',
   'overview.banner.healthy': '정상 대안:',
   'overview.card.incidents.compact': '건',
-  'overview.recovered': 'Resolved',
+  'overview.recovered': '최근 복구',
   'overview.recentlyResolved': '최근 복구됨',
   'overview.seeAnalysis': '분석 상세 보기',
   'analysis.recoveredAt': '복구 시각',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -421,7 +421,7 @@ function ActionBanner({ services, setPage, t }) {
 export default function Overview() {
   const { t, lang } = useLang()
   const { setPage, categoryFilter, setCategoryFilter } = usePage()
-  const { services: allServices, loading, error, lastUpdated, refresh, recentlyRecovered } = usePolling()
+  const { services: allServices, loading, error, lastUpdated, refresh, recentlyRecovered, aiAnalysis } = usePolling()
   const { settings } = useSettings()
   const services = allServices.filter((s) => settings.enabledServices.includes(s.id))
   const [filter, setFilter] = useState('all')
@@ -503,7 +503,7 @@ export default function Overview() {
       <ActionBanner services={services} setPage={setPage} t={t} />
 
       {/* ── Recently Resolved Banner ── */}
-      {recentlyRecovered.length > 0 && (
+      {Object.keys(recentlyRecovered).some(id => services.find(s => s.id === id)) && (
         <div className="rounded-lg border" style={{ borderColor: 'var(--blue)', background: 'var(--blue-dim)', padding: '12px 16px' }}>
           <div className="flex items-center gap-2 flex-wrap text-[12px]">
             <span style={{ color: 'var(--blue)' }}>✓</span>
@@ -511,15 +511,28 @@ export default function Overview() {
               {t('overview.recentlyResolved')}
             </span>
             <span className="text-[var(--text1)]">
-              {recentlyRecovered.map(id => services.find(s => s.id === id)?.name).filter(Boolean).join(', ')}
+              {Object.keys(recentlyRecovered).map(id => {
+                const svc = services.find(s => s.id === id)
+                if (!svc) return null
+                return (
+                  <span
+                    key={id}
+                    className="cursor-pointer hover:underline"
+                    style={{ color: 'var(--blue)' }}
+                    onClick={() => setPage({ name: 'service', serviceId: id })}
+                  >{svc.name}</span>
+                )
+              }).filter(Boolean).reduce((acc, el, i) => i === 0 ? [el] : [...acc, ', ', el], [])}
             </span>
-            <span
-              className="mono text-[10px] cursor-pointer hover:underline"
-              style={{ color: 'var(--blue)' }}
-              onClick={() => window.dispatchEvent(new CustomEvent('open-analysis'))}
-            >
-              🤖 {t('overview.seeAnalysis')}
-            </span>
+            {Object.keys(recentlyRecovered).some(id => aiAnalysis[id]) && (
+              <span
+                className="mono text-[10px] cursor-pointer hover:underline"
+                style={{ color: 'var(--blue)' }}
+                onClick={() => window.dispatchEvent(new CustomEvent('open-analysis'))}
+              >
+                🤖 {t('overview.seeAnalysis')}
+              </span>
+            )}
           </div>
         </div>
       )}
@@ -552,7 +565,7 @@ export default function Overview() {
               service={svc}
               index={i}
               t={t}
-              isRecovered={recentlyRecovered.includes(svc.id)}
+              isRecovered={!!recentlyRecovered[svc.id]}
               onClick={() => { trackEvent('select_service', { service_id: svc.id }); setPage({ name: 'service', serviceId: svc.id }) }}
             />
           ))}
@@ -575,7 +588,7 @@ export default function Overview() {
                 service={svc}
                 index={i}
                 t={t}
-                isRecovered={recentlyRecovered.includes(svc.id)}
+                isRecovered={!!recentlyRecovered[svc.id]}
                 onClick={() => { trackEvent('select_service', { service_id: svc.id }); setPage({ name: 'service', serviceId: svc.id }) }}
               />
             ))}

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -210,7 +210,7 @@ function ServiceLatencyTrend({ service, t, hourlyData }) {
   )
 }
 
-function IncidentRow({ incident, detectedAt, t, lang }) {
+function IncidentRow({ incident, detectedAt, isRecentlyRecovered, t, lang }) {
   const [expanded, setExpanded] = useState(false)
   const STATUS_CLS = {
     investigating: 'text-[var(--red)]',
@@ -272,9 +272,15 @@ function IncidentRow({ incident, detectedAt, t, lang }) {
             {incident.duration ? ` · ${incident.duration}` : ''}
           </p>
         </div>
-        <span className={`shrink-0 text-[10px] mono ${dotCls}`}>
-          {t(`incidents.status.${displayStatus}`)}
-        </span>
+        {isRecentlyRecovered ? (
+          <span className="shrink-0 mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '1px 5px' }}>
+            {t('overview.recovered')}
+          </span>
+        ) : (
+          <span className={`shrink-0 text-[10px] mono ${dotCls}`}>
+            {t(`incidents.status.${displayStatus}`)}
+          </span>
+        )}
       </div>
       {expanded && (
         <div className="ml-6">
@@ -654,7 +660,7 @@ export default function ServiceDetails({ serviceId }) {
           )}
         </div>
         <div className="flex items-center gap-1.5">
-          {recentlyRecovered.includes(service.id) && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
+          {!!recentlyRecovered[service.id] && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
           <StatusPill status={service.status} />
         </div>
       </div>
@@ -780,7 +786,7 @@ export default function ServiceDetails({ serviceId }) {
             ) : (
               <div className="flex flex-col" style={{ gap: '8px' }}>
                 {recentIncidents.map((inc) => (
-                  <IncidentRow key={inc.id} incident={inc} detectedAt={service.detectedAt} t={t} lang={lang} />
+                  <IncidentRow key={inc.id} incident={inc} detectedAt={service.detectedAt} isRecentlyRecovered={!!(recentlyRecovered[service.id] ?? []).includes(inc.id)} t={t} lang={lang} />
                 ))}
               </div>
             )}

--- a/worker/src/__tests__/recently-recovered.test.ts
+++ b/worker/src/__tests__/recently-recovered.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { formatDuration } from '../utils'
 
 // Test the resolvedAt marking behavior and recentlyRecovered logic
 
@@ -33,79 +34,215 @@ describe('AI analysis resolvedAt marking', () => {
   })
 })
 
-describe('recentlyRecovered filtering', () => {
+describe('recentlyRecovered filtering (Record<svcId, incId[]> format)', () => {
   const services = [
-    { id: 'claude', status: 'operational' },
-    { id: 'openai', status: 'degraded' },
-    { id: 'together', status: 'operational' },
-    { id: 'gemini', status: 'operational' },
+    { id: 'claude', status: 'operational', incidents: [] as { id: string }[] },
+    { id: 'openai', status: 'degraded', incidents: [{ id: 'oai-1' }] },
+    { id: 'together', status: 'operational', incidents: [{ id: 'tog-1' }] },
+    { id: 'gemini', status: 'operational', incidents: [] as { id: string }[] },
   ]
 
-  const aiAnalysis: Record<string, { resolvedAt?: string; incidentId: string }> = {
-    together: { resolvedAt: '2026-03-30T11:00:00Z', incidentId: 'tog-1' },
-  }
-
-  it('includes operational services with resolvedAt in recentlyRecovered', () => {
-    const activeAnalysis: Record<string, unknown> = {} // no active incidents
-    const recentlyRecovered: string[] = []
+  it('includes operational services with recovered KV in recentlyRecovered', () => {
+    const aiAnalysis: Record<string, unknown> = {}
+    const recoveredKV: Record<string, string> = {
+      'recovered:together:tog-1': '{}',
+    }
+    const recentlyRecovered: Record<string, string[]> = {}
 
     for (const svc of services) {
       if (svc.status !== 'operational') continue
-      if (activeAnalysis[svc.id]) continue
-      const analysis = aiAnalysis[svc.id]
-      if (analysis?.resolvedAt) {
-        recentlyRecovered.push(svc.id)
+      if (aiAnalysis[svc.id]) continue
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
+        }
       }
     }
 
-    expect(recentlyRecovered).toEqual(['together'])
+    expect(recentlyRecovered).toEqual({ together: ['tog-1'] })
   })
 
   it('excludes non-operational services from recentlyRecovered', () => {
-    const nonOpAnalysis: Record<string, { resolvedAt?: string }> = {
-      openai: { resolvedAt: '2026-03-30T11:00:00Z' },
+    const recoveredKV: Record<string, string> = {
+      'recovered:openai:oai-1': '{}',
     }
-    const recentlyRecovered: string[] = []
+    const recentlyRecovered: Record<string, string[]> = {}
 
     for (const svc of services) {
       if (svc.status !== 'operational') continue
-      const analysis = nonOpAnalysis[svc.id]
-      if (analysis?.resolvedAt) {
-        recentlyRecovered.push(svc.id)
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          recentlyRecovered[svc.id].push(inc.id)
+        }
       }
     }
 
-    expect(recentlyRecovered).toEqual([])
+    expect(recentlyRecovered).toEqual({})
   })
 
   it('excludes services already in active analysis', () => {
-    const activeAnalysis: Record<string, unknown> = { together: { incidentId: 'tog-2' } }
-    const recentlyRecovered: string[] = []
+    const aiAnalysis: Record<string, unknown> = { together: [{ incidentId: 'tog-2' }] }
+    const recoveredKV: Record<string, string> = {
+      'recovered:together:tog-1': '{}',
+    }
+    const recentlyRecovered: Record<string, string[]> = {}
 
     for (const svc of services) {
       if (svc.status !== 'operational') continue
-      if (activeAnalysis[svc.id]) continue
-      const analysis = aiAnalysis[svc.id]
-      if (analysis?.resolvedAt) {
-        recentlyRecovered.push(svc.id)
+      if (aiAnalysis[svc.id]) continue
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          recentlyRecovered[svc.id].push(inc.id)
+        }
       }
     }
 
-    expect(recentlyRecovered).toEqual([])
+    expect(recentlyRecovered).toEqual({})
   })
 
-  it('returns empty when no resolved analyses exist', () => {
-    const emptyAnalysis: Record<string, { resolvedAt?: string }> = {}
-    const recentlyRecovered: string[] = []
+  it('returns empty when no recovered KV exists', () => {
+    const recoveredKV: Record<string, string> = {}
+    const recentlyRecovered: Record<string, string[]> = {}
 
     for (const svc of services) {
       if (svc.status !== 'operational') continue
-      const analysis = emptyAnalysis[svc.id]
-      if (analysis?.resolvedAt) {
-        recentlyRecovered.push(svc.id)
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          recentlyRecovered[svc.id].push(inc.id)
+        }
       }
     }
 
-    expect(recentlyRecovered).toEqual([])
+    expect(recentlyRecovered).toEqual({})
+  })
+})
+
+// Test independent recovered:{svcId}:{incId} KV marker logic (#224)
+describe('independent recovery KV marker', () => {
+  it('builds correct recovery marker payload', () => {
+    const now = '2026-04-13T02:40:00Z'
+    const incident = {
+      id: 'inc-123',
+      title: 'Moonshot Kimi K2.5',
+      startedAt: '2026-04-13T02:23:00Z',
+    }
+    const duration = formatDuration(new Date(incident.startedAt), new Date(now))
+    const marker = {
+      resolvedAt: now,
+      incidentTitle: incident.title,
+      duration,
+    }
+    expect(marker.resolvedAt).toBe(now)
+    expect(marker.incidentTitle).toBe('Moonshot Kimi K2.5')
+    expect(marker.duration).toBe('17m')
+  })
+
+  it('handles missing startedAt gracefully', () => {
+    const now = '2026-04-13T02:40:00Z'
+    const incident = { id: 'inc-456', title: 'Some outage', startedAt: undefined }
+    const duration = incident.startedAt ? formatDuration(new Date(incident.startedAt), new Date(now)) : undefined
+    const marker = {
+      resolvedAt: now,
+      incidentTitle: incident.title,
+      duration: duration ?? '',
+    }
+    expect(marker.duration).toBe('')
+  })
+
+  it('recovery marker provides recentlyRecovered with incident IDs independent of AI analysis', () => {
+    const services = [
+      { id: 'together', status: 'operational', incidents: [{ id: 'inc-1', resolvedAt: '2026-04-13T02:40:00Z' }] },
+      { id: 'claude', status: 'operational', incidents: [] as { id: string }[] },
+    ]
+    const aiAnalysis: Record<string, unknown[]> = {}
+    const recoveredKV: Record<string, string> = {
+      'recovered:together:inc-1': JSON.stringify({ resolvedAt: '2026-04-13T02:40:00Z', incidentTitle: 'Kimi K2.5', duration: '17m' }),
+    }
+
+    const recentlyRecovered: Record<string, string[]> = {}
+    for (const svc of services) {
+      if (svc.status !== 'operational') continue
+      if (aiAnalysis[svc.id]) continue
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
+        }
+      }
+    }
+
+    expect(recentlyRecovered).toEqual({ together: ['inc-1'] })
+  })
+
+  it('excludes monitoring status from recentlyRecovered', () => {
+    const services = [
+      { id: 'together', status: 'monitoring', incidents: [{ id: 'inc-1', resolvedAt: '2026-04-13T02:40:00Z' }] },
+    ]
+    const recoveredKV: Record<string, string> = {
+      'recovered:together:inc-1': JSON.stringify({ resolvedAt: '2026-04-13T02:40:00Z' }),
+    }
+
+    const recentlyRecovered: Record<string, string[]> = {}
+    for (const svc of services) {
+      if (svc.status !== 'operational') continue
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          recentlyRecovered[svc.id].push(inc.id)
+        }
+      }
+    }
+
+    expect(recentlyRecovered).toEqual({})
+  })
+
+  it('tracks multiple recovered incidents per service', () => {
+    const services = [
+      { id: 'together', status: 'operational', incidents: [
+        { id: 'inc-1', resolvedAt: '2026-04-13T02:40:00Z' },
+        { id: 'inc-2', resolvedAt: '2026-04-13T02:45:00Z' },
+        { id: 'inc-3', resolvedAt: '2026-04-13T01:00:00Z' },
+      ]},
+    ]
+    const recoveredKV: Record<string, string> = {
+      'recovered:together:inc-1': '{}',
+      'recovered:together:inc-2': '{}',
+      // inc-3 has no recovered KV (older, TTL expired)
+    }
+
+    const recentlyRecovered: Record<string, string[]> = {}
+    for (const svc of services) {
+      if (svc.status !== 'operational') continue
+      for (const inc of svc.incidents) {
+        if (recoveredKV[`recovered:${svc.id}:${inc.id}`]) {
+          if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+          if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
+        }
+      }
+    }
+
+    expect(recentlyRecovered).toEqual({ together: ['inc-1', 'inc-2'] })
+    expect(recentlyRecovered['together']).not.toContain('inc-3')
+  })
+
+  it('only marks specific incident, not all resolved incidents for the service', () => {
+    // This is the key test for #224: only the incident with recovered KV gets marked
+    const recentlyRecovered: Record<string, string[]> = { together: ['inc-1'] }
+    const incidents = [
+      { id: 'inc-1', status: 'resolved' },
+      { id: 'inc-2', status: 'resolved' },
+      { id: 'inc-3', status: 'resolved' },
+    ]
+
+    const markedIncidents = incidents.filter(inc =>
+      (recentlyRecovered['together'] ?? []).includes(inc.id)
+    )
+
+    expect(markedIncidents).toHaveLength(1)
+    expect(markedIncidents[0].id).toBe('inc-1')
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,7 +6,7 @@ import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type Serv
 import { calculateAIWatchScore } from './score'
 import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop } from './alerts'
 import { analyzeIncident, refreshOrReanalyze, analysisKey, type AIAnalysisResult } from './ai-analysis'
-import { kvPut, kvDel, detectComponentMismatches, isCacheStale } from './utils'
+import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 
 interface Env {
@@ -459,22 +459,35 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
       const svcId = alert.key.split(':').pop()!
       await kvDel(env.STATUS_CACHE, `alerted:recovered:${svcId}`)
     }
-    // Mark AI analyses as resolved (keep for 2h instead of deleting) — per-incident keys
+    // Mark recovery: write independent recovered:{svcId}:{incId} KV + update AI analysis if exists
     if (isRecoveryAlert) {
       const svcId = alert.key.replace('alerted:recovered:', '')
       const svc = scored.find(s => s.id === svcId)
-      const incidentIds = (svc?.incidents ?? []).map(i => i.id)
-      await Promise.all(incidentIds.map(async (incId) => {
-        const key = analysisKey(svcId, incId)
+      const now = new Date().toISOString()
+      const incidents = svc?.incidents ?? []
+      await Promise.all(incidents.map(async (inc) => {
+        // Independent recovery marker (works even without AI analysis)
+        const duration = inc.startedAt ? formatDuration(new Date(inc.startedAt), new Date(now)) : undefined
+        const recoveredOk = await kvPut(env.STATUS_CACHE, `recovered:${svcId}:${inc.id}`, JSON.stringify({
+          resolvedAt: now,
+          incidentTitle: inc.title ?? '',
+          duration: duration ?? '',
+        }), { expirationTtl: 7200 })
+        if (!recoveredOk) console.error('[cron] failed to write recovery marker:', svcId, inc.id)
+        // Also mark AI analysis as resolved if it exists
+        const key = analysisKey(svcId, inc.id)
         const analysisRaw = await env.STATUS_CACHE.get(key).catch(() => null)
         if (!analysisRaw) return
         try {
           const analysis = JSON.parse(analysisRaw) as AIAnalysisResult
           if (!analysis.resolvedAt) {
-            analysis.resolvedAt = new Date().toISOString()
+            analysis.resolvedAt = now
             await kvPut(env.STATUS_CACHE, key, JSON.stringify(analysis), { expirationTtl: 7200 })
           }
-        } catch { await kvDel(env.STATUS_CACHE, key) }
+        } catch (err) {
+          console.warn('[kv] ai:analysis parse failed during recovery mark:', svcId, inc.id, err instanceof Error ? err.message : err)
+          await kvDel(env.STATUS_CACHE, key)
+        }
       }))
     }
 
@@ -1496,7 +1509,7 @@ export default {
 
         // Read AI analysis (per-incident keys) — uses filtered incident list
         const aiAnalysis: Record<string, AIAnalysisResult[]> = {}
-        const recentlyRecovered: string[] = []
+        const recentlyRecovered: Record<string, string[]> = {}
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
         // monitoring = "recovery confirmed" — exclude from active analysis display
         const withActiveInc = cached.services.filter(s =>
@@ -1513,13 +1526,19 @@ export default {
             } catch (err) { console.warn('[kv] ai:analysis parse failed:', svc.id, inc.id, err instanceof Error ? err.message : err) }
           })
         ))
-        // Recently recovered: operational services with resolved analysis in per-incident keys
-        // Only check recently resolved incidents — ai:analysis keys have max 2h TTL after resolvedAt,
-        // so only incidents resolved in the last 3h could still have analysis data in KV
+        // Recently recovered: operational services with recovered:{svcId}:{incId} KV (independent of AI analysis)
+        // Also check ai:analysis keys for enrichment (resolved analysis data for modal display)
         const recoveryCutoff = Date.now() - 3 * 3600_000
         const operationalCached = cached.services.filter(s => s.status === 'operational' && !aiAnalysis[s.id])
         await Promise.all(operationalCached.flatMap(svc =>
           (svc.incidents ?? []).filter(i => i.resolvedAt && new Date(i.resolvedAt).getTime() >= recoveryCutoff).map(async (inc) => {
+            // Check independent recovery marker first
+            const recoveredRaw = await env.STATUS_CACHE!.get(`recovered:${svc.id}:${inc.id}`).catch(() => null)
+            if (recoveredRaw) {
+              if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+              if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
+            }
+            // Also check AI analysis for enrichment (optional — banner shows regardless)
             const raw = await env.STATUS_CACHE!.get(analysisKey(svc.id, inc.id)).catch(() => null)
             if (!raw) return
             try {
@@ -1527,9 +1546,10 @@ export default {
               if (parsed.resolvedAt) {
                 if (!aiAnalysis[svc.id]) aiAnalysis[svc.id] = []
                 aiAnalysis[svc.id].push(parsed)
-                if (!recentlyRecovered.includes(svc.id)) recentlyRecovered.push(svc.id)
+                if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+                if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
               }
-            } catch { /* ignore */ }
+            } catch (err) { console.warn('[kv] ai:analysis parse failed:', svc.id, inc.id, err instanceof Error ? err.message : err) }
           })
         ))
 
@@ -1546,7 +1566,7 @@ export default {
           latency24h,
           ...(probe24h.length > 0 ? { probe24h } : {}),
           ...(Object.keys(aiAnalysis).length > 0 ? { aiAnalysis } : {}),
-          ...(recentlyRecovered.length > 0 ? { recentlyRecovered } : {}),
+          ...(Object.keys(recentlyRecovered).length > 0 ? { recentlyRecovered } : {}),
         }), {
           status: 200,
           headers: { ...cors, 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=30' },
@@ -1682,7 +1702,7 @@ export default {
 
       // Read AI analysis from KV — per-incident keys, active incidents + recently resolved
       const aiAnalysis: Record<string, AIAnalysisResult[]> = {}
-      const recentlyRecovered: string[] = []
+      const recentlyRecovered: Record<string, string[]> = {}
       if (env.STATUS_CACHE) {
         // Active incidents: read ai:analysis:{svcId}:{incId} for each
         // monitoring = "recovery confirmed" — exclude from active analysis display
@@ -1700,10 +1720,19 @@ export default {
             } catch (err) { console.warn('[kv] ai:analysis parse failed:', svc.id, inc.id, err instanceof Error ? err.message : err) }
           })
         ))
-        // Recently recovered: operational services with resolved analysis in per-incident keys
+        // Recently recovered: operational services with recovered:{svcId}:{incId} KV (independent of AI analysis)
+        // Only check recently resolved incidents — recovered: keys have 2h TTL, 3h cutoff for safety margin
+        const recoveryCutoff = Date.now() - 3 * 3600_000
         const operationalSvcs = servicesWithScore.filter(s => s.status === 'operational' && !aiAnalysis[s.id])
         await Promise.all(operationalSvcs.flatMap(svc =>
-          (svc.incidents ?? []).map(async (inc) => {
+          (svc.incidents ?? []).filter(i => i.resolvedAt && new Date(i.resolvedAt).getTime() >= recoveryCutoff).map(async (inc) => {
+            // Check independent recovery marker first
+            const recoveredRaw = await env.STATUS_CACHE!.get(`recovered:${svc.id}:${inc.id}`).catch(() => null)
+            if (recoveredRaw) {
+              if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+              if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
+            }
+            // Also check AI analysis for enrichment (optional — banner shows regardless)
             const raw = await env.STATUS_CACHE!.get(analysisKey(svc.id, inc.id)).catch(() => null)
             if (!raw) return
             try {
@@ -1711,9 +1740,10 @@ export default {
               if (parsed.resolvedAt) {
                 if (!aiAnalysis[svc.id]) aiAnalysis[svc.id] = []
                 aiAnalysis[svc.id].push(parsed)
-                if (!recentlyRecovered.includes(svc.id)) recentlyRecovered.push(svc.id)
+                if (!recentlyRecovered[svc.id]) recentlyRecovered[svc.id] = []
+                if (!recentlyRecovered[svc.id].includes(inc.id)) recentlyRecovered[svc.id].push(inc.id)
               }
-            } catch { /* ignore parse errors */ }
+            } catch (err) { console.warn('[kv] ai:analysis parse failed:', svc.id, inc.id, err instanceof Error ? err.message : err) }
           })
         ))
       }
@@ -1724,7 +1754,7 @@ export default {
         latency24h,
         ...(probe24h.length > 0 ? { probe24h } : {}),
         ...(Object.keys(aiAnalysis).length > 0 ? { aiAnalysis } : {}),
-        ...(recentlyRecovered.length > 0 ? { recentlyRecovered } : {}),
+        ...(Object.keys(recentlyRecovered).length > 0 ? { recentlyRecovered } : {}),
       }), {
         status: 200,
         headers: {


### PR DESCRIPTION
## Summary
- Decouple Recently Resolved banner from AI analysis by writing independent `recovered:{svcId}:{incId}` KV (2h TTL) on recovery detection
- Change `recentlyRecovered` API response from `string[]` to `Record<svcId, incId[]>` for per-incident badge matching
- Service names in banner link to service detail page; "See details in Analyze" only shown when AI analysis exists
- ServiceDetails Incident History shows "Recently Resolved" badge only on the specific recovered incident

refs #224

## Test plan
- [x] Worker unit tests pass (684 tests, including 12 recently-recovered tests)
- [x] Frontend build succeeds
- [x] Wrangler dry-run build check passes
- [ ] Verify Recently Resolved banner on Vercel preview with mock data
- [ ] Verify per-incident badge in ServiceDetails (only matching incident, not all resolved)
- [ ] Verify banner hidden when no AI analysis (no "See details in Analyze" link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)