### PR TITLE
fix: replace N/A recovery display with descriptive text (#230)

### DIFF
--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -3,6 +3,13 @@
 import type { ServiceSEO } from './seo-content'
 import { SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE, RELATED_SLUGS } from './slug-map'
 
+/** Format recovery display — shared with worker/src/ai-analysis.ts */
+function formatRecoveryDisplay(recovery: string): string {
+  if (recovery === 'No historical data for estimation') return 'Monitoring recovery signals...'
+  if (recovery === 'N/A') return 'Exceeded typical pattern'
+  return recovery
+}
+
 interface ServiceData {
   id: string
   name: string
@@ -102,7 +109,7 @@ export function renderPage(
 ): string {
   const title = `Is ${seo.displayName} Down? Live Status | AIWatch`
   const desc = (aiInsight && service && service.status !== 'operational')
-    ? `${seo.displayName} is currently ${statusLabel(service.status).toLowerCase()}. AI Analysis: ${aiInsight.summary.slice(0, 120)} Est. recovery: ${aiInsight.estimatedRecovery}.`
+    ? `${seo.displayName} is currently ${statusLabel(service.status).toLowerCase()}. AI Analysis: ${aiInsight.summary.slice(0, 120)} Est. recovery: ${formatRecoveryDisplay(aiInsight.estimatedRecovery)}.`
     : service
     ? `Check if ${seo.displayName} is down right now. Current status: ${statusLabel(service.status)}. ${typeof service.uptime30d === 'number' && !Number.isNaN(service.uptime30d) ? `30-day uptime: ${service.uptime30d.toFixed(2)}%.` : ''} Updated every 5 minutes.`
     : `Check if ${seo.displayName} is down right now. Real-time status monitoring by AIWatch.`
@@ -257,9 +264,7 @@ function renderAIInsight(insight?: { summary: string; estimatedRecovery: string;
   if (!insight) return ''
   const ago = Math.floor((Date.now() - new Date(insight.analyzedAt).getTime()) / 60000)
   const agoText = ago < 1 ? 'just now' : ago < 60 ? `${ago}m ago` : `${Math.floor(ago / 60)}h ago`
-  const recovery = insight.estimatedRecovery === 'No historical data for estimation'
-    ? 'Monitoring recovery signals...'
-    : insight.estimatedRecovery
+  const recovery = formatRecoveryDisplay(insight.estimatedRecovery)
   const isResolved = serviceStatus === 'operational'
   const isRecentlyRecovered = isResolved && !!insight.resolvedAt
   const resolvedBadge = isResolved
@@ -449,7 +454,7 @@ function renderShareButtons(seo: ServiceSEO, service: ServiceData | null, canoni
 
   // Status-based share templates — randomly selected per render for variety
   // Include AI analysis when available
-  const aiSuffix = aiInsight ? `\nAI Analysis: ${aiInsight.summary.slice(0, 100)}. Est. recovery: ${aiInsight.estimatedRecovery}.` : ''
+  const aiSuffix = aiInsight ? `\nAI Analysis: ${aiInsight.summary.slice(0, 100)}. Est. recovery: ${formatRecoveryDisplay(aiInsight.estimatedRecovery)}.` : ''
   const n = seo.displayName
   const downTexts = [
     `Is ${n} down? Current status: Major Outage.`,

--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -117,7 +117,9 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
                       <div className="mono text-[10px] text-[var(--text2)]" style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                         <span>⏱ <strong style={{ color: 'var(--text1)' }}>{lang === 'ko' ? '예상 복구' : 'Est. Recovery'}:</strong> {analysis.estimatedRecovery === 'No historical data for estimation'
                           ? (lang === 'ko' ? '복구 신호 모니터링 중...' : 'Monitoring recovery signals...')
-                          : analysis.estimatedRecovery}
+                          : analysis.estimatedRecovery === 'N/A'
+                            ? (lang === 'ko' ? '일반 패턴 초과 — 예측 불가' : 'Exceeded typical pattern')
+                            : analysis.estimatedRecovery}
                         </span>
                         {analysis.affectedScope?.length > 0 && (
                           <span>📡 <strong style={{ color: 'var(--text1)' }}>{lang === 'ko' ? '영향 범위' : 'Scope'}:</strong> {analysis.affectedScope.join(', ')}</span>

--- a/worker/src/__tests__/ai-analysis.test.ts
+++ b/worker/src/__tests__/ai-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, parseRecoveryHours, type KVLike } from '../ai-analysis'
+import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, parseRecoveryHours, formatRecoveryDisplay, type KVLike } from '../ai-analysis'
 import type { Incident, ServiceStatus } from '../types'
 
 const mockIncident = (overrides: Partial<Incident> = {}): Incident => ({
@@ -1105,5 +1105,26 @@ describe('parseRecoveryHours', () => {
 
   it('handles hyphen as range separator', () => {
     expect(parseRecoveryHours('2-4h')).toBe(4)
+  })
+})
+
+describe('formatRecoveryDisplay', () => {
+  it('replaces N/A with user-friendly text', () => {
+    expect(formatRecoveryDisplay('N/A')).toBe('Exceeded typical pattern')
+  })
+
+  it('replaces no-historical-data text', () => {
+    expect(formatRecoveryDisplay('No historical data for estimation')).toBe('Monitoring recovery signals...')
+  })
+
+  it('passes through normal recovery times', () => {
+    expect(formatRecoveryDisplay('1–3h')).toBe('1–3h')
+    expect(formatRecoveryDisplay('30m–1h')).toBe('30m–1h')
+    expect(formatRecoveryDisplay('5–10m')).toBe('5–10m')
+  })
+
+  it('passes through single values', () => {
+    expect(formatRecoveryDisplay('~1h')).toBe('~1h')
+    expect(formatRecoveryDisplay('Resolved')).toBe('Resolved')
   })
 })

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -65,6 +65,16 @@ export function parseRecoveryHours(recovery: string): number | null {
   return hours > 0 ? Math.round(hours * 100) / 100 : null
 }
 
+/**
+ * Format recovery display text — replaces raw AI output with user-friendly text.
+ * "N/A" → "Exceeded typical pattern", "No historical data..." → "Monitoring recovery signals..."
+ */
+export function formatRecoveryDisplay(recovery: string): string {
+  if (recovery === 'No historical data for estimation') return 'Monitoring recovery signals...'
+  if (recovery === 'N/A') return 'Exceeded typical pattern'
+  return recovery
+}
+
 /** Centralized KV key for per-incident analysis */
 export function analysisKey(svcId: string, incId: string): string {
   return `ai:analysis:${svcId}:${incId}`

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5,7 +5,7 @@
 import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type ServiceStatus } from './services'
 import { calculateAIWatchScore } from './score'
 import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop } from './alerts'
-import { analyzeIncident, refreshOrReanalyze, analysisKey, type AIAnalysisResult } from './ai-analysis'
+import { analyzeIncident, refreshOrReanalyze, analysisKey, formatRecoveryDisplay, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 
@@ -517,7 +517,7 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
               usage.success++
               const kvOk = await kvPut(env.STATUS_CACHE, analysisKey(svc.id, inc.id), JSON.stringify(analysis), { expirationTtl: 3600 })
               if (kvOk) {
-                analysisSection = `\n${DIV}\n🤖 **AI ANALYSIS** [Beta]\n${analysis.summary}\n⏱ Est. recovery: ${analysis.estimatedRecovery}${analysis.affectedScope.length > 0 ? `\n📡 Scope: ${analysis.affectedScope.join(', ')}` : ''}`
+                analysisSection = `\n${DIV}\n🤖 **AI ANALYSIS** [Beta]\n${analysis.summary}\n⏱ Est. recovery: ${formatRecoveryDisplay(analysis.estimatedRecovery)}${analysis.affectedScope.length > 0 ? `\n📡 Scope: ${analysis.affectedScope.join(', ')}` : ''}`
               }
             } else {
               usage.failed++


### PR DESCRIPTION
## Summary
- Replace raw `N/A` in AI Analysis recovery time with "Exceeded typical pattern" (EN) / "일반 패턴 초과 — 예측 불가" (KO)
- Extract `formatRecoveryDisplay()` utility to avoid duplication across Discord embed, Is X Down, and dashboard modal
- Add 4 unit tests for the new utility

closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)