### PR TITLE
fix: cancel unconsumed response bodies to prevent deadlock (refs #233)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -146,6 +146,7 @@ async function writeProbeSnapshot(kv: KVNamespace): Promise<void> {
         signal: AbortSignal.timeout(5000),
       })
       data[id] = { status: res.status, rtt: Date.now() - start }
+      res.body?.cancel()
     } catch (err) {
       console.warn(`[probe] fetch failed for ${id}:`, err instanceof Error ? err.message : err)
       data[id] = failedProbe()
@@ -252,6 +253,8 @@ async function sendDiscordAlert(webhookUrl: string, embed: { title: string; desc
     })
     if (!resp.ok) {
       console.error(`[discord] webhook returned ${resp.status}: ${await resp.text().catch(() => '')}`)
+    } else {
+      resp.body?.cancel()
     }
   } catch (err) {
     console.error('[discord] webhook failed:', err instanceof Error ? err.message : err)
@@ -1239,6 +1242,7 @@ export default {
         // Track delivery count in-memory (flushed to KV by daily summary cron)
         if (resp.ok) deliveryCounter[isDiscord ? 'discord' : 'slack']++
         else deliveryCounter.failed++
+        resp.body?.cancel()
         return new Response(JSON.stringify({ ok: resp.ok, status: resp.status }), {
           status: resp.ok ? 200 : 502,
           headers: { ...cors, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Add `res.body?.cancel()` in 3 paths where response bodies were not consumed
  - Probe health checks (19 endpoints per cron cycle) — only `res.status` was used
  - Discord webhook success path — body discarded on 200
  - `/api/alert` proxy endpoint — only `resp.ok` and `resp.status` used
- Prevents Cloudflare Workers "stalled HTTP response canceled to prevent deadlock" warnings

refs #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)