### PR TITLE
fix: route AI analysis through Cloudflare AI Gateway (#232)

### DIFF
--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -186,7 +186,7 @@ export async function analyzeIncident(
   const prompt = buildAnalysisPrompt(serviceName, currentIncident, similar, prevPrediction)
 
   try {
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
+    const res = await fetch('https://gateway.ai.cloudflare.com/v1/11485987aa7d4639df5ba09d671b5615/aiwatch/anthropic/v1/messages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Route Anthropic API calls through Cloudflare AI Gateway to bypass 403 WAF block
- `api.anthropic.com` → `gateway.ai.cloudflare.com/.../anthropic/v1/messages`
- Same Cloudflare network = no WAF/DNS blocking
- Bonus: request logging + auto retry via gateway settings

## Test
- Gateway endpoint returns HTTP 200 (verified locally)
- Worker build + 696 tests pass

closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)