### PR TITLE
fix: estimate-only services show '—' in Uptime Rankings (closes #236)

### DIFF
--- a/src/pages/Uptime.jsx
+++ b/src/pages/Uptime.jsx
@@ -12,6 +12,7 @@ import EmptyState from '../components/EmptyState'
 // ── Constants ────────────────────────────────────────────────
 
 const WARN_THRESHOLD = 95.0 // < 95% → red
+const isEstimateNoData = (s) => s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -55,7 +56,7 @@ function UptimeBar({ service, sla, t }) {
   const MIN_DISPLAY = 95
   const range = 100 - MIN_DISPLAY
   const uptime = service.uptime30d ?? 0
-  const hasUptime = service.uptime30d != null
+  const hasUptime = service.uptime30d != null && !isEstimateNoData(service)
   const clampedPct = Math.max(MIN_DISPLAY, uptime)
   const widthPct = hasUptime ? Math.round(((clampedPct - MIN_DISPLAY) / range) * 100) : 0
   const slaPos = Math.round(((sla - MIN_DISPLAY) / range) * 100)
@@ -81,7 +82,7 @@ function UptimeBar({ service, sla, t }) {
             title={service.uptimeSource === 'official' ? t('uptime.sub.official')
               : service.uptimeSource === 'platform_avg' ? t('uptime.sub.platform_avg')
               : service.uptimeSource === 'estimate' ? t('uptime.sub.estimate') : undefined}>
-        {service.uptimeSource === 'official' ? 'off' : service.uptimeSource === 'platform_avg' ? 'avg' : service.uptimeSource === 'estimate' ? 'est' : ''}
+        {!hasUptime ? '' : service.uptimeSource === 'official' ? 'off' : service.uptimeSource === 'platform_avg' ? 'avg' : service.uptimeSource === 'estimate' ? 'est' : ''}
       </span>
     </div>
   )
@@ -96,8 +97,17 @@ export default function Uptime() {
   const sla = settings.sla
   const services = (rawServices ?? []).filter((s) => settings.enabledServices.includes(s.id))
 
+  const hasReliableUptime = (s) => s.uptime30d != null && !isEstimateNoData(s)
   const sortedByUptime = useMemo(
-    () => [...services].sort((a, b) => (b.uptime30d ?? 0) - (a.uptime30d ?? 0)),
+    () => [...services]
+      .sort((a, b) => {
+        const aUp = isEstimateNoData(a) ? null : a.uptime30d
+        const bUp = isEstimateNoData(b) ? null : b.uptime30d
+        if (aUp == null && bUp == null) return 0
+        if (aUp == null) return 1
+        if (bUp == null) return -1
+        return bUp - aUp
+      }),
     [services]
   )
 
@@ -107,7 +117,6 @@ export default function Uptime() {
 
   if (services.length === 0) return <EmptyState type="neutral" />
 
-  const hasReliableUptime = (s) => s.uptime30d != null && !(s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0)
   const uptimeServices = services.filter(hasReliableUptime)
   const hasUptimeData = uptimeServices.length > 0
   const mostStable = hasUptimeData

--- a/tests/uptime.spec.js
+++ b/tests/uptime.spec.js
@@ -26,3 +26,53 @@ test.describe('Uptime page', () => {
     await expect(main.getByText(/API|Cloud|AI|Copilot|Cursor|Windsurf/).first()).toBeVisible({ timeout: 10000 })
   })
 })
+
+test.describe('Uptime Rankings — estimate-only services', () => {
+  const MOCK = {
+    services: [
+      { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, uptimeSource: 'official', calendarDays: 30, incidents: [] },
+      { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', latency: 200, uptime30d: 99.99, uptimeSource: 'official', calendarDays: 30, incidents: [] },
+      { id: 'bedrock', category: 'api', name: 'Amazon Bedrock', provider: 'AWS', status: 'operational', latency: 280, uptime30d: 100, uptimeSource: 'estimate', calendarDays: 14, incidents: [] },
+      { id: 'azureopenai', category: 'api', name: 'Azure OpenAI', provider: 'Microsoft', status: 'operational', latency: 350, uptime30d: 100, uptimeSource: 'estimate', calendarDays: 14, incidents: [] },
+      { id: 'gemini', category: 'api', name: 'Gemini API', provider: 'Google', status: 'operational', latency: 150, calendarDays: 14, incidents: [] },
+    ],
+    lastUpdated: new Date().toISOString(),
+  }
+
+  test('shows estimate-only services as "—" instead of percentage', async ({ page }) => {
+    await page.route('**/api/status', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+    await page.goto('/#uptime')
+    const rankings = page.locator('section').filter({ hasText: /Uptime Rankings/ })
+    await expect(rankings).toBeVisible({ timeout: 20000 })
+
+    // Official services show percentages in rankings
+    await expect(rankings.getByText('99.99%').first()).toBeVisible()
+    await expect(rankings.getByText('99.95%').first()).toBeVisible()
+
+    // Estimate-only services (no incidents) should show "—", not 100.00%
+    await expect(rankings.getByText('Amazon Bedrock')).toBeVisible()
+    await expect(rankings.getByText('Azure OpenAI')).toBeVisible()
+    await expect(rankings.getByText('100.00%')).not.toBeVisible()
+
+    // Gemini (null uptime) also shows "—"
+    await expect(rankings.getByText('Gemini API')).toBeVisible()
+  })
+
+  test('excludes estimate-only services from summary cards', async ({ page }) => {
+    await page.route('**/api/status', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+    await page.goto('/#uptime')
+    const main = page.locator('main')
+    await expect(main.getByText(/Uptime Rankings/).first()).toBeVisible({ timeout: 20000 })
+
+    // Most Stable should be a real service (OpenAI 99.99%), not estimate-only Bedrock/Azure at 100%
+    await expect(main.getByText('OpenAI API').first()).toBeVisible({ timeout: 10000 })
+    // Average of Claude (99.95) + OpenAI (99.99) = 99.97 — but mock merges with MOCK_SERVICES,
+    // so just verify that 100.00% (from estimate services) is NOT shown in summary cards
+    const summaryCards = main.locator('.grid').first()
+    await expect(summaryCards.getByText('100.00%')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Estimate-only services (Bedrock, Azure OpenAI) now display "—" in Uptime Rankings instead of misleading `100.00% est`
- Source tag (`est`/`off`/`avg`) hidden when uptime shows "—"
- Estimate-only services sorted to bottom alongside null-uptime services
- 2 E2E tests added for estimate-only display behavior

## Test plan
- [x] `npm run build` passes
- [x] Playwright tests pass (68/68 excl. Is X Down)
- [x] Local verify with production KV data — Bedrock/Azure show "—", others show correct percentages with tags
- [x] Code review passed

closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)