### PR TITLE
chore: update Product Hunt link to /products/aiwatch-2

### DIFF
--- a/api/intro/html-template.ts
+++ b/api/intro/html-template.ts
@@ -465,7 +465,7 @@ export function renderLandingPage(opts: LandingOptions): string {
 
 <!-- PH BANNER -->
 <div id="ph-banner" style="display:${phDisplay};background:var(--green-dim);border-bottom:1px solid rgba(63,185,80,0.3);padding:10px 24px;text-align:center;">
-  <a href="https://www.producthunt.com/posts/ai-watch" target="_blank" rel="noopener" onclick="typeof gtag==='function'&&gtag('event','click_ph_upvote',{location:'landing_banner'})" style="font-size:13px;color:var(--green);font-family:var(--font-mono);text-decoration:none;">
+  <a href="https://www.producthunt.com/products/aiwatch-2" target="_blank" rel="noopener" onclick="typeof gtag==='function'&&gtag('event','click_ph_upvote',{location:'landing_banner'})" style="font-size:13px;color:var(--green);font-family:var(--font-mono);text-decoration:none;">
     👋 Welcome, Product Hunters! &nbsp;·&nbsp; If AIWatch is useful, <strong style="text-decoration:underline;text-underline-offset:3px;">an upvote means the world to us</strong> 🙏
   </a>
 </div>

--- a/tests/intro.spec.js
+++ b/tests/intro.spec.js
@@ -36,13 +36,13 @@ test.describe('Landing page (/intro)', () => {
     await expect(banner).not.toHaveCSS('display', 'none')
     await expect(banner).toContainText('Product Hunters')
     const link = banner.locator('a')
-    await expect(link).toHaveAttribute('href', 'https://www.producthunt.com/posts/ai-watch')
+    await expect(link).toHaveAttribute('href', 'https://www.producthunt.com/products/aiwatch-2')
     await expect(link).toHaveAttribute('target', '_blank')
   })
 
   test('PH banner visible with Referer header', async ({ request }) => {
     const res = await request.get('/intro', {
-      headers: { 'Referer': 'https://www.producthunt.com/posts/ai-watch' },
+      headers: { 'Referer': 'https://www.producthunt.com/products/aiwatch-2' },
     })
     expect(res.status()).toBe(200)
     const html = await res.text()


### PR DESCRIPTION
## Summary
- Update PH banner link in landing page from `/posts/ai-watch` to `/products/aiwatch-2`
- Update matching test assertions

## Test plan
- [x] Local verify at `localhost:3333/intro?ref=producthunt` — link points to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)