### PR TITLE
perf: add build assets to Service Worker precache via asset manifest (refs #175)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,38 +1,62 @@
-// AIWatch Service Worker — stale-while-revalidate for static assets
-// Version: bump CACHE_NAME on each deploy that changes static assets
+// AIWatch Service Worker — precache build assets + stale-while-revalidate
+// Cache name is auto-derived from asset-manifest.json version on install
 
-const CACHE_NAME = 'aiwatch-v5'
-const STATIC_ASSETS = ['/', '/index.html', '/manifest.json', '/favicon.png']
+const STATIC_ASSETS = ['/', '/index.html', '/manifest.json', '/favicon.png', '/asset-manifest.json']
+const FALLBACK_CACHE = 'aiwatch-static-v1'
+
+// Module-scoped variable set during install to avoid re-fetching manifest
+let activeCacheName = null
 
 self.addEventListener('install', (e) => {
   e.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+    fetch('/asset-manifest.json')
+      .then((res) => res.json())
+      .then((manifest) => {
+        activeCacheName = 'aiwatch-' + manifest.version
+        return caches.open(activeCacheName).then((cache) =>
+          cache.addAll([...STATIC_ASSETS, ...manifest.assets])
+        )
+      })
+      .catch(() => {
+        activeCacheName = FALLBACK_CACHE
+        return caches.open(FALLBACK_CACHE).then((cache) => cache.addAll(STATIC_ASSETS))
+      })
   )
   self.skipWaiting()
 })
 
 self.addEventListener('activate', (e) => {
   e.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-    )
+    caches.keys().then((keys) => {
+      // Keep the newest aiwatch-* cache (the one just installed)
+      const aiwatchCaches = keys.filter((k) => k.startsWith('aiwatch-')).sort()
+      const keep = activeCacheName || aiwatchCaches[aiwatchCaches.length - 1] || FALLBACK_CACHE
+      return Promise.all(
+        keys.filter((k) => k !== keep).map((k) => caches.delete(k))
+      )
+    })
   )
   self.clients.claim()
 })
 
+// Find the active aiwatch cache name from existing caches
+async function getActiveCacheName() {
+  if (activeCacheName) return activeCacheName
+  const keys = await caches.keys()
+  const aiwatchCaches = keys.filter((k) => k.startsWith('aiwatch-')).sort()
+  return aiwatchCaches[aiwatchCaches.length - 1] || FALLBACK_CACHE
+}
+
 self.addEventListener('fetch', (event) => {
-  // Skip non-GET requests
   if (event.request.method !== 'GET') return
 
   const url = event.request.url
 
   // Always network — never cache these paths
-  // /is-*: Edge SSR pages need freshness for SEO
-  // /api/*: real-time status data
   if (url.includes('/is-') || url.includes('/api/')) return
 
   // Only cache same-origin requests
-  if (new URL(event.request.url).origin !== self.location.origin) return
+  if (new URL(url).origin !== self.location.origin) return
 
   // stale-while-revalidate: serve cache immediately, update in background
   event.respondWith(
@@ -41,7 +65,9 @@ self.addEventListener('fetch', (event) => {
         .then((networkRes) => {
           if (networkRes.ok) {
             const clone = networkRes.clone()
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))
+            getActiveCacheName().then((name) =>
+              caches.open(name).then((c) => c.put(event.request, clone))
+            )
           }
           return networkRes
         })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,32 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { createHash } from 'crypto'
 
 import { cloudflare } from "@cloudflare/vite-plugin";
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
+function assetManifestPlugin() {
+  return {
+    name: 'asset-manifest',
+    writeBundle(options) {
+      const outDir = options.dir || resolve('dist')
+      const assetsDir = resolve(outDir, 'assets')
+      const files = readdirSync(assetsDir).map((f) => `/assets/${f}`)
+      const hash = createHash('md5').update(files.sort().join(',')).digest('hex').slice(0, 8)
+      writeFileSync(
+        resolve(outDir, 'asset-manifest.json'),
+        JSON.stringify({ version: hash, assets: files })
+      )
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss(), cloudflare()],
+  plugins: [react(), tailwindcss(), cloudflare(), assetManifestPlugin()],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
## Summary
- Add Vite plugin (`assetManifestPlugin`) that generates `dist/asset-manifest.json` at build time with version hash + asset paths
- Rewrite `sw.js` to precache all hashed build assets from manifest on install
- Auto-derive `CACHE_NAME` from manifest version — no manual bump needed
- Fallback to static-only cache if manifest fetch fails (offline resilience)

## Changes
- `vite.config.js` — add `assetManifestPlugin()` (~15 lines)
- `public/sw.js` — manifest-based precache, module-scoped `activeCacheName`, sorted cache cleanup

## Test plan
- [x] `npm run build` passes and generates `dist/asset-manifest.json`
- [x] Playwright E2E tests pass (10/10)
- [ ] Verify SW caches build assets in DevTools → Application → Cache Storage (after deploy)
- [ ] Verify repeat visits serve JS/CSS from SW cache (Network tab shows `(ServiceWorker)`)

refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)