### PR TITLE
fix: multi-service incident display — show all affected services consistently (closes #244)

### DIFF
--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -16,31 +16,21 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
   // Group by service, then dedup shared incidentIds across sibling services
   // aiAnalysis: Record<svcId, AIAnalysisResult[]>
   // Result: array of { svcIds, analyses[] } — one entry per service group
-  const seenIncidents = new Set() // dedup shared incidentIds across services
-  const groups = [] // { svcIds: string[], analyses: analysis[], startedAt }
+  const groups = [] // { svcIds: string[], incIds: Set<string>, analyses: analysis[], startedAt }
   for (const [svcId, rawAnalyses] of Object.entries(aiAnalysis)) {
     const arr = Array.isArray(rawAnalyses) ? rawAnalyses : [rawAnalyses]
-    const validAnalyses = arr.filter(a => {
+    for (const a of arr) {
       const incId = a.incidentId ?? svcId
-      if (seenIncidents.has(incId)) return false
-      seenIncidents.add(incId)
-      return true
-    })
-    if (validAnalyses.length === 0) continue
-    // Check if another group already covers this service (shared incidentId → merge svcIds)
-    const existingGroup = groups.find(g =>
-      g.analyses.some(a => validAnalyses.some(v => v.incidentId === a.incidentId))
-    )
-    if (existingGroup) {
-      if (!existingGroup.svcIds.includes(svcId)) existingGroup.svcIds.push(svcId)
-    } else {
-      const svc = services.find(s => s.id === svcId)
-      const earliestInc = validAnalyses.reduce((earliest, a) => {
-        const inc = svc?.incidents?.find(i => i.id === a.incidentId)
-        const t = inc?.startedAt ?? a.analyzedAt ?? ''
-        return t < earliest ? t : earliest
-      }, validAnalyses[0].analyzedAt ?? '')
-      groups.push({ svcIds: [svcId], analyses: validAnalyses, startedAt: earliestInc })
+      // Find existing group that already has this incidentId
+      const existingGroup = groups.find(g => g.incIds.has(incId))
+      if (existingGroup) {
+        if (!existingGroup.svcIds.includes(svcId)) existingGroup.svcIds.push(svcId)
+      } else {
+        const svc = services.find(s => s.id === svcId)
+        const inc = svc?.incidents?.find(i => i.id === incId)
+        const startedAt = inc?.startedAt ?? a.analyzedAt ?? ''
+        groups.push({ svcIds: [svcId], incIds: new Set([incId]), analyses: [a], startedAt })
+      }
     }
   }
   groups.sort((a, b) => b.startedAt.localeCompare(a.startedAt))

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -173,7 +173,9 @@ function IncidentRow({ incident, isSelected, onClick, onClose, t, lang }) {
             {t(`incidents.status.${incident.status}`)}
           </span>
         </div>
-        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text1)' }}>{incident.serviceName}</span>
+        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text1)' }}>
+          {incident.affectedNames?.length > 1 ? incident.affectedNames.join(', ') : incident.serviceName}
+        </span>
         <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>{incident.duration ?? t('incidents.duration.ongoing')}</span>
         <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>{t(`incidents.status.${incident.status}`)}</span>
       </div>
@@ -204,7 +206,7 @@ function IncidentCard({ incident, isSelected, onClick, onClose, t, lang }) {
         <div className="flex items-center flex-wrap mono text-[var(--text2)]" style={{ fontSize: '10px', gap: '6px' }}>
           <span>{ctx.label} {formatDate(ctx.date, lang)}</span>
           <span>·</span>
-          <span>{incident.serviceName}</span>
+          <span>{incident.affectedNames?.length > 1 ? incident.affectedNames.join(', ') : incident.serviceName}</span>
           <span>·</span>
           <span>{incident.duration ?? t('incidents.duration.ongoing')}</span>
         </div>
@@ -233,14 +235,10 @@ export default function Incidents() {
   // incidents belonging to that service so none get hidden by earlier-processed services.
   const allIncidents = useMemo(
     () => {
-      const seenOriginalIds = serviceFilter === 'all' ? new Set() : null
-      return services.flatMap((svc) =>
-        (svc.incidents ?? []).flatMap((inc) => {
-          if (seenOriginalIds) {
-            if (seenOriginalIds.has(inc.id)) return []
-            seenOriginalIds.add(inc.id)
-          }
-          return [{
+      if (serviceFilter !== 'all') {
+        // With service filter: show all incidents for that service
+        return services.flatMap((svc) =>
+          (svc.incidents ?? []).flatMap((inc) => [{
             ...inc,
             id: `${svc.id}:${inc.id}`,
             status: inc.status === 'resolved' ? 'resolved'
@@ -248,9 +246,31 @@ export default function Incidents() {
               : 'ongoing',
             serviceName: svc.name,
             serviceId: svc.id,
-          }]
-        })
-      )
+          }])
+        )
+      }
+      // Without filter: dedup by incidentId, collect all affected service names
+      const incMap = new Map() // incidentId → merged incident
+      for (const svc of services) {
+        for (const inc of svc.incidents ?? []) {
+          const existing = incMap.get(inc.id)
+          if (existing) {
+            if (!existing.affectedNames.includes(svc.name)) existing.affectedNames.push(svc.name)
+          } else {
+            incMap.set(inc.id, {
+              ...inc,
+              id: `${svc.id}:${inc.id}`,
+              status: inc.status === 'resolved' ? 'resolved'
+                : inc.status === 'monitoring' ? 'monitoring'
+                : 'ongoing',
+              serviceName: svc.name,
+              serviceId: svc.id,
+              affectedNames: [svc.name],
+            })
+          }
+        }
+      }
+      return [...incMap.values()]
     },
     [services, serviceFilter]
   )

--- a/tests/multi-service-incident.spec.js
+++ b/tests/multi-service-incident.spec.js
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+
+const SHARED_INCIDENT = {
+  id: 'shared-inc-123',
+  title: 'Opus 4.6 elevated rate of errors',
+  status: 'investigating',
+  impact: 'major',
+  startedAt: new Date(Date.now() - 3600_000).toISOString(),
+  resolvedAt: null,
+  duration: null,
+  timeline: [],
+}
+
+const SHARED_ANALYSIS = {
+  incidentId: 'shared-inc-123',
+  summary: 'Recurring Opus 4.6 model error pattern identified with fix being implemented.',
+  estimatedRecovery: '30m–2h',
+  affectedScope: ['Claude Opus 4.6 API', 'Model inference requests'],
+  needsFallback: true,
+  analyzedAt: new Date().toISOString(),
+}
+
+const MOCK = {
+  services: [
+    { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'degraded', latency: 120, incidents: [SHARED_INCIDENT] },
+    { id: 'claudeai', category: 'app', name: 'claude.ai', provider: 'Anthropic', status: 'degraded', latency: 0, incidents: [SHARED_INCIDENT] },
+    { id: 'claudecode', category: 'agent', name: 'Claude Code', provider: 'Anthropic', status: 'degraded', latency: 0, incidents: [SHARED_INCIDENT] },
+    { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', latency: 200, incidents: [] },
+  ],
+  aiAnalysis: {
+    claude: [SHARED_ANALYSIS],
+    claudeai: [SHARED_ANALYSIS],
+    claudecode: [SHARED_ANALYSIS],
+  },
+  lastUpdated: new Date().toISOString(),
+}
+
+test.describe('Multi-service incident display', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/status', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+    await page.route('**/api/status/cached', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+  })
+
+  test('AI Analysis modal groups shared incidentId and shows all service names', async ({ page }) => {
+    await page.goto('/')
+    // Wait for data to load
+    await expect(page.getByText('Claude API').first()).toBeVisible({ timeout: 20000 })
+
+    // Click Analyze button
+    const analyzeBtn = page.locator('button').filter({ hasText: /Analyze|분석/ })
+    await analyzeBtn.click()
+
+    // Modal should show all 3 service names in one card
+    const modal = page.locator('.fixed.inset-0')
+    await expect(modal).toBeVisible()
+    await expect(modal.getByText('Claude API')).toBeVisible()
+    await expect(modal.getByText('claude.ai')).toBeVisible()
+    await expect(modal.getByText('Claude Code')).toBeVisible()
+
+    // Should only have 1 analysis group (not 3 separate ones)
+    // The summary text should appear exactly once
+    const summaries = modal.getByText('Recurring Opus 4.6 model error pattern')
+    await expect(summaries).toHaveCount(1)
+  })
+
+  test('Incidents page shows all affected service names for shared incident', async ({ page }) => {
+    await page.goto('/#incidents')
+    await expect(page.getByText('Opus 4.6 elevated rate of errors').first()).toBeVisible({ timeout: 20000 })
+
+    const main = page.locator('main')
+    // All 3 affected service names should appear together (order depends on mock services array)
+    await expect(main.getByText(/claude\.ai, Claude API, Claude Code/).first()).toBeVisible()
+  })
+})

--- a/worker/src/__tests__/alerts.test.ts
+++ b/worker/src/__tests__/alerts.test.ts
@@ -93,34 +93,23 @@ describe('buildIncidentAlerts', () => {
     expect(buildIncidentAlerts([svc], new Set(), NOW)).toHaveLength(0)
   })
 
-  it('generates duplicate alerts for shared-status-page services (caller must dedup by key)', () => {
+  it('groups shared-incidentId services into single alert with all service names', () => {
     // Claude API, claude.ai, Claude Code share Anthropic status page → same inc.id
     const sharedIncident = { id: 'shared1', title: 'Elevated errors', status: 'investigating', startedAt: recentDate, impact: 'major' }
-    const claude = mockService({ id: 'claude', name: 'Claude API', category: 'api', incidents: [sharedIncident] })
-    const claudeai = mockService({ id: 'claudeai', name: 'claude.ai', category: 'app', incidents: [sharedIncident] })
-    const claudecode = mockService({ id: 'claudecode', name: 'Claude Code', category: 'agent', incidents: [sharedIncident] })
+    const claude = mockService({ id: 'claude', name: 'Claude API', provider: 'Anthropic', category: 'api', incidents: [sharedIncident] })
+    const claudeai = mockService({ id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app', incidents: [sharedIncident] })
+    const claudecode = mockService({ id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', incidents: [sharedIncident] })
 
     const alerts = buildIncidentAlerts([claude, claudeai, claudecode], new Set(), NOW)
 
-    // buildIncidentAlerts produces one alert per service — all with the same key
-    expect(alerts).toHaveLength(3)
+    // buildIncidentAlerts groups same incidentId into one alert
+    expect(alerts).toHaveLength(1)
     expect(alerts[0].key).toBe('alerted:new:shared1')
-    expect(alerts[1].key).toBe('alerted:new:shared1')
-    expect(alerts[2].key).toBe('alerted:new:shared1')
-    // Different service names
+    // Title includes all affected service names
     expect(alerts[0].title).toContain('Claude API')
-    expect(alerts[1].title).toContain('claude.ai')
-    expect(alerts[2].title).toContain('Claude Code')
-
-    // Caller (cronAlertCheck) uses seenKeys Set to dedup → only first is sent
-    const seenKeys = new Set<string>()
-    const deduped = alerts.filter(a => {
-      if (seenKeys.has(a.key)) return false
-      seenKeys.add(a.key)
-      return true
-    })
-    expect(deduped).toHaveLength(1)
-    expect(deduped[0].title).toContain('Claude API')
+    expect(alerts[0].title).toContain('claude.ai')
+    expect(alerts[0].title).toContain('Claude Code')
+    expect(alerts[0].title).toContain('Anthropic')
   })
 
   it('shows same-category fallback only for shared incidents (no cross-category)', () => {

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -4,6 +4,7 @@
 import { getFallbacks, buildFallbackText } from './fallback'
 import { sanitize, formatDuration } from './utils'
 import type { ServiceStatus } from './services'
+import type { Incident } from './types'
 
 export interface AlertCandidate {
   key: string
@@ -31,7 +32,9 @@ export function buildIncidentAlerts(
   alertedNewIds: Set<string>,
   now: number = Date.now(),
 ): AlertCandidate[] {
-  const alerts: AlertCandidate[] = []
+  // Group services by incidentId to show all affected services in one alert
+  const newIncidents = new Map<string, { names: string[]; ids: string[]; inc: Incident; category: string; firstSvc: ScoredService }>()
+  const resolvedIncidents = new Map<string, { names: string[]; ids: string[]; inc: Incident; firstSvc: ScoredService }>()
 
   for (const svc of services) {
     for (const inc of svc.incidents ?? []) {
@@ -39,29 +42,52 @@ export function buildIncidentAlerts(
       if (incAge > 86_400_000) continue
 
       if (inc.status !== 'resolved' && !alertedNewIds.has(inc.id)) {
-        // Per-incident alert: show same-category fallbacks only
-        const fallbackText = svc.status !== 'operational'
-          ? buildFallbackText(getFallbacks(svc.id, svc.category, services))
-          : ''
-        alerts.push({
-          key: `alerted:new:${inc.id}`,
-          title: `🔴 ${svc.name} — New Incident`,
-          description: sanitize(inc.title),
-          fallbackText,
-          color: 0xED4245,
-          url: `https://ai-watch.dev/#${svc.id}`,
-        })
+        const existing = newIncidents.get(inc.id)
+        if (existing) {
+          if (!existing.names.includes(svc.name)) existing.names.push(svc.name)
+          if (!existing.ids.includes(svc.id)) existing.ids.push(svc.id)
+        } else {
+          newIncidents.set(inc.id, { names: [svc.name], ids: [svc.id], inc, category: svc.category, firstSvc: svc })
+        }
       } else if (inc.status === 'resolved' && alertedNewIds.has(inc.id)) {
-        const durationText = inc.duration ? ` (${inc.duration})` : ''
-        alerts.push({
-          key: `alerted:res:${inc.id}`,
-          title: `🟢 ${svc.name} — Incident Resolved${durationText}`,
-          description: sanitize(inc.title),
-          color: 0x57F287,
-          url: `https://ai-watch.dev/#${svc.id}`,
-        })
+        const existing = resolvedIncidents.get(inc.id)
+        if (existing) {
+          if (!existing.names.includes(svc.name)) existing.names.push(svc.name)
+          if (!existing.ids.includes(svc.id)) existing.ids.push(svc.id)
+        } else {
+          resolvedIncidents.set(inc.id, { names: [svc.name], ids: [svc.id], inc, firstSvc: svc })
+        }
       }
     }
+  }
+
+  const alerts: AlertCandidate[] = []
+
+  for (const [incId, { names, ids, inc, category, firstSvc }] of newIncidents) {
+    const displayName = names.length > 1 ? `${firstSvc.provider} (${names.join(', ')})` : names[0]
+    const fallbackText = firstSvc.status !== 'operational'
+      ? buildFallbackText(getFallbacks(firstSvc.id, category, services))
+      : ''
+    alerts.push({
+      key: `alerted:new:${incId}`,
+      title: `🔴 ${displayName} — New Incident`,
+      description: sanitize(inc.title),
+      fallbackText,
+      color: 0xED4245,
+      url: `https://ai-watch.dev/#${ids[0]}`,
+    })
+  }
+
+  for (const [incId, { names, ids, inc, firstSvc }] of resolvedIncidents) {
+    const displayName = names.length > 1 ? `${firstSvc.provider} (${names.join(', ')})` : names[0]
+    const durationText = inc.duration ? ` (${inc.duration})` : ''
+    alerts.push({
+      key: `alerted:res:${incId}`,
+      title: `🟢 ${displayName} — Incident Resolved${durationText}`,
+      description: sanitize(inc.title),
+      color: 0x57F287,
+      url: `https://ai-watch.dev/#${ids[0]}`,
+    })
   }
 
   return alerts


### PR DESCRIPTION
## Summary
When a provider links one incident to multiple components (e.g., Anthropic Opus 4.6 → Claude API, claude.ai, Claude Code), each display surface previously showed a different service name. Now all affected services are shown consistently.

- **AI Analysis modal**: fix grouping logic to merge all svcIds sharing same incidentId (was broken by premature dedup)
- **Incidents page**: collect `affectedNames` array via Map-based dedup, display comma-separated
- **Discord alerts**: group by incidentId → title shows `Anthropic (Claude API, claude.ai, Claude Code)`

## Test plan
- [x] `npm run build` passes
- [x] Worker unit tests pass (696/696)
- [x] New E2E tests pass (2/2) — mock shared incidentId across 3 services
- [x] AI modal: 1 card with all 3 service names
- [x] Incidents page: comma-separated service names for shared incident

closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)