### PR TITLE
fix: skip AI analysis for generic incidents + hide fallback for excluded services (closes #246)

### DIFF
--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -1,6 +1,6 @@
 // AI Analysis Modal — shows incident analysis results from Claude
 import { useLang } from '../hooks/useLang'
-import { getFallbacks } from '../utils/constants'
+import { getFallbacks, EXCLUDE_FALLBACK } from '../utils/constants'
 
 function timeAgo(date, lang) {
   const diff = Date.now() - new Date(date).getTime()
@@ -127,9 +127,9 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
                         {isRecovered && <span>✅ {t('analysis.recoveredAt')}: {timeAgo(analysis.resolvedAt, lang)}</span>}
                         <span>🕐 {lang === 'ko' ? '분석 업데이트' : 'Analysis updated'} {timeAgo(analysis.analyzedAt, lang)}</span>
                       </div>
-                      {/* Contextual fallback recommendation */}
-                      {analysis.needsFallback && !isRecovered && (() => {
-                        const primarySvc = svcs[0]
+                      {/* Contextual fallback recommendation — skip for EXCLUDE_FALLBACK services */}
+                      {analysis.needsFallback && !isRecovered && !svcs.every(s => EXCLUDE_FALLBACK.includes(s.id)) && (() => {
+                        const primarySvc = svcs.find(s => !EXCLUDE_FALLBACK.includes(s.id)) ?? svcs[0]
                         const fallbacks = getFallbacks(primarySvc, services)
                         return (
                           <div className="mono text-[10px]" style={{ marginTop: '8px', padding: '8px 10px', background: 'var(--bg1)', borderRadius: '6px', borderLeft: '3px solid var(--amber)' }}>

--- a/worker/src/__tests__/ai-analysis.test.ts
+++ b/worker/src/__tests__/ai-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, parseRecoveryHours, formatRecoveryDisplay, type KVLike } from '../ai-analysis'
+import { findSimilarIncidents, buildAnalysisPrompt, analyzeIncident, refreshOrReanalyze, analysisKey, isBoilerplate, isGenericIncident, parseRecoveryHours, formatRecoveryDisplay, type KVLike } from '../ai-analysis'
 import type { Incident, ServiceStatus } from '../types'
 
 const mockIncident = (overrides: Partial<Incident> = {}): Incident => ({
@@ -56,6 +56,40 @@ describe('isBoilerplate', () => {
     expect(isBoilerplate('The frequency of those errors has gone down. We are continuing to closely monitor')).toBe(false)
     expect(isBoilerplate('Error rates increased to 15% on us-east-1 region')).toBe(false)
     expect(isBoilerplate('Root cause identified as a database connection pool exhaustion')).toBe(false)
+  })
+})
+
+describe('isGenericIncident', () => {
+  it('detects generic title + boilerplate timeline', () => {
+    expect(isGenericIncident('Investigating an issue', [
+      { text: 'We are currently investigating this issue.' },
+    ])).toBe(true)
+  })
+
+  it('detects generic title with no timeline', () => {
+    expect(isGenericIncident('Investigating an issue', [])).toBe(true)
+    expect(isGenericIncident('Service disruption')).toBe(true)
+    expect(isGenericIncident('Scheduled maintenance', undefined)).toBe(true)
+  })
+
+  it('detects various generic title patterns', () => {
+    expect(isGenericIncident('Investigating the issue', [])).toBe(true)
+    expect(isGenericIncident('Service outage', [])).toBe(true)
+    expect(isGenericIncident('System disruption', [])).toBe(true)
+    expect(isGenericIncident('Partial degradation', [])).toBe(true)
+  })
+
+  it('returns false for specific titles', () => {
+    expect(isGenericIncident('Opus 4.6 elevated rate of errors', [])).toBe(false)
+    expect(isGenericIncident('TTS API Latency Spike', [])).toBe(false)
+    expect(isGenericIncident('Database connection pool exhaustion', [])).toBe(false)
+  })
+
+  it('returns false when generic title has technical timeline detail', () => {
+    expect(isGenericIncident('Investigating an issue', [
+      { text: 'We are currently investigating this issue.' },
+      { text: 'Error rates spiked to 40% on /v1/messages endpoint.' },
+    ])).toBe(false)
   })
 })
 

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -19,6 +19,29 @@ const BOILERPLATE_PATTERNS = [
   /^(this|the) (incident|issue) is (being )?(monitored|investigated)/i,
 ]
 
+/** Generic incident title patterns — no actionable detail to analyze */
+const GENERIC_TITLE_PATTERNS = [
+  /^investigating (an |the |this )?issue$/i,
+  /^(service |system )?(disruption|outage|issue|incident)$/i,
+  /^we are (currently )?(investigating|aware)/i,
+  /^(scheduled |planned )?maintenance$/i,
+  /^(partial |minor |major )?(service )?(degradation|interruption)$/i,
+]
+
+/**
+ * Check if an incident has no actionable detail — generic title + all boilerplate timeline.
+ * AI analysis would produce unhelpful output for such incidents.
+ */
+export function isGenericIncident(
+  title: string,
+  timeline?: Array<{ text: string | null }>,
+): boolean {
+  const genericTitle = GENERIC_TITLE_PATTERNS.some(p => p.test(title.trim()))
+  if (!genericTitle) return false
+  if (!timeline || timeline.length === 0) return true
+  return timeline.every(t => isBoilerplate(t.text))
+}
+
 export function isBoilerplate(text: string | null | undefined): boolean {
   if (!text) return true
   const trimmed = text.trim()
@@ -401,6 +424,12 @@ export async function refreshOrReanalyze(
       }
 
       if (!apiKey || reAnalysisCount >= cap) {
+        result.skipped.push(svc.id)
+        continue
+      }
+
+      // Skip generic incidents with no actionable detail (e.g., "Investigating an issue")
+      if (isGenericIncident(inc.title, inc.timeline)) {
         result.skipped.push(svc.id)
         continue
       }


### PR DESCRIPTION
## Summary
- **Generic incident skip**: Add `isGenericIncident()` — incidents with generic titles (e.g., "Investigating an issue") + boilerplate timeline are skipped from AI analysis (saves API call, avoids unhelpful output)
- **Fallback hiding**: AI modal hides fallback recommendation section for `EXCLUDE_FALLBACK` services (e.g., Character.AI)

## Context
Character.AI incident "Investigating an issue" with timeline "We are currently investigating this issue." — no actionable detail. AI analysis produced generic unhelpful output and showed fallback recommendations that shouldn't appear for excluded services.

## Test plan
- [x] Worker unit tests pass (701/701, +5 new)
- [x] `npm run build` passes
- [x] `npx wrangler deploy --dry-run` passes

closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)