### PR TITLE
feat: add GitHub Copilot changelog to weekly briefing (refs #213)

### DIFF
--- a/worker/src/__tests__/changelog.test.ts
+++ b/worker/src/__tests__/changelog.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect } from 'vitest'
 import { parseRssEntries, parseAnthropicNews, isRelevantEntry, formatChangelogSection, CHANGELOG_SOURCES, type ChangelogEntry } from '../changelog'
 
 describe('CHANGELOG_SOURCES', () => {
-  it('has 3 pilot sources', () => {
-    expect(CHANGELOG_SOURCES).toHaveLength(3)
-    expect(CHANGELOG_SOURCES.map((s) => s.id)).toEqual(['openai', 'google', 'anthropic'])
+  it('has 4 sources (3 pilot + copilot)', () => {
+    expect(CHANGELOG_SOURCES).toHaveLength(4)
+    expect(CHANGELOG_SOURCES.map((s) => s.id)).toEqual(['openai', 'google', 'anthropic', 'copilot'])
+  })
+
+  it('copilot source uses rss type with pre-filtered changelog feed', () => {
+    const copilot = CHANGELOG_SOURCES.find((s) => s.id === 'copilot')!
+    expect(copilot.type).toBe('rss')
+    expect(copilot.feedUrl).toContain('github.blog/changelog/label/copilot')
   })
 
   it('anthropic source uses html type', () => {
@@ -191,6 +197,14 @@ describe('isRelevantEntry', () => {
     it('generic posts without keywords are filtered', () => {
       expect(isRelevantEntry('Our thoughts on responsible AI', 'openai')).toBe(false)
       expect(isRelevantEntry('Partnering with schools in Kenya', 'google')).toBe(false)
+    })
+  })
+
+  describe('GitHub Copilot changelog', () => {
+    it('all entries are relevant (pre-filtered feed)', () => {
+      expect(isRelevantEntry('Enable Copilot cloud agent via custom properties', 'copilot')).toBe(true)
+      expect(isRelevantEntry('Model selection for Claude and Codex agents on github.com', 'copilot')).toBe(true)
+      expect(isRelevantEntry('Copilot now supports multi-file edits', 'copilot')).toBe(true)
     })
   })
 })

--- a/worker/src/changelog.ts
+++ b/worker/src/changelog.ts
@@ -21,6 +21,7 @@ export const CHANGELOG_SOURCES: ChangelogSource[] = [
   { id: 'openai', name: 'OpenAI', feedUrl: 'https://openai.com/blog/rss.xml', type: 'rss' },
   { id: 'google', name: 'Google AI', feedUrl: 'https://blog.google/technology/ai/rss/', type: 'rss' },
   { id: 'anthropic', name: 'Anthropic', feedUrl: 'https://www.anthropic.com/news', type: 'html' },
+  { id: 'copilot', name: 'GitHub Copilot', feedUrl: 'https://github.blog/changelog/label/copilot/feed/', type: 'rss' },
 ]
 
 // OpenAI/Google blog RSS contains non-API content — filter to relevant items
@@ -36,6 +37,8 @@ export function isRelevantEntry(title: string, source: string): boolean {
     if (ANTHROPIC_NOISE.test(title)) return false
     return ANTHROPIC_RELEVANCE.test(title)
   }
+  // Pre-filtered changelog sources — all entries are relevant
+  if (source === 'copilot') return true
   // Blog posts: require relevance keyword, reject noise
   if (NOISE_KEYWORDS.test(title)) return false
   return RELEVANCE_KEYWORDS.test(title)
@@ -197,6 +200,7 @@ export function formatChangelogSection(entries: ChangelogEntry[]): string {
     openai: 'OpenAI',
     google: 'Google AI',
     anthropic: 'Anthropic',
+    copilot: 'GitHub Copilot',
   }
 
   return entries

--- a/worker/src/changelog.ts
+++ b/worker/src/changelog.ts
@@ -4,7 +4,7 @@
 import { kvPut } from './utils'
 
 export interface ChangelogEntry {
-  source: string    // 'openai' | 'google' | 'anthropic'
+  source: string    // 'openai' | 'google' | 'anthropic' | 'copilot'
   title: string
   url: string
   date: string      // ISO date


### PR DESCRIPTION
## Summary
Add GitHub Copilot pre-filtered changelog RSS (`github.blog/changelog/label/copilot/feed/`) as 4th weekly briefing source. Phase 2 of #213.

- Pre-filtered by `copilot` label — no keyword filtering needed
- Covers feature launches, model additions, agent updates
- Example: "Model selection for Claude and Codex agents on github.com"

## Changes
- `worker/src/changelog.ts` — add copilot source + `isRelevantEntry` bypass + `formatChangelogSection` name
- `worker/src/__tests__/changelog.test.ts` — update source count test + add copilot relevance tests

## Test plan
- [x] Worker unit tests pass (698/698)
- [x] `npx wrangler deploy --dry-run` passes

refs #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)