### PR TITLE
feat: add security section to weekly Discord briefing (refs #215)

### DIFF
--- a/worker/src/__tests__/weekly-briefing.test.ts
+++ b/worker/src/__tests__/weekly-briefing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, type WeeklyBriefingData } from '../weekly-briefing'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary, type WeeklyBriefingData } from '../weekly-briefing'
 
 describe('getWeekRange', () => {
   it('returns Mon–Sun for a Wednesday', () => {
@@ -115,5 +115,61 @@ describe('buildWeeklyBriefing', () => {
     expect(result).toContain('No service changes detected')
     expect(result).toContain('No incidents this week')
     expect(result).toContain('No significant changes')
+  })
+
+  it('includes security section when security data is present', () => {
+    const data: WeeklyBriefingData = {
+      weekStart: '2026-04-06',
+      weekEnd: '2026-04-12',
+      changelog: [],
+      incidents: [],
+      stabilityChanges: [],
+      security: { hnCount: 3, osvCount: 2, highlights: ['xAI API key leaked on GitHub', 'CVE-2026-1234 in anthropic SDK'] },
+    }
+    const result = buildWeeklyBriefing(data)
+    expect(result).toContain('🔒 **Security**')
+    expect(result).toContain('2 SDK vulnerabilities')
+    expect(result).toContain('3 security news')
+    expect(result).toContain('xAI API key leaked')
+    expect(result).toContain('CVE-2026-1234')
+  })
+
+  it('omits security section when no security data', () => {
+    const data: WeeklyBriefingData = {
+      weekStart: '2026-04-06',
+      weekEnd: '2026-04-12',
+      changelog: [],
+      incidents: [],
+      stabilityChanges: [],
+    }
+    const result = buildWeeklyBriefing(data)
+    expect(result).not.toContain('Security')
+  })
+})
+
+describe('buildSecuritySummary', () => {
+  it('counts HN and OSV keys separately', () => {
+    const keys = [
+      { name: 'security:seen:hn:12345' },
+      { name: 'security:seen:hn:67890' },
+      { name: 'security:seen:osv:GHSA-abc' },
+    ]
+    const result = buildSecuritySummary(keys, ['Some highlight'])
+    expect(result.hnCount).toBe(2)
+    expect(result.osvCount).toBe(1)
+    expect(result.highlights).toEqual(['Some highlight'])
+  })
+
+  it('returns zero counts for empty keys', () => {
+    const result = buildSecuritySummary([], [])
+    expect(result.hnCount).toBe(0)
+    expect(result.osvCount).toBe(0)
+    expect(result.highlights).toEqual([])
+  })
+
+  it('limits highlights to 5', () => {
+    const highlights = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const result = buildSecuritySummary([], highlights)
+    expect(result.highlights).toHaveLength(5)
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -645,7 +645,7 @@ import { detectSecurityAlerts, formatSecurityDigest } from './security-monitor'
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { collectChangelogs } from './changelog'
-import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing } from './weekly-briefing'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary } from './weekly-briefing'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, type ProbeDailyData } from './probe-archival'
 import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
@@ -907,7 +907,19 @@ export default {
           for (const svc of SERVICES) serviceNames[svc.id] = svc.name
           const stabilityChanges = buildStabilityChanges(thisWeekCounters, prevWeekCounters, serviceNames)
 
-          const briefing = buildWeeklyBriefing({ weekStart, weekEnd, changelog, incidents, stabilityChanges })
+          // Security summary: count security:seen:* keys (7d TTL — approximate week coverage, ±1d)
+          // KV list returns max 1000 keys — sufficient for weekly security alerts (~50-100 typical)
+          let security
+          try {
+            const secKeys = await env.STATUS_CACHE.list({ prefix: 'security:seen:' })
+            if (secKeys.keys.length > 0) {
+              // TODO: highlights require storing alert titles in KV values or a dedicated accumulation key
+              // KV list() only returns key names — pass empty for now
+              security = buildSecuritySummary(secKeys.keys, [])
+            }
+          } catch { console.warn('[cron] security summary list failed') }
+
+          const briefing = buildWeeklyBriefing({ weekStart, weekEnd, changelog, incidents, stabilityChanges, security })
           await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
             title: `📋 Weekly Briefing (${weekStart} ~ ${weekEnd})`,
             description: briefing,

--- a/worker/src/weekly-briefing.ts
+++ b/worker/src/weekly-briefing.ts
@@ -18,12 +18,19 @@ export interface WeeklyStabilityChange {
   currUptime: number
 }
 
+export interface WeeklySecuritySummary {
+  hnCount: number
+  osvCount: number
+  highlights: string[] // top security alert titles (max 5)
+}
+
 export interface WeeklyBriefingData {
   weekStart: string // ISO date (Mon)
   weekEnd: string   // ISO date (Sun)
   changelog: ChangelogEntry[]
   incidents: WeeklyIncidentSummary[]
   stabilityChanges: WeeklyStabilityChange[]
+  security?: WeeklySecuritySummary
 }
 
 /**
@@ -157,5 +164,36 @@ export function buildWeeklyBriefing(data: WeeklyBriefingData): string {
     }
   }
 
+  // Section 4: Security
+  if (data.security && (data.security.hnCount > 0 || data.security.osvCount > 0)) {
+    lines.push(`\n🔒 **Security**`)
+    const parts: string[] = []
+    if (data.security.osvCount > 0) parts.push(`${data.security.osvCount} SDK vulnerabilities`)
+    if (data.security.hnCount > 0) parts.push(`${data.security.hnCount} security news`)
+    lines.push(parts.join(', '))
+    if (data.security.highlights.length > 0) {
+      for (const h of data.security.highlights.slice(0, 5)) {
+        lines.push(`• ${h}`)
+      }
+    }
+  }
+
   return lines.join('\n')
+}
+
+/**
+ * Build security summary from KV keys list (security:seen:hn:*, security:seen:osv:*).
+ * Called by cron with the list of security KV keys created this week.
+ */
+export function buildSecuritySummary(
+  keys: Array<{ name: string; metadata?: unknown }>,
+  highlights: string[],
+): WeeklySecuritySummary {
+  let hnCount = 0
+  let osvCount = 0
+  for (const k of keys) {
+    if (k.name.startsWith('security:seen:hn:')) hnCount++
+    else if (k.name.startsWith('security:seen:osv:')) osvCount++
+  }
+  return { hnCount, osvCount, highlights: highlights.slice(0, 5) }
 }


### PR DESCRIPTION
## Summary
Add Security summary section to weekly Discord briefing. Counts HN security news and OSV SDK vulnerabilities detected during the week via `security:seen:*` KV keys.

Example output:
```
🔒 Security
2 SDK vulnerabilities, 3 security news
```

## Changes
- `worker/src/weekly-briefing.ts` — `WeeklySecuritySummary`, `buildSecuritySummary()`, Security section in briefing
- `worker/src/index.ts` — list `security:seen:*` keys in weekly cron, pass to briefing builder
- `worker/src/__tests__/weekly-briefing.test.ts` — 5 new tests

## Known Limitations
- `highlights` (alert titles) are empty — KV list() returns key names only. Future: accumulation key for titles
- KV list max 1000 keys — sufficient for typical volume (~50-100/week)
- TTL-based counting has ±1d boundary approximation vs exact week range

## Test plan
- [x] Worker unit tests pass (701/701, +5 new)
- [x] `npx wrangler deploy --dry-run` passes
- [x] Code review: comments for KV limitations added

refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)