### PR TITLE
fix: show browser receive time instead of stale server cache time in Topbar

### DIFF
--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -650,7 +650,7 @@ function usePollingInternal() {
           loading: false,
           refreshing: false,
           error: null,
-          lastUpdated: new Date(data.lastUpdated),
+          lastUpdated: new Date(),
           latency24h: data.latency24h ?? [],
           probe24h: probeSnapshots,
           probeServiceIds,


### PR DESCRIPTION
## Problem
Topbar "LIVE · HH:MM" showed Worker's KV cache timestamp (`cachedAt`) which could be 1-5min behind real time. Even after clicking refresh, the stale time persisted because refresh uses cached endpoint first for speed.

## Fix
`lastUpdated: new Date(data.lastUpdated)` → `lastUpdated: new Date()`

Uses browser receive time instead of server cache time. No logic depends on server timestamp — `lastUpdated` is display-only (Topbar, Overview).

## Test plan
- [x] `npm run build` passes
- [x] Local verification: time updates immediately on refresh
- [x] Code review: no breaking changes, timezone safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)