### PR TITLE
feat: Detection Lead audit log + daily summary section (closes #256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ When adding a new monitored service, update ALL of the following:
 | `alerted:probe-spike:{svcId}` | `"1"` | 1h | ~2 | Probe RTT spike alert dedup (early detection) |
 | `pending:degraded:{svcId}` | `"1"` | 10min | ~5 | Anti-flapping: 2-cycle consecutive detection |
 | `detected:{svcId}` | ISO timestamp | 7d | ~5 | Detection Lead: earliest detection time (probe spike or status page, whichever is earlier) |
+| `detection:lead:{YYYY-MM-DD}` | `DetectionLeadEntry[]` JSON | 7d | ~0-5 | Detection Lead audit log — appended on each new incident with positive lead, dedup by incId, surfaced in Daily Summary Discord embed (#256) |
 | `reddit:seen:{postId}` | `"1"` | 24h | ~120 | Reddit post dedup (hourly scan, max 5/hour) |
 | `security:seen:hn:{objectId}` | `SecurityAlertMeta` JSON | 7d | ~0 | HN security post dedup + dashboard display |
 | `security:seen:osv:{vulnId}` | `SecurityAlertMeta` JSON | 7d | ~0 | OSV.dev vulnerability dedup + dashboard display |
@@ -315,6 +316,7 @@ worker/
     probe-archival.ts # Daily probe RTT archival + 7-day summary (p50, p95, cvCombined)
     platform-monitor.ts # Status page platform health monitoring (metastatuspage.com for Atlassian)
     detection.ts # Detection Lead entry parsing + incident-aware reset logic
+    detection-lead-log.ts # Detection Lead audit log — per-day KV array (#256), tagged AppendResult, 24h sliding window for daily summary
     reddit.ts   # Reddit r/ChatGPT + r/netsec + r/cybersecurity monitoring
     security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities)
     parsers/    # Platform-specific parsers (statuspage, incident-io, gcloud, instatus, betterstack, aws)
@@ -414,11 +416,11 @@ Cron Trigger (*/5 min)
   → read KV cache → detect incidents/status changes
   → record detection timestamps (detected:{serviceId}) for Detection Lead (probe spike time preferred if earlier)
   → KV ID-based dedup → Discord alerts (single embed per incident, with Detection Lead if probe detected first)
-  → incident detected → AI analysis via Gemma 4 (Workers AI, primary) or Sonnet (AI Gateway, fallback) (8s timeout) + Detection Lead (1-60min advance detection → "⚡ Detection Lead: Xm") → merged into incident embed
+  → incident detected → AI analysis via Gemma 4 (Workers AI, primary) or Sonnet (AI Gateway, fallback) (8s timeout) + Detection Lead (1-60min advance detection → "⚡ Detection Lead: Xm") → merged into incident embed + persisted to detection:lead:{date} audit log (#256, dedup by incId, surfaced in daily summary)
   → recovery detected → mark ai:analysis:{svcId}:{incId} with resolvedAt (2h TTL, powers "Recently Resolved" UI)
   → active incidents: refresh analysis TTL / re-analyze if expired / dedup sibling services
   → alert count tracked in KV (alert:count:{date}) for Daily Summary
-  → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75
+  → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75 + Detection Lead audit log (24h sliding window from today + yesterday keys)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@
 - **한국어/영어** — 이중 언어 지원
 - **모바일 반응형** — 사이드바 오버레이, 모바일 액션 바
 - **AIWatch Score** — uptime, 인시던트, 복구 시간, probe 기반 응답성을 결합한 종합 신뢰도 점수 ([계산 방식](https://ai-watch.dev/#about-score))
-- **Detection Lead** — 공식 발표 대비 AIWatch의 조기 감지 시간 표시 (대시보드 배지 + Discord 알림 임베드)
+- **Detection Lead** — 공식 발표 대비 AIWatch의 조기 감지 시간 표시 (대시보드 배지 + Discord 알림 임베드 + 일일 요약에 최근 24시간 감지 audit 표시)
 - **리전별 가용성** — xAI, Gemini, OpenAI의 리전별 인시던트 상태 및 전환 추천
 - **스마트 알림** — degraded/down 상태 Discord 알림 (anti-flapping + 인시던트 억제 + 복구 지속 시간)
 - **오프라인 UI** — API 연결 불가 시 안내 화면 (프로덕션 전용)
@@ -138,6 +138,7 @@ Cloudflare KV
   ├── ai:usage:{date}      (일별 AI 사용량 카운터, TTL 2일)
   ├── alerted:*            (알림 중복 방지 키, TTL 2시간-7일)
   ├── detected:{svcId}     (Detection Lead 타임스탬프, TTL 7일)
+  ├── detection:lead:{date} (Detection Lead audit 로그, UTC 일별, TTL 7일, 일일 요약에 24h 슬라이딩 윈도우)
   ├── reddit:seen:{postId} (Reddit 게시글 중복 방지, TTL 24시간)
   └── vitals:{YYYY-MM-DD}  (Web Vitals 일별 집계, TTL 2일)
 ```
@@ -323,6 +324,7 @@ worker/
     probe-archival.ts # 일별 probe RTT 아카이브 + 7일 요약
     platform-monitor.ts # 상태 페이지 플랫폼 모니터링 (metastatuspage.com)
     detection.ts # Detection Lead 파싱 + 리셋 로직
+    detection-lead-log.ts # Detection Lead audit 로그 (#256, 일일 요약)
     reddit.ts    # Reddit 장애 감지 모니터링
     parsers/     # 플랫폼별 파서
       statuspage.ts   # Atlassian Statuspage (7개 서비스)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Real-time monitoring dashboard for **30 AI services** — track status, latency,
 - **Bilingual** — Korean / English
 - **Mobile responsive** — Sidebar overlay, mobile action bar
 - **AIWatch Score** — Composite reliability score combining uptime, incidents, recovery time, and probe-based responsiveness ([how it works](https://ai-watch.dev/#about-score))
-- **Detection Lead** — Shows how much earlier AIWatch detected an incident vs official report (dashboard badge + Discord alert embed)
+- **Detection Lead** — Shows how much earlier AIWatch detected an incident vs official report (dashboard badge + Discord alert embed + daily summary audit log surfacing 24h of events)
 - **Regional availability** — Per-region incident status for xAI, Gemini, OpenAI with switch recommendation
 - **Smart alerts** — Discord alerts for degraded/down status with anti-flapping, incident suppression, and recovery duration
 - **Offline UI** — Graceful error state when API is unreachable (production only)
@@ -139,6 +139,7 @@ Cloudflare KV
   ├── ai:usage:{date}      (daily AI usage counter, TTL 2d)
   ├── alerted:*            (alert dedup keys, TTL 2h-7d)
   ├── detected:{svcId}     (Detection Lead timestamp, TTL 7d)
+  ├── detection:lead:{date} (Detection Lead audit log per UTC day, TTL 7d, 24h sliding window in daily summary)
   ├── reddit:seen:{postId} (Reddit post dedup, TTL 24h)
   └── vitals:{YYYY-MM-DD}  (Web Vitals daily aggregation, TTL 2d)
 ```
@@ -324,6 +325,7 @@ worker/
     probe-archival.ts # Daily probe RTT archival + 7-day summary
     platform-monitor.ts # Status page platform health monitoring (metastatuspage.com)
     detection.ts # Detection Lead entry parsing + reset logic
+    detection-lead-log.ts # Detection Lead audit log (#256, daily summary)
     reddit.ts    # Reddit outage chatter monitoring
     parsers/     # Platform-specific parsers
       statuspage.ts   # Atlassian Statuspage (7 services)

--- a/worker/src/__tests__/daily-summary.test.ts
+++ b/worker/src/__tests__/daily-summary.test.ts
@@ -289,6 +289,33 @@ describe('buildDailySummary', () => {
     expect(result).toContain('Alerts Sent')
     expect(result).toContain('5 posts detected')
   })
+
+  it('appends Detection Lead section when entries present', () => {
+    const result = buildDailySummary({
+      services: [makeSvc({ id: 'together', name: 'Together AI' })],
+      aiUsage: null,
+      latencySnapshots: [],
+      incidentCountToday: { newCount: 1, resolvedCount: 0 },
+      redditCount: 0,
+      detectionLeadEntries: [
+        { svcId: 'together', incId: 'i1', leadMs: 7 * 60_000, detectedAt: '2026-04-18T11:53:00Z', officialAt: '2026-04-18T12:00:00Z' },
+      ],
+    })
+    expect(result).toContain('Detection Lead (last 24h)')
+    expect(result).toContain('Together AI: 7m lead')
+  })
+
+  it('omits Detection Lead section when entries empty', () => {
+    const result = buildDailySummary({
+      services: [makeSvc({ id: 'a' })],
+      aiUsage: null,
+      latencySnapshots: [],
+      incidentCountToday: { newCount: 0, resolvedCount: 0 },
+      redditCount: 0,
+      detectionLeadEntries: [],
+    })
+    expect(result).not.toContain('Detection Lead')
+  })
 })
 
 describe('isInSummaryWindow', () => {

--- a/worker/src/__tests__/detection-lead-log.test.ts
+++ b/worker/src/__tests__/detection-lead-log.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi } from 'vitest'
+import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, detectionLeadKey, computeLeadMs, type DetectionLeadEntry } from '../detection-lead-log'
+
+function mockKV(store: Record<string, string> = {}) {
+  return {
+    get: vi.fn(async (k: string) => store[k] ?? null),
+    put: vi.fn(async (k: string, v: string) => { store[k] = v }),
+  } as unknown as KVNamespace
+}
+
+const fixedDate = new Date('2026-04-18T12:00:00Z')
+const sampleEntry: DetectionLeadEntry = {
+  svcId: 'together',
+  incId: 'inc-123',
+  leadMs: 7 * 60_000, // 7m
+  detectedAt: '2026-04-18T11:53:00Z',
+  officialAt: '2026-04-18T12:00:00Z',
+}
+
+describe('detectionLeadKey', () => {
+  it('produces YYYY-MM-DD scoped key', () => {
+    expect(detectionLeadKey(fixedDate)).toBe('detection:lead:2026-04-18')
+  })
+})
+
+describe('computeLeadMs', () => {
+  it('returns positive ms when probe detected at least 1m before official', () => {
+    expect(computeLeadMs('2026-04-18T11:53:00Z', '2026-04-18T12:00:00Z')).toBe(7 * 60_000)
+  })
+
+  it('returns null for sub-minute leads (audit + Discord both skip)', () => {
+    // 30s — too short to display as ≥1m, dropped
+    expect(computeLeadMs('2026-04-18T11:59:30Z', '2026-04-18T12:00:00Z')).toBeNull()
+    // 59s — same
+    expect(computeLeadMs('2026-04-18T11:59:01Z', '2026-04-18T12:00:00Z')).toBeNull()
+  })
+
+  it('accepts exactly 1m (boundary)', () => {
+    expect(computeLeadMs('2026-04-18T11:59:00Z', '2026-04-18T12:00:00Z')).toBe(60_000)
+  })
+
+  it('returns null when detection is at or after official (no positive lead)', () => {
+    expect(computeLeadMs('2026-04-18T12:00:00Z', '2026-04-18T12:00:00Z')).toBeNull() // tie
+    expect(computeLeadMs('2026-04-18T12:05:00Z', '2026-04-18T12:00:00Z')).toBeNull() // late
+  })
+
+  it('returns null when lead >= 60min (filters stale `detected:` KV entries)', () => {
+    // exactly 60min — excluded
+    expect(computeLeadMs('2026-04-18T11:00:00Z', '2026-04-18T12:00:00Z')).toBeNull()
+    // 59:59 — included
+    expect(computeLeadMs('2026-04-18T11:00:01Z', '2026-04-18T12:00:00Z')).toBe(59 * 60_000 + 59_000)
+  })
+
+  it('returns null on invalid ISO strings', () => {
+    expect(computeLeadMs('not-a-date', '2026-04-18T12:00:00Z')).toBeNull()
+    expect(computeLeadMs('2026-04-18T12:00:00Z', '')).toBeNull()
+  })
+})
+
+describe('appendDetectionLead', () => {
+  it('returns "persisted" + writes new entry to today key with 7d TTL', async () => {
+    const store: Record<string, string> = {}
+    const kv = mockKV(store)
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(result).toBe('persisted')
+    expect(kv.put).toHaveBeenCalledWith(
+      'detection:lead:2026-04-18',
+      expect.stringContaining('inc-123'),
+      { expirationTtl: 7 * 86400 },
+    )
+    const stored = JSON.parse(store['detection:lead:2026-04-18'])
+    expect(stored).toHaveLength(1)
+    expect(stored[0]).toEqual(sampleEntry)
+  })
+
+  it('appends to existing array preserving order', async () => {
+    // Use timestamps consistent with leadMs (12 * 60_000) so isValidEntry doesn't drop the prior entry
+    const earlier: DetectionLeadEntry = {
+      svcId: 'openai', incId: 'inc-001', leadMs: 12 * 60_000,
+      detectedAt: '2026-04-18T11:48:00Z', officialAt: '2026-04-18T12:00:00Z',
+    }
+    const store: Record<string, string> = {
+      'detection:lead:2026-04-18': JSON.stringify([earlier]),
+    }
+    const kv = mockKV(store)
+    await appendDetectionLead(kv, sampleEntry, fixedDate)
+    const stored = JSON.parse(store['detection:lead:2026-04-18'])
+    expect(stored).toHaveLength(2)
+    expect(stored[0].svcId).toBe('openai')
+    expect(stored[1].svcId).toBe('together')
+  })
+
+  it('idempotent — first returns "persisted", second returns "duplicate" (not failed — benign re-run)', async () => {
+    const store: Record<string, string> = {}
+    const kv = mockKV(store)
+    const first = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    const second = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(first).toBe('persisted')
+    expect(second).toBe('duplicate')
+    const stored = JSON.parse(store['detection:lead:2026-04-18'])
+    expect(stored).toHaveLength(1)
+  })
+
+  it('rejects entry with leadMs < 1m as "failed"', async () => {
+    const kv = mockKV({})
+    expect(await appendDetectionLead(kv, { ...sampleEntry, leadMs: 0 }, fixedDate)).toBe('failed')
+    expect(await appendDetectionLead(kv, { ...sampleEntry, leadMs: 30_000 }, fixedDate)).toBe('failed')
+    expect(await appendDetectionLead(kv, { ...sampleEntry, leadMs: -1000 }, fixedDate)).toBe('failed')
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it('rejects entry with leadMs >= 60min as "failed"', async () => {
+    const kv = mockKV({})
+    expect(await appendDetectionLead(kv, { ...sampleEntry, leadMs: 60 * 60_000 }, fixedDate)).toBe('failed')
+    expect(await appendDetectionLead(kv, { ...sampleEntry, leadMs: 90 * 60_000 }, fixedDate)).toBe('failed')
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it('aborts on persistent KV read failure as "failed" — does NOT overwrite prior data', async () => {
+    const kv = {
+      get: vi.fn(async () => { throw new Error('KV persistent failure') }),
+      put: vi.fn(),
+    } as unknown as KVNamespace
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(result).toBe('failed')
+    expect(kv.get).toHaveBeenCalledTimes(2) // initial + 1 retry
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it('aborts on JSON.parse failure as "failed" — preserves corrupt data for manual recovery', async () => {
+    const store: Record<string, string> = { 'detection:lead:2026-04-18': '{not-valid-json' }
+    const kv = mockKV(store)
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(result).toBe('failed')
+    expect(kv.put).not.toHaveBeenCalled()
+    expect(store['detection:lead:2026-04-18']).toBe('{not-valid-json')
+  })
+
+  it('aborts on non-array JSON as "failed" — preserve for inspection', async () => {
+    const store: Record<string, string> = { 'detection:lead:2026-04-18': '{"foo":"bar"}' }
+    const kv = mockKV(store)
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(result).toBe('failed')
+    expect(kv.put).not.toHaveBeenCalled()
+    expect(store['detection:lead:2026-04-18']).toBe('{"foo":"bar"}')
+  })
+
+  it('drops malformed entries from existing array before append', async () => {
+    const store: Record<string, string> = {
+      'detection:lead:2026-04-18': JSON.stringify([
+        { svcId: 'old', incId: 'old-1', leadMs: 5 * 60_000, detectedAt: '2026-04-18T11:00:00Z', officialAt: '2026-04-18T11:05:00Z' },
+        { foo: 'bar' },
+        { svcId: '', incId: 'x', leadMs: 1, detectedAt: 'a', officialAt: 'b' },
+      ]),
+    }
+    const kv = mockKV(store)
+    await appendDetectionLead(kv, sampleEntry, fixedDate)
+    const stored = JSON.parse(store['detection:lead:2026-04-18'])
+    expect(stored).toHaveLength(2)
+    expect(stored.map((e: DetectionLeadEntry) => e.svcId)).toEqual(['old', 'together'])
+  })
+
+  it('returns "failed" when kvPut throws', async () => {
+    const kv = {
+      get: vi.fn(async () => null),
+      put: vi.fn(async () => { throw new Error('KV write failed') }),
+    } as unknown as KVNamespace
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(result).toBe('failed')
+  })
+
+  it('rejects entry where leadMs disagrees with timestamp diff (consistency invariant)', async () => {
+    const kv = mockKV({})
+    // detectedAt → officialAt diff = 7m, but leadMs claims 5m → inconsistent → drop on read
+    const inconsistent: DetectionLeadEntry = {
+      svcId: 'svc', incId: 'i', leadMs: 5 * 60_000, // claims 5m
+      detectedAt: '2026-04-18T11:53:00Z', officialAt: '2026-04-18T12:00:00Z', // actual 7m
+    }
+    // The defensive guard at top accepts this (leadMs is in window) — but downstream isValidEntry
+    // catches the inconsistency on read in the same call. We test by reading via readDetectionLeadEntries.
+    // For the append path, this entry would still write since leadMs alone is in [1m, 60m).
+    // Real defense is on the READ path (isValidEntry filter). Test that:
+    const store = { 'detection:lead:2026-04-18': JSON.stringify([inconsistent, sampleEntry]) }
+    const readKv = mockKV(store)
+    const entries = await readDetectionLeadEntries(readKv, fixedDate)
+    expect(entries).toEqual([sampleEntry]) // inconsistent dropped
+  })
+
+  it('rejects entry with future officialAt beyond skew tolerance (clock-skew defense)', async () => {
+    // officialAt 10min in the future from `now` (fixedDate) — beyond 5min skew tolerance
+    const future: DetectionLeadEntry = {
+      svcId: 'skewed', incId: 'i', leadMs: 5 * 60_000,
+      detectedAt: '2026-04-18T12:05:00Z', officialAt: '2026-04-18T12:10:00Z', // both > now
+    }
+    const store = { 'detection:lead:2026-04-18': JSON.stringify([future, sampleEntry]) }
+    const kv = mockKV(store)
+    const entries = await readDetectionLeadEntries(kv, fixedDate)
+    expect(entries).toEqual([sampleEntry]) // future entry dropped
+  })
+})
+
+describe('readDetectionLeadEntries', () => {
+  it('returns entries from today by default', async () => {
+    const store = {
+      'detection:lead:2026-04-18': JSON.stringify([sampleEntry]),
+    }
+    const kv = mockKV(store)
+    const entries = await readDetectionLeadEntries(kv, fixedDate)
+    expect(entries).toEqual([sampleEntry])
+  })
+
+  it('returns empty array when key missing', async () => {
+    const kv = mockKV({})
+    const entries = await readDetectionLeadEntries(kv, fixedDate)
+    expect(entries).toEqual([])
+  })
+
+  it('returns empty array when value is malformed JSON (logs error)', async () => {
+    const kv = mockKV({ 'detection:lead:2026-04-18': 'not-json' })
+    const entries = await readDetectionLeadEntries(kv, fixedDate)
+    expect(entries).toEqual([])
+  })
+
+  it('reads multiple days when {days: 2} and dedups by (svcId, incId)', async () => {
+    // Day boundary fix: daily summary at UTC 09:00 reads today + yesterday so leads from
+    // yesterday's 09:00-24:00 window aren't lost. Timestamps internally consistent with leadMs.
+    const yesterdayEntry: DetectionLeadEntry = {
+      svcId: 'openai', incId: 'inc-y', leadMs: 5 * 60_000,
+      detectedAt: '2026-04-17T19:55:00Z', officialAt: '2026-04-17T20:00:00Z',
+    }
+    const todayEntry: DetectionLeadEntry = sampleEntry
+    const overlap: DetectionLeadEntry = { ...todayEntry } // duplicate across day-keys
+    const store = {
+      'detection:lead:2026-04-17': JSON.stringify([yesterdayEntry, overlap]),
+      'detection:lead:2026-04-18': JSON.stringify([todayEntry]),
+    }
+    const kv = mockKV(store)
+    const entries = await readDetectionLeadEntries(kv, fixedDate, { days: 2 })
+    expect(entries).toHaveLength(2) // yesterday's + today's, overlap deduped
+    const ids = entries.map(e => `${e.svcId}::${e.incId}`).sort()
+    expect(ids).toEqual(['openai::inc-y', 'together::inc-123'])
+  })
+
+  it('clamps days to [1, 7] (defends against NaN/Infinity/negative/unbounded)', async () => {
+    const kv = mockKV({ 'detection:lead:2026-04-18': JSON.stringify([sampleEntry]) })
+    // Each call should hit exactly 1 KV read (today only) since all clamp to 1
+    for (const days of [0, -5, NaN, Infinity]) {
+      vi.mocked(kv.get).mockClear()
+      const entries = await readDetectionLeadEntries(kv, fixedDate, { days })
+      expect(entries).toEqual([sampleEntry])
+      expect(kv.get).toHaveBeenCalledTimes(1) // proves clamp executed (not e.g. 0 iterations)
+    }
+    // days=10 clamped to 7
+    vi.mocked(kv.get).mockClear()
+    await readDetectionLeadEntries(kv, fixedDate, { days: 10 })
+    expect(kv.get).toHaveBeenCalledTimes(7)
+  })
+
+  it('windowMs filter excludes entries with officialAt older than windowStart (prevents cross-day re-reporting)', async () => {
+    // Daily summary at UTC 09:00 with windowMs=24h: yesterday's pre-09:00 entries already reported should be excluded
+    const lead = 5 * 60_000
+    const old: DetectionLeadEntry = {
+      svcId: 'old', incId: 'old', leadMs: lead,
+      detectedAt: '2026-04-17T07:55:00Z', officialAt: '2026-04-17T08:00:00Z', // 28h ago
+    }
+    const recent: DetectionLeadEntry = {
+      svcId: 'recent', incId: 'recent', leadMs: lead,
+      detectedAt: '2026-04-17T19:55:00Z', officialAt: '2026-04-17T20:00:00Z', // 16h ago
+    }
+    const today: DetectionLeadEntry = {
+      svcId: 'today', incId: 'today', leadMs: lead,
+      detectedAt: '2026-04-18T04:55:00Z', officialAt: '2026-04-18T05:00:00Z', // 7h ago
+    }
+    const store = {
+      'detection:lead:2026-04-17': JSON.stringify([old, recent]),
+      'detection:lead:2026-04-18': JSON.stringify([today]),
+    }
+    const kv = mockKV(store)
+    const entries = await readDetectionLeadEntries(kv, fixedDate, { days: 2, windowMs: 24 * 3_600_000 })
+    expect(entries.map(e => e.svcId).sort()).toEqual(['recent', 'today'])
+  })
+
+  it('filters out malformed entries on read (no NaNm in Discord)', async () => {
+    const store = {
+      'detection:lead:2026-04-18': JSON.stringify([
+        sampleEntry,
+        { svcId: 'bad', leadMs: 'not-a-number' }, // malformed
+        null,
+        { svcId: '', incId: '', leadMs: 0, detectedAt: '', officialAt: '' }, // empty fields
+        { ...sampleEntry, incId: 'bad-iso', detectedAt: 'not-a-date' }, // unparseable detectedAt
+        { ...sampleEntry, incId: 'bad-iso2', officialAt: 'garbage' }, // unparseable officialAt
+      ]),
+    }
+    const kv = mockKV(store)
+    const entries = await readDetectionLeadEntries(kv, fixedDate)
+    expect(entries).toEqual([sampleEntry]) // only valid one returned
+  })
+})
+
+describe('getWithRetry (transient KV failure handling)', () => {
+  it('retries once on transient kv.get throw — succeeds on second attempt', async () => {
+    let calls = 0
+    const kv = {
+      get: vi.fn(async () => {
+        calls++
+        if (calls === 1) throw new Error('transient KV blip')
+        return JSON.stringify([sampleEntry])
+      }),
+      put: vi.fn(),
+    } as unknown as KVNamespace
+    // Successful retry → entry already in array → idempotent "duplicate" return (not "failed")
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(calls).toBe(2)
+    expect(result).toBe('duplicate')
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it('isolates retry-success from idempotency: different entry → "persisted" via retry', async () => {
+    // Locks the retry-success behavior independently from the idempotent skip path
+    let calls = 0
+    const store: Record<string, string> = {}
+    const kv = {
+      get: vi.fn(async (k: string) => {
+        calls++
+        if (calls === 1) throw new Error('transient KV blip')
+        return store[k] ?? null
+      }),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v }),
+    } as unknown as KVNamespace
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(calls).toBe(2)
+    expect(result).toBe('persisted')
+    expect(kv.put).toHaveBeenCalled()
+  })
+
+  it('aborts after both attempts fail as "failed"', async () => {
+    const kv = {
+      get: vi.fn(async () => { throw new Error('persistent KV failure') }),
+      put: vi.fn(),
+    } as unknown as KVNamespace
+    const result = await appendDetectionLead(kv, sampleEntry, fixedDate)
+    expect(kv.get).toHaveBeenCalledTimes(2)
+    expect(result).toBe('failed')
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatDetectionLeadSection', () => {
+  it('returns empty string when no entries (caller skips section)', () => {
+    expect(formatDetectionLeadSection([], new Map())).toBe('')
+  })
+
+  it('renders single event with service name + lead in minutes', () => {
+    const nameMap = new Map([['together', 'Together AI']])
+    const out = formatDetectionLeadSection([sampleEntry], nameMap)
+    expect(out).toContain('Detection Lead (last 24h)')
+    expect(out).toContain('1 event')
+    expect(out).toContain('Together AI: 7m lead')
+  })
+
+  it('renders multiple events sorted by lead descending (biggest first)', () => {
+    const small: DetectionLeadEntry = { ...sampleEntry, svcId: 'openai', incId: 'i2', leadMs: 3 * 60_000 }
+    const large: DetectionLeadEntry = { ...sampleEntry, svcId: 'gemini', incId: 'i3', leadMs: 25 * 60_000 }
+    const nameMap = new Map([['together', 'Together AI'], ['openai', 'OpenAI'], ['gemini', 'Gemini']])
+    const out = formatDetectionLeadSection([sampleEntry, small, large], nameMap)
+    // Order: 25m → 7m → 3m
+    const geminiIdx = out.indexOf('Gemini')
+    const togetherIdx = out.indexOf('Together AI')
+    const openaiIdx = out.indexOf('OpenAI')
+    expect(geminiIdx).toBeLessThan(togetherIdx)
+    expect(togetherIdx).toBeLessThan(openaiIdx)
+    expect(out).toContain('3 events')
+  })
+
+  it('falls back to svcId when service name missing from map', () => {
+    const out = formatDetectionLeadSection([sampleEntry], new Map())
+    expect(out).toContain('together: 7m lead')
+  })
+
+  it('floors lead milliseconds (never displays 60m for [59m30s, 60m) inputs)', () => {
+    // Math.floor — 7m 31s → 7m (not 8m); 59m 59s → 59m (not 60m which would violate the cap)
+    const entry7m31s = { ...sampleEntry, leadMs: 7 * 60_000 + 31_000 }
+    expect(formatDetectionLeadSection([entry7m31s], new Map([['together', 'Together AI']]))).toContain('Together AI: 7m lead')
+
+    const entry59m59s = { ...sampleEntry, leadMs: 59 * 60_000 + 59_000 }
+    const out = formatDetectionLeadSection([entry59m59s], new Map([['together', 'Together AI']]))
+    expect(out).toContain('Together AI: 59m lead')
+    expect(out).not.toContain('60m')
+  })
+})

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -3,6 +3,7 @@
 
 import { getFallbacks, buildFallbackText } from './fallback'
 import { sanitize, formatDuration } from './utils'
+import { computeLeadMs } from './detection-lead-log'
 import type { ServiceStatus } from './services'
 import type { Incident } from './types'
 
@@ -219,13 +220,11 @@ export function buildServiceAlerts(
  */
 export function formatDetectionLead(detectedAt: string | null, incidentStartedAt: string): string {
   if (!detectedAt) return ''
-  const detected = new Date(detectedAt).getTime()
-  const started = new Date(incidentStartedAt).getTime()
-  if (isNaN(detected) || isNaN(started)) return ''
-  const diffMs = started - detected
-  if (diffMs <= 0) return ''
-  const mins = Math.floor(diffMs / 60_000)
-  if (mins < 1 || mins >= 60) return ''
+  // Use computeLeadMs as single source of truth — guarantees Discord display + audit log share the same window.
+  // Math.floor (not round) ensures display never claims 60m when leadMs is in [59m30s, 60m) — the cap is exclusive.
+  const leadMs = computeLeadMs(detectedAt, incidentStartedAt)
+  if (leadMs === null) return ''
+  const mins = Math.floor(leadMs / 60_000)
   return `⚡ **Detection Lead: ${mins}m** — AIWatch detected this before the official report`
 }
 

--- a/worker/src/daily-summary.ts
+++ b/worker/src/daily-summary.ts
@@ -3,8 +3,10 @@
 import type { ServiceStatus } from './types'
 import type { ProbeSnapshot } from './probe'
 import type { VitalsDaily } from './vitals'
+import type { DetectionLeadEntry } from './detection-lead-log'
 import { formatVitalsSection } from './vitals'
 import { aggregateProbeDaily } from './probe-archival'
+import { formatDetectionLeadSection } from './detection-lead-log'
 
 export interface DailySummaryData {
   services: ServiceStatus[]
@@ -18,10 +20,11 @@ export interface DailySummaryData {
   securityCount?: number
   vitals?: VitalsDaily | null
   probeSnapshots?: ProbeSnapshot[]
+  detectionLeadEntries?: DetectionLeadEntry[]
 }
 
 export function buildDailySummary(data: DailySummaryData): string {
-  const { services, aiUsage, latencySnapshots, incidentCountToday, alertCounts, webhookCounts, deliveryCounts, redditCount, vitals } = data
+  const { services, aiUsage, latencySnapshots, incidentCountToday, alertCounts, webhookCounts, deliveryCounts, redditCount, vitals, detectionLeadEntries } = data
   const total = services.length
   const operational = services.filter(s => s.status === 'operational').length
   const degraded = services.filter(s => s.status === 'degraded').length
@@ -138,6 +141,13 @@ export function buildDailySummary(data: DailySummaryData): string {
   // Section: Web Vitals
   if (vitals && vitals.count > 0) {
     lines.push(formatVitalsSection(vitals))
+  }
+
+  // Section: Detection Lead audit log (today's events) — verifies the feature is working day-to-day
+  if (detectionLeadEntries && detectionLeadEntries.length > 0) {
+    const nameMap = new Map(services.map(s => [s.id, s.name]))
+    const section = formatDetectionLeadSection(detectionLeadEntries, nameMap)
+    if (section) lines.push(section)
   }
 
   return lines.join('\n')

--- a/worker/src/detection-lead-log.ts
+++ b/worker/src/detection-lead-log.ts
@@ -1,0 +1,223 @@
+// Detection Lead audit log — persists every Detection Lead occurrence for daily summary + retrospective inspection.
+// Per-day KV array (7d TTL) keyed by `detection:lead:{YYYY-MM-DD}`. Dedup by incidentId so retries don't double-count.
+//
+// Window contract (#256 review): MIN_LEAD_MS = 60_000 (1m), MAX_LEAD_MS = 60min. Both alerts.ts:formatDetectionLead
+// and this module call computeLeadMs() so display + audit log can never drift on sub-minute or 60min+ leads.
+//
+// Failure semantics:
+// - All KV writes go through kvPut helper (logs failures with [kv] tag, returns false).
+// - Read failures (KV throw, JSON parse, non-array, malformed entries) all log via console.error/warn so silent
+//   corruption is visible in production logs.
+// - On read/parse/non-array failure, appendDetectionLead aborts (returns 'failed') instead of
+//   overwriting — prevents data loss from transient KV blips. Append outcome is a tagged union
+//   AppendResult = 'persisted' | 'duplicate' | 'failed' so callers can distinguish benign idempotent
+//   re-runs from real persist failures.
+// - Per-entry shape validated on read; malformed entries are filtered out + warned (prevents NaNm in Discord).
+
+import { kvPut } from './utils'
+
+export interface DetectionLeadEntry {
+  svcId: string
+  incId: string
+  leadMs: number
+  detectedAt: string  // ISO — when AIWatch (probe) first noticed
+  officialAt: string  // ISO — incident.startedAt from status page
+}
+
+export const MIN_LEAD_MS = 60_000          // 1m — sub-minute leads aren't displayed in Discord, so don't audit them either
+export const MAX_LEAD_MS = 60 * 60_000     // 60m — formatDetectionLead caps at <60min to filter stale `detected:` entries
+export const DAYS_FOR_DAILY_SUMMARY = 2    // today + yesterday — covers the 24h window ending at UTC 09:00 cron run
+
+export function detectionLeadKey(date: Date = new Date()): string {
+  return `detection:lead:${date.toISOString().split('T')[0]}`
+}
+
+const READ_FAILED = Symbol('detection-lead-read-failed')
+
+/** Read KV with one retry (50ms backoff) — converts most transient failures into success
+ *  without compromising abort-on-corruption guarantees (parse/non-array still abort hard).
+ *  Backoff intentionally short: cron has a sub-30s budget, and KV blips are typically eventual-
+ *  consistency races (sub-100ms), not throttling. Don't bloat unless evidence of real backpressure. */
+async function getWithRetry(kv: KVNamespace, key: string): Promise<string | null | typeof READ_FAILED> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await kv.get(key)
+    } catch (err) {
+      if (attempt === 1) {
+        console.error('[detection-lead] KV read failed after retry:', key, '-', err instanceof Error ? err.message : err)
+        return READ_FAILED
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  return READ_FAILED
+}
+
+/** Compute lead in ms from detection + official timestamps.
+ *  Returns null when timestamps are invalid OR lead is outside [MIN_LEAD_MS, MAX_LEAD_MS).
+ *  Single source of truth so the audit log and Discord display never disagree on the window. */
+export function computeLeadMs(detectedAt: string, officialAt: string): number | null {
+  const detected = new Date(detectedAt).getTime()
+  const official = new Date(officialAt).getTime()
+  if (isNaN(detected) || isNaN(official)) return null
+  const diff = official - detected
+  if (diff < MIN_LEAD_MS || diff >= MAX_LEAD_MS) return null
+  return diff
+}
+
+// Tolerance for clock skew between AIWatch (Cloudflare PoP NTP) and upstream status pages.
+// 5min is conservative: rejects obvious garbage (status page "future" timestamps, manual backdates)
+// while not rejecting legitimate near-real-time incidents. Sub-second NTP drift fits comfortably.
+const CLOCK_SKEW_TOLERANCE_MS = 5 * 60_000
+// Tolerance for leadMs ↔ (officialMs - detectedMs) drift — 1s covers JSON serialization rounding
+// and Date arithmetic between calls. Producers compute leadMs directly from the same timestamp pair,
+// so drift is normally 0; the slack exists for future writers, not as a defense against real corruption.
+const LEAD_MS_DRIFT_TOLERANCE_MS = 1000
+
+/** Validates a parsed JSON object matches the DetectionLeadEntry shape including:
+ *  - parseable ISO timestamps
+ *  - leadMs consistent with (officialAt - detectedAt) within 1s tolerance
+ *  - officialAt not meaningfully in the future (rejects clock-skew/garbage timestamps that would
+ *    otherwise produce fictitious "Detection Lead: 45m" entries from synthesized timestamps) */
+function isValidEntry(e: unknown, now: number = Date.now()): e is DetectionLeadEntry {
+  if (!e || typeof e !== 'object') return false
+  const o = e as Record<string, unknown>
+  if (typeof o.svcId !== 'string' || o.svcId.length === 0) return false
+  if (typeof o.incId !== 'string' || o.incId.length === 0) return false
+  if (typeof o.leadMs !== 'number' || !Number.isFinite(o.leadMs)) return false
+  if (o.leadMs < MIN_LEAD_MS || o.leadMs >= MAX_LEAD_MS) return false
+  if (typeof o.detectedAt !== 'string') return false
+  if (typeof o.officialAt !== 'string') return false
+  const detectedMs = new Date(o.detectedAt).getTime()
+  const officialMs = new Date(o.officialAt).getTime()
+  if (isNaN(detectedMs) || isNaN(officialMs)) return false
+  // Reject future timestamps beyond skew tolerance (prevents fabricated leads from clock-skewed sources)
+  if (officialMs > now + CLOCK_SKEW_TOLERANCE_MS) return false
+  // leadMs must agree with timestamp diff within tolerance — defends against drift between fields
+  if (Math.abs((officialMs - detectedMs) - o.leadMs) > LEAD_MS_DRIFT_TOLERANCE_MS) return false
+  return true
+}
+
+/** Outcome of an append attempt. 'duplicate' is benign (idempotent re-run), 'failed' indicates real
+ *  drift between Discord display and audit log that the caller should warn on. */
+export type AppendResult = 'persisted' | 'duplicate' | 'failed'
+
+/** Append a Detection Lead occurrence to today's KV array.
+ *  Idempotent on (svcId, incId) — re-running the same cron won't duplicate.
+ *  Rejects entries with leadMs outside the window — mirrors Discord display rules.
+ *  ABORTS on KV read/parse/non-array failure ('failed') instead of overwriting prior data. */
+export async function appendDetectionLead(
+  kv: KVNamespace,
+  entry: DetectionLeadEntry,
+  now: Date = new Date(),
+): Promise<AppendResult> {
+  // Defensive: enforce all DetectionLeadEntry invariants at the write boundary so corrupt entries
+  // never reach KV. isValidEntry runs the same checks downstream readers apply, keeping append +
+  // read symmetry — a future producer bug can't write garbage that read silently drops.
+  if (!isValidEntry(entry, now.getTime())) {
+    console.warn('[detection-lead] rejecting invalid entry at append:', { svcId: entry.svcId, incId: entry.incId, leadMs: entry.leadMs })
+    return 'failed'
+  }
+  const key = detectionLeadKey(now)
+  // Distinguish "KV read failed" from "key absent". On failure, abort instead of overwriting.
+  // getWithRetry already retries once on transient KV errors before declaring failure.
+  const raw = await getWithRetry(kv, key)
+  if (raw === READ_FAILED) return 'failed'
+  let entries: DetectionLeadEntry[] = []
+  if (raw) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      // JSON parse failure means stored value is corrupt — abort rather than overwrite. Manual KV
+      // inspection can recover; silent overwrite cannot. Same for non-array (different schema entirely).
+      console.error('[detection-lead] existing log unparseable, aborting append:', err instanceof Error ? err.message : err)
+      return 'failed'
+    }
+    if (!Array.isArray(parsed)) {
+      console.error('[detection-lead] existing log is not an array, aborting append:', typeof parsed)
+      return 'failed'
+    }
+    entries = parsed.filter((e) => isValidEntry(e, now.getTime()))
+  }
+  // Idempotent: skip if this incident already logged today
+  if (entries.some(e => e.incId === entry.incId && e.svcId === entry.svcId)) return 'duplicate'
+  entries.push(entry)
+  const ok = await kvPut(kv, key, JSON.stringify(entries), { expirationTtl: 7 * 86400 })
+  if (!ok) {
+    console.error('[detection-lead] PERSIST FAILED — daily summary will be missing entry:', { svcId: entry.svcId, incId: entry.incId, leadMs: entry.leadMs })
+    return 'failed'
+  }
+  return 'persisted'
+}
+
+/** Read Detection Lead entries from KV, validating per-entry shape and dropping malformed.
+ *  `opts.days` controls how many recent days to read (default 1 = today only). Clamped to [1, 7].
+ *  `opts.windowMs` filters entries by `officialAt` to a sliding window ending at `date` — prevents
+ *  entries from being re-reported across consecutive daily summaries (e.g., 24h window at UTC 09:00
+ *  excludes yesterday's pre-09:00 entries already shown in yesterday's summary).
+ *  Daily summary uses `{ days: DAYS_FOR_DAILY_SUMMARY, windowMs: 24*3600_000 }`.
+ *  Internal dedup by (svcId, incId) handles same-incident overlap across day-key boundaries. */
+export async function readDetectionLeadEntries(
+  kv: KVNamespace,
+  date: Date = new Date(),
+  opts: { days?: number; windowMs?: number } = {},
+): Promise<DetectionLeadEntry[]> {
+  // Clamp days to [1, 7] — defends against NaN, Infinity, negative, or unbounded read attempts
+  const rawDays = Number.isFinite(opts.days) ? (opts.days as number) : 1
+  const days = Math.max(1, Math.min(7, Math.floor(rawDays)))
+  const windowStart = Number.isFinite(opts.windowMs) ? date.getTime() - (opts.windowMs as number) : null
+  const out: DetectionLeadEntry[] = []
+  const seen = new Set<string>()
+  for (let offset = 0; offset < days; offset++) {
+    const target = new Date(date.getTime() - offset * 86_400_000)
+    const targetKey = detectionLeadKey(target)
+    const raw = await getWithRetry(kv, targetKey)
+    if (raw === READ_FAILED || !raw) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      console.error('[detection-lead] read parse failed for', targetKey, '— daily summary will be incomplete:', err instanceof Error ? err.message : err)
+      continue
+    }
+    if (!Array.isArray(parsed)) {
+      console.warn('[detection-lead] non-array value at', targetKey)
+      continue
+    }
+    let dropped = 0
+    const nowMs = date.getTime()
+    for (const entry of parsed) {
+      if (!isValidEntry(entry, nowMs)) { dropped++; continue }
+      // Time-window filter: skip entries outside the requested window (prevents cross-day re-reporting)
+      if (windowStart !== null) {
+        const officialMs = new Date(entry.officialAt).getTime()
+        if (officialMs < windowStart) continue
+      }
+      const dedupKey = `${entry.svcId}::${entry.incId}`
+      if (seen.has(dedupKey)) continue
+      seen.add(dedupKey)
+      out.push(entry)
+    }
+    if (dropped > 0) console.warn(`[detection-lead] dropped ${dropped} malformed entr${dropped === 1 ? 'y' : 'ies'} from ${targetKey}`)
+  }
+  return out
+}
+
+/** Format Detection Lead entries as a Discord embed section.
+ *  Returns empty string if no entries (caller skips the section). */
+export function formatDetectionLeadSection(
+  entries: DetectionLeadEntry[],
+  serviceNames: Map<string, string>,
+): string {
+  if (entries.length === 0) return ''
+  // Sort by lead time descending — biggest wins first
+  const sorted = [...entries].sort((a, b) => b.leadMs - a.leadMs)
+  const lines = sorted.map(e => {
+    const name = serviceNames.get(e.svcId) ?? e.svcId
+    // Math.floor matches formatDetectionLead — never displays 60m for leads in [59m30s, 60m)
+    const mins = Math.floor(e.leadMs / 60_000)
+    return `   ${name}: ${mins}m lead`
+  })
+  return `\n⚡ **Detection Lead (last 24h)** (${entries.length} ${entries.length === 1 ? 'event' : 'events'})\n${lines.join('\n')}`
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,6 +8,7 @@ import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDet
 import { analyzeIncident, refreshOrReanalyze, analysisKey, formatRecoveryDisplay, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
+import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
 
 interface Env {
   ALLOWED_ORIGIN: string
@@ -555,11 +556,26 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
             console.error('[cron] AI analysis failed:', err instanceof Error ? err.message : err)
           }
         }
-        // Detection Lead: show early detection advantage in Discord alert
+        // Detection Lead: show early detection advantage in Discord alert + persist to audit log
         try {
           const detectRaw = await env.STATUS_CACHE.get(`detected:${svc.id}`).catch(() => null)
           const detectedAt = getDetectionTimestamp(detectRaw)
           detectionLeadSection = formatDetectionLead(detectedAt, inc.startedAt)
+          // Persist to audit log: computeLeadMs returns null outside [1m, 60m) — single source of truth
+          // shared with formatDetectionLead, so audit log can never drift from Discord display rules.
+          if (detectedAt) {
+            const leadMs = computeLeadMs(detectedAt, inc.startedAt)
+            if (leadMs !== null) {
+              const result = await appendDetectionLead(env.STATUS_CACHE, {
+                svcId: svc.id, incId: inc.id, leadMs, detectedAt, officialAt: inc.startedAt,
+              })
+              // Tagged return ('persisted' | 'duplicate' | 'failed') — only 'failed' is a real drift signal;
+              // 'duplicate' fires on legitimate idempotent re-runs of the same incident across cron ticks.
+              if (result === 'failed') {
+                console.warn('[cron] detection lead displayed in Discord but NOT persisted to audit log:', { svcId: svc.id, incId: inc.id, leadMs })
+              }
+            }
+          }
         } catch (err) {
           console.error('[cron] detection lead failed:', err instanceof Error ? err.message : err)
         }
@@ -1164,6 +1180,19 @@ export default {
             return null
           })
 
+          // Detection Lead audit log — read today + yesterday keys (DAYS_FOR_DAILY_SUMMARY=2) so entries
+          // from yesterday's 09:00–24:00 window are surfaced. windowMs=24h filters the union to a sliding
+          // 24h window ending now, preventing entries already shown in yesterday's 09:00 summary from being
+          // re-reported today. Internal dedup by (svcId, incId) handles same-incident overlap.
+          // .catch boundary: defensive — readDetectionLeadEntries returns [] internally on every error
+          // path today, but a future refactor introducing a synchronous throw would otherwise crash the
+          // entire daily summary cron. Cheap to keep.
+          const detectionLeadEntries = await readDetectionLeadEntries(env.STATUS_CACHE, new Date(), { days: DAYS_FOR_DAILY_SUMMARY, windowMs: 24 * 3_600_000 })
+            .catch((err) => {
+              console.error('[daily-summary] detection lead read failed:', err instanceof Error ? err.message : err)
+              return []
+            })
+
           const description = buildDailySummary({
             services: dailyServices,
             aiUsage,
@@ -1176,6 +1205,7 @@ export default {
             securityCount,
             vitals: vitalsSummary,
             probeSnapshots,
+            detectionLeadEntries,
           })
 
           if (isCatchUp) console.log(`[daily-summary] catch-up run for ${today}`)


### PR DESCRIPTION
## Summary
Make Detection Lead verifiable day-to-day. Adds a per-day KV audit log of every probe-detected lead and surfaces the last 24h in the existing Discord daily summary.

> **Base branch is `feat/132-responsiveness-score` (PR #255)** — depends on it landing first. Once #255 merges to main, this PR can be retargeted.

## Changes
**New module** `worker/src/detection-lead-log.ts`:
- `computeLeadMs(detectedAt, officialAt)` — single source of truth for the [1m, 60m) lead window. Used by both `alerts.ts:formatDetectionLead` (display) and `index.ts` cron (audit append). Display + audit log can no longer drift.
- `appendDetectionLead(kv, entry)` returns tagged `AppendResult = 'persisted' \| 'duplicate' \| 'failed'`. Cron warns only on `'failed'` (not benign idempotent re-runs).
- `readDetectionLeadEntries(kv, date, opts)` reads N days with `windowMs` sliding-window filter. Daily summary uses `{ days: 2, windowMs: 24h }` to surface yesterday's 09:00–24:00 leads without re-reporting earlier ones.
- `formatDetectionLeadSection(entries, names)` — Discord embed string sorted by lead desc, `Math.floor` so 59m59s never displays as 60m.

**KV** `detection:lead:{YYYY-MM-DD}` JSON array, 7d TTL, ~0-5 writes/day, dedup by `(svcId, incId)`.

**Wiring**:
- `index.ts` cron calls `appendDetectionLead` after Discord alert send (only when `formatDetectionLead` produces a positive lead). Tagged return checked; only `'failed'` warns.
- Daily summary cron passes today + yesterday entries to `buildDailySummary` → renders `⚡ Detection Lead (last 24h)` section after Web Vitals.

## Defense in depth
- **Single-source window**: both display + audit gate on `computeLeadMs`. Sub-minute and 60min+ leads filtered identically.
- **`isValidEntry`** validates shape, ISO parseability, `leadMs ↔ timestamp` consistency (1s tolerance), and future-clock skew (5min tolerance). Runs at both append AND read.
- **Abort-on-corruption**: `appendDetectionLead` returns `'failed'` on KV read/parse/non-array failure rather than silent overwrite. Existing KV data preserved for manual recovery.
- **`getWithRetry`** absorbs single transient KV blip (50ms backoff) before declaring failure.
- **`days` clamp `[1, 7]`** defends against NaN/Infinity/negative/unbounded input.

## Tests
**798 worker tests pass** (+38 new):
- `detection-lead-log.test.ts` (34 cases): computeLeadMs boundaries (1m/60m), tagged returns, idempotency, retry success/failure isolation, malformed entry filter, future skew rejection, leadMs drift detection, day clamp, windowMs filter
- `daily-summary.test.ts` (+2): section appears with entries / omitted when empty
- `wrangler dry-run` clean

## Code review
5 rounds of automated review (general / silent-failure / test-coverage / type-design):
- R1: 4 CRIT/HIGH issues (drift, silent overwrite, race, etc.) → all fixed
- R2: 2 CRIT (drift between display+audit, silent overwrite on read fail) → all fixed
- R3: 1 CRIT (Math.round → 60m display) + 5 IMP → all fixed
- R4: 0 CRIT + 1 test gap + 4 hardening → all addressed
- R5: 0 CRIT + 1 doc fix + 2 MEDIUM → all addressed
- Final type design rating: **9.4/10**

## Test plan
- [x] Worker dry-run + unit tests
- [x] Build + lint clean
- [x] Code review iterations (5 rounds, converged at R5)
- [ ] Verify in production: next real incident with probe-detected lead → daily summary shows the entry the following morning

## Documentation
- CLAUDE.md: KV schema row, directory layout entry, data flow descriptions for cron + daily summary
- README.md/ko.md: feature description updated, KV section + file listing

closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)