### PR TITLE
perf: async Google Fonts load to unblock LCP (refs #191)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `click_service_detail` | `location`, `service_id` | Is X Down (footer) | Service detail page click |
 | `click_reports` | `location`, `source` | Is X Down (alternatives/footer) | Monthly reports link click (Is X Down) |
 | `click_ph_upvote` | `location` | Landing page (PH banner) | Product Hunt upvote link click |
+| `font_load_failed` | `transport_type: 'beacon'` | index.html `<link>` onerror | Google Fonts CSS preload failed (CDN outage, ad blocker, network) — surfaces silent fallback to system fonts (refs #191) |
 
 Is X Down pages (Edge SSR) and Landing page use inline `gtag()` calls directly since they don't use React.
 

--- a/index.html
+++ b/index.html
@@ -45,10 +45,24 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Async Google Fonts load: preload as 'style' (non-blocking), swap to stylesheet on load.
+         Combined with display=swap, text renders immediately in fallback then swaps to web font.
+         Saves ~450ms LCP per Lighthouse audit (refs #191).
+         onerror reports CDN/network failures via GA4 — without this, font load failure is silent
+         (page renders in system fallback indefinitely with no signal). -->
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap"
-      rel="stylesheet"
+      onload="this.onload=null;this.rel='stylesheet'"
+      onerror="this.onerror=null;window.gtag&&gtag('event','font_load_failed',{transport_type:'beacon'})"
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap"
+      />
+    </noscript>
   </head>
   <body>
     <script>


### PR DESCRIPTION
## Summary
Lighthouse audit (2026-04-16) flagged Google Fonts CSS as 826ms render-blocking with ~450ms estimated LCP savings. Convert to async preload-swap pattern.

## Changes
- `index.html`: synchronous `<link rel="stylesheet">` → async `<link rel="preload" as="style" onload="...">` + `<noscript>` fallback
- `onerror` handler reports `font_load_failed` GA4 event (CDN/network failure detection — without this, page silently falls back to system fonts)
- `CLAUDE.md`: GA4 events table updated

## Why this works
- **`display=swap`** already in URL → @font-face level FOUT handling (text renders in fallback immediately)
- **`sans-serif` / `monospace`** generic fallbacks in `src/index.css` CSS variables → no FOIT for LCP element
- **Filament Group canonical pattern** — `this.onload=null` prevents repeated firing, `this.rel='stylesheet'` triggers actual apply
- **`<noscript>`** preserves font load for JS-disabled visitors

## Why this is independent of #255/#257
LCP optimization is independent of Score formula changes. Targets `main` directly. PR #255 (Responsiveness Score) and PR #257 (Detection Lead audit) are queued separately.

## Code review
2 rounds of automated review:
- General code: **Approve** — standard pattern, no CSP/LCP/compat blockers
- Silent failure: 0 CRIT + 2 HIGH addressed (onerror handler added; crossorigin skip verified per canonical pattern)

## Test plan
- [x] `npm run build` clean
- [x] HMR dev server renders with async pattern
- [ ] Production verification:
  - Vercel preview deploy → DevTools Network tab shows preload, no "preload not used" warning
  - Lighthouse re-run after deploy → LCP improvement vs 7.5s baseline
  - GA4 dashboard: `font_load_failed` events should be near zero in normal operation

## Production observability
After deploy, monitor `font_load_failed` event count. Non-zero count indicates ad-blocker stripping, CDN issue, or network regression — all silent failure modes that previously produced no signal.

refs #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)