### PR TITLE
fix: apply Atlassian impact weighting to estimate-source uptime (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ worker/
     security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities)
     parsers/    # Platform-specific parsers (statuspage, incident-io, gcloud, instatus, betterstack, aws)
                 # dailyImpact support: statuspage (uptimeData), incident-io (component impacts), betterstack (status_history from index.json)
+                # impact-weights.ts: shared MAJOR_WEIGHT=1.0, MINOR_WEIGHT=0.3 — used by both statuspage.ts (official) and incident-io.ts (estimate from durations) for Atlassian-aligned uptime%
 ```
 
 ### Design System

--- a/README.ko.md
+++ b/README.ko.md
@@ -120,8 +120,9 @@ Cloudflare Worker
   └── POST /api/alert   → Webhook 프록시 (Slack/Discord, SSRF 보호)
   ↓
 파서 (worker/src/parsers/)
-  ├── statuspage.ts      → Atlassian Statuspage API + uptimeData HTML
-  ├── incident-io.ts     → incident.io 호환 API + component_uptimes/impacts
+  ├── impact-weights.ts  → 공유 MAJOR_WEIGHT/MINOR_WEIGHT (Atlassian 공식, 두 파서 공통)
+  ├── statuspage.ts      → Atlassian Statuspage API + uptimeData HTML (가중치 적용 공식 uptime)
+  ├── incident-io.ts     → incident.io 호환 API + component_uptimes/impacts (인시던트 추정 uptime도 동일 가중치 공식 사용)
   ├── gcloud.ts          → Google Cloud incidents.json
   ├── instatus.ts        → Instatus Nuxt/Next.js SSR
   ├── betterstack.ts     → Better Stack RSS + /index.json 가동률 API + dailyImpact (status_history)

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ Cloudflare Worker
   └── POST /api/alert   → webhook proxy (Slack/Discord, SSRF protected)
   ↓
 Parsers (worker/src/parsers/)
-  ├── statuspage.ts      → Atlassian Statuspage API + uptimeData HTML
-  ├── incident-io.ts     → incident.io compat API + component_uptimes/impacts
+  ├── impact-weights.ts  → shared MAJOR_WEIGHT/MINOR_WEIGHT (Atlassian formula, used by both)
+  ├── statuspage.ts      → Atlassian Statuspage API + uptimeData HTML (weighted official uptime)
+  ├── incident-io.ts     → incident.io compat API + component_uptimes/impacts (estimate from durations uses the same weighted formula)
   ├── gcloud.ts          → Google Cloud incidents.json
   ├── instatus.ts        → Instatus Nuxt/Next.js SSR
   ├── betterstack.ts     → Better Stack RSS + /index.json uptime API + dailyImpact (status_history)

--- a/worker/src/parsers/__tests__/incident-io.test.ts
+++ b/worker/src/parsers/__tests__/incident-io.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { parseIncidentIoUptime, parseIncidentIoComponentImpacts, computeUptimeFromIncidents, parseIncidentIoUpdates, applyTextCache, buildTextCache } from '../incident-io'
 import type { IncidentTextCache } from '../incident-io'
 import type { Incident } from '../../types'
@@ -103,43 +103,397 @@ describe('parseIncidentIoComponentImpacts', () => {
 })
 
 describe('computeUptimeFromIncidents', () => {
+  // Belt-and-suspenders: if any future contributor adds .concurrent or top-level
+  // afterEach config drift, this restores any leaked spies between tests.
+  afterEach(() => vi.restoreAllMocks())
+
   it('returns null for empty incidents', () => {
     expect(computeUptimeFromIncidents([])).toBeNull()
   })
 
   it('returns 100 when all incidents are outside 90-day window', () => {
     const result = computeUptimeFromIncidents([{
-      id: '1', title: 'Old', status: 'resolved', impact: null,
+      id: '1', title: 'Old', status: 'resolved', impact: 'major',
       startedAt: '2020-01-01T00:00:00Z', duration: '1h 0m',
-      componentNames: [], timeline: [],
+      timeline: [],
     }])
     expect(result).toBe(100)
   })
 
-  it('computes uptime from recent incidents', () => {
+  it('computes uptime from recent major incidents (weight 1.0)', () => {
     const now = new Date()
     const yesterday = new Date(now.getTime() - 86_400_000).toISOString()
     const result = computeUptimeFromIncidents([{
       id: '1', title: 'Recent', status: 'resolved', impact: 'major',
       startedAt: yesterday, duration: '1h 0m',
-      componentNames: [], timeline: [],
+      timeline: [],
     }])
     expect(result).not.toBeNull()
     expect(result!).toBeGreaterThan(99)
     expect(result!).toBeLessThan(100)
   })
 
-  it('merges overlapping intervals', () => {
+  it('merges overlapping intervals (no double-count)', () => {
     const now = new Date()
     const base = new Date(now.getTime() - 86_400_000).toISOString()
     const result = computeUptimeFromIncidents([
-      { id: '1', title: 'A', status: 'resolved', impact: 'major', startedAt: base, duration: '2h 0m', componentNames: [], timeline: [] },
-      { id: '2', title: 'B', status: 'resolved', impact: 'major', startedAt: base, duration: '1h 0m', componentNames: [], timeline: [] },
+      { id: '1', title: 'A', status: 'resolved', impact: 'major', startedAt: base, duration: '2h 0m', timeline: [] },
+      { id: '2', title: 'B', status: 'resolved', impact: 'major', startedAt: base, duration: '1h 0m', timeline: [] },
     ])
-    // Overlapping — should not double count
+    // Union = 2h out of 90 days = 1 - 2/(90×24); floored to 2 decimals
+    const downMs = 2 * 3_600_000
+    const expected = Math.floor((1 - downMs / (90 * 86_400_000)) * 10000) / 100
     expect(result).not.toBeNull()
-    // 2h out of 90 days ≈ 99.91%
-    expect(result!).toBeGreaterThan(99.9)
+    expect(result!).toBe(expected)
+  })
+
+  it('weights minor incidents at 0.3 (Atlassian formula)', () => {
+    const now = new Date()
+    const yesterday = new Date(now.getTime() - 86_400_000).toISOString()
+    const minorOnly = computeUptimeFromIncidents([{
+      id: '1', title: 'Minor', status: 'resolved', impact: 'minor',
+      startedAt: yesterday, duration: '10h 0m',
+      timeline: [],
+    }])
+    const majorOnly = computeUptimeFromIncidents([{
+      id: '2', title: 'Major', status: 'resolved', impact: 'major',
+      startedAt: yesterday, duration: '10h 0m',
+      timeline: [],
+    }])
+    // Minor's weighted downtime is 30% of major's
+    // → minor uptime is closer to 100 than major uptime
+    expect(minorOnly).not.toBeNull()
+    expect(majorOnly).not.toBeNull()
+    expect(minorOnly!).toBeGreaterThan(majorOnly!)
+    // Approximate check: minor downtime ≈ 0.3 × major downtime
+    const minorDown = 100 - minorOnly!
+    const majorDown = 100 - majorOnly!
+    expect(minorDown).toBeCloseTo(majorDown * 0.3, 2)
+  })
+
+  it('skips null-impact incidents (informational only)', () => {
+    const now = new Date()
+    const yesterday = new Date(now.getTime() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([{
+      id: '1', title: 'Info', status: 'resolved', impact: null,
+      startedAt: yesterday, duration: '10h 0m',
+      timeline: [],
+    }])
+    // null impact filtered → no outage intervals → 100%
+    expect(result).toBe(100)
+  })
+
+  it('uses max weight when major and minor overlap', () => {
+    const now = new Date()
+    const base = new Date(now.getTime() - 86_400_000).toISOString()
+    // Major (weight 1.0) covers the full 2h; minor (0.3) overlaps for 1h
+    // Max-weight-wins → effective weighted downtime = 2h × 1.0 = 2h
+    const overlap = computeUptimeFromIncidents([
+      { id: '1', title: 'Maj', status: 'resolved', impact: 'major', startedAt: base, duration: '2h 0m', timeline: [] },
+      { id: '2', title: 'Min', status: 'resolved', impact: 'minor', startedAt: base, duration: '1h 0m', timeline: [] },
+    ])
+    const majorOnly = computeUptimeFromIncidents([
+      { id: '1', title: 'Maj', status: 'resolved', impact: 'major', startedAt: base, duration: '2h 0m', timeline: [] },
+    ])
+    expect(overlap).not.toBeNull()
+    expect(majorOnly).not.toBeNull()
+    // Overlap should match major-only — minor doesn't add downtime in the overlap window
+    expect(overlap!).toBeCloseTo(majorOnly!, 2)
+  })
+
+  it('treats critical with the same weight as major (1.0)', () => {
+    const now = new Date()
+    const yesterday = new Date(now.getTime() - 86_400_000).toISOString()
+    const critical = computeUptimeFromIncidents([{
+      id: '1', title: 'Crit', status: 'resolved', impact: 'critical',
+      startedAt: yesterday, duration: '5h 0m',
+      timeline: [],
+    }])
+    const major = computeUptimeFromIncidents([{
+      id: '2', title: 'Maj', status: 'resolved', impact: 'major',
+      startedAt: yesterday, duration: '5h 0m',
+      timeline: [],
+    }])
+    expect(critical).not.toBeNull()
+    expect(major).not.toBeNull()
+    expect(critical!).toBeCloseTo(major!, 2)
+  })
+
+  it('counts ongoing (unresolved) incidents up to now', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 3_600_000).toISOString()
+    const result = computeUptimeFromIncidents([{
+      id: '1', title: 'Active', status: 'investigating', impact: 'major',
+      startedAt: twoHoursAgo, duration: null,
+      timeline: [{ stage: 'investigating', text: null, at: twoHoursAgo }],
+    }])
+    // ~2h × 1.0 / (90 × 24h) → ~99.907%
+    expect(result).not.toBeNull()
+    const expected = 100 - (2 / (90 * 24)) * 100
+    expect(result!).toBeCloseTo(expected, 1)
+  })
+
+  it('clamps incidents that started before the 90-day window', () => {
+    const startedAt = new Date(Date.now() - 100 * 86_400_000).toISOString() // 100d ago
+    // Duration 91d → resolves 9d ago, ~81d falls inside the 90-day window
+    const result = computeUptimeFromIncidents([{
+      id: '1', title: 'Old long', status: 'resolved', impact: 'major',
+      startedAt, duration: `${91 * 24}h 0m`,
+      timeline: [],
+    }])
+    // ~81d × 1.0 / 90d → ~10% uptime (without clamp this would go negative → 0)
+    expect(result).not.toBeNull()
+    expect(result!).toBeGreaterThan(9)
+    expect(result!).toBeLessThan(11)
+  })
+
+  it('treats unknown impact strings as no-outage (defensive + warn)', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([{
+      id: '1', title: 'Future impact', status: 'resolved',
+      impact: 'maintenance' as never, // hypothetical Atlassian addition
+      startedAt: yesterday, duration: '10h 0m',
+      timeline: [],
+    }])
+    // Unknown impact → parseErrorSkips=1; whole feed is unparseable → null (not 100)
+    expect(result).toBeNull()
+  })
+
+  it('regresses ElevenLabs-shaped scenario: many minor incidents → ~99.7% (not ~91%)', () => {
+    // 20 non-overlapping 10h minor incidents over 90 days → 200h × 0.3 weight
+    // Old (un-weighted): 1 - 200/(90×24) ≈ 90.74%
+    // New (weighted):    1 - 60/(90×24)  ≈ 97.22%
+    const incidents = Array.from({ length: 20 }, (_, i) => ({
+      id: `m${i}`,
+      title: `Minor ${i}`,
+      status: 'resolved' as const,
+      impact: 'minor' as const,
+      // Spread across 90d window with safe spacing (4d apart, latest 10d ago, earliest 86d ago)
+      startedAt: new Date(Date.now() - (10 + i * 4) * 86_400_000).toISOString(),
+      duration: '10h 0m',
+      timeline: [],
+    }))
+    const result = computeUptimeFromIncidents(incidents)
+    // Exact match — weighted downtime = 200h × 0.3 = 60h, floored to 2 decimals
+    const downMs = 200 * 0.3 * 3_600_000
+    const expected = Math.floor((1 - downMs / (90 * 86_400_000)) * 10000) / 100
+    expect(result).toBe(expected)
+  })
+
+  it('handles abutting intervals (A.end === B.start) without losing or double-counting', () => {
+    const now = Date.now()
+    const t0 = new Date(now - 5 * 3_600_000).toISOString()
+    const tMid = new Date(now - 3 * 3_600_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'A', status: 'resolved', impact: 'major', startedAt: t0, duration: '2h 0m', timeline: [] },
+      { id: '2', title: 'B', status: 'resolved', impact: 'minor', startedAt: tMid, duration: '2h 0m', timeline: [] },
+    ])
+    // Boundary instant assigned to A only — no overlap, no gap
+    // Weighted downtime = 2h × 1.0 + 2h × 0.3 = 2.6h, floored to 2 decimals
+    const downMs = 2.6 * 3_600_000
+    const expected = Math.floor((1 - downMs / (90 * 86_400_000)) * 10000) / 100
+    expect(result).not.toBeNull()
+    expect(result!).toBe(expected)
+  })
+
+  it('preserves 2-decimal precision (no truncation at typical uptime scale)', () => {
+    // Construct downtime targeting ~98.79% (ElevenLabs-shaped)
+    const downMs = Math.round(0.0121 * 90 * 86_400_000)
+    const startedAt = new Date(Date.now() - downMs - 1000).toISOString()
+    const hours = Math.floor(downMs / 3_600_000)
+    const mins = Math.floor((downMs % 3_600_000) / 60_000)
+    const result = computeUptimeFromIncidents([{
+      id: '1', title: 'Big', status: 'resolved', impact: 'major',
+      startedAt, duration: `${hours}h ${mins}m`,
+      timeline: [],
+    }])
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(98.79, 1)
+    // Output must keep ≤2 decimals (not rounded to integer or 1 decimal)
+    expect(result!.toString()).toMatch(/^\d+(\.\d{1,2})?$/)
+  })
+
+  it('returns null when entire feed is unparseable (vs misleading 100)', () => {
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Bad date', status: 'resolved', impact: 'major', startedAt: 'not-a-date', duration: '1h 0m', timeline: [] },
+      { id: '2', title: 'Future', status: 'resolved', impact: 'minor', startedAt: new Date(Date.now() + 86_400_000).toISOString(), duration: '1h 0m', timeline: [] },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it('returns 100 for informational-only feed (no false negative)', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '2', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '2h 0m', timeline: [] },
+    ])
+    expect(result).toBe(100)
+  })
+
+  it('returns null when all impactful entries fail (informational entries do not rescue)', () => {
+    // Guards the `i.impact !== null` filter on the null-vs-100 decision — without it,
+    // mixed feeds (3 informational + 2 bad-date) would silently flip to 100%.
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '2', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '3', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '4', title: 'Bad', status: 'resolved', impact: 'major', startedAt: 'not-a-date', duration: '1h 0m', timeline: [] },
+      { id: '5', title: 'Bad', status: 'resolved', impact: 'major', startedAt: 'not-a-date', duration: '1h 0m', timeline: [] },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it('silently drops unknown-impact entries when valid entries exist (partial parse OK)', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Future impact', status: 'resolved', impact: 'maintenance' as never,
+        startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '2', title: 'Valid', status: 'resolved', impact: 'major',
+        startedAt: yesterday, duration: '5h 0m', timeline: [] },
+    ])
+    // Only the valid 5h major counts; unknown is dropped + warned (not return-null)
+    const downMs = 5 * 3_600_000
+    const expected = Math.floor((1 - downMs / (90 * 86_400_000)) * 10000) / 100
+    expect(result).toBe(expected)
+  })
+
+  it('does not poison computed uptime when some entries are resolved-with-no-end (mixed feed)', () => {
+    // incident.io occasionally marks status=resolved without a timeline resolved entry.
+    // Such entries should be skipped (warn-only, not parse error) so a mixed feed still
+    // computes weighted uptime from the usable entries.
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'No end', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+      { id: '2', title: 'Valid', status: 'resolved', impact: 'major', startedAt: yesterday, duration: '1h 0m', timeline: [] },
+    ])
+    // Only the valid 1h major counts (no-end is dropped without poisoning)
+    const downMs = 1 * 3_600_000
+    const expected = Math.floor((1 - downMs / (90 * 86_400_000)) * 10000) / 100
+    expect(result).toBe(expected)
+  })
+
+  it('returns null when entire impactful feed is resolved-with-no-end (no honest 100 claim)', () => {
+    // If every impactful entry is unusable (no recoverable end), the honest answer is
+    // "we cannot measure uptime" → null. Claiming 100% would hide the data-quality issue.
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'No end', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+      { id: '2', title: 'No end', status: 'resolved', impact: 'minor', startedAt: yesterday, duration: null, timeline: [] },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it('returns null for mixed parse-error + no-end + informational (all impactful unusable)', () => {
+    // 2 informational + 1 bad-date + 1 no-end → impactful=2, totalSkips=2 → null
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '2', title: 'Note', status: 'resolved', impact: null, startedAt: yesterday, duration: '5h 0m', timeline: [] },
+      { id: '3', title: 'Bad', status: 'resolved', impact: 'major', startedAt: 'not-a-date', duration: '1h 0m', timeline: [] },
+      { id: '4', title: 'No end', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it('emits one warn listing all distinct unknown impact values (joined-message dedup)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+      const make = (id: string, impact: string) => ({
+        id, title: '', status: 'resolved' as const,
+        impact: impact as never, startedAt: yesterday, duration: '1h 0m', timeline: [],
+      })
+      computeUptimeFromIncidents([
+        make('a1', 'maintenance'), make('a2', 'maintenance'),
+        make('b1', 'planned'), make('b2', 'planned'),
+        make('c1', 'severe'), make('c2', 'severe'),
+      ])
+      const unknownWarns = warnSpy.mock.calls.map(c => String(c[0])).filter(m => m.includes('unknown impact'))
+      expect(unknownWarns).toHaveLength(1)
+      expect(unknownWarns[0]).toMatch(/maintenance/)
+      expect(unknownWarns[0]).toMatch(/planned/)
+      expect(unknownWarns[0]).toMatch(/severe/)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('treats "0h 0m" duration with no timeline as no-end (incident.io same-minute resolve)', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    const result = computeUptimeFromIncidents([
+      { id: '1', title: 'Same-minute', status: 'resolved', impact: 'major',
+        startedAt: yesterday, duration: '0h 0m', timeline: [] },
+    ])
+    // Single no-end impactful entry, no usable intervals → null
+    expect(result).toBeNull()
+  })
+
+  it('does not throw when timeline is missing (defensive optional chaining)', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    // Force timeline=undefined despite type — simulates parser contract drift
+    const incident = { id: '1', title: 'No timeline', status: 'resolved', impact: 'major',
+      startedAt: yesterday, duration: '0h 0m' } as unknown as Incident
+    let result: number | null = -1
+    expect(() => { result = computeUptimeFromIncidents([incident]) }).not.toThrow()
+    // Single impactful entry with no recoverable end → totalSkips=1, impactful=1 → null.
+    // Don't add a second valid incident here — that would flip the result to a number;
+    // split into a separate test instead.
+    expect(result).toBeNull()
+  })
+
+  it('warns on each parse-error path so silent regressions stay visible', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+      computeUptimeFromIncidents([
+        { id: '1', title: '', status: 'resolved', impact: 'maintenance' as never,
+          startedAt: yesterday, duration: '1h 0m', timeline: [] },
+        { id: '2', title: '', status: 'resolved', impact: 'major',
+          startedAt: 'not-a-date', duration: '1h 0m', timeline: [] },
+        { id: '3', title: '', status: 'resolved', impact: 'major',
+          startedAt: new Date(Date.now() + 86_400_000).toISOString(), duration: '1h 0m', timeline: [] },
+        { id: '4', title: '', status: 'resolved', impact: 'major',
+          startedAt: yesterday, duration: null, timeline: [] },
+      ])
+      const messages = warnSpy.mock.calls.map(c => String(c[0]))
+      expect(messages.some(m => m.includes('unknown impact'))).toBe(true)
+      expect(messages.some(m => m.includes('invalid startedAt'))).toBe(true)
+      expect(messages.some(m => m.includes('future-dated'))).toBe(true)
+      expect(messages.some(m => m.includes('no recoverable end timestamp'))).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('includes the first encountered ID as a sample in the no-end summary warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+    computeUptimeFromIncidents([
+      { id: 'first', title: '', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+      { id: 'second', title: '', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+      { id: 'third', title: '', status: 'resolved', impact: 'major', startedAt: yesterday, duration: null, timeline: [] },
+    ])
+    const noEndWarn = warnSpy.mock.calls.map(c => String(c[0])).find(m => m.includes('no recoverable end timestamp'))
+    expect(noEndWarn).toBeDefined()
+    expect(noEndWarn!).toMatch(/first of 3: first/)
+  })
+
+  it('dedups unknown-impact warnings (1 log per call, not per incident)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+      const incidents = Array.from({ length: 50 }, (_, i) => ({
+        id: `m${i}`, title: '', status: 'resolved' as const,
+        impact: 'maintenance' as never,
+        startedAt: yesterday, duration: '1h 0m', timeline: [],
+      }))
+      computeUptimeFromIncidents(incidents)
+      const unknownWarns = warnSpy.mock.calls.filter(c => String(c[0]).includes('unknown impact'))
+      // 50 incidents, 1 unique impact value → exactly 1 warn (Logpush spam guard)
+      expect(unknownWarns).toHaveLength(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })
 

--- a/worker/src/parsers/__tests__/statuspage.test.ts
+++ b/worker/src/parsers/__tests__/statuspage.test.ts
@@ -133,6 +133,10 @@ describe('parseUptimeData', () => {
     const result = parseUptimeData(html, 'comp1')
     expect(result.dailyImpact['2026-03-01']).toBe('critical') // m > p
     expect(result.dailyImpact['2026-03-02']).toBe('major')    // p >= m
+    // Lock the combined-impact uptime% formula: MAJOR_WEIGHT(1.0) × m + MINOR_WEIGHT(0.3) × p
+    // Day 1: 1.0×200 + 0.3×100 = 230s ; Day 2: 1.0×100 + 0.3×300 = 190s ; total = 420s over 2 days
+    const expected = Math.floor((1 - 420 / (2 * 86400)) * 10000) / 100
+    expect(result.uptimePercent).toBe(expected)
   })
 
   it('returns empty when component not found', () => {

--- a/worker/src/parsers/impact-weights.ts
+++ b/worker/src/parsers/impact-weights.ts
@@ -1,0 +1,15 @@
+// Atlassian-style impact weights for uptime calculation.
+// Shared by statuspage.ts (official component_uptimes) and incident-io.ts
+// (estimate from incident durations) so both sources produce comparable uptime%.
+// Reference: Statuspage's `(major × 1.0 + partial × 0.3) / windowSec` formula. (#259)
+
+export const MAJOR_WEIGHT = 1.0
+export const MINOR_WEIGHT = 0.3
+
+/** Maps incident.io impact severity strings to weights.
+ *  null = informational (skipped); missing key = unknown level (skipped + logged by caller). */
+export const INCIDENT_IO_IMPACT_WEIGHTS: Record<string, number> = {
+  critical: MAJOR_WEIGHT,
+  major: MAJOR_WEIGHT,
+  minor: MINOR_WEIGHT,
+}

--- a/worker/src/parsers/incident-io.ts
+++ b/worker/src/parsers/incident-io.ts
@@ -2,6 +2,7 @@
 
 import type { TimelineEntry, Incident, DailyImpactLevel } from '../types'
 import { fetchWithTimeout } from '../utils'
+import { INCIDENT_IO_IMPACT_WEIGHTS } from './impact-weights'
 
 export function parseIncidentIoUptime(html: string, componentId: string, groupId?: string): number | null {
   const chunks = html.match(/self\.__next_f\.push\(\[1,([\s\S]*?)\]\)\s*<\/script/g) ?? []
@@ -102,6 +103,14 @@ export function parseIncidentIoComponentImpacts(html: string, componentId: strin
   return result
 }
 
+/** Resolve impact severity → weight. Returns null for informational/null impact;
+ *  -1 sentinel for unknown levels (caller should warn + skip). */
+function resolveImpactWeight(impact: Incident['impact']): number | null {
+  if (impact === null) return null
+  if (impact in INCIDENT_IO_IMPACT_WEIGHTS) return INCIDENT_IO_IMPACT_WEIGHTS[impact]
+  return -1
+}
+
 export function computeUptimeFromIncidents(incidents: Incident[]): number | null {
   // No incidents at all → return null (no data) rather than asserting 100%
   if (incidents.length === 0) return null
@@ -110,63 +119,129 @@ export function computeUptimeFromIncidents(incidents: Incident[]): number | null
   const windowMs = 90 * 86_400_000
   const windowStart = now - windowMs
 
-  // Collect outage intervals, then merge overlapping ones to avoid double-counting
-  const intervals: Array<{ start: number; end: number }> = []
+  // Collect weighted intervals; track skip categories so we can return null (vs. 100)
+  // when the entire impactful feed is unusable.
+  //   parseErrorSkips: structural errors (unknown impact, bad date, future date)
+  //   noEndSkips: incident.io data-quality cases (resolved status, no recoverable end)
+  // Both categories indicate "we can't measure outage" and should suppress a misleading
+  // 100% claim when no usable intervals remain.
+  const intervals: Array<{ start: number; end: number; weight: number }> = []
+  let parseErrorSkips = 0
+  let noEndSkips = 0
+  let noEndSampleId: string | null = null
+  // Dedup per-call to prevent Logpush spam when upstream emits a new impact level
+  // or many malformed entries across many incidents.
+  const unknownImpacts = new Set<string>()
   for (const inc of incidents) {
+    const weight = resolveImpactWeight(inc.impact)
+    if (weight === null) continue // informational
+    if (weight === -1) {
+      unknownImpacts.add(String(inc.impact))
+      parseErrorSkips++
+      continue
+    }
     const start = new Date(inc.startedAt).getTime()
-    if (isNaN(start)) continue
+    if (isNaN(start)) {
+      console.warn(`[computeUptimeFromIncidents] invalid startedAt "${inc.startedAt}" for ${inc.id} — skipping`)
+      parseErrorSkips++
+      continue
+    }
+    if (start >= now) {
+      console.warn(`[computeUptimeFromIncidents] future-dated startedAt for ${inc.id} (clock skew?) — skipping`)
+      parseErrorSkips++
+      continue
+    }
 
-    let endMs: number
+    // Defensive: timeline is typed as required but parser contracts vary; optional
+    // chaining prevents a single malformed incident from throwing and aborting the
+    // whole batch (which would lose the post-loop dedup warns).
+    let endMs: number | null = null
     if (inc.status === 'resolved' && inc.duration) {
       const hours = parseInt(inc.duration.match(/(\d+)h/)?.[1] ?? '0')
       const mins = parseInt(inc.duration.match(/(\d+)m/)?.[1] ?? '0')
-      endMs = start + (hours * 3600 + mins * 60) * 1000
-      // Fallback: if duration parsed to 0, try resolved timestamp from timeline
-      if (endMs === start) {
-        const resolvedEntry = inc.timeline.find((t) => t.stage === 'resolved')
+      const parsed = start + (hours * 3600 + mins * 60) * 1000
+      if (parsed > start) {
+        endMs = parsed
+      } else {
+        // Duration parsed to 0 — try resolved timestamp from timeline
+        const resolvedEntry = inc.timeline?.find((t) => t.stage === 'resolved')
         if (resolvedEntry) {
           const resolvedMs = new Date(resolvedEntry.at).getTime()
           if (!isNaN(resolvedMs) && resolvedMs > start) endMs = resolvedMs
         }
       }
     } else if (inc.status === 'resolved') {
-      // No duration string — try resolved timestamp from timeline
-      const resolvedEntry = inc.timeline.find((t) => t.stage === 'resolved')
+      // No duration string — fall back to resolved timestamp
+      const resolvedEntry = inc.timeline?.find((t) => t.stage === 'resolved')
       if (resolvedEntry) {
         const resolvedMs = new Date(resolvedEntry.at).getTime()
         if (!isNaN(resolvedMs) && resolvedMs > start) endMs = resolvedMs
-        else continue
-      } else {
-        continue
       }
     } else {
       endMs = now // unresolved → ongoing outage
     }
 
-    // Clamp to 90-day window
-    if (endMs > windowStart && start < now) {
-      intervals.push({ start: Math.max(start, windowStart), end: Math.min(endMs, now) })
+    if (endMs === null || endMs <= start) {
+      noEndSkips++
+      if (noEndSampleId === null) noEndSampleId = inc.id
+      continue
+    }
+
+    // Clamp to 90-day window; guard against zero-length intervals after clamping
+    if (endMs > windowStart) {
+      const clampedStart = Math.max(start, windowStart)
+      const clampedEnd = Math.min(endMs, now)
+      if (clampedEnd > clampedStart) {
+        intervals.push({ start: clampedStart, end: clampedEnd, weight })
+      }
     }
   }
 
-  // Merge overlapping intervals to prevent double-counting
-  if (intervals.length === 0) return 100
-  intervals.sort((a, b) => a.start - b.start)
-  let totalOutageMs = 0
-  let curStart = intervals[0].start
-  let curEnd = intervals[0].end
-  for (let i = 1; i < intervals.length; i++) {
-    if (intervals[i].start <= curEnd) {
-      curEnd = Math.max(curEnd, intervals[i].end)
+  if (unknownImpacts.size > 0) {
+    console.warn(`[computeUptimeFromIncidents] unknown impact level(s): ${[...unknownImpacts].join(', ')} — update INCIDENT_IO_IMPACT_WEIGHTS`)
+  }
+  if (noEndSkips > 0) {
+    console.warn(`[computeUptimeFromIncidents] ${noEndSkips} resolved incident(s) had no recoverable end timestamp (first of ${noEndSkips}: ${noEndSampleId}) — likely upstream data-quality issue`)
+  }
+
+  if (intervals.length === 0) {
+    // Distinguish informational-only feed (genuinely no outages → 100) from a feed
+    // where every impactful entry was unusable (return null — claiming 100 would mislead).
+    const totalSkips = parseErrorSkips + noEndSkips
+    const impactfulCount = incidents.filter(i => i.impact !== null).length
+    return totalSkips > 0 && totalSkips === impactfulCount ? null : 100
+  }
+
+  // Sweep events to compute weighted outage with max-weight-wins overlap handling.
+  // E.g. minor (0.3) overlapping major (1.0) contributes 1.0 weight in the overlap window —
+  // matches Atlassian's behavior where the more severe component status dominates.
+  const events: Array<{ t: number; weight: number; type: 'start' | 'end' }> = []
+  for (const iv of intervals) {
+    events.push({ t: iv.start, weight: iv.weight, type: 'start' })
+    events.push({ t: iv.end, weight: iv.weight, type: 'end' })
+  }
+  events.sort((a, b) => a.t - b.t || (a.type === 'end' ? -1 : 1))
+
+  let weightedOutageMs = 0
+  let lastT = events[0].t
+  const active: number[] = []
+  for (const ev of events) {
+    if (ev.t > lastT && active.length > 0) {
+      const maxWeight = Math.max(...active)
+      weightedOutageMs += (ev.t - lastT) * maxWeight
+    }
+    if (ev.type === 'start') {
+      active.push(ev.weight)
     } else {
-      totalOutageMs += curEnd - curStart
-      curStart = intervals[i].start
-      curEnd = intervals[i].end
+      const idx = active.indexOf(ev.weight)
+      if (idx >= 0) active.splice(idx, 1)
     }
+    lastT = ev.t
   }
-  totalOutageMs += curEnd - curStart
 
-  return Math.max(0, Math.round((1 - totalOutageMs / windowMs) * 10000) / 100)
+  // Use Math.floor (not round) to match statuspage.ts and avoid overstating uptime
+  // (e.g. 99.998% must not appear as 100%).
+  return Math.max(0, Math.floor((1 - weightedOutageMs / windowMs) * 10000) / 100)
 }
 
 interface IncidentIoUpdate {

--- a/worker/src/parsers/statuspage.ts
+++ b/worker/src/parsers/statuspage.ts
@@ -2,6 +2,7 @@
 
 import type { TimelineEntry, Incident, DailyImpactLevel } from '../types'
 import { formatDuration } from '../utils'
+import { MAJOR_WEIGHT, MINOR_WEIGHT } from './impact-weights'
 
 export interface StatuspageResponse {
   status: { indicator: string; description: string }
@@ -130,8 +131,8 @@ export function parseUptimeData(html: string, componentId: string): UptimeDataRe
       if (!day.outages) continue
       const m = day.outages.m ?? 0
       const p = day.outages.p ?? 0
-      // Statuspage weights: major=100%, partial=30% (Atlassian default)
-      totalWeightedSec += m + 0.3 * p
+      // Atlassian weights — see ./impact-weights.ts (shared with incident-io.ts)
+      totalWeightedSec += MAJOR_WEIGHT * m + MINOR_WEIGHT * p
       if (m > 0 && m > p) result.dailyImpact[day.date] = 'critical'  // major outage dominant → red
       else if (p > 0 || m > 0) result.dailyImpact[day.date] = 'major'  // partial outage dominant → orange
     }

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -382,16 +382,19 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         }
         allIncidents.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
         const filtered = filterIncidents(allIncidents, config)
-        // Estimate uptime from incidents; no incidents = 100% (RSS confirmed reachable)
-        const uptimeEst = computeUptimeFromIncidents(filtered) ?? 100
+        // Uptime semantics — match the main incident.io path (line 326):
+        //   - 0 incidents → 100% (RSS confirmed reachable, no measurable outage)
+        //   - >0 incidents but all unparseable → null (omit uptime30d to avoid claiming 100%)
+        //   - otherwise → computed weighted uptime
+        const uptimeRaw = computeUptimeFromIncidents(filtered)
+        const uptimeEst = filtered.length === 0 ? 100 : uptimeRaw
         return {
           ...base,
           status: deriveAwsStatus(filtered),
           latency: config.category === 'api' ? latency : null,
           incidents: filtered,
           calendarDays: 14,
-          uptime30d: uptimeEst,
-          uptimeSource: 'estimate' as const,
+          ...(uptimeEst != null ? { uptime30d: uptimeEst, uptimeSource: 'estimate' as const } : {}),
         }
       }
 
@@ -411,15 +414,17 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         await resetFetchFailure(kv, config.id)
         const incidents = parseAwsRssIncidents(await rssRes.text())
         const filtered = filterIncidents(incidents, config)
-        const uptimeEst = computeUptimeFromIncidents(filtered) ?? 100
+        // Same uptime semantics as the AWS RSS path above — propagate null instead of
+        // silently claiming 100% when all incidents were unparseable.
+        const uptimeRaw = computeUptimeFromIncidents(filtered)
+        const uptimeEst = filtered.length === 0 ? 100 : uptimeRaw
         return {
           ...base,
           status: deriveAwsStatus(filtered),
           latency: config.category === 'api' ? latency : null,
           incidents: filtered,
           calendarDays: 14,
-          uptime30d: uptimeEst,
-          uptimeSource: 'estimate' as const,
+          ...(uptimeEst != null ? { uptime30d: uptimeEst, uptimeSource: 'estimate' as const } : {}),
         }
       }
 


### PR DESCRIPTION
## Summary

- **Problem**: estimate-source services (ElevenLabs, Replicate, Bedrock, Azure OpenAI, Stability) computed uptime by summing every incident's full duration regardless of severity, while official-source services (Cohere, Groq, ChatGPT) already used Atlassian's `(major × 1.0 + partial × 0.3)` weighted formula. ElevenLabs: 96.85% under the un-weighted formula vs ~98.78% under Atlassian's official formula.
- **Fix**: shared `impact-weights.ts` constants (`MAJOR_WEIGHT=1.0`, `MINOR_WEIGHT=0.3`) consumed by both parsers; `computeUptimeFromIncidents` rewritten as a weighted sweep with max-weight-wins overlap handling and `Math.floor` rounding to match `statuspage.ts`.
- **Honest null signal**: returns `null` (omits `uptime30d`/`uptimeSource` from the response) when the entire impactful feed is unusable — never claims 100% uptime when we can't measure it. AWS/Azure RSS callers in `services.ts` propagate this signal instead of silently coercing to 100.

## Live impact

| Service | Before | After | Notes |
|---|---|---|---|
| ElevenLabs | 96.85% / score ~30 | 98.78% / score 63 | minor incidents now weighted at 0.3 |
| Replicate | ~ | 99.73% / score 70 | small improvement |
| Bedrock / Azure OpenAI | 100% | 100% (no incidents) | unchanged |
| Stability | 100% | 100% | unchanged |
| Cohere / Groq / ChatGPT | unchanged | unchanged | already using official weighted formula |

## Defensive logging

- Unknown impact strings → `console.warn` (Set-deduped per call to prevent Logpush spam)
- `isNaN(start)` / future-dated start / no recoverable end timestamp → warned with sample ID
- `inc.timeline?.find(...)` defensive optional chaining prevents one malformed incident from killing the whole batch

## Test plan

- [x] `npm run test:worker` — 753 / 753 pass (added 13 new tests for `computeUptimeFromIncidents` covering: weighted overlap, ongoing incidents, window clamping, unknown impact, ElevenLabs-shape regression, abutting boundaries, precision, parse-error/no-end/informational disambiguation, warn-spy assertions, and dedup behavior)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean
- [x] Local `wrangler dev` — verified ElevenLabs 96.85% → 98.78%, other services unchanged
- [x] 5 rounds of `/pr-review-toolkit:review-pr` (code-reviewer + silent-failure-hunter + pr-test-analyzer in parallel) — all critical/important findings addressed; round 5 reached convergence with only cosmetic items remaining

## Follow-ups (separate issues already filed)

- #260 — align `affectedDays` weighting with uptime impact weights
- #261 — exclude null-impact incidents from `affectedDays`

🤖 Generated with [Claude Code](https://claude.com/claude-code)