### PR TITLE
fix: weekly briefing changelog hyperlinks + Anthropic parser image-URL guard (#273 #275)

### DIFF
--- a/worker/src/__tests__/changelog.test.ts
+++ b/worker/src/__tests__/changelog.test.ts
@@ -131,6 +131,44 @@ describe('parseAnthropicNews', () => {
   it('returns empty for non-Anthropic HTML', () => {
     expect(parseAnthropicNews('<html><body>Hello</body></html>')).toEqual([])
   })
+
+  it('rejects featured-grid items where the regex matches an inline image URL (sanity.io) instead of the article URL (#275)', () => {
+    // Real production case: featured grid item with an inline `image.url` that
+    // appears before the article `url`. The non-greedy regex captures the image URL,
+    // so we must reject anything that isn't an anthropic.com path.
+    const sanityImageHtml = `<html><script>self.__next_f.push([1,"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-04-07\\",\\"summary\\":\\"intro\\",\\"title\\":\\"Introducing Claude Opus 4.7\\",\\"url\\":\\"https://cdn.sanity.io/images/abc/c0af2a56-1000x1000.svg\\"
+      \\"publishedOn\\":\\"2026-04-16T14:30:00.000Z\\",\\"slug\\":{\\"_type\\":\\"slug\\",\\"current\\":\\"claude-opus-4-7\\"},\\"subjects\\":[],\\"title\\":\\"Introducing Claude Opus 4.7\\"
+    "])</script></html>`
+    const entries = parseAnthropicNews(sanityImageHtml)
+    // Only the slug-based news-list entry should be present, with the canonical /news/ URL
+    expect(entries).toHaveLength(1)
+    expect(entries[0].url).toBe('https://www.anthropic.com/news/claude-opus-4-7')
+    // No CDN asset URL leaks through
+    for (const e of entries) {
+      expect(e.url).not.toMatch(/cdn\.sanity\.io|\.svg$/)
+    }
+  })
+
+  it('rejects featured-grid item with sanity.io URL even when no slug-list fallback exists (#275 isolation)', () => {
+    // Locks down the featRe rejection path independently — without a slug-list entry
+    // to recover via, a regression that disables the URL filter would produce a bogus
+    // entry instead of cleanly returning 0. The combined-fallback test alone would
+    // still pass length=1 if the filter broke and slug recovered.
+    const featuredOnlyBadUrl = `<html><script>self.__next_f.push([1,"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-04-07\\",\\"summary\\":\\"x\\",\\"title\\":\\"Bad URL Item\\",\\"url\\":\\"https://cdn.sanity.io/images/abc/x.svg\\"
+    "])</script></html>`
+    expect(parseAnthropicNews(featuredOnlyBadUrl)).toHaveLength(0)
+  })
+
+  it('rejects protocol-relative URLs (//host/path) — would otherwise produce double-prefixed broken URL', () => {
+    // Without the `!startsWith('//')` guard, `urlPath = '//evil.com/x'` passes the
+    // `startsWith('/')` check, then gets prefixed to `https://www.anthropic.com//evil.com/x`.
+    const protocolRelHtml = `<html><script>self.__next_f.push([1,"
+      \\"_type\\":\\"featuredGridLink\\",\\"date\\":\\"2026-04-07\\",\\"summary\\":\\"x\\",\\"title\\":\\"Bad PR URL\\",\\"url\\":\\"//evil.com/news/x\\"
+    "])</script></html>`
+    expect(parseAnthropicNews(protocolRelHtml)).toHaveLength(0)
+  })
 })
 
 describe('isRelevantEntry', () => {
@@ -210,14 +248,56 @@ describe('isRelevantEntry', () => {
 })
 
 describe('formatChangelogSection', () => {
-  it('formats entries with date and source', () => {
+  it('renders titles as Discord markdown links to the source URL (#273)', () => {
     const entries: ChangelogEntry[] = [
-      { source: 'openai', title: 'GPT-5 released', url: 'https://openai.com', date: '2026-04-10T00:00:00Z' },
-      { source: 'anthropic', title: 'Introducing Claude Sonnet 4.6', url: 'https://anthropic.com', date: '2026-04-09T00:00:00Z' },
+      { source: 'openai', title: 'GPT-5 released', url: 'https://openai.com/blog/gpt-5', date: '2026-04-10T00:00:00Z' },
+      { source: 'anthropic', title: 'Introducing Claude Sonnet 4.6', url: 'https://www.anthropic.com/news/claude-sonnet-4-6', date: '2026-04-09T00:00:00Z' },
     ]
     const result = formatChangelogSection(entries)
-    expect(result).toContain('OpenAI: GPT-5 released (4/10)')
-    expect(result).toContain('Anthropic: Introducing Claude Sonnet 4.6 (4/9)')
+    // Markdown link format: [title](url)
+    expect(result).toContain('OpenAI: [GPT-5 released](https://openai.com/blog/gpt-5) (4/10)')
+    expect(result).toContain('Anthropic: [Introducing Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) (4/9)')
+  })
+
+  it('falls back to plain title when url is empty (defensive)', () => {
+    const entries: ChangelogEntry[] = [
+      { source: 'openai', title: 'No URL entry', url: '', date: '2026-04-10T00:00:00Z' },
+    ]
+    const result = formatChangelogSection(entries)
+    expect(result).toContain('OpenAI: No URL entry (4/10)')
+    // No empty markdown link rendered
+    expect(result).not.toContain('](')
+  })
+
+  it('falls back to plain title when url is whitespace-only (would render broken markdown)', () => {
+    const entries: ChangelogEntry[] = [
+      { source: 'openai', title: 'Whitespace URL', url: '   ', date: '2026-04-10T00:00:00Z' },
+    ]
+    const result = formatChangelogSection(entries)
+    expect(result).toContain('OpenAI: Whitespace URL (4/10)')
+    expect(result).not.toContain('](')
+  })
+
+  it('escapes ] in title to prevent markdown link-text early termination', () => {
+    const entries: ChangelogEntry[] = [
+      { source: 'openai', title: '[Update] GPT-5 ships', url: 'https://openai.com/blog/x', date: '2026-04-10T00:00:00Z' },
+    ]
+    const result = formatChangelogSection(entries)
+    // The literal `]` must be escaped so Discord doesn't terminate the link at "Update]"
+    expect(result).toContain('[[Update\\] GPT-5 ships](https://openai.com/blog/x)')
+  })
+
+  it('falls back to plain title when url contains ( ) or whitespace (would break Discord link parser)', () => {
+    const entries: ChangelogEntry[] = [
+      { source: 'openai', title: 'URL with paren', url: 'https://en.wikipedia.org/wiki/Foo_(bar)', date: '2026-04-10T00:00:00Z' },
+      { source: 'openai', title: 'URL with space', url: 'https://example.com/has space', date: '2026-04-09T00:00:00Z' },
+    ]
+    const result = formatChangelogSection(entries)
+    // Neither URL should appear inside markdown link syntax
+    expect(result).toContain('OpenAI: URL with paren (4/10)')
+    expect(result).toContain('OpenAI: URL with space (4/9)')
+    expect(result).not.toContain('wikipedia.org')
+    expect(result).not.toContain('example.com')
   })
 
   it('returns fallback message for empty entries', () => {

--- a/worker/src/changelog.ts
+++ b/worker/src/changelog.ts
@@ -70,7 +70,10 @@ export function parseRssEntries(xml: string, source: string): ChangelogEntry[] {
  * Parse Anthropic /news HTML page (Next.js SSR payload).
  * Extracts from two data structures:
  * 1. Featured grid items: {"_type":"featuredGridLink","date":"...","title":"...","url":"..."}
- * 2. News list items: publishedOn + slug + title pattern
+ *    URL must be relative (`/...`) or anthropic.com — rejects image-asset URLs
+ *    (e.g. `cdn.sanity.io/...svg`) that the non-greedy regex would otherwise match
+ *    when an inline `image.url` precedes the article `url` in the JSON. (#275)
+ * 2. News list items: publishedOn + slug + title pattern (canonical /news/{slug})
  */
 export function parseAnthropicNews(html: string): ChangelogEntry[] {
   const entries: ChangelogEntry[] = []
@@ -81,16 +84,41 @@ export function parseAnthropicNews(html: string): ChangelogEntry[] {
   // 1. Featured grid items (e.g. Project Glasswing — published at /glasswing, not /news/)
   const featRe = /"_type":"featuredGridLink","date":"([^"]+)","(?:subject":"[^"]*",")?(summary":"[^"]*",")?title":"([^"]+)","url":"([^"]+)"/g
   let m
+  // Track filter outcomes for schema-drift detection. featRe's non-greedy match
+  // can grab an inline `image.url` (sanity.io CDN .svg) before the actual article
+  // `url` (#275); the filter rejects these. In normal operation N rejected per fetch
+  // is expected — only escalate to a warn if EVERY match was rejected (i.e., the
+  // regex is firing but our gate is letting nothing through, indicating drift).
+  let featAccepted = 0
+  let featRejected = 0
+  let featRejectedSample = ''
   while ((m = featRe.exec(u)) !== null) {
     const date = m[1]
     const title = m[3]
     const urlPath = m[4]
+    // Article URLs are absolute paths (`/foo`) or full anthropic.com URLs.
+    // Explicitly reject protocol-relative `//host/path` (would double-prefix to
+    // `https://www.anthropic.com//host/path`) and external CDN/asset URLs.
+    const isAbsolutePath = urlPath.startsWith('/') && !urlPath.startsWith('//')
+    const isAnthropicUrl = urlPath.startsWith('https://www.anthropic.com')
+    if (!(isAbsolutePath || isAnthropicUrl)) {
+      if (featRejected === 0) featRejectedSample = urlPath.slice(0, 120)
+      featRejected++
+      continue
+    }
     const parsed = new Date(date)
     if (isNaN(parsed.getTime())) continue
-    const fullUrl = urlPath.startsWith('http') ? urlPath : `https://www.anthropic.com${urlPath}`
+    const fullUrl = isAnthropicUrl ? urlPath : `https://www.anthropic.com${urlPath}`
     if (seen.has(fullUrl)) continue
     seen.add(fullUrl)
     entries.push({ source: 'anthropic', title, url: fullUrl, date: parsed.toISOString() })
+    featAccepted++
+  }
+  // Only warn when the regex matched but EVERY match was filtered — that's the
+  // signal that something changed upstream (e.g., article URL field renamed).
+  // Steady-state log noise (per-hour) would dilute the regression signal.
+  if (featRejected > 0 && featAccepted === 0) {
+    console.warn(`[changelog] anthropic featRe: rejected ${featRejected} URL(s), accepted 0 — possible schema drift (sample: ${featRejectedSample})`)
   }
 
   // 2. News list items: publishedOn + slug pairs
@@ -203,14 +231,34 @@ export function formatChangelogSection(entries: ChangelogEntry[]): string {
     copilot: 'GitHub Copilot',
   }
 
-  return entries
+  const sorted = entries
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 8) // max 8 items in Discord embed
-    .map((e) => {
-      const date = new Date(e.date)
-      const dateStr = `${date.getMonth() + 1}/${date.getDate()}`
-      const name = sourceNames[e.source] ?? e.source
-      return `• ${name}: ${e.title} (${dateStr})`
-    })
-    .join('\n')
+
+  const droppedSamples: string[] = []
+  const lines = sorted.map((e) => {
+    const date = new Date(e.date)
+    const dateStr = `${date.getMonth() + 1}/${date.getDate()}`
+    const name = sourceNames[e.source] ?? e.source
+    // Discord embed description supports [text](url) markdown — make titles clickable (#273).
+    // Sanitize against markdown injection: escape `]` in title (would close link text early)
+    // and reject URLs that contain `(`/`)` or whitespace (would break Discord's link parser).
+    const url = (e.url ?? '').trim()
+    const safeUrl = url && !/[()\s]/.test(url) ? url : ''
+    if (url && !safeUrl && droppedSamples.length < 3) {
+      droppedSamples.push(`${e.source}:${url.slice(0, 80)}`)
+    }
+    const titleLink = safeUrl
+      ? `[${e.title.replace(/]/g, '\\]')}](${safeUrl})`
+      : e.title
+    return `• ${name}: ${titleLink} (${dateStr})`
+  })
+
+  // Surface dropped URLs so a systematic upstream change (e.g., new tracking-param
+  // format with parens) doesn't silently degrade every entry to plain text.
+  if (droppedSamples.length > 0) {
+    console.warn(`[changelog] dropped ${droppedSamples.length} unsafe URL(s) from briefing markdown — samples: ${droppedSamples.join(' | ')}`)
+  }
+
+  return lines.join('\n')
 }


### PR DESCRIPTION
## Summary

- **#273** — Weekly Discord briefing changelog items now render as **clickable markdown links** (`[title](url)`). Previously titles were plain text — users couldn't click through to the actual announcement.
- **#275** — Fixed `parseAnthropicNews` featured-grid regex that was capturing inline `image.url` (sanity.io CDN `.svg`) before the actual article URL. Reproduced for Apr 16 Opus 4.7. Added URL filter accepting only absolute paths or `https://www.anthropic.com` — Project Glasswing-style featured-only entries (path `/glasswing`) preserved.

## Hardening

- **Markdown injection defense** — `]` in title escaped (`\]`); URLs containing `(`/`)` or whitespace fall back to plain title (Discord link parser breaks on these)
- **Protocol-relative URL rejection** — `//host/path` would otherwise double-prefix to `https://www.anthropic.com//host/path`
- **Schema-drift warn** — `featRe` only warns when EVERY match is rejected (not on steady-state image-URL filtering)
- **Drop-URL log** — formatter logs up to 3 samples when URLs fail safety check (surfaces upstream URL-format changes in Worker logs)

## Test plan

- [x] `npm run test:worker` — 828/828 pass (changelog suite 22 → 29 with 6 new tests + 1 rewritten link test)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean
- [x] 3 rounds of `/pr-review-toolkit:review-pr` — Critical/Important converged after round 2

## Out of scope (tracked separately)

- **#274** — Adjacent observability gap: Anthropic source entirely missed Apr 16 Opus 4.7 + Apr 17 Claude Design from the Apr 13–19 weekly briefing. Root cause is fetch-pipeline level (suspected 8s timeout too aggressive for the 350KB Anthropic /news SSR page), not the parser. Separate fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)