### PR TITLE
feat: expand Reddit cron monitoring to r/AINews + r/LocalLLaMA (closes #280)

### DIFF
--- a/docs/marketing-playbook.md
+++ b/docs/marketing-playbook.md
@@ -130,13 +130,13 @@ Reddit communities discuss AI outages in real time. AIWatch is useful in those t
 | r/ClaudeAI | Strict — mods remove obvious promo | Active Claude outage thread on front page of sub | ✅ outage mode |
 | r/ChatGPT | Permissive on outage threads | Active OpenAI / ChatGPT outage thread | ✅ outage mode |
 | r/OpenAI | Moderate — outage posts allowed | Active OpenAI outage | ✅ outage mode |
-| r/LocalLLaMA | Strict technical bar — no fluff posts | Only when discussion already cites API reliability as a local-vs-hosted argument | ⚠️ competitive mode only (status-monitor keywords) — outage posts are not auto-detected; check manually |
+| r/LocalLLaMA | Strict technical bar — no fluff posts | Only when discussion already cites API reliability as a local-vs-hosted argument | ✅ outage mode |
+| r/AINews | Permissive | Major outage with journalist coverage | ✅ outage mode (Discord 🎯 PROMOTE alert only fires if the title passes the question-style promotable filter — news-style headlines still require manual engagement) |
 | r/MachineLearning | Very strict — must be research-relevant | Do not post unless AIWatch shipped a methodology writeup | ❌ not monitored by cron — check manually |
-| r/AINews | Permissive | Major outage with journalist coverage | ❌ not monitored by cron — check manually |
 
 Before each first post to any of these, **read the sub's rules page** — `/wiki/rules` or the sidebar. Rule changes are not tracked here.
 
-**Cron coverage caveat.** `worker/src/reddit.ts` watches r/ClaudeAI, r/ChatGPT, r/OpenAI (+ r/ClaudeCode / r/cursor / r/windsurf / r/Codeium for coding agents) in outage mode — matches on "down / not working / outage / broken / offline / unavailable / degraded" keywords and sends a Discord alert with a "🎯 PROMOTE" tag when a promotable post appears. The subs marked ⚠️ / ❌ above require manual monitoring via the Reddit search RSS feeds listed below. Expanding cron outage-mode coverage to r/AINews and r/LocalLLaMA is tracked in issue #280. r/MachineLearning is out of scope for that issue — the sub's research-heavy posts need a stricter keyword matcher before it can be added without false positives.
+**Cron coverage caveat.** `worker/src/reddit.ts` watches r/ClaudeAI, r/ChatGPT, r/OpenAI, r/LocalLLaMA, r/AINews (+ r/ClaudeCode / r/cursor / r/windsurf / r/Codeium for coding agents) in outage mode — matches on "down / not working / outage / broken / offline / unavailable / degraded" keywords and sends a Discord alert with a "🎯 PROMOTE" tag when the post's title is question-style (per the `isPromotable` filter). News-flavored headlines on r/AINews still require manual engagement because they don't trigger PROMOTE. r/MachineLearning remains out of scope — research posts use outage keywords in methodology contexts ("what's wrong with this loss curve"), and adding it without a service-name-required matcher would spam Discord.
 
 ### When to engage
 

--- a/worker/src/__tests__/reddit.test.ts
+++ b/worker/src/__tests__/reddit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseRedditResponse, matchesKeywords, matchesSecurityKeywords, isPromotable, formatRedditAlert, formatSecurityAlert } from '../reddit'
+import { parseRedditResponse, matchesKeywords, matchesSecurityKeywords, isPromotable, formatRedditAlert, formatSecurityAlert, REDDIT_TARGETS } from '../reddit'
 import type { RedditAlert } from '../reddit'
 
 describe('parseRedditResponse', () => {
@@ -238,5 +238,72 @@ describe('formatRedditAlert', () => {
     const formatted = formatRedditAlert(alert)
     expect(formatted.description).not.toContain('is-')
     expect(formatted.title).toContain('PROMOTE')
+  })
+})
+
+describe('REDDIT_TARGETS — playbook coverage (#280)', () => {
+  // Locks the playbook Subreddit list ↔ cron coverage mapping. If this table diverges from
+  // docs/marketing-playbook.md, either update this test or the playbook — whichever reflects
+  // the intent. Do not silently drop a playbook engagement target.
+  const modeOf = (service: string) =>
+    service === '_competitive' ? 'competitive'
+      : service === '_security' ? 'security' : 'outage'
+
+  it('includes all playbook engagement targets in outage mode', () => {
+    const subsInOutageMode = REDDIT_TARGETS
+      .filter(t => modeOf(t.service) === 'outage')
+      .map(t => t.subreddit)
+    // Playbook-listed subs where cron should auto-detect outage posts for Discord 🎯 PROMOTE
+    expect(subsInOutageMode).toContain('ClaudeAI')
+    expect(subsInOutageMode).toContain('ChatGPT')
+    expect(subsInOutageMode).toContain('OpenAI')
+    // #280: r/LocalLLaMA switched from competitive → outage to match the playbook's
+    // "API reliability in local-vs-hosted threads" engagement hook.
+    expect(subsInOutageMode).toContain('LocalLLaMA')
+    // #280: r/AINews added for press-adjacent outage threads.
+    expect(subsInOutageMode).toContain('AINews')
+  })
+
+  it('keeps coding agent subs in outage mode (existing coverage)', () => {
+    const subsInOutageMode = REDDIT_TARGETS
+      .filter(t => modeOf(t.service) === 'outage')
+      .map(t => t.subreddit)
+    expect(subsInOutageMode).toContain('ClaudeCode')
+    expect(subsInOutageMode).toContain('cursor')
+    expect(subsInOutageMode).toContain('windsurf')
+    expect(subsInOutageMode).toContain('Codeium')
+  })
+
+  it('keeps competitive-only subs in competitive mode (not outage)', () => {
+    const competitive = REDDIT_TARGETS.filter(t => modeOf(t.service) === 'competitive').map(t => t.subreddit)
+    expect(competitive).toContain('devops')
+    expect(competitive).toContain('artificial')
+    // Guard against regression: LocalLLaMA must not be demoted back to competitive
+    expect(competitive).not.toContain('LocalLLaMA')
+  })
+
+  it('keeps security subs in security mode', () => {
+    const security = REDDIT_TARGETS.filter(t => modeOf(t.service) === 'security').map(t => t.subreddit)
+    expect(security).toContain('netsec')
+    expect(security).toContain('cybersecurity')
+  })
+
+  it('does not monitor r/MachineLearning yet — deferred pending stricter matcher (#280)', () => {
+    const subs = REDDIT_TARGETS.map(t => t.subreddit)
+    // Playbook says r/MachineLearning is out-of-scope for auto-detection because
+    // research posts naturally contain outage keywords ("broken loss curve", etc.).
+    // Adding it without a service-name-required matcher would spam Discord.
+    expect(subs).not.toContain('MachineLearning')
+  })
+
+  it('uses only known service-field conventions', () => {
+    // _competitive and _security are special markers; everything else falls to outage mode.
+    // A typo like '_competetive' would silently route to outage — this test catches that.
+    const specialMarkers = new Set(['_competitive', '_security'])
+    for (const target of REDDIT_TARGETS) {
+      if (target.service.startsWith('_')) {
+        expect(specialMarkers.has(target.service)).toBe(true)
+      }
+    }
   })
 })

--- a/worker/src/reddit.ts
+++ b/worker/src/reddit.ts
@@ -20,8 +20,11 @@ export interface RedditAlert {
   type: RedditAlertType
 }
 
-// Subreddit → search keywords mapping
-const REDDIT_TARGETS: Array<{ subreddit: string; service: string }> = [
+// Subreddit → search keywords mapping.
+// service value semantics: '_competitive' / '_security' → those modes; anything else → outage mode.
+// Exported for tests — presence/mode assertions enforce that the playbook's engagement list
+// stays in sync with the cron (#280).
+export const REDDIT_TARGETS: ReadonlyArray<{ subreddit: string; service: string }> = [
   // Service-specific subreddits (outage detection + promotion)
   { subreddit: 'ClaudeAI',        service: 'Claude' },
   { subreddit: 'ClaudeCode',      service: 'Claude Code' },
@@ -30,10 +33,16 @@ const REDDIT_TARGETS: Array<{ subreddit: string; service: string }> = [
   { subreddit: 'cursor',          service: 'Cursor' },
   { subreddit: 'windsurf',        service: 'Windsurf' },
   { subreddit: 'Codeium',         service: 'Windsurf' },
+  // Broader AI communities in outage mode — playbook engagement targets (#280).
+  // r/LocalLLaMA was previously competitive mode; switched to outage so API-reliability
+  // threads (the playbook's actual engagement hook) are caught. r/AINews added for
+  // press-adjacent outage threads. Promotion filter (isPromotable) still gates Discord
+  // alerts, so news-flavored posts that aren't question-seeking won't spam.
+  { subreddit: 'LocalLLaMA',      service: 'AI Community' },
+  { subreddit: 'AINews',          service: 'AI Community' },
   // Competitive monitoring — broader AI/DevOps communities
   { subreddit: 'devops',          service: '_competitive' },
   { subreddit: 'artificial',      service: '_competitive' },
-  { subreddit: 'LocalLLaMA',      service: '_competitive' },
   // Security monitoring — security communities for AI service breach/vulnerability chatter
   { subreddit: 'netsec',          service: '_security' },
   { subreddit: 'cybersecurity',   service: '_security' },


### PR DESCRIPTION
## Summary
Closes the playbook ↔ cron coverage gap flagged in PR #279 review.

- **r/AINews** added to `REDDIT_TARGETS` in outage mode — was completely unmonitored before.
- **r/LocalLLaMA** moved from competitive mode → outage mode. Old config searched only "status monitor / uptime dashboard" keywords, so the playbook's actual engagement hook ("API reliability cited in local-vs-hosted threads") was never auto-detected.
- **`REDDIT_TARGETS` exported** as `ReadonlyArray` so tests can assert the playbook ↔ cron mapping stays in sync.
- **r/MachineLearning** deliberately excluded — research posts use outage keywords in methodology contexts, would spam Discord without a stricter matcher (documented in #280).

## Why
PR #279 (marketing playbook) Round 5 review surfaced that the playbook's Subreddit engagement list was not fully covered by the Reddit cron. Without this fix, operators have to manually check r/AINews via RSS during outage windows — defeats the purpose of the cron.

## Files changed
- `worker/src/reddit.ts` — `REDDIT_TARGETS` table updated + exported
- `worker/src/__tests__/reddit.test.ts` — new `REDDIT_TARGETS — playbook coverage (#280)` describe block, 6 tests (engagement targets present in outage mode, coding agent subs preserved, competitive/security modes intact, r/MachineLearning excluded, service-field convention enforced)
- `docs/marketing-playbook.md` — cron coverage column updated (LocalLLaMA ⚠️→✅, AINews ❌→✅), caveat paragraph rewritten

## Behavioral notes
- r/AINews **news-style headlines** ("Anthropic confirms outage") won't trigger the Discord 🎯 PROMOTE alert because `isPromotable` requires question-style phrasing. They'll still be marked seen in KV; manual engagement remains the path for those — documented in the playbook.
- r/LocalLLaMA loses competitive-mode detection (status-monitor tool posts). Loss is minimal — that volume was near-zero in practice.

## Test plan
- [x] 854/854 worker unit tests pass (27 Reddit-specific including 6 new for #280)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` clean
- [x] Local verify: `wrangler dev --test-scheduled` + `/__scheduled?cron=*/5+*+*+*+*&time=2026-04-20T00:02:00Z` → HTTP 200, KV stays clean (no current outage matches), live Reddit URLs respond, `matchesKeywords` correctly skips 5/5 non-outage candidates from r/LocalLLaMA last-24h sample
- [ ] Vercel preview — N/A (no frontend changes)
- [ ] Production verify after worker deploy — confirm next 5-min cron fetches both new subs without errors

## Out of scope
- r/MachineLearning auto-detection (needs stricter matcher — separate follow-up issue when designed)

## Related
- #280 issue
- PR #279 (marketing playbook — where the gap was first flagged)
- #267 #270 (original playbook tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)