### PR TITLE
feat: group flap-style incident notices in UI (closes #282)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ npm run lint       # Run ESLint
 
 ```bash
 npm test           # Run Playwright E2E tests
+npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js)
 npm run test:worker # Run Worker unit tests (vitest)
 ```
 
@@ -111,11 +112,12 @@ gh pr merge --squash --delete-branch
 3. **Code** — implement the feature or fix
 3.5. **Local verify** — start the appropriate dev server and let the user confirm in browser before proceeding. See "Local verification by page type" table above for which command to use. Never skip this step.
 4. **Build + Test** — based on change scope:
-   - **Frontend changes** (`src/`): `npm run build` + `npm test` (Playwright)
+   - **Frontend changes** (`src/`): `npm run build` + `npm run test:src` (Vitest, if utility/logic tests exist) + `npm test` (Playwright E2E)
    - **Backend changes** (`worker/`): `npx wrangler deploy --config worker/wrangler.toml --dry-run` + `npm run test:worker` (Vitest)
    - **Both**: run all of the above
    - **Worker logic additions**: new functions must have unit tests — extract to separate files with exports, test in `worker/src/__tests__/` or `worker/src/parsers/__tests__/`
-   - **Bug fixes**: every bug fix must include a test that would have caught the bug — E2E (Playwright) for frontend, Vitest for worker
+   - **Frontend utility additions** (`src/utils/`): pure-function utilities should have unit tests in `src/utils/__tests__/*.test.js` (Vitest)
+   - **Bug fixes**: every bug fix must include a test that would have caught the bug — E2E (Playwright) or Vitest for frontend, Vitest for worker
 5. **Review** — run PR review **before** creating PR:
    ```
    /pr-review-toolkit:review-pr

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "deploy": "npm run build && wrangler deploy",
     "deploy:worker": "npx wrangler deploy --config worker/wrangler.toml",
     "dev:worker": "npx wrangler dev --config worker/wrangler.toml --port 8788",
-    "dev:all": "npx wrangler dev --config worker/wrangler.toml --port 8788 & vite"
+    "dev:all": "npx wrangler dev --config worker/wrangler.toml --port 8788 & vite",
+    "test:src": "npx vitest run --config vitest.config.js"
   },
   "dependencies": {
     "chart.js": "^4.4.7",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -126,6 +126,10 @@ const en = {
   'incidents.timeline.monitoring': 'Monitoring',
   'incidents.timeline.resolved': 'Resolved',
   'incidents.timeline.empty': 'No timeline data available',
+  'incidents.group.flaps': '× {n} flaps',
+  'incidents.group.expand': 'Show all entries',
+  'incidents.group.collapse': 'Hide entries',
+  'incidents.group.statusUniform': 'all {status}',
 
   // Uptime
   'uptime.stable': 'Most Stable',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -126,6 +126,10 @@ const ko = {
   'incidents.timeline.monitoring': '모니터링',
   'incidents.timeline.resolved': '해결됨',
   'incidents.timeline.empty': '타임라인 데이터가 없습니다',
+  'incidents.group.flaps': '× {n}회 반복',
+  'incidents.group.expand': '전체 항목 보기',
+  'incidents.group.collapse': '항목 숨기기',
+  'incidents.group.statusUniform': '모두 {status}',
 
   // Uptime
   'uptime.stable': '가장 안정적',

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -7,6 +7,7 @@ import { useState, useMemo } from 'react'
 import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
+import { groupIncidents } from '../utils/incidentGrouping'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -216,6 +217,135 @@ function IncidentCard({ incident, isSelected, onClick, onClose, t, lang }) {
   )
 }
 
+// Desktop group row (collapsed): single grid row with [×N flaps] badge; click toggles entries.
+// Entries render as ordinary IncidentRows below in their own rowgroup.
+function IncidentGroupRow({ group, expanded, onToggle, selectedId, onSelect, onClose, t, lang }) {
+  const dominantStatus = group.uniformStatus
+    ? Object.keys(group.statusCounts)[0]
+    : (['ongoing', 'monitoring', 'resolved'].find(s => group.statusCounts[s]) ?? 'resolved')
+  const statusCls = STATUS_BADGE_CLASS[dominantStatus] ?? STATUS_BADGE_CLASS.resolved
+  const statusLabel = group.uniformStatus
+    ? t('incidents.group.statusUniform').replace('{status}', t(`incidents.status.${dominantStatus}`).toLowerCase())
+    : Object.entries(group.statusCounts).map(([s, n]) => `${n} ${t(`incidents.status.${s}`).toLowerCase()}`).join(' · ')
+  const firstEntry = group.entries[0]
+  const serviceLabel = firstEntry.affectedNames?.length > 1 ? firstEntry.affectedNames.join(', ') : firstEntry.serviceName
+  return (
+    <>
+      <div
+        onClick={onToggle}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle() } }}
+        tabIndex={0}
+        role="row"
+        aria-expanded={expanded}
+        aria-label={expanded ? t('incidents.group.collapse') : t('incidents.group.expand')}
+        className="cursor-pointer transition-colors hover:bg-[var(--bg2)] focus:outline-none focus:ring-1 focus:ring-[var(--border-hi)]"
+        style={{ display: 'grid', gridTemplateColumns: '190px 1fr 100px 80px 80px', gap: '12px', padding: '10px 14px', borderBottom: '1px solid var(--border)', alignItems: 'center' }}
+      >
+        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>
+          {formatDate(group.rangeStart, lang)} → {formatDate(group.rangeEnd, lang)}
+        </span>
+        <div role="cell" className="flex items-center gap-2 min-w-0">
+          <span className="text-[9px] text-[var(--text2)]" aria-hidden="true">{expanded ? '▾' : '▸'}</span>
+          <span style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text0)' }} className="truncate">{group.normalizedTitle}</span>
+          <span
+            className="shrink-0 mono text-[var(--text2)] bg-[var(--bg2)]"
+            style={{ fontSize: '9px', letterSpacing: '0.04em', padding: '2px 6px', borderRadius: '3px' }}
+          >
+            {t('incidents.group.flaps').replace('{n}', String(group.count))}
+          </span>
+        </div>
+        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text1)' }}>{serviceLabel}</span>
+        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>—</span>
+        <span role="cell" className={`mono ${statusCls}`} style={{ fontSize: '9px', letterSpacing: '0.04em', padding: '2px 6px', borderRadius: '3px', justifySelf: 'start' }}>
+          {statusLabel}
+        </span>
+      </div>
+      {expanded && (
+        // Visually distinguish grouped children from siblings: tinted background +
+        // left accent border. Without this, expanded children look identical to
+        // ungrouped rows above/below and lose their group affiliation visually.
+        <div role="rowgroup" className="bg-[var(--bg2)]" style={{ borderLeft: '2px solid var(--border-hi)', borderBottom: '1px solid var(--border)' }}>
+          {group.entries.map((inc) => (
+            <IncidentRow
+              key={inc.id}
+              incident={inc}
+              isSelected={inc.id === selectedId}
+              onClick={() => onSelect(inc.id)}
+              onClose={onClose}
+              t={t}
+              lang={lang}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+function IncidentGroupCard({ group, expanded, onToggle, selectedId, onSelect, onClose, t, lang }) {
+  const dominantStatus = group.uniformStatus
+    ? Object.keys(group.statusCounts)[0]
+    : (['ongoing', 'monitoring', 'resolved'].find(s => group.statusCounts[s]) ?? 'resolved')
+  const statusLabel = group.uniformStatus
+    ? t('incidents.group.statusUniform').replace('{status}', t(`incidents.status.${dominantStatus}`).toLowerCase())
+    : Object.entries(group.statusCounts).map(([s, n]) => `${n} ${t(`incidents.status.${s}`).toLowerCase()}`).join(' · ')
+  const firstEntry = group.entries[0]
+  const serviceLabel = firstEntry.affectedNames?.length > 1 ? firstEntry.affectedNames.join(', ') : firstEntry.serviceName
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-label={expanded ? t('incidents.group.collapse') : t('incidents.group.expand')}
+        // minHeight: 44px ensures touch target meets WCAG / Apple HIG recommendation
+        className="w-full text-left rounded border border-[var(--border)] bg-[var(--bg1)] hover:bg-[var(--bg2)] transition-colors space-y-1"
+        style={{ padding: '10px', minHeight: '44px' }}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span style={{ fontSize: '13px', fontWeight: 500, color: 'var(--text0)', flex: 1 }}>
+            {group.normalizedTitle}
+          </span>
+          <span
+            className="shrink-0 mono text-[var(--text2)] bg-[var(--bg2)]"
+            style={{ fontSize: '10px', padding: '2px 6px', borderRadius: '3px' }}
+          >
+            {t('incidents.group.flaps').replace('{n}', String(group.count))}
+          </span>
+        </div>
+        <div className="flex items-center flex-wrap mono text-[var(--text2)]" style={{ fontSize: '10px', gap: '6px' }}>
+          <span>{formatDate(group.rangeStart, lang)} → {formatDate(group.rangeEnd, lang)}</span>
+          <span>·</span>
+          <span>{serviceLabel}</span>
+          <span>·</span>
+          <span>{statusLabel}</span>
+          <span className="ml-auto text-[var(--text2)]" aria-hidden="true">{expanded ? '▾' : '▸'}</span>
+        </div>
+      </button>
+      {expanded && (
+        // Mirror desktop: indent + left accent + bg tint so the expanded entries read
+        // as belonging to the group above, not as new top-level cards.
+        <div
+          className="flex flex-col gap-2 bg-[var(--bg2)] rounded"
+          style={{ marginTop: '8px', marginLeft: '12px', paddingLeft: '10px', paddingTop: '8px', paddingBottom: '8px', paddingRight: '6px', borderLeft: '2px solid var(--border-hi)' }}
+        >
+          {group.entries.map((inc) => (
+            <IncidentCard
+              key={inc.id}
+              incident={inc}
+              isSelected={inc.id === selectedId}
+              onClick={() => onSelect(inc.id)}
+              onClose={onClose}
+              t={t}
+              lang={lang}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Main Component ───────────────────────────────────────────
 
 export default function Incidents() {
@@ -227,6 +357,7 @@ export default function Incidents() {
   const [statusFilter,  setStatusFilter]  = useState('all')
   const [period,        setPeriod]        = useState(7)
   const [selectedId,    setSelectedId]    = useState(null)
+  const [expandedGroups, setExpandedGroups] = useState(() => new Set())
 
   // Flatten all incidents from all services (stable ref while services unchanged)
   // Normalize Worker statuses (investigating/identified) → 'ongoing' for display
@@ -292,6 +423,17 @@ export default function Incidents() {
       })
   }, [allIncidents, serviceFilter, statusFilter, period])
 
+  // groupIncidents re-sorts purely by date — re-apply STATUS_PRIORITY so ongoing
+  // incidents stay above resolved flap groups. Sort is stable (ES2019+), so
+  // newest-first ordering within the same status is preserved.
+  const grouped = useMemo(() => {
+    const rows = groupIncidents(filtered)
+    const statusOf = (r) => r.kind === 'single'
+      ? r.incident.status
+      : (['ongoing', 'monitoring', 'resolved'].find(s => r.statusCounts[s]) ?? 'resolved')
+    return rows.slice().sort((a, b) => (STATUS_PRIORITY[statusOf(a)] ?? 2) - (STATUS_PRIORITY[statusOf(b)] ?? 2))
+  }, [filtered])
+
   if (loading && services.length === 0) return <IncidentsSkeleton />
   if (!loading && services.length === 0 && error) return <EmptyState type="offline" onAction={refresh} />
   if (error)   return <EmptyState type="error" onAction={() => window.location.reload()} />
@@ -310,6 +452,12 @@ export default function Incidents() {
     setPeriod(7)
     setSelectedId(null)
   }
+  const groupKey = (g) => `${g.dayKey}::${g.normalizedTitle}`
+  const toggleGroup = (key) => setExpandedGroups((prev) => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key); else next.add(key)
+    return next
+  })
 
   return (
     <div className="flex flex-col" style={{ gap: '16px' }}>
@@ -355,12 +503,24 @@ export default function Incidents() {
             </div>
             {/* Rows — inline styles required: Tailwind v4 base reset zeroes padding on interactive elements */}
             <div role="rowgroup">
-              {filtered.map((inc) => (
+              {grouped.map((row) => row.kind === 'group' ? (
+                <IncidentGroupRow
+                  key={`group:${groupKey(row)}`}
+                  group={row}
+                  expanded={expandedGroups.has(groupKey(row))}
+                  onToggle={() => toggleGroup(groupKey(row))}
+                  selectedId={selectedId}
+                  onSelect={handleSelect}
+                  onClose={() => setSelectedId(null)}
+                  t={t}
+                  lang={lang}
+                />
+              ) : (
                 <IncidentRow
-                  key={inc.id}
-                  incident={inc}
-                  isSelected={inc.id === selectedId}
-                  onClick={() => handleSelect(inc.id)}
+                  key={row.incident.id}
+                  incident={row.incident}
+                  isSelected={row.incident.id === selectedId}
+                  onClick={() => handleSelect(row.incident.id)}
                   onClose={() => setSelectedId(null)}
                   t={t}
                   lang={lang}
@@ -371,12 +531,24 @@ export default function Incidents() {
 
           {/* Mobile card list — shown only on mobile */}
           <div className="flex flex-col gap-2 md:hidden">
-            {filtered.map((inc) => (
+            {grouped.map((row) => row.kind === 'group' ? (
+              <IncidentGroupCard
+                key={`group:${groupKey(row)}`}
+                group={row}
+                expanded={expandedGroups.has(groupKey(row))}
+                onToggle={() => toggleGroup(groupKey(row))}
+                selectedId={selectedId}
+                onSelect={handleSelect}
+                onClose={() => setSelectedId(null)}
+                t={t}
+                lang={lang}
+              />
+            ) : (
               <IncidentCard
-                key={inc.id}
-                incident={inc}
-                isSelected={inc.id === selectedId}
-                onClick={() => handleSelect(inc.id)}
+                key={row.incident.id}
+                incident={row.incident}
+                isSelected={row.incident.id === selectedId}
+                onClick={() => handleSelect(row.incident.id)}
                 onClose={() => setSelectedId(null)}
                 t={t}
                 lang={lang}

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -10,6 +10,7 @@ import { usePolling } from '../hooks/usePolling'
 import { trackEvent } from '../utils/analytics'
 import { formatDate } from '../utils/time'
 import { buildCalendarFromIncidents } from '../utils/calendar'
+import { groupIncidents } from '../utils/incidentGrouping'
 import { SCORE_TEXT_CLASS } from '../utils/constants'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
@@ -293,6 +294,75 @@ function IncidentRow({ incident, detectedAt, isRecentlyRecovered, t, lang }) {
             t={t}
             lang={lang}
           />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function IncidentGroupRow({ group, t, lang }) {
+  const [expanded, setExpanded] = useState(false)
+  // BetterStack-flap groups are always null-impact; the visible status is whatever the entries
+  // share. When mixed, render the highest-priority status.
+  const dominantStatus = group.uniformStatus
+    ? Object.keys(group.statusCounts)[0]
+    : (['investigating', 'identified', 'monitoring', 'resolved'].find(s => group.statusCounts[s]))
+  const STATUS_CLS = {
+    investigating: 'text-[var(--red)]',
+    identified:    'text-[var(--red)]',
+    monitoring:    'text-[var(--amber)]',
+    resolved:      'text-[var(--text2)]',
+  }
+  const dotCls = STATUS_CLS[dominantStatus] ?? STATUS_CLS.resolved
+  const statusLabel = group.uniformStatus
+    ? t('incidents.group.statusUniform').replace('{status}', t(`incidents.status.${dominantStatus === 'investigating' || dominantStatus === 'identified' ? 'ongoing' : dominantStatus}`).toLowerCase())
+    : Object.entries(group.statusCounts).map(([s, n]) => `${n} ${t(`incidents.status.${s === 'investigating' || s === 'identified' ? 'ongoing' : s}`).toLowerCase()}`).join(' · ')
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-label={expanded ? t('incidents.group.collapse') : t('incidents.group.expand')}
+        className="w-full text-left flex items-start gap-[10px] cursor-pointer hover:bg-[var(--bg2)] rounded transition-colors"
+        style={{ padding: '8px 4px', margin: '-2px -4px', minHeight: '44px' }}
+      >
+        <span className={`shrink-0 mt-0.5 text-[10px] mono ${dotCls}`} aria-hidden="true">●</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-xs text-[var(--text1)] truncate">{group.normalizedTitle}</p>
+            <span
+              className="shrink-0 mono text-[9px] text-[var(--text2)] bg-[var(--bg2)] rounded"
+              style={{ padding: '1px 5px' }}
+            >
+              {t('incidents.group.flaps').replace('{n}', String(group.count))}
+            </span>
+            <span className="shrink-0 text-[9px] text-[var(--text2)]">{expanded ? '▾' : '▸'}</span>
+          </div>
+          <p className="text-[10px] text-[var(--text2)] mono mt-0.5">
+            {formatDate(group.rangeStart, lang)} → {formatDate(group.rangeEnd, lang)} · {statusLabel}
+          </p>
+        </div>
+      </button>
+      {expanded && (
+        <div
+          className="flex flex-col bg-[var(--bg2)]"
+          style={{
+            gap: '6px',
+            marginLeft: '12px',
+            marginTop: '4px',
+            paddingLeft: '12px',
+            paddingTop: '8px',
+            paddingBottom: '8px',
+            paddingRight: '8px',
+            borderLeft: '2px solid var(--border-hi)',
+            borderRadius: '0 4px 4px 0',
+          }}
+        >
+          {group.entries.map((inc) => (
+            <IncidentRow key={inc.id} incident={inc} detectedAt={null} isRecentlyRecovered={false} t={t} lang={lang} />
+          ))}
         </div>
       )}
     </div>
@@ -803,8 +873,10 @@ export default function ServiceDetails({ serviceId }) {
               </div>
             ) : (
               <div className="flex flex-col" style={{ gap: '8px' }}>
-                {recentIncidents.map((inc) => (
-                  <IncidentRow key={inc.id} incident={inc} detectedAt={service.detectedAt} isRecentlyRecovered={!!(recentlyRecovered[service.id] ?? []).includes(inc.id)} t={t} lang={lang} />
+                {groupIncidents(recentIncidents).map((row) => row.kind === 'group' ? (
+                  <IncidentGroupRow key={`group:${row.dayKey}:${row.normalizedTitle}`} group={row} t={t} lang={lang} />
+                ) : (
+                  <IncidentRow key={row.incident.id} incident={row.incident} detectedAt={service.detectedAt} isRecentlyRecovered={!!(recentlyRecovered[service.id] ?? []).includes(row.incident.id)} t={t} lang={lang} />
                 ))}
               </div>
             )}

--- a/src/utils/__tests__/incidentGrouping.test.js
+++ b/src/utils/__tests__/incidentGrouping.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest'
+import { groupIncidents, GROUP_THRESHOLD, normalizeTitle } from '../incidentGrouping'
+
+// Minimal Incident factory — fields match worker/src/types.ts shape
+function makeIncident({ id, title, startedAt, status = 'resolved', impact = null, duration = '5m' }) {
+  return { id, title, startedAt, status, impact, duration, timeline: [] }
+}
+
+describe('normalizeTitle', () => {
+  it('strips trailing " — recovered"', () => {
+    expect(normalizeTitle('Nomic Embed Text v1.5 embeddings API — recovered'))
+      .toBe('Nomic Embed Text v1.5 embeddings API')
+  })
+
+  it('leaves untouched titles alone', () => {
+    expect(normalizeTitle('Major Outage Reported')).toBe('Major Outage Reported')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeTitle('  Service X — recovered  ')).toBe('Service X')
+  })
+
+  it('does not strip "recovered" elsewhere in title', () => {
+    expect(normalizeTitle('Service recovered after issue'))
+      .toBe('Service recovered after issue')
+  })
+})
+
+describe('groupIncidents — threshold + impact rules', () => {
+  // Tests in this block pin timeZone: 'UTC' so day-key extraction is deterministic regardless
+  // of where Vitest runs. KST-specific behavior is exercised in the dedicated TZ block below.
+  const UTC = { timeZone: 'UTC' }
+
+  it('groups 14 same-day same-title null-impact entries into one group (Fireworks AI Nomic case)', () => {
+    const incs = Array.from({ length: 14 }, (_, i) => makeIncident({
+      id: `nomic-${i}`,
+      title: 'Nomic Embed Text v1.5 embeddings API — recovered',
+      // Spread across 17h on same UTC day (2026-04-16)
+      startedAt: `2026-04-16T${String(6 + Math.floor(i * 1.2)).padStart(2, '0')}:00:00Z`,
+    }))
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('group')
+    expect(result[0].count).toBe(14)
+    expect(result[0].normalizedTitle).toBe('Nomic Embed Text v1.5 embeddings API')
+    expect(result[0].entries).toHaveLength(14)
+  })
+
+  it('does NOT group when count is below threshold (2 entries)', () => {
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T10:00:00Z' }),
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-16T15:00:00Z' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(2)
+    expect(result.every(r => r.kind === 'single')).toBe(true)
+  })
+
+  it('groups exactly at threshold (3 entries)', () => {
+    expect(GROUP_THRESHOLD).toBe(3)
+    const incs = Array.from({ length: 3 }, (_, i) => makeIncident({
+      id: `x-${i}`,
+      title: 'X — recovered',
+      startedAt: `2026-04-16T${10 + i}:00:00Z`,
+    }))
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('group')
+    expect(result[0].count).toBe(3)
+  })
+
+  it('never groups entries with non-null impact, even if 3+ match the key', () => {
+    const incs = Array.from({ length: 5 }, (_, i) => makeIncident({
+      id: `real-${i}`,
+      title: 'API Outage — recovered',
+      startedAt: `2026-04-16T${10 + i}:00:00Z`,
+      impact: 'major',
+    }))
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(5)
+    expect(result.every(r => r.kind === 'single')).toBe(true)
+  })
+
+  it('mixes grouped + individual rows when a service has both flap and real incidents', () => {
+    const incs = [
+      ...Array.from({ length: 5 }, (_, i) => makeIncident({
+        id: `flap-${i}`,
+        title: 'Embeddings API — recovered',
+        startedAt: `2026-04-16T${10 + i}:00:00Z`,
+      })),
+      makeIncident({
+        id: 'real-1',
+        title: 'Major Outage',
+        startedAt: '2026-04-16T18:00:00Z',
+        impact: 'major',
+      }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(2)
+    const group = result.find(r => r.kind === 'group')
+    const single = result.find(r => r.kind === 'single')
+    expect(group.count).toBe(5)
+    expect(single.incident.id).toBe('real-1')
+  })
+})
+
+describe('groupIncidents — local timezone day boundary (KST = UTC+9)', () => {
+  // All tests in this block pin timeZone: 'Asia/Seoul' so behavior is deterministic
+  // regardless of where Vitest runs (CI vs local). Production callers omit timeZone and
+  // get the runtime default (browser TZ in the SPA).
+  const KST = { timeZone: 'Asia/Seoul' }
+
+  it('splits a UTC-day-spanning batch when entries fall on different KST dates', () => {
+    // The exact case from production: BetterStack flap entries straddling 15:00 UTC
+    // (= 00:00 KST). User reads these as different days in the UI even though UTC date matches.
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T14:30:00Z' }), // KST 04-16 23:30
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-16T14:55:00Z' }), // KST 04-16 23:55
+      makeIncident({ id: 'c', title: 'X — recovered', startedAt: '2026-04-16T16:30:00Z' }), // KST 04-17 01:30
+      makeIncident({ id: 'd', title: 'X — recovered', startedAt: '2026-04-16T17:30:00Z' }), // KST 04-17 02:30
+      makeIncident({ id: 'e', title: 'X — recovered', startedAt: '2026-04-16T20:00:00Z' }), // KST 04-17 05:00
+    ]
+    const result = groupIncidents(incs, KST)
+    // Two KST dates: 04-16 (2 entries → below threshold) + 04-17 (3 entries → group)
+    expect(result.filter(r => r.kind === 'group')).toHaveLength(1)
+    const group = result.find(r => r.kind === 'group')
+    expect(group.dayKey).toBe('2026-04-17')
+    expect(group.count).toBe(3)
+    expect(result.filter(r => r.kind === 'single')).toHaveLength(2)
+  })
+
+  it('groups entries spanning UTC midnight that share the same KST date', () => {
+    // 23:00 UTC and 02:00 next-UTC-day are both KST 04-17 (08:00 and 11:00 KST).
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T23:00:00Z' }), // KST 04-17 08:00
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-17T01:00:00Z' }), // KST 04-17 10:00
+      makeIncident({ id: 'c', title: 'X — recovered', startedAt: '2026-04-17T02:00:00Z' }), // KST 04-17 11:00
+    ]
+    const result = groupIncidents(incs, KST)
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('group')
+    expect(result[0].dayKey).toBe('2026-04-17')
+    expect(result[0].count).toBe(3)
+  })
+
+  it('does not group entries on consecutive KST days even if titles match', () => {
+    const incs = [
+      ...Array.from({ length: 3 }, (_, i) => makeIncident({
+        id: `d1-${i}`,
+        title: 'X — recovered',
+        // KST 04-17 (UTC 04-16 18:00–20:00 = KST 04-17 03:00–05:00)
+        startedAt: `2026-04-16T${18 + i}:00:00Z`,
+      })),
+      ...Array.from({ length: 3 }, (_, i) => makeIncident({
+        id: `d2-${i}`,
+        title: 'X — recovered',
+        // KST 04-18 (UTC 04-17 18:00–20:00 = KST 04-18 03:00–05:00)
+        startedAt: `2026-04-17T${18 + i}:00:00Z`,
+      })),
+    ]
+    const result = groupIncidents(incs, KST)
+    expect(result).toHaveLength(2)
+    expect(result.every(r => r.kind === 'group')).toBe(true)
+    expect(result.map(r => r.dayKey).sort()).toEqual(['2026-04-17', '2026-04-18'])
+  })
+
+  it('UTC option produces UTC-date grouping when explicitly requested', () => {
+    // Sanity check that the timeZone option is actually wired through.
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T14:30:00Z' }),
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-16T20:00:00Z' }),
+      makeIncident({ id: 'c', title: 'X — recovered', startedAt: '2026-04-16T23:00:00Z' }),
+    ]
+    const result = groupIncidents(incs, { timeZone: 'UTC' })
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('group')
+    expect(result[0].dayKey).toBe('2026-04-16')
+  })
+})
+
+describe('groupIncidents — group metadata', () => {
+  const UTC = { timeZone: 'UTC' }
+
+  it('preserves status distribution when statuses differ within a group', () => {
+    const incs = [
+      makeIncident({ id: '1', title: 'X — recovered', startedAt: '2026-04-16T10:00:00Z', status: 'resolved' }),
+      makeIncident({ id: '2', title: 'X — recovered', startedAt: '2026-04-16T11:00:00Z', status: 'resolved' }),
+      makeIncident({ id: '3', title: 'X — recovered', startedAt: '2026-04-16T12:00:00Z', status: 'monitoring' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result[0].kind).toBe('group')
+    expect(result[0].statusCounts).toEqual({ resolved: 2, monitoring: 1 })
+    expect(result[0].uniformStatus).toBe(false)
+  })
+
+  it('marks uniformStatus when all entries share the same status', () => {
+    const incs = Array.from({ length: 4 }, (_, i) => makeIncident({
+      id: `x-${i}`,
+      title: 'X — recovered',
+      startedAt: `2026-04-16T${10 + i}:00:00Z`,
+      status: 'resolved',
+    }))
+    const result = groupIncidents(incs, UTC)
+    expect(result[0].uniformStatus).toBe(true)
+    expect(result[0].statusCounts).toEqual({ resolved: 4 })
+  })
+
+  it('exposes time range: earliest startedAt and latest startedAt', () => {
+    // Spread within a single UTC hour range so KST also keeps them on one local day
+    // regardless of the system TZ that runs this assertion.
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T11:00:00Z' }),
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-16T09:00:00Z' }),
+      makeIncident({ id: 'c', title: 'X — recovered', startedAt: '2026-04-16T10:00:00Z' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result[0].rangeStart).toBe('2026-04-16T09:00:00Z')
+    expect(result[0].rangeEnd).toBe('2026-04-16T11:00:00Z')
+  })
+
+  it('preserves entries in original (input) order within the group', () => {
+    const incs = [
+      makeIncident({ id: 'a', title: 'X — recovered', startedAt: '2026-04-16T11:00:00Z' }),
+      makeIncident({ id: 'b', title: 'X — recovered', startedAt: '2026-04-16T09:00:00Z' }),
+      makeIncident({ id: 'c', title: 'X — recovered', startedAt: '2026-04-16T10:00:00Z' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result[0].entries.map(e => e.id)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('groupIncidents — ordering of mixed output', () => {
+  const UTC = { timeZone: 'UTC' }
+
+  it('places groups and singles in newest-first order by representative startedAt', () => {
+    const incs = [
+      // Group on 04-16
+      ...Array.from({ length: 3 }, (_, i) => makeIncident({
+        id: `g1-${i}`,
+        title: 'X — recovered',
+        startedAt: `2026-04-16T${10 + i}:00:00Z`,
+      })),
+      // Single on 04-18 (newer)
+      makeIncident({ id: 's1', title: 'Real Outage', startedAt: '2026-04-18T08:00:00Z', impact: 'major' }),
+      // Single on 04-15 (older)
+      makeIncident({ id: 's2', title: 'Real Outage', startedAt: '2026-04-15T08:00:00Z', impact: 'major' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    // Newest first by representative time (rangeEnd for groups, startedAt for singles)
+    const reps = result.map(r => r.kind === 'group' ? r.rangeEnd : r.incident.startedAt)
+    const sorted = [...reps].sort().reverse()
+    expect(reps).toEqual(sorted)
+  })
+})
+
+describe('groupIncidents — edge cases', () => {
+  const UTC = { timeZone: 'UTC' }
+
+  it('returns empty array for empty input', () => {
+    expect(groupIncidents([], UTC)).toEqual([])
+  })
+
+  it('returns single rows when all incidents have unique titles', () => {
+    const incs = [
+      makeIncident({ id: 'a', title: 'A — recovered', startedAt: '2026-04-16T10:00:00Z' }),
+      makeIncident({ id: 'b', title: 'B — recovered', startedAt: '2026-04-16T11:00:00Z' }),
+      makeIncident({ id: 'c', title: 'C — recovered', startedAt: '2026-04-16T12:00:00Z' }),
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(3)
+    expect(result.every(r => r.kind === 'single')).toBe(true)
+  })
+
+  it('treats undefined impact as null (defensive)', () => {
+    const incs = Array.from({ length: 3 }, (_, i) => {
+      const inc = makeIncident({ id: `x-${i}`, title: 'X — recovered', startedAt: `2026-04-16T${10 + i}:00:00Z` })
+      delete inc.impact
+      return inc
+    })
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('group')
+  })
+})

--- a/src/utils/incidentGrouping.js
+++ b/src/utils/incidentGrouping.js
@@ -1,0 +1,155 @@
+/**
+ * Group flap-style auto-recovery incidents in the UI without altering source data.
+ *
+ * Background: BetterStack-based status feeds (Fireworks AI, Together AI) emit a separate
+ * "<model> — recovered" entry per transient blip. A single model can flap 10-20 times in a
+ * day, swamping the Incident History UI. Grouping pulls these into a single expandable
+ * row while leaving raw incident data untouched (Discord pipeline + monthly reports stay raw).
+ *
+ * Threshold rationale: ≥3 (not ≥2). Two entries don't earn a group row — the UI overhead
+ * outweighs the dedup benefit.
+ *
+ * impact != null is never grouped: real human-tagged incidents stay individually visible.
+ *
+ * Day boundary: **viewer's local date**. Earlier draft used UTC because cron archival
+ * keys on UTC, but that's a server concern. The user reads timestamps rendered in their
+ * local timezone — grouping by UTC produced groups that visibly straddle two displayed
+ * dates (e.g., a UTC 2026-04-16 20:00 entry shows as 2026-04-17 05:00 KST and got merged
+ * with same-day entries that show as 2026-04-16 23:30 KST). Grouping must follow what
+ * the eye sees, not what the storage layer uses.
+ *
+ * The `timeZone` option exists for deterministic tests — production callers omit it
+ * and get the runtime default (browser TZ in the SPA).
+ *
+ * See issue #282.
+ */
+
+export const GROUP_THRESHOLD = 3
+
+/**
+ * @param {string} title
+ * @returns {string}
+ */
+export function normalizeTitle(title) {
+  return String(title ?? '').replace(/\s*—\s*recovered\s*$/, '').trim()
+}
+
+/**
+ * @typedef {Object} Incident
+ * @property {string} id
+ * @property {string} title
+ * @property {string} startedAt - ISO 8601
+ * @property {'investigating'|'identified'|'monitoring'|'resolved'} status
+ * @property {'minor'|'major'|'critical'|null} [impact]
+ * @property {string|null} [duration]
+ * @property {string|null} [resolvedAt]
+ * @property {Array<unknown>} [timeline]
+ */
+
+/**
+ * @typedef {Object} GroupRow
+ * @property {'group'} kind
+ * @property {string} dayKey - YYYY-MM-DD in viewer's local timezone (or supplied `timeZone`)
+ * @property {string} normalizedTitle
+ * @property {number} count
+ * @property {string} rangeStart - ISO 8601, earliest startedAt
+ * @property {string} rangeEnd - ISO 8601, latest startedAt
+ * @property {Record<string, number>} statusCounts
+ * @property {boolean} uniformStatus - true if all entries share the same status
+ * @property {Incident[]} entries - in original input order
+ */
+
+/**
+ * @typedef {Object} SingleRow
+ * @property {'single'} kind
+ * @property {Incident} incident
+ */
+
+/**
+ * Format an ISO timestamp as a YYYY-MM-DD calendar day in the given timezone.
+ * Uses 'en-CA' locale (always YYYY-MM-DD) — independent of the viewer's locale.
+ * @param {string} iso
+ * @param {string|undefined} timeZone - omit for runtime default (browser TZ in SPA)
+ * @returns {string}
+ */
+function localDayKey(iso, timeZone) {
+  return new Date(iso).toLocaleDateString('en-CA', timeZone ? { timeZone } : undefined)
+}
+
+/**
+ * Group qualifying incidents; pass others through individually.
+ * Output sorted newest-first by representative time
+ * (rangeEnd for groups, startedAt for singles).
+ *
+ * @param {Incident[]} incidents
+ * @param {{ timeZone?: string }} [options] - timeZone override (tests). Omit in production.
+ * @returns {Array<GroupRow|SingleRow>}
+ */
+export function groupIncidents(incidents, options = {}) {
+  if (!Array.isArray(incidents) || incidents.length === 0) return []
+  const { timeZone } = options
+
+  // Bucket by (dayKey, normalizedTitle). Skip non-null impact — those never group.
+  const buckets = new Map()
+  const ungroupable = []
+  incidents.forEach((inc, idx) => {
+    if (inc.impact != null) {
+      ungroupable.push({ idx, inc })
+      return
+    }
+    const dayKey = localDayKey(inc.startedAt, timeZone)
+    const key = `${dayKey}::${normalizeTitle(inc.title)}`
+    let bucket = buckets.get(key)
+    if (!bucket) {
+      bucket = { dayKey, normalizedTitle: normalizeTitle(inc.title), entries: [], firstIdx: idx }
+      buckets.set(key, bucket)
+    }
+    bucket.entries.push(inc)
+  })
+
+  /** @type {Array<{ row: GroupRow|SingleRow, sortKey: string, idx: number }>} */
+  const rows = []
+
+  for (const { dayKey, normalizedTitle: nt, entries, firstIdx } of buckets.values()) {
+    if (entries.length >= GROUP_THRESHOLD) {
+      const startedAtTimes = entries.map(e => e.startedAt)
+      const rangeStart = startedAtTimes.reduce((a, b) => a < b ? a : b)
+      const rangeEnd = startedAtTimes.reduce((a, b) => a > b ? a : b)
+      const statusCounts = {}
+      for (const e of entries) statusCounts[e.status] = (statusCounts[e.status] ?? 0) + 1
+      rows.push({
+        row: {
+          kind: 'group',
+          dayKey,
+          normalizedTitle: nt,
+          count: entries.length,
+          rangeStart,
+          rangeEnd,
+          statusCounts,
+          uniformStatus: Object.keys(statusCounts).length === 1,
+          entries,
+        },
+        sortKey: rangeEnd,
+        idx: firstIdx,
+      })
+    } else {
+      // Below threshold — render each as a single row.
+      entries.forEach((inc) => {
+        const idx = incidents.indexOf(inc)
+        rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+      })
+    }
+  }
+
+  for (const { idx, inc } of ungroupable) {
+    rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+  }
+
+  // Newest first by sortKey; tiebreak by original input index for stable ordering.
+  rows.sort((a, b) => {
+    if (a.sortKey !== b.sortKey) return a.sortKey < b.sortKey ? 1 : -1
+    return a.idx - b.idx
+  })
+
+  return rows.map(r => r.row)
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.js'],
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
Addresses the BetterStack-RSS flap noise problem flagged during the #278 rollout. A single model on Fireworks AI / Together AI can produce 14+ near-identical `"<model> — recovered"` entries per day. #261 already excluded these from the Score's `affectedDays` metric, but the UI still rendered every entry. This PR groups them into a single expandable row.

API data is untouched — Discord alert pipeline + monthly reports still see every raw entry. Webhook-side flap suppression is tracked separately in #283.

## Key design decisions

- **Threshold ≥ 3** — 2-entry dups aren't worth the grouped-row UI overhead.
- **Day boundary = viewer's local timezone** — UTC was the first draft but produced groups that visibly straddled two displayed dates (KST 23:30 merging with KST next-day 05:00 via shared UTC date). Grouping must follow what the eye reads.
- **`status` excluded from group key** — same day `degraded → recovered → degraded → recovered` stays a single group; status distribution surfaces as a badge instead.
- **`impact != null` never grouped** — real human-tagged incidents keep individual visibility.
- **Range, not sum** — summing 14 × 6min = "84 minutes down" overclaims impact. Time range + flap count communicates "intermittent over a window."
- **`.js` + JSDoc, not `.ts`** — frontend `src/` is 100% `.js` today with no tsconfig. A lone `.ts` file creates false type-safety sense. Frontend TS migration is a separate concern.

## Changes
| Area | File |
|---|---|
| Grouping utility | `src/utils/incidentGrouping.js` |
| Unit tests (21) | `src/utils/__tests__/incidentGrouping.test.js` |
| Frontend Vitest harness | `vitest.config.js` (new), `package.json` (`test:src` script) |
| ServiceDetails Incident History | `src/pages/ServiceDetails.jsx` — `IncidentGroupRow` |
| Incidents page — desktop table | `src/pages/Incidents.jsx` — `IncidentGroupRow` |
| Incidents page — mobile card | `src/pages/Incidents.jsx` — `IncidentGroupCard` (≥44px touch target) |
| i18n | `src/locales/en.js`, `src/locales/ko.js` — 4 new keys |
| Docs | `CLAUDE.md` — `test:src` in commands + frontend utility-test guidance |

## Testing
- 21 new frontend unit tests — threshold, impact filter, status distribution, range metadata, newest-first ordering, UTC vs KST day-boundary behavior, edge cases
- Local verify via headless Playwright in `Asia/Seoul` timezone: Fireworks AI's Nomic Embed entries correctly split into `× 5 flaps` (KST 04-16) + `× 12 flaps` (KST 04-17)
- Manual browser check: expanded group children render with indent + left accent border + bg tint — visually distinct from ungrouped rows on all 3 components
- Incidents.jsx preserves `STATUS_PRIORITY` ordering after grouping — ongoing incidents stay above resolved flap groups (stable sort)

## Test plan
- [x] 21 frontend unit tests pass
- [x] 848 worker unit tests unchanged (no worker changes)
- [x] `npm run build` clean
- [x] Code review: 0 critical, 0 important (round 2 converged after fixing Rules-of-Hooks + status-priority regression)
- [ ] Vercel preview: verify `/#fireworks`, `/#together` split correctly by KST date
- [ ] Vercel preview: verify `/#incidents` desktop + mobile (768px breakpoint) group/expand behavior
- [ ] Regression check: `/#claude`, `/#openai` show individual incidents (no spurious grouping)

## Out of scope
- Discord alert flap suppression → #283
- Server-side grouping in parser
- Frontend `.ts` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)