### PR TITLE
fix: show all affected services for bulk-linked Overview incidents (closes #285)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -235,7 +235,7 @@ function IncidentItem({ incident, lang, t }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             <div className="text-[12px] font-medium text-[var(--text0)] truncate" style={{ marginBottom: '2px' }}>
-              {incident.serviceName} — {incident.title}
+              {(incident.affectedNames?.length > 1 ? incident.affectedNames.join(', ') : incident.serviceName)} — {incident.title}
             </div>
             {hasTimeline && expanded && (
               <span className="shrink-0 text-[9px] text-[var(--text2)]">▾</span>
@@ -249,7 +249,7 @@ function IncidentItem({ incident, lang, t }) {
       {expanded && (
         <div className="ml-[66px]">
           <IncidentTimeline
-            title={`${incident.serviceName} — ${incident.title}`}
+            title={`${incident.affectedNames?.length > 1 ? incident.affectedNames.join(', ') : incident.serviceName} — ${incident.title}`}
             subtitle={`${formatDate(incident.startedAt, lang)}  ·  ${incident.duration ?? (incident.status === 'monitoring' ? t('overview.incidents.monitoring') : t('incidents.status.ongoing'))}`}
             timeline={incident.timeline}
             onClose={() => setExpanded(false)}
@@ -476,13 +476,20 @@ export default function Overview() {
     : agentServices
 
   const sevenDaysAgo = Date.now() - 7 * 86_400_000
-  const seenIncIds = new Set()
-  const recentIncidents = catServices
-    .flatMap((s) => s.incidents.flatMap((inc) => {
-      if (seenIncIds.has(inc.id)) return []
-      seenIncIds.add(inc.id)
-      return [{ ...inc, serviceName: s.name }]
-    }))
+  // Dedup by incident ID (Anthropic bulk-links one incident to claude.ai + Claude API + Claude Code)
+  // while collecting every affected service name. Mirrors the Incidents.jsx aggregation pattern.
+  const incMap = new Map()
+  for (const s of catServices) {
+    for (const inc of s.incidents ?? []) {
+      const existing = incMap.get(inc.id)
+      if (existing) {
+        if (!existing.affectedNames.includes(s.name)) existing.affectedNames.push(s.name)
+      } else {
+        incMap.set(inc.id, { ...inc, serviceName: s.name, affectedNames: [s.name] })
+      }
+    }
+  }
+  const recentIncidents = [...incMap.values()]
     .filter((inc) => inc.status !== 'resolved' || new Date(inc.startedAt).getTime() >= sevenDaysAgo)
     .sort((a, b) => {
       const aActive = a.status !== 'resolved' ? 1 : 0

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -74,6 +74,33 @@ test.describe('Overview page', () => {
     }
   })
 
+  test('Recent Incidents shows all affected services for bulk-linked incident (#285)', async ({ page }) => {
+    // Regression: Anthropic bulk-links one incident ID to claude.ai + Claude API + Claude Code.
+    // Overview previously showed only the first service's name via Set-based dedup.
+    // Fix: collect affectedNames[], render joined when length > 1.
+    const sharedId = 'shared-anthropic-incident-285'
+    // status: 'investigating' (unresolved) + recent startedAt keeps this incident above any
+    // mock incidents in MOCK_SERVICES that mergeWithMock leaves in place for services we
+    // don't override here. Overview sorts non-resolved ahead of resolved, then by newest.
+    const inc = { id: sharedId, title: 'Claude Sonnet 4.5 error spike', status: 'investigating', impact: 'major', startedAt: new Date(Date.now() - 60_000).toISOString(), duration: null, timeline: [] }
+    const mkSvc = (id, cat, name) => ({ id, category: cat, name, provider: 'Anthropic', status: 'degraded', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [inc] })
+    const bulkLinkedMock = { json: {
+      services: [mkSvc('claude', 'api', 'Claude API'), mkSvc('claudeai', 'app', 'claude.ai'), mkSvc('claudecode', 'agent', 'Claude Code')],
+      lastUpdated: new Date().toISOString(),
+    } }
+    await page.route('**/api/status', async (route) => { await route.fulfill(bulkLinkedMock) })
+    await page.route('**/api/status/cached', async (route) => { await route.fulfill(bulkLinkedMock) })
+    await page.goto('/')
+    await waitForDataLoad(page)
+    const entry = page.locator('main').getByText(/Claude Sonnet 4\.5 error spike/).first()
+    await expect(entry).toBeVisible({ timeout: 10000 })
+    const entryText = await entry.textContent()
+    // All 3 affected service names must appear in the Recent Incidents entry
+    expect(entryText).toContain('Claude API')
+    expect(entryText).toContain('claude.ai')
+    expect(entryText).toContain('Claude Code')
+  })
+
   test('action banner shows severity labels and excludes affected from alternatives', async ({ page }) => {
     // Banner only shows when services are degraded/down (requires Worker data or dev mock)
     const banner = page.locator('main').getByText(/Degraded|성능 저하|Down|서비스 중단/)


### PR DESCRIPTION
## Summary
Overview's Recent Incidents card showed only one service name when an incident affected multiple (via Anthropic's bulk-linked incident IDs). Example on 2026-04-20: \"Claude Sonnet 4.5 error spike\" hit claude.ai + Claude API + Claude Code, but the card rendered only \`claude.ai — Claude Sonnet 4.5 error spike\`. The Incidents page already handled this correctly via an \`affectedNames[]\` aggregation. This PR aligns Overview with the same pattern.

## Root cause
\`Overview.jsx:480-485\` used a \`seenIncIds\` Set: first service to surface a given \`inc.id\` won; all other services that shared the ID were dropped.

## Fix
- Replace Set dedup with Map-based aggregation at \`Overview.jsx:478-503\` — collect every affected service's name into \`affectedNames[]\`, mirroring \`Incidents.jsx:253-268\`.
- Render \`affectedNames.join(', ')\` when length > 1 in the card body (line 238) and in the expanded \`IncidentTimeline\` title (line 252). Fall back to \`serviceName\` when only one service is affected — backward compatible.

## Test
New Playwright regression in \`tests/overview.spec.js\`:
- Mocks 3 Anthropic services sharing one incident ID
- Asserts all three service names appear in the Recent Incidents entry text
- Before fix: only the first name rendered → test fails
- After fix: all three appear joined by \`, \` → test passes

## Verification
- [x] 8/8 Overview E2E tests pass (including new regression)
- [x] \`npm run build\` clean
- [ ] Vercel preview: manual check that the 2026-04-20 Claude Sonnet 4.5 incident now shows all 3 services

## Scope
Frontend-only. Worker/API untouched. No i18n changes needed.

## Related
- #285 issue
- Pattern alignment with \`src/pages/Incidents.jsx:253-268\` (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)