### PR TITLE
fix: daily summary security count uses purpose-built daily counter (closes #288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ When adding a new monitored service, update ALL of the following:
 | `security:seen:hn:{objectId}` | `SecurityAlertMeta` JSON | 7d | ~0 | HN security post dedup + dashboard display |
 | `security:seen:osv:{vulnId}` | `SecurityAlertMeta` JSON | 7d | ~0 | OSV.dev vulnerability dedup + dashboard display |
 | `security:monthly:{YYYY-MM}` | `SecurityAlertMeta[]` JSON | 60d | ~1/day | Monthly security alert accumulation for reports |
+| `security:detected:{YYYY-MM-DD}` | integer string | 3d | ~0-3/day | Daily counter of newly-detected security alerts (#288). Incremented by `securityAlerts.length` when HN/OSV detection fires. Daily summary reads this instead of counting `security:seen:*` (which accumulates over 7d and inflates the figure) |
 | `ai:analysis:{svcId}:{incId}` | `AIAnalysisResult` JSON | 1h (active) / 2h (resolved) | ~5 per incident | Hybrid AI analysis result — Gemma 4 primary + Sonnet fallback (TTL refreshed while active; on recovery, `resolvedAt` added instead of deleting — kept 2h for "Recently Resolved" UI). `model` field tracks which model produced the analysis |
 | `ai:reanalysis-skip:{svcId}:{incId}` | `"1"` | 30min | ~2 per incident | Per-incident re-analysis failure cooldown |
 | `ai:usage:{YYYY-MM-DD}` | `{ calls, success, failed, gemma?, sonnet? }` JSON | 2d | ~5 | Daily AI analysis usage counter (includes re-analysis, model breakdown) |

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, formatSecurityDigest } from '../security-monitor'
+import { mapOSVSeverity, detectSecurityAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount } from '../security-monitor'
 import type { SecurityAlert } from '../security-monitor'
 
 describe('mapOSVSeverity', () => {
@@ -165,5 +165,33 @@ describe('formatSecurityDigest', () => {
     // Should not contain a service tag like [Hugging Face], but [Details]/[HN] links are expected
     expect(digest.description).not.toMatch(/\[(?!Details|HN|Source)[A-Z][a-zA-Z ]+\]/)
     expect(digest.description).toContain('GHSA-noservice')
+  })
+})
+
+describe('securityDetectedKey + incrementSecurityCount (#288)', () => {
+  it('scopes key to UTC date', () => {
+    expect(securityDetectedKey('2026-04-20')).toBe('security:detected:2026-04-20')
+  })
+
+  it('starts at N when no prior value exists', () => {
+    expect(incrementSecurityCount(null, 3)).toBe(3)
+    expect(incrementSecurityCount('', 2)).toBe(2)
+  })
+
+  it('adds to an existing integer value', () => {
+    expect(incrementSecurityCount('5', 2)).toBe(7)
+  })
+
+  it('treats corrupt values as 0 to avoid NaN propagation', () => {
+    // Defensive: KV could return a non-numeric string from a prior schema migration
+    // or user-facing debug write. The daily summary should never display NaN.
+    expect(incrementSecurityCount('not-a-number', 3)).toBe(3)
+    expect(incrementSecurityCount('1.5.3', 2)).toBe(3) // parseInt stops at first non-digit → 1
+  })
+
+  it('add-by-zero read pattern returns the current value', () => {
+    // Daily summary uses incrementSecurityCount(raw, 0) to parse without mutating.
+    expect(incrementSecurityCount('14', 0)).toBe(14)
+    expect(incrementSecurityCount(null, 0)).toBe(0)
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -682,7 +682,7 @@ function corsHeaders(origin: string, allowedOrigin: string | undefined): Headers
 import { generateBadgeSvg } from './badge'
 import { generateOgSvg } from './og'
 import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, formatSecurityAlert as formatRedditSecurityAlert, isPromotable } from './reddit'
-import { detectSecurityAlerts, formatSecurityDigest } from './security-monitor'
+import { detectSecurityAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount } from './security-monitor'
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { collectChangelogs, getStaleSources } from './changelog'
@@ -852,6 +852,17 @@ export default {
             await kvPut(env.STATUS_CACHE, alert.kvKey, meta, { expirationTtl: 604800 }).catch(err => { // 7d dedup
               console.error('[cron] Failed to mark security alert as seen:', alert.kvKey, err instanceof Error ? err.message : err)
             })
+          }
+
+          // #288: purpose-built daily counter for the daily summary. security:seen:* has a
+          // 7d TTL for dedup semantics and shouldn't double as a "today's count" source.
+          const detectedKey = securityDetectedKey(nowISO.slice(0, 10))
+          try {
+            const prevRaw = await env.STATUS_CACHE.get(detectedKey).catch(() => null)
+            const next = incrementSecurityCount(prevRaw, securityAlerts.length)
+            await kvPut(env.STATUS_CACHE, detectedKey, String(next), { expirationTtl: 259200 }) // 3d TTL
+          } catch (err) {
+            console.warn('[cron] security daily counter increment failed:', err instanceof Error ? err.message : err)
           }
 
           // Accumulate for monthly reports (security:monthly:{YYYY-MM}, 60d TTL)
@@ -1122,13 +1133,15 @@ export default {
             console.warn('[daily-summary] Failed to list reddit keys:', err instanceof Error ? err.message : err)
           }
 
-          // Count security alerts seen today (HN + OSV)
+          // #288: read the purpose-built daily counter instead of counting security:seen:*
+          // keys (that prefix has 7d TTL and accumulates across the week, inflating the number).
+          // Fallback to 0 if missing (e.g., first run of the day before any detections fire).
           let securityCount = 0
           try {
-            const listed = await env.STATUS_CACHE.list({ prefix: 'security:seen:' })
-            securityCount = listed.keys.length
+            const raw = await env.STATUS_CACHE.get(securityDetectedKey(today)).catch(() => null)
+            securityCount = incrementSecurityCount(raw, 0)
           } catch (err) {
-            console.warn('[daily-summary] Failed to list security keys:', err instanceof Error ? err.message : err)
+            console.warn('[daily-summary] Failed to read security daily counter:', err instanceof Error ? err.message : err)
           }
 
           // Read daily alert counter

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -311,3 +311,19 @@ export function formatSecurityDigest(alerts: SecurityAlert[]): {
     color,
   }
 }
+
+// #288: daily counter for "security alerts detected today" in the daily summary.
+// security:seen:* has 7d TTL for dedup — conflating it with "today's count" inflates the
+// number by up to a factor of 7. This counter is incremented per new alert in the cron
+// dispatch path and read fresh by the daily summary.
+
+/** KV key for the daily detected-alert counter, scoped to UTC date. */
+export function securityDetectedKey(dateUtc: string): string {
+  return `security:detected:${dateUtc}`
+}
+
+/** Parse the stored counter and add N. Treats missing/corrupt values as 0 to avoid NaN propagation. */
+export function incrementSecurityCount(raw: string | null, addBy: number): number {
+  const prev = raw ? parseInt(raw, 10) : 0
+  return (Number.isFinite(prev) ? prev : 0) + addBy
+}


### PR DESCRIPTION
## Summary
Daily Discord summary reported \`🔒 Security: N alerts detected\` where N was derived by \`.list({ prefix: 'security:seen:' })\`. Those keys carry a **7-day TTL** (dedup ledger), so N was \"cumulative over the past week,\" not \"detected today.\" Users observed \`3 alerts detected\` on days when no Discord security alert actually fired — the 3 were residue from prior days.

## Fix
Introduce \`security:detected:{YYYY-MM-DD}\` counter (3-day TTL, UTC-day scoped) written per-new-alert in the cron dispatch path. Daily summary reads that key instead of counting the dedup prefix.

## Changes
| File | Change |
|---|---|
| \`worker/src/security-monitor.ts\` | Two pure helpers: \`securityDetectedKey(dateUtc)\`, \`incrementSecurityCount(raw, addBy)\` |
| \`worker/src/index.ts\` | Cron increments after \`detectSecurityAlerts\` fires; daily summary reader replaced |
| \`worker/src/__tests__/security-monitor.test.ts\` | 5 unit tests — key format, null/empty input, NaN guard, add-by-zero read pattern, standard increment |
| \`CLAUDE.md\` | New KV schema row for \`security:detected:{YYYY-MM-DD}\` |

## Left intentionally untouched
- **Weekly briefing** (\`worker/src/index.ts\` around line 983) still reads \`security:seen:*\` — its 7d TTL naturally approximates the weekly window, which is the correct semantics there.
- **Dashboard API route** (\`worker/src/index.ts\` around line 1683) still reads those keys to display recent alert metadata in the SPA — unrelated to the daily count display.

Only the daily summary was conflating dedup semantics with display semantics.

## Test plan
- [x] 5 new unit tests pass (853 total worker tests)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` clean
- [x] Local verify: \`wrangler dev --test-scheduled\` + cron trigger → HTTP 200, no errors in new counter path
- [ ] Production verify after deploy: inspect \`security:detected:{YYYY-MM-DD}\` key over 24h, confirm it matches the count of Discord security alerts that fired today (not the 7d residue)

## Related
- #288 issue
- Surfaced during #283 E2E smoke test verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)