### PR TITLE
fix: drop stale ChatGPT statusComponentId after OpenAI restructure (#292)

### DIFF
--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { normalizeStatus } from '../parsers/statuspage'
+import { filterIncidents, SERVICES } from '../services'
+import type { Incident, ServiceConfig } from '../types'
 import { type KVLike } from '../utils'
 
 /**
@@ -185,6 +187,98 @@ async function trackComponentMissLogic(
     return 'reset'
   }
 }
+
+/**
+ * Regression tests for #292: ChatGPT has no umbrella component on
+ * status.openai.com, so its config omits statusComponentId / incidentIoComponentId
+ * and status is resolved from the overall page indicator + incidentKeywords filter
+ * alone. Covers both directions (keyword match → degraded/down, unmatched overall
+ * → operational via cross-contamination guard) so a future status-page change that
+ * silently breaks this path is caught.
+ */
+describe('ChatGPT without statusComponentId (#292)', () => {
+  function mockIncident(overrides: Partial<Incident> = {}): Incident {
+    return {
+      id: 'inc-1',
+      title: 'Test incident',
+      status: 'investigating',
+      impact: 'major',
+      startedAt: '2026-04-20T10:00:00Z',
+      resolvedAt: null,
+      duration: null,
+      timeline: [],
+      ...overrides,
+    }
+  }
+
+  const chatgptConfig = SERVICES.find((s) => s.id === 'chatgpt') as ServiceConfig
+
+  it('config has no statusComponentId or incidentIoComponentId (post-migration)', () => {
+    // Guard against accidental reintroduction of the stale IDs. incidentExclude
+    // must stay absent too — the cross-contamination guard in fetchService
+    // relies on incidentKeywords being the sole filter.
+    expect(chatgptConfig).toBeDefined()
+    expect(chatgptConfig.statusComponentId).toBeUndefined()
+    expect(chatgptConfig.statusComponent).toBeUndefined()
+    expect(chatgptConfig.incidentIoComponentId).toBeUndefined()
+    expect(chatgptConfig.incidentExclude).toBeUndefined()
+    expect(chatgptConfig.incidentKeywords).toContain('chatgpt')
+    expect(chatgptConfig.incidentKeywords).toContain('conversation')
+  })
+
+  it('keyword-matched ChatGPT incident → degraded', () => {
+    const incidents = [
+      mockIncident({ id: 'chat-1', title: 'Elevated conversation errors' }),
+    ]
+    const filtered = filterIncidents(incidents, chatgptConfig)
+    expect(filtered).toHaveLength(1)
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('degraded')
+  })
+
+  it('OpenAI API-only incident with overall=minor → operational (cross-contamination guard)', () => {
+    // Overall page shows "minor" because an OpenAI API incident is active, but
+    // the incident title has no ChatGPT keyword → keyword filter drops it →
+    // the "no component + no matching incidents → operational" guard kicks in.
+    const incidents = [
+      mockIncident({ id: 'api-1', title: 'Elevated latency on /v1/responses' }),
+    ]
+    const filtered = filterIncidents(incidents, chatgptConfig)
+    expect(filtered).toHaveLength(0) // keyword filter drops non-ChatGPT incident
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('operational')
+  })
+
+  it('major overall + ChatGPT-matched unresolved incident → down', () => {
+    const incidents = [
+      mockIncident({ id: 'chat-2', title: 'ChatGPT login failures', status: 'identified' }),
+    ]
+    const filtered = filterIncidents(incidents, chatgptConfig)
+    expect(filtered).toHaveLength(1)
+
+    const summary: SummaryData = { status: { indicator: 'major' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('down')
+  })
+
+  it('stale "minor" overall + all ChatGPT incidents resolved → operational', () => {
+    const incidents = [
+      mockIncident({ id: 'chat-old', title: 'ChatGPT conversation errors', status: 'resolved' }),
+    ]
+    const filtered = filterIncidents(incidents, chatgptConfig)
+    expect(filtered).toHaveLength(1)
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    // Overall stale but no unresolved keyword-matched incident → operational
+    expect(determineSvcStatus({}, summary, filtered)).toBe('operational')
+  })
+
+  it('overall operational → operational regardless of filter output', () => {
+    const summary: SummaryData = { status: { indicator: 'none' } }
+    expect(determineSvcStatus({}, summary, [])).toBe('operational')
+  })
+})
 
 describe('component miss tracking (#135)', () => {
   it('tracks miss when statusComponentId is configured but not found', async () => {

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -48,7 +48,12 @@ export const SERVICES: ServiceConfig[] = [
   // AI Apps
   { id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude.ai', 'across surfaces', 'claude desktop'], statusComponent: 'claude.ai', statusComponentId: 'rwppv331jlwc' },
   { id: 'characterai', name: 'Character.AI', provider: 'Character AI', category: 'app', statusUrl: 'https://status.character.ai', apiUrl: 'https://status.character.ai/api/v2/summary.json', statusComponentId: 'fw8g76r7dqcl' },
-  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG', statusComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG' },
+  // ChatGPT has no single umbrella component on status.openai.com; sub-components
+  // (Login/Feed/Video/Atlas) are too granular to represent the service. Status is
+  // resolved from the overall indicator + incidentKeywords filter, with the
+  // "no relevant unresolved incidents → operational" guard in fetchService
+  // preventing cross-contamination from OpenAI API incidents (#292).
+  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents' },
   // Coding Agents
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },


### PR DESCRIPTION
closes #292

## Summary
- OpenAI removed the ChatGPT umbrella component (`01JMXBNJXGV1T5GT2M9XA83XNG`) from `status.openai.com`; remaining sub-components (Login/Feed/Video/Atlas) are too granular to represent the service. Worker was logging `[fetchService] Component ID not found: chatgpt …` for 3+ consecutive checks, triggering the #135 mismatch alert.
- Drop `statusComponentId` and `incidentIoComponentId` for the `chatgpt` entry. Status now resolves via overall page indicator + `incidentKeywords` filter, with the existing "no relevant unresolved incidents → operational" guard in `fetchService` (`services.ts:272-281`) preventing cross-contamination from OpenAI API incidents.
- Add a Vitest regression block (`describe('ChatGPT without statusComponentId (#292)')`) pinning both the config-shape contract and the status-determination path in both directions, so a future status-page change that silently breaks this path is caught.

## Trade-off
`uptime30d` for ChatGPT becomes `null` until a reliable aggregation source is identified. The previous number was being computed against a non-existent component and was stale. `aiwatchScore` still computes from incidents + recovery components.

## Test plan
- [x] `npm run test:worker` — 854/854 pass (21/21 in status-determination.test.ts, including 6 new #292 cases)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — success
- [x] Local `wrangler dev` on port 8788: `GET /api/status` returns ChatGPT with `status: "degraded"` driven by 2 active ChatGPT-specific incidents; no bleedthrough from OpenAI API incidents; no component-miss warning in logs
- [ ] Deploy worker after review (manual: `npm run deploy:worker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)