### PR TITLE
feat: add OpenAI Codex as 5th coding agent — Phase 1 worker (refs #294)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,10 +225,10 @@ When adding a new monitored service, update ALL of the following:
 
 ## Architecture
 
-**AIWatch** is a React SPA that monitors 30 AI services in real time:
+**AIWatch** is a React SPA that monitors 31 AI services in real time:
 - **23 API services**: Claude, OpenAI, Gemini, Mistral, Cohere, Groq, Together, Fireworks, Perplexity, HuggingFace, Replicate, ElevenLabs, AssemblyAI, Deepgram, xAI, DeepSeek, OpenRouter, Bedrock, Azure OpenAI, Pinecone, Stability AI, Voyage AI, Modal
 - **3 AI apps**: claude.ai, ChatGPT, Character.AI
-- **4 coding agents**: Claude Code, GitHub Copilot, Cursor, Windsurf
+- **5 coding agents**: Claude Code, GitHub Copilot, Cursor, Windsurf, OpenAI Codex
 
 ### Tech Stack
 - **React 19 + Vite 6** — SPA, no router library
@@ -241,7 +241,7 @@ When adding a new monitored service, update ALL of the following:
 
 | Key Pattern | Value | TTL | Writes/Day | Purpose |
 |---|---|---|---|---|
-| `services:latest` | `{ services, cachedAt }` JSON | 5min | ~288 | Real-time status cache (all 30 services) |
+| `services:latest` | `{ services, cachedAt }` JSON | 5min | ~288 | Real-time status cache (all 31 services) |
 | `daily:{YYYY-MM-DD}` | `{ [svcId]: { ok, total } }` JSON | 2d | ~288 | Daily uptime counters |
 | `history:{YYYY-MM-DD}` | Same as daily | 90d | 1 | Archived yesterday's counters |
 | `latency:24h` | `{ snapshots: [{ t, data }] }` JSON | 25h | ~48 | 30-min latency snapshots (max 48) |
@@ -410,7 +410,7 @@ Per-service status is resolved in `services.ts` with this priority:
 ```
 Browser (React SPA, 60s polling)
   → Cloudflare Worker (/api/status)
-    → parallel fetch (30 services)
+    → parallel fetch (31 services)
     → normalize to ServiceStatus[]
     → write to KV (cache + daily counters)
     → probe cross-validation: filter Mistral micro-incident noise (no RTT spike → excluded)

--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -280,6 +280,105 @@ describe('ChatGPT without statusComponentId (#292)', () => {
   })
 })
 
+/**
+ * Regression tests for #294: OpenAI Codex is a coding agent monitored via
+ * status.openai.com with the same no-umbrella-component structure as ChatGPT.
+ * Keywords cover all 4 surface components (Codex Web/API, CLI, VS Code ext)
+ * via title OR componentNames match. Cross-contamination from OpenAI API /
+ * ChatGPT incidents is blocked by the guard in fetchService.
+ */
+describe('OpenAI Codex without statusComponentId (#294)', () => {
+  function mockIncident(overrides: Partial<Incident> = {}): Incident {
+    return {
+      id: 'cdx-1',
+      title: 'Test incident',
+      status: 'investigating',
+      impact: 'major',
+      startedAt: '2026-04-20T10:00:00Z',
+      resolvedAt: null,
+      duration: null,
+      timeline: [],
+      ...overrides,
+    }
+  }
+
+  const codexConfig = SERVICES.find((s) => s.id === 'codex') as ServiceConfig
+
+  it('config: agent category, no component IDs, keyword coverage for all 4 surfaces', () => {
+    expect(codexConfig).toBeDefined()
+    expect(codexConfig.category).toBe('agent')
+    expect(codexConfig.provider).toBe('OpenAI')
+    expect(codexConfig.statusComponentId).toBeUndefined()
+    expect(codexConfig.statusComponent).toBeUndefined()
+    expect(codexConfig.incidentIoComponentId).toBeUndefined()
+    expect(codexConfig.incidentExclude).toBeUndefined()
+    expect(codexConfig.incidentKeywords).toContain('codex')
+    expect(codexConfig.incidentKeywords).toContain('cli')
+    expect(codexConfig.incidentKeywords).toContain('vs code')
+  })
+
+  it('Codex-titled incident → degraded', () => {
+    const incidents = [
+      mockIncident({ id: 'cdx-load', title: 'Users unable to load ChatGPT and Codex' }),
+    ]
+    const filtered = filterIncidents(incidents, codexConfig)
+    expect(filtered).toHaveLength(1)
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('degraded')
+  })
+
+  it('CLI-only component incident with no keyword in title → matched via componentNames', () => {
+    const incidents = [
+      mockIncident({ id: 'cli-inc', title: 'Authentication failing', componentNames: ['CLI'] }),
+    ]
+    const filtered = filterIncidents(incidents, codexConfig)
+    expect(filtered).toHaveLength(1) // matched via componentNames
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('degraded')
+  })
+
+  it('VS Code extension-only incident → matched', () => {
+    const incidents = [
+      mockIncident({ id: 'vsc-inc', title: 'Extension not loading', componentNames: ['VS Code extension'] }),
+    ]
+    expect(filterIncidents(incidents, codexConfig)).toHaveLength(1)
+  })
+
+  it('OpenAI API-only incident with overall=minor → operational (cross-contamination guard)', () => {
+    const incidents = [
+      mockIncident({ id: 'api-inc', title: 'Elevated latency on /v1/responses', componentNames: ['Responses'] }),
+    ]
+    const filtered = filterIncidents(incidents, codexConfig)
+    expect(filtered).toHaveLength(0)
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('operational')
+  })
+
+  it('ChatGPT-only incident with overall=minor → operational (not leaked into Codex)', () => {
+    const incidents = [
+      mockIncident({ id: 'chat-inc', title: 'ChatGPT conversation errors', componentNames: ['Feed'] }),
+    ]
+    const filtered = filterIncidents(incidents, codexConfig)
+    // 'codex' keyword doesn't match 'chatgpt', no overlap with 'cli'/'vs code'
+    expect(filtered).toHaveLength(0)
+
+    const summary: SummaryData = { status: { indicator: 'minor' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('operational')
+  })
+
+  it('major overall + Codex-matched unresolved incident → down', () => {
+    const incidents = [
+      mockIncident({ id: 'cdx-major', title: 'Codex Web completely down', status: 'identified' }),
+    ]
+    const filtered = filterIncidents(incidents, codexConfig)
+    const summary: SummaryData = { status: { indicator: 'major' } }
+    expect(determineSvcStatus({}, summary, filtered)).toBe('down')
+  })
+})
+
 describe('component miss tracking (#135)', () => {
   it('tracks miss when statusComponentId is configured but not found', async () => {
     const kv = mockKV()

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -59,6 +59,12 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
   { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
+  // OpenAI Codex (coding agent): published across 4 distinct surface components on
+  // status.openai.com (Codex Web / Codex API / CLI / VS Code extension) with no
+  // umbrella component. Same #292 pattern as chatgpt — overall indicator +
+  // incidentKeywords filter, cross-contamination guard in fetchService blocks
+  // OpenAI API / ChatGPT incidents from bleeding through.
+  { id: 'codex', name: 'OpenAI Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents' },
 ]
 
 export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {


### PR DESCRIPTION
refs #294

Phase 1 of a 3-phase rollout. Phases 2 (frontend + SEO) and 3 (reports + assets) remain open — this PR intentionally uses \`refs\`, not \`closes\`.

## Summary
- **New service**: \`codex\` (OpenAI Codex, coding agent) — 5th entry in the agent category alongside Claude Code, GitHub Copilot, Cursor, Windsurf.
- **#292 pattern applied**: no \`statusComponentId\` / \`incidentIoComponentId\`. OpenAI publishes Codex across 4 surface components (Codex Web / Codex API / CLI / VS Code extension) with no umbrella, so the same no-component path proven for \`chatgpt\` is used here. Cross-contamination from OpenAI API / ChatGPT incidents is blocked by the existing guard in \`fetchService\` (\`services.ts:267-281\`).
- **Keywords**: \`['codex', 'cli', 'vs code']\` — cover all four surfaces via title OR componentNames match in \`filterIncidents\`.
- **Trade-off**: \`uptime30d\` is \`null\` (same as chatgpt post-#292). \`aiwatchScore\` still computes from incidents + recovery.

## Files
| File | Change |
|---|---|
| \`worker/src/services.ts\` | \`codex\` entry + state-based explanatory comment |
| \`worker/src/__tests__/status-determination.test.ts\` | \`describe('OpenAI Codex without statusComponentId (#294)')\` — 7 regression cases |
| \`CLAUDE.md\` | service count 30→31, coding agent count 4→5, data-flow comment |

## Test plan
- [x] 889/889 worker unit tests pass (7 new for Codex; sibling block covers chatgpt #292)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` clean
- [x] Local \`wrangler dev\`: \`GET /api/status\` returns 31 services, \`codex\` entry = \`{ provider: OpenAI, category: agent, status: down \}\` reflecting active incident \"Users unable to load ChatGPT and Codex\"; no component-miss warning in logs; no bleedthrough from unrelated OpenAI API / ChatGPT incidents
- [ ] Deploy worker after review (manual: \`npm run deploy:worker\`)

## Out of scope (Phase 2 / 3 in #294)
- Frontend constants / MOCK_SERVICES / ServiceDetails STATUS_URL
- Is X Down page (\`/is-codex-down\`) + SEO copy with OpenAI-Codex-coding-agent disambiguation
- Landing page service count updates
- aiwatch-reports site, OG image regeneration, screenshot recapture

## Related
- #292 chatgpt — same pattern, this is a direct application
- #294 tracking issue with full 3-phase checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)