### PR TITLE
fix: Codex API uptime + reorder coding agents (closes #301, refs #294)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ When adding a new monitored service, update ALL of the following:
 **AIWatch** is a React SPA that monitors 31 AI services in real time:
 - **23 API services**: Claude, OpenAI, Gemini, Mistral, Cohere, Groq, Together, Fireworks, Perplexity, HuggingFace, Replicate, ElevenLabs, AssemblyAI, Deepgram, xAI, DeepSeek, OpenRouter, Bedrock, Azure OpenAI, Pinecone, Stability AI, Voyage AI, Modal
 - **3 AI apps**: claude.ai, ChatGPT, Character.AI
-- **5 coding agents**: Claude Code, GitHub Copilot, Cursor, Windsurf, Codex
+- **5 coding agents**: Claude Code, Codex, Cursor, GitHub Copilot, Windsurf
 
 ### Tech Stack
 - **React 19 + Vite 6** — SPA, no router library

--- a/README.ko.md
+++ b/README.ko.md
@@ -93,10 +93,10 @@
 | 서비스 | 제공업체 |
 |--------|----------|
 | Claude Code | Anthropic |
-| GitHub Copilot | Microsoft |
-| Cursor | Anysphere |
-| Windsurf | Codeium |
 | Codex | OpenAI |
+| Cursor | Anysphere |
+| GitHub Copilot | Microsoft |
+| Windsurf | Codeium |
 
 ## 기술 스택
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ Real-time monitoring dashboard for **31 AI services** — track status, latency,
 | Service | Provider |
 |---------|----------|
 | Claude Code | Anthropic |
-| GitHub Copilot | Microsoft |
-| Cursor | Anysphere |
-| Windsurf | Codeium |
 | Codex | OpenAI |
+| Cursor | Anysphere |
+| GitHub Copilot | Microsoft |
+| Windsurf | Codeium |
 
 ## Tech Stack
 

--- a/api/is-down/seo-content.ts
+++ b/api/is-down/seo-content.ts
@@ -362,6 +362,7 @@ const SEO_CONTENT: Record<string, ServiceSEO> = {
       { q: 'Is this the old Codex API from 2023?', a: 'No. This page tracks the current OpenAI Codex coding agent released as part of OpenAI\'s agent products. The 2023 Codex code-generation API was deprecated and is not what AIWatch monitors here.' },
       { q: 'Why is Codex not working?', a: 'Codex outages usually stem from one of: a broader OpenAI platform incident (also affects ChatGPT and the API), a Codex-specific backend issue, or an upstream model outage. Check the Recent Incidents section for current context.' },
       { q: 'What are alternatives to Codex?', a: 'When Codex is down, Claude Code, GitHub Copilot, Cursor, or Windsurf are alternative coding agents. AIWatch shows which are currently operational.' },
+      { q: 'Which Codex surface does the uptime percentage track?', a: 'The 30-day uptime shown on this page reflects the Codex API component specifically, which backs the CLI and VS Code extension. Codex Web frontend outages may not be counted in that percentage — check the Recent Incidents section for surface-specific events across all four Codex surfaces (Codex Web, Codex API, CLI, VS Code extension).' },
     ],
   },
 }

--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -442,23 +442,11 @@ const MOCK_SERVICES = [
     ],
   },
   {
-    id: 'copilot', category: 'agent', name: 'GitHub Copilot', provider: 'Microsoft', status: 'operational',
-    latency: null, uptime30d: 99.40,
-    history30d: hist([9, 24]),
-    history3m: [{ month: '2026-01', uptime: 99.60 }, { month: '2026-02', uptime: 99.50 }, { month: '2026-03', uptime: 99.40 }],
-    incidents: [
-      { id: 'cp-1', title: 'Code Completion Degraded', startedAt: ago(1 * D + 2 * H), duration: null, status: 'monitoring',
-        timeline: [
-          { stage: 'investigating', text: '코드 자동 완성 품질이 저하되고 있습니다.', at: ago(1 * D + 2 * H) },
-          { stage: 'identified', text: '모델 서빙 레이어 이슈로 확인.', at: ago(1 * D + 2 * H - 45 * M) },
-          { stage: 'monitoring', text: '모델 롤백을 적용했습니다. 모니터링 중.', at: ago(1 * D + 2 * H - 90 * M) },
-        ] },
-      { id: 'cp-2', title: 'GitHub Actions Integration Error', startedAt: ago(3 * D + 7 * H), duration: '1h 50m', status: 'resolved',
-        timeline: [
-          { stage: 'investigating', text: 'GitHub Actions에서 Copilot 연동 오류가 발생.', at: ago(3 * D + 7 * H) },
-          { stage: 'resolved', text: 'API 엔드포인트 수정으로 정상화.', at: ago(3 * D + 7 * H - 110 * M) },
-        ] },
-    ],
+    id: 'codex', category: 'agent', name: 'Codex', provider: 'OpenAI', status: 'operational',
+    latency: null, uptime30d: null,
+    history30d: hist([]),
+    history3m: [],
+    incidents: [],
   },
   {
     id: 'cursor', category: 'agent', name: 'Cursor', provider: 'Anysphere', status: 'operational',
@@ -480,6 +468,25 @@ const MOCK_SERVICES = [
     ],
   },
   {
+    id: 'copilot', category: 'agent', name: 'GitHub Copilot', provider: 'Microsoft', status: 'operational',
+    latency: null, uptime30d: 99.40,
+    history30d: hist([9, 24]),
+    history3m: [{ month: '2026-01', uptime: 99.60 }, { month: '2026-02', uptime: 99.50 }, { month: '2026-03', uptime: 99.40 }],
+    incidents: [
+      { id: 'cp-1', title: 'Code Completion Degraded', startedAt: ago(1 * D + 2 * H), duration: null, status: 'monitoring',
+        timeline: [
+          { stage: 'investigating', text: '코드 자동 완성 품질이 저하되고 있습니다.', at: ago(1 * D + 2 * H) },
+          { stage: 'identified', text: '모델 서빙 레이어 이슈로 확인.', at: ago(1 * D + 2 * H - 45 * M) },
+          { stage: 'monitoring', text: '모델 롤백을 적용했습니다. 모니터링 중.', at: ago(1 * D + 2 * H - 90 * M) },
+        ] },
+      { id: 'cp-2', title: 'GitHub Actions Integration Error', startedAt: ago(3 * D + 7 * H), duration: '1h 50m', status: 'resolved',
+        timeline: [
+          { stage: 'investigating', text: 'GitHub Actions에서 Copilot 연동 오류가 발생.', at: ago(3 * D + 7 * H) },
+          { stage: 'resolved', text: 'API 엔드포인트 수정으로 정상화.', at: ago(3 * D + 7 * H - 110 * M) },
+        ] },
+    ],
+  },
+  {
     id: 'windsurf', category: 'agent', name: 'Windsurf', provider: 'Codeium', status: 'operational',
     latency: null, uptime30d: 98.80,
     history30d: hist([10, 27]),
@@ -493,13 +500,6 @@ const MOCK_SERVICES = [
           { stage: 'resolved', text: '서비스가 정상화되었습니다.', at: ago(3 * D + 3 * H - 128 * M) },
         ] },
     ],
-  },
-  {
-    id: 'codex', category: 'agent', name: 'Codex', provider: 'OpenAI', status: 'operational',
-    latency: null, uptime30d: null,
-    history30d: hist([]),
-    history3m: [],
-    incidents: [],
   },
 ]
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,7 +22,7 @@ export const API_SERVICE_IDS = [
 export const APP_SERVICE_IDS = ['claudeai', 'chatgpt', 'characterai']
 
 // Coding agents
-export const AGENT_SERVICE_IDS = ['claudecode', 'copilot', 'cursor', 'windsurf', 'codex']
+export const AGENT_SERVICE_IDS = ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf']
 
 // Display order: app → LLM → voice → inference → agent
 export const SERVICE_AND_APP_IDS = [
@@ -46,7 +46,7 @@ export const SERVICE_CATEGORIES = {
   apps:      { labelKey: 'filter.apps',      ids: ['claudeai', 'chatgpt', 'characterai'] },
   llm:       { labelKey: 'filter.llm',       ids: ['claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq', 'together', 'fireworks', 'perplexity', 'xai', 'deepseek', 'openrouter'] },
   inference: { labelKey: 'filter.inference', ids: ['elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone', 'stability', 'voyageai', 'modal'] },
-  agents:    { labelKey: 'filter.agents',    ids: ['claudecode', 'copilot', 'cursor', 'windsurf', 'codex'] },
+  agents:    { labelKey: 'filter.agents',    ids: ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf'] },
 }
 
 // Services excluded from fallback recommendations (not interchangeable with LLM APIs)

--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -304,14 +304,20 @@ describe('OpenAI Codex without statusComponentId (#294)', () => {
 
   const codexConfig = SERVICES.find((s) => s.id === 'codex') as ServiceConfig
 
-  it('config: agent category, no component IDs, keyword coverage for all 4 surfaces', () => {
+  it('config: agent category, Codex API component ID for uptime, keyword coverage for all 4 surfaces', () => {
     expect(codexConfig).toBeDefined()
     expect(codexConfig.category).toBe('agent')
     expect(codexConfig.provider).toBe('OpenAI')
+    // statusComponentId stays absent — status determination still uses the
+    // overall indicator + cross-contamination guard (#294).
     expect(codexConfig.statusComponentId).toBeUndefined()
     expect(codexConfig.statusComponent).toBeUndefined()
-    expect(codexConfig.incidentIoComponentId).toBeUndefined()
     expect(codexConfig.incidentExclude).toBeUndefined()
+    // incidentIoComponentId = Codex API (#301) — sourcing official uptime
+    // from the surface that backs CLI + VS Code extension. Guard against
+    // accidental removal; if this assertion ever fails, either the ID was
+    // renamed upstream or someone reverted #301.
+    expect(codexConfig.incidentIoComponentId).toBe('01KMP3KP5MGE23B80K1EK4S8PV')
     expect(codexConfig.incidentKeywords).toContain('codex')
     expect(codexConfig.incidentKeywords).toContain('cli')
     expect(codexConfig.incidentKeywords).toContain('vs code')

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -56,9 +56,6 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents' },
   // Coding Agents
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
-  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
-  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
-  { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
   // OpenAI Codex (coding agent): published across 4 distinct surface components on
   // status.openai.com (Codex Web / Codex API / CLI / VS Code extension) with no
   // umbrella component. Same #292 pattern as chatgpt — overall indicator +
@@ -71,6 +68,9 @@ export const SERVICES: ServiceConfig[] = [
   // frontend only) surface via incidentKeywords in Recent Incidents, not in
   // the uptime%. Is Codex Down SEO page documents this scoping.
   { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV' },
+  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
+  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
+  { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
 ]
 
 export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -64,7 +64,13 @@ export const SERVICES: ServiceConfig[] = [
   // umbrella component. Same #292 pattern as chatgpt — overall indicator +
   // incidentKeywords filter, cross-contamination guard in fetchService blocks
   // OpenAI API / ChatGPT incidents from bleeding through.
-  { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents' },
+  //
+  // Uptime source: Codex API component only (#301). Chosen because it backs
+  // the CLI and VS Code extension — API availability is the strongest proxy
+  // for developer-use availability. Surface-specific outages (e.g., Codex Web
+  // frontend only) surface via incidentKeywords in Recent Incidents, not in
+  // the uptime%. Is Codex Down SEO page documents this scoping.
+  { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV' },
 ]
 
 export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {


### PR DESCRIPTION
## Summary

Supersedes closed #302 (base branch deleted when #306 merged). Rebased onto `main` with only the unique commits.

- `worker/src/services.ts` — add `incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV'` (OpenAI's official Codex API component). Codex now reports real uptime from status.openai.com instead of `null`. (closes #301)
- Reorder coding agents across services.ts / usePolling.js mock / constants.js: claudecode → codex → cursor → copilot → windsurf (per #294 sidebar positioning decision).
- `worker/src/__tests__/status-determination.test.ts` — assertion updated: `codex.incidentIoComponentId === '01KMP3KP5MGE23B80K1EK4S8PV'`.
- README.md / README.ko.md / CLAUDE.md / `api/is-down/seo-content.ts` — reordered entries and Codex uptime-source note.

## Test plan

- [x] `npm run test:worker` — 906/906 pass
- [x] Rebase clean (dropped already-merged commits from #295/#300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)