### PR TITLE
feat: snapshot security alerts into permanent monthly archive (closes #290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ When adding a new monitored service, update ALL of the following:
 | `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 | `incidents:monthly:{YYYY-MM}` | `MonthlyIncidents` JSON | 60d | 1/day | Monthly incident accumulation (deduped by ID, updated in daily summary cron) |
-| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service) |
+| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service, optional `security` summary from `security:monthly:{YYYY-MM}` snapshot taken before its 60d TTL lapses — #290) |
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 
@@ -435,7 +435,7 @@ Cron Trigger (*/5 min)
   → alert count tracked in KV (alert:count:{date}) for Daily Summary
   → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75 + Detection Lead audit log (24h sliding window from today + yesterday keys)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
-  → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
+  → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* + security:monthly:* → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
   → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -7,8 +7,10 @@ import {
   buildMonthlyArchive,
   accumulateMonthlyIncidents,
   parseDurationMin,
+  summarizeSecurityAlerts,
 } from '../monthly-archive'
 import type { ServiceStatus } from '../types'
+import type { MonthlySecurityEntry } from '../monthly-archive'
 
 // ── parseDurationMin ─────────────────────────────────────────────────
 
@@ -275,6 +277,82 @@ describe('accumulateMonthlyIncidents', () => {
   })
 })
 
+// ── summarizeSecurityAlerts (#290) ───────────────────────────────────
+
+describe('summarizeSecurityAlerts', () => {
+  it('counts by source, severity, service; preserves all fields on top findings', () => {
+    const entries: MonthlySecurityEntry[] = [
+      { title: 'A', url: 'u1', source: 'osv',        severity: 'critical', service: 'OpenAI',             detectedAt: '2026-03-01T00:00:00Z' },
+      { title: 'B', url: 'u2', source: 'osv',        severity: 'high',     service: 'OpenAI',             detectedAt: '2026-03-02T00:00:00Z' },
+      { title: 'C', url: 'u3', source: 'osv',        severity: 'medium',   service: 'Anthropic (Claude)', detectedAt: '2026-03-03T00:00:00Z' },
+      { title: 'D', url: 'u4', source: 'hackernews',                                                      detectedAt: '2026-03-04T00:00:00Z' },
+    ]
+    const s = summarizeSecurityAlerts(entries)
+    expect(s.totalAlerts).toBe(4)
+    expect(s.bySource).toEqual({ osv: 3, hackernews: 1 })
+    expect(s.bySeverity).toEqual({ critical: 1, high: 1, medium: 1, low: 0 })
+    expect(s.byService).toEqual({ OpenAI: 2, 'Anthropic (Claude)': 1 })
+    // Regression guard: a refactor that narrows the projection to {title, url, severity}
+    // would quietly break the report template that renders service + detectedAt.
+    expect(s.topFindings[0]).toEqual(entries[0])
+  })
+
+  it('sorts topFindings by severity desc with recent-first tie-break', () => {
+    const entries: MonthlySecurityEntry[] = [
+      { title: 'old-critical', url: 'u1', source: 'osv', severity: 'critical', detectedAt: '2026-03-01T00:00:00Z' },
+      { title: 'new-critical', url: 'u2', source: 'osv', severity: 'critical', detectedAt: '2026-03-30T00:00:00Z' },
+      { title: 'high',         url: 'u3', source: 'osv', severity: 'high',     detectedAt: '2026-03-15T00:00:00Z' },
+      { title: 'medium',       url: 'u4', source: 'osv', severity: 'medium',   detectedAt: '2026-03-20T00:00:00Z' },
+    ]
+    const s = summarizeSecurityAlerts(entries)
+    expect(s.topFindings.map(f => f.title)).toEqual(['new-critical', 'old-critical', 'high', 'medium'])
+  })
+
+  it('ranks missing/unknown severity below low', () => {
+    const entries: MonthlySecurityEntry[] = [
+      { title: 'no-sev',  url: 'u1', source: 'hackernews', detectedAt: '2026-03-10T00:00:00Z' },
+      { title: 'low',     url: 'u2', source: 'osv', severity: 'low',            detectedAt: '2026-03-11T00:00:00Z' },
+      { title: 'weird',   url: 'u3', source: 'osv', severity: 'SUPERCRITICAL',  detectedAt: '2026-03-12T00:00:00Z' },
+    ]
+    const s = summarizeSecurityAlerts(entries)
+    // low outranks both no-severity and the unrecognized label
+    expect(s.topFindings[0].title).toBe('low')
+    // bySeverity should only count recognized buckets
+    expect(s.bySeverity).toEqual({ critical: 0, high: 0, medium: 0, low: 1 })
+  })
+
+  it('caps topFindings at 10', () => {
+    const entries: MonthlySecurityEntry[] = Array.from({ length: 15 }, (_, i) => ({
+      title: `entry-${i}`,
+      url: `u${i}`,
+      source: 'osv' as const,
+      severity: 'medium',
+      detectedAt: `2026-03-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    const s = summarizeSecurityAlerts(entries)
+    expect(s.totalAlerts).toBe(15)
+    expect(s.topFindings).toHaveLength(10)
+  })
+
+  it('is case-insensitive on severity normalization', () => {
+    const entries: MonthlySecurityEntry[] = [
+      { title: 'A', url: 'u1', source: 'osv', severity: 'CRITICAL', detectedAt: '2026-03-01T00:00:00Z' },
+      { title: 'B', url: 'u2', source: 'osv', severity: 'High',     detectedAt: '2026-03-02T00:00:00Z' },
+    ]
+    const s = summarizeSecurityAlerts(entries)
+    expect(s.bySeverity).toEqual({ critical: 1, high: 1, medium: 0, low: 0 })
+  })
+
+  it('returns zero-filled summary with empty topFindings for empty input', () => {
+    const s = summarizeSecurityAlerts([])
+    expect(s.totalAlerts).toBe(0)
+    expect(s.bySource).toEqual({ osv: 0, hackernews: 0 })
+    expect(s.bySeverity).toEqual({ critical: 0, high: 0, medium: 0, low: 0 })
+    expect(s.byService).toEqual({})
+    expect(s.topFindings).toEqual([])
+  })
+})
+
 // ── buildMonthlyArchive ──────────────────────────────────────────────
 
 describe('buildMonthlyArchive', () => {
@@ -379,6 +457,84 @@ describe('buildMonthlyArchive', () => {
     expect(archive.period).toBe('2026-12')
     expect(archive.services.claude.incidents).toBe(2)
     expect(archive.services.claude.uptime).toBe(100)
+  })
+
+  it('snapshots security summary from security:monthly:{period} (#290)', async () => {
+    const secEntries: MonthlySecurityEntry[] = [
+      { title: 'RCE in openai', url: 'u1', source: 'osv', severity: 'critical', service: 'OpenAI', detectedAt: '2026-03-10T00:00:00Z' },
+      { title: 'HN breach story', url: 'u2', source: 'hackernews', detectedAt: '2026-03-15T00:00:00Z' },
+      { title: 'Path traversal', url: 'u3', source: 'osv', severity: 'high', service: 'Anthropic (Claude)', detectedAt: '2026-03-20T00:00:00Z' },
+    ]
+    const kvWithSecurity = {
+      get: async (key: string) => {
+        if (key === `security:monthly:2026-03`) return JSON.stringify(secEntries)
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(kvWithSecurity, 2026, 3)
+    expect(archive.security).not.toBeNull()
+    expect(archive.security?.totalAlerts).toBe(3)
+    expect(archive.security?.bySource).toEqual({ osv: 2, hackernews: 1 })
+    expect(archive.security?.topFindings[0].title).toBe('RCE in openai') // critical first
+  })
+
+  it('leaves archive.security = null when security:monthly key is missing', async () => {
+    // Months predating this feature (and months with zero detections) must not crash.
+    const archive = await buildMonthlyArchive(mockKV, 2026, 3)
+    expect(archive.security).toBeNull()
+  })
+
+  it('leaves archive.security = null on malformed security:monthly JSON', async () => {
+    const corruptSecurityKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-03') return '{not valid json'
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(corruptSecurityKV, 2026, 3)
+    expect(archive.security).toBeNull()
+  })
+
+  it('leaves archive.security = null when the security:monthly KV get rejects', async () => {
+    // Pairs with the `.catch(() => null)` guard on the security read — if a future refactor
+    // drops the catch, this test fails before the archive rejection propagates to the cron.
+    const rejectingKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-03') throw new Error('KV read rejected')
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(rejectingKV, 2026, 3)
+    expect(archive.security).toBeNull()
+  })
+
+  it('leaves archive.security = null on empty security:monthly array', async () => {
+    // A month with the key present but no detections shouldn't produce a zero-valued summary —
+    // null is the signal "no security data for this month" for downstream rendering.
+    const emptyArrayKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-03') return '[]'
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(emptyArrayKV, 2026, 3)
+    expect(archive.security).toBeNull()
   })
 
   it('sets avgResolutionMin to null when totalMinutes is 0', async () => {

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -25,6 +25,38 @@ export interface MonthlyArchive {
   generatedAt: string            // ISO timestamp
   daysCollected: number          // number of days with actual uptime data
   services: Record<string, MonthlyServiceData>
+  // Optional — null for months before this feature shipped (or no detections).
+  // Sourced from security:monthly:{period} at archive build time before its 60d TTL lapses (#290).
+  security?: MonthlySecuritySummary | null
+}
+
+// ── Monthly security summary ─────────────────────────────────────────
+//
+// Shape stored in security:monthly:{YYYY-MM} (60d TTL) by the hourly security cron.
+// The archive snapshots this into a permanent summary before TTL expiry (#290).
+
+export type SecuritySeverityBucket = 'critical' | 'high' | 'medium' | 'low'
+
+export interface MonthlySecurityEntry {
+  title: string
+  url: string
+  source: 'osv' | 'hackernews'
+  severity?: string
+  service?: string
+  detectedAt: string             // ISO 8601
+}
+
+export interface MonthlySecurityTopFinding extends MonthlySecurityEntry {
+  // Identical fields to MonthlySecurityEntry today. Kept as a distinct type so #291 can
+  // extend only top findings with an optional `timeline` array without widening the raw entry.
+}
+
+export interface MonthlySecuritySummary {
+  totalAlerts: number
+  bySource: { osv: number; hackernews: number }
+  bySeverity: Record<SecuritySeverityBucket, number>
+  byService: Record<string, number>                // service name → count
+  topFindings: MonthlySecurityTopFinding[]         // sorted by severity desc, max 10
 }
 
 // ── Incident accumulation (written daily by daily summary cron) ──────
@@ -157,6 +189,51 @@ export function computeMonthlyLatency(
   return result
 }
 
+// ── Security summary builder ─────────────────────────────────────────
+
+const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 }
+
+function normalizeSeverity(raw: string | undefined): SecuritySeverityBucket | null {
+  if (!raw) return null
+  const lower = raw.toLowerCase()
+  return lower === 'critical' || lower === 'high' || lower === 'medium' || lower === 'low'
+    ? lower
+    : null
+}
+
+/**
+ * Summarize a month's accumulated security alerts into the permanent archive shape.
+ * Pure function — takes the parsed `security:monthly:{period}` contents, returns the summary.
+ *
+ * Top findings are sorted by severity descending (critical → low); unknown severities rank
+ * below "low". Max 10 entries. Stable tie-breaker on detectedAt (more recent first) so a
+ * re-generation of the same month always yields the same archive.
+ */
+export function summarizeSecurityAlerts(entries: MonthlySecurityEntry[]): MonthlySecuritySummary {
+  const bySource: MonthlySecuritySummary['bySource'] = { osv: 0, hackernews: 0 }
+  const bySeverity: MonthlySecuritySummary['bySeverity'] = { critical: 0, high: 0, medium: 0, low: 0 }
+  const byService: Record<string, number> = {}
+
+  for (const e of entries) {
+    if (e.source === 'osv') bySource.osv++
+    else if (e.source === 'hackernews') bySource.hackernews++
+    const sev = normalizeSeverity(e.severity)
+    if (sev) bySeverity[sev]++
+    if (e.service) byService[e.service] = (byService[e.service] ?? 0) + 1
+  }
+
+  const topFindings = [...entries]
+    .sort((a, b) => {
+      const rankA = SEVERITY_RANK[normalizeSeverity(a.severity) ?? ''] ?? 0
+      const rankB = SEVERITY_RANK[normalizeSeverity(b.severity) ?? ''] ?? 0
+      if (rankA !== rankB) return rankB - rankA
+      return b.detectedAt.localeCompare(a.detectedAt) // recent first on severity tie
+    })
+    .slice(0, 10)
+
+  return { totalAlerts: entries.length, bySource, bySeverity, byService, topFindings }
+}
+
 /** Get all dates in a given month (YYYY-MM-DD strings) */
 export function getMonthDates(year: number, month: number): string[] {
   const dates: string[] = []
@@ -232,6 +309,21 @@ export async function buildMonthlyArchive(
     }
   }
 
+  // Snapshot accumulated security alerts before their 60d TTL lapses (#290). Missing
+  // or malformed data must not fail the archive — security is optional enrichment.
+  const secRaw = await kv.get(`security:monthly:${period}`).catch(() => null)
+  let security: MonthlySecuritySummary | null = null
+  if (secRaw) {
+    try {
+      const parsed = JSON.parse(secRaw) as MonthlySecurityEntry[]
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        security = summarizeSecurityAlerts(parsed)
+      }
+    } catch (err) {
+      console.warn(`[monthly-archive] corrupt security accumulation for ${period}:`, err instanceof Error ? err.message : err)
+    }
+  }
+
   const uptimeMap = computeMonthlyUptime(dailyData)
   const latencyMap = computeMonthlyLatency(probeData)
 
@@ -275,6 +367,7 @@ export async function buildMonthlyArchive(
     generatedAt: new Date().toISOString(),
     daysCollected,
     services,
+    security,
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #290. \`security:monthly:{YYYY-MM}\` has a 60d TTL, so without snapshotting the data into the permanent archive (\`archive:monthly:{YYYY-MM}\`, no TTL), any monthly report more than ~2 months after month-end would have no record of what security alerts fired. This PR adds that snapshot.

- New types: \`MonthlySecurityEntry\` / \`MonthlySecurityTopFinding\` / \`MonthlySecuritySummary\` / \`SecuritySeverityBucket\`.
- Pure \`summarizeSecurityAlerts(entries)\` — counts by source (osv / hackernews), severity (critical/high/medium/low — unknown buckets below low), service; top findings sorted by severity desc with recent-first tiebreak; cap 10.
- \`MonthlyArchive.security\` is **optional** (\`?: | null\`). Existing archived months stay shape-compatible (null sentinel). \`buildMonthlyArchive\` reads the KV key and tolerates missing / malformed / empty / rejecting KV without failing the rest of the archive.
- \`MonthlySecurityTopFinding\` is a distinct type today but structured so #291 can extend it with an optional \`timeline\` array without widening the entry type written by the cron.

## Test plan

- [x] \`npm run test:worker\` — 917/917 pass (+11 new)
  - 7 pure-function tests on \`summarizeSecurityAlerts\` (counts + field-preservation regression guard / sort with tiebreak / unknown severity ranked below low / cap=10 / case-insensitive severity / empty input)
  - 4 integration tests inside \`buildMonthlyArchive\` (happy path snapshot / missing key / malformed JSON / empty array / KV rejection — all → \`security: null\`)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — clean
- [x] PR review (code / tests) — converged, 0 Critical / 0 Important
- [ ] Deploy worker (post-merge, next daily window)

## References

- Issue #290 design + acceptance criteria
- Follow-up #291 (OSV-only per-alert timeline) — depends on this PR's archive schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)