### PR TITLE
docs: correct stale KV "free tier" refs — Workers Paid (Standard) (#312)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ When adding a new monitored service, update ALL of the following:
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 
-**Free tier budget**: 1,000 writes/day. Estimated total: ~845-958 writes/day + changelog (~3/day) + changelog last-fetch markers (~96/day, 4 sources × 24 hourly cron, #274) + weekly briefing (~1/week) + vitals (1 per visit) + platform status (~1/cycle when changed) + recovery markers (~2-5/day). Monitor if daily visits exceed ~50.
+**KV write budget** (Workers Paid / Standard plan): 1,000,000 writes/month included (~33,333/day); overage billed at $0.50 per additional 1M. Current estimated usage: ~845-958 writes/day + changelog (~3/day) + changelog last-fetch markers (~96/day, 4 sources × 24 hourly cron, #274) + weekly briefing (~1/week) + vitals (1 per visit) + platform status (~1/cycle when changed) + recovery markers (~2-5/day) ≈ **~3% of monthly inclusion**. Existing throttling constants (e.g., `KV_WRITE_INTERVAL_MS = 600_000`) are retained for cost hygiene even though the hard free-tier limit no longer applies.
 
 ### Directory Layout
 ```
@@ -470,7 +470,7 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
   - **Estimate-only services** (`uptimeSource === 'estimate'` + 0 incidents): `bedrock`, `azureopenai` — hidden from Ranking, Uptime rankings, fallback recommendations, category averages. Dashboard shows "— Not provided" instead of misleading 100% uptime
 - Status polling proxy: `worker/` directory (monorepo), Cloudflare Workers
   - `cd worker && npm run dev` — local dev (port 8787)
-  - **Worker deployment rules** (KV free tier: 1,000 writes/day):
+  - **Worker deployment rules** (Workers Paid / Standard — 1M KV writes/month included; repeated deploys still reset per-isolate throttling, so minimize unnecessary redeploys to stay well inside the monthly allowance):
     1. During development → `npx wrangler dev --config worker/wrangler.toml --port 8788` (local test only, never deploy)
     2. Before deploy → `npx wrangler deploy --config worker/wrangler.toml --dry-run` (build check)
     3. Deploy → after commit + user approval, **once only** `npm run deploy:worker`

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -22,7 +22,7 @@ interface Env {
 
 const CACHE_TTL_SECONDS = 900 // 15 min — must exceed KV_WRITE_INTERVAL_MS (10 min) to avoid cache gaps
 let lastKvWrite = 0
-const KV_WRITE_INTERVAL_MS = 600_000 // 10 minutes — 2 writes per interval = ~288/day within free tier
+const KV_WRITE_INTERVAL_MS = 600_000 // 10 minutes — 2 writes per interval = ~288/day (cost hygiene on Workers Paid 1M/month inclusion)
 let lastArchivedDate = '' // prevent duplicate archival writes within same isolate
 let lastKvLimitAlert = 0 // in-memory throttle for KV limit alerts (can't use KV when KV is full)
 let lastLatencySlot = '' // prevent duplicate 30-min latency writes within same isolate
@@ -324,7 +324,7 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
 
   // If cache is stale (>10min) or empty, fetch live data to avoid alert decisions on outdated status.
   // Does NOT write to KV — cache writes are handled exclusively by /api/status handler's cacheWrite()
-  // to respect the 10-min KV write throttle and stay within the 1,000 writes/day free tier.
+  // so the 10-min KV write throttle keeps us well inside the Workers Paid 1M writes/month inclusion.
   let cronProbes: ProbeSnapshot[] = []
   if (stale) {
     try {
@@ -804,7 +804,7 @@ export default {
     if (!env.DISCORD_WEBHOOK_URL) return
 
     // Reddit community monitoring — runs once per hour (minute 0-4) to respect rate limits
-    // KV budget: max 5 writes/hour = 120/day (well within 1,000/day free tier)
+    // KV budget: max 5 writes/hour = 120/day (trivial against the Workers Paid 1M/month inclusion)
     const now = new Date()
     if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCMinutes() < 5) {
       try {

--- a/worker/src/parsers/incident-io.ts
+++ b/worker/src/parsers/incident-io.ts
@@ -329,7 +329,7 @@ export function buildTextCache(inc: Incident): IncidentTextCache {
 // may differ from the native ULID used in detail page URLs.
 export async function enrichIncidentIoText(incidents: Incident[], baseUrl: string, pageUrls: Map<string, string>, kv?: KVNamespace): Promise<Incident[]> {
   // Phase 1: Apply cached text from KV for all incidents that have null-text entries.
-  // KV reads do not count toward the 50 subrequest limit, so we read for all candidates freely.
+  // KV reads do not count against the per-invocation subrequest cap, so we read for all candidates freely.
   let workingIncidents = incidents
   const needsText = incidents.filter((inc) => inc.timeline.some((t) => !t.text))
   if (kv && needsText.length > 0) {
@@ -343,7 +343,8 @@ export async function enrichIncidentIoText(incidents: Incident[], baseUrl: strin
   }
 
   // Phase 2: Scrape incidents still missing text after cache application (up to budget=1).
-  // Budget = 1 per service: 44 base requests + 6 services × 1 = 50 (at Cloudflare free tier limit).
+  // Budget = 1 per service: 44 base requests + 6 services × 1 = 50 (kept as a self-imposed cap
+  // for CPU-time hygiene — well under the 1,000 subrequest cap on Workers Paid / Standard).
   // Prioritise: non-resolved first (may get new updates), then most recently started.
   const toEnrich = workingIncidents
     .filter((inc) => inc.timeline.some((t) => !t.text))


### PR DESCRIPTION
## Summary
- CLAUDE.md and four source comments referenced "KV free tier: 1,000 writes/day", but the project runs on Workers Paid (Standard) — 1M writes/month included (~33k/day) with $0.50/1M overage.
- Rewrites the budget paragraph to state Workers Standard inclusion + current ~3% usage + rationale for keeping throttling constants as cost hygiene.
- Aligns `KV_WRITE_INTERVAL_MS`, cronAlertCheck, Reddit budget, and incident-io enrich/KV-read comments with the paid plan.
- No runtime code changes; no identifier renames; no constant value changes.

## Test plan
- [x] `npm run test:worker` — 906/906 passing
- [x] `wrangler deploy --config worker/wrangler.toml --dry-run` — OK
- [x] Repo-wide grep confirms no remaining stale "free tier" / "1,000 writes" refs in source (excludes node_modules, coverage/, .wrangler/)
- [x] PR review auto-loop (round 2, code-reviewer): 0 Critical / 0 Important — converged
- [ ] Verify CLAUDE.md renders correctly on the merged main (no markdown breakage)

## Unblocks
#313 — LLM model-level probing Phase 1 scoping now has accurate budget figures to reason about.

closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)