### PR TITLE
fix: AnalysisModal dedup service header + fallback for same-service multi-incident (#315)

### DIFF
--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -13,24 +13,68 @@ function timeAgo(date, lang) {
 
 export default function AnalysisModal({ aiAnalysis, services, onClose }) {
   const { t, lang } = useLang()
-  // Group by service, then dedup shared incidentIds across sibling services
   // aiAnalysis: Record<svcId, AIAnalysisResult[]>
-  // Result: array of { svcIds, analyses[] } — one entry per service group
-  const groups = [] // { svcIds: string[], incIds: Set<string>, analyses: analysis[], startedAt }
+  //
+  // Two-pass grouping (avoids cross-service bleed — see #315):
+  //   Pass 1: bucket by incidentId to collect which svcIds each incident affects.
+  //           Sibling services sharing an incident (e.g. Claude API + claude.ai + Claude Code
+  //           pointing at the same incidentId) collapse into one bucket here.
+  //   Pass 2: a multi-svc bucket becomes its own card. Single-svc buckets for the same svcId
+  //           merge into a single card so the service header and fallback block render once
+  //           even when a service has multiple distinct incidents (e.g. Together AI with two
+  //           concurrent model outages).
+  const byIncident = new Map()
   for (const [svcId, rawAnalyses] of Object.entries(aiAnalysis)) {
     const arr = Array.isArray(rawAnalyses) ? rawAnalyses : [rawAnalyses]
     for (const a of arr) {
       const incId = a.incidentId ?? svcId
-      // Find existing group that already has this incidentId
-      const existingGroup = groups.find(g => g.incIds.has(incId))
-      if (existingGroup) {
-        if (!existingGroup.svcIds.includes(svcId)) existingGroup.svcIds.push(svcId)
-      } else {
-        const svc = services.find(s => s.id === svcId)
-        const inc = svc?.incidents?.find(i => i.id === incId)
-        const startedAt = inc?.startedAt ?? a.analyzedAt ?? ''
-        groups.push({ svcIds: [svcId], incIds: new Set([incId]), analyses: [a], startedAt })
+      const bucket = byIncident.get(incId)
+      if (bucket) {
+        if (!bucket.svcIds.includes(svcId)) bucket.svcIds.push(svcId)
+        continue
       }
+      const svc = services.find(s => s.id === svcId)
+      const inc = svc?.incidents?.find(i => i.id === incId)
+      byIncident.set(incId, {
+        incId,
+        svcIds: [svcId],
+        analysis: a,
+        startedAt: inc?.startedAt ?? a.analyzedAt ?? '',
+      })
+    }
+  }
+
+  const groups = []
+  const singleSvcGroupByOwner = new Map() // svcId → group
+  for (const bucket of byIncident.values()) {
+    if (bucket.svcIds.length > 1) {
+      groups.push({
+        svcIds: bucket.svcIds,
+        incIds: new Set([bucket.incId]),
+        analyses: [bucket.analysis],
+        startedAt: bucket.startedAt,
+      })
+      continue
+    }
+    const ownerSvcId = bucket.svcIds[0]
+    const existing = singleSvcGroupByOwner.get(ownerSvcId)
+    if (existing) {
+      existing.incIds.add(bucket.incId)
+      existing.analyses.push(bucket.analysis)
+      // Keep the card anchored to the most recent incident in the group so sort places
+      // freshly erupting issues above long-running ones.
+      if (bucket.startedAt && bucket.startedAt > existing.startedAt) {
+        existing.startedAt = bucket.startedAt
+      }
+    } else {
+      const g = {
+        svcIds: [ownerSvcId],
+        incIds: new Set([bucket.incId]),
+        analyses: [bucket.analysis],
+        startedAt: bucket.startedAt,
+      }
+      singleSvcGroupByOwner.set(ownerSvcId, g)
+      groups.push(g)
     }
   }
   groups.sort((a, b) => b.startedAt.localeCompare(a.startedAt))
@@ -72,6 +116,22 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
             const isAllResolved = svcs.every(s => s.status === 'operational')
             const hasActiveInc = svcs.some(s => (s.incidents ?? []).some(i => i.status !== 'resolved' && i.status !== 'monitoring'))
             const allRecovered = analyses.every(a => !!a.resolvedAt)
+            // Surface the gap between the operational status dot and active analyses
+            // (e.g. BetterStack per-model churn below the <30% threshold leaves the service
+            // operational while individual model incidents are still being analyzed).
+            // Restrict to single-service groups — a sibling-shared incident that happens to
+            // show operational on every surface is a real cross-service incident, not an
+            // isolated one.
+            const isolatedModelIssue = svcs.length === 1
+              && isAllResolved
+              && !allRecovered
+              && analyses.some(a => !a.resolvedAt)
+            const showFallback = !allRecovered
+              && analyses.some(a => a.needsFallback && !a.resolvedAt)
+              && !svcs.every(s => EXCLUDE_FALLBACK.includes(s.id))
+            const fallbacks = showFallback
+              ? getFallbacks(svcs.find(s => !EXCLUDE_FALLBACK.includes(s.id)) ?? svcs[0], services)
+              : []
 
             return (
               <div key={svcIds.join(',')} className="bg-[var(--bg2)] rounded-lg" style={{ padding: '12px 14px', marginBottom: '10px', opacity: isAllResolved && !hasActiveInc && !allRecovered ? 0.6 : 1 }}>
@@ -85,6 +145,17 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
                   {(allRecovered || (isAllResolved && !hasActiveInc)) && (
                     <span className="mono text-[9px] rounded" style={{ color: 'var(--green)', background: 'var(--status-bg-green)', padding: '3px 8px', display: 'inline-block' }}>
                       Resolved
+                    </span>
+                  )}
+                  {isolatedModelIssue && (
+                    <span
+                      className="mono text-[9px] rounded"
+                      style={{ color: 'var(--amber)', background: 'var(--status-bg-amber)', padding: '3px 8px', display: 'inline-block' }}
+                      title={lang === 'ko'
+                        ? '서비스 전체는 정상이지만 일부 모델/컴포넌트에서 이슈가 감지되었습니다'
+                        : 'Service operational — isolated model/component issues detected'}
+                    >
+                      {lang === 'ko' ? '부분 이슈' : 'Isolated issue'}
                     </span>
                   )}
                 </div>
@@ -117,32 +188,29 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
                         {isRecovered && <span>✅ {t('analysis.recoveredAt')}: {timeAgo(analysis.resolvedAt, lang)}</span>}
                         <span>🕐 {lang === 'ko' ? '분석 업데이트' : 'Analysis updated'} {timeAgo(analysis.analyzedAt, lang)}</span>
                       </div>
-                      {/* Contextual fallback recommendation — skip for EXCLUDE_FALLBACK services */}
-                      {analysis.needsFallback && !isRecovered && !svcs.every(s => EXCLUDE_FALLBACK.includes(s.id)) && (() => {
-                        const primarySvc = svcs.find(s => !EXCLUDE_FALLBACK.includes(s.id)) ?? svcs[0]
-                        const fallbacks = getFallbacks(primarySvc, services)
-                        return (
-                          <div className="mono text-[10px]" style={{ marginTop: '8px', padding: '8px 10px', background: 'var(--bg1)', borderRadius: '6px', borderLeft: '3px solid var(--amber)' }}>
-                            <span style={{ color: 'var(--text1)', fontWeight: 600 }}>🔄 {lang === 'ko' ? '대안 서비스' : 'Alternatives'}</span>
-                            {fallbacks.length > 0 ? (
-                              <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
-                                {fallbacks.map(f => (
-                                  <span key={f.id} style={{ color: 'var(--text1)' }}>
-                                    • {f.name}{f.aiwatchScore != null ? ` (Score: ${f.aiwatchScore})` : ''}
-                                  </span>
-                                ))}
-                              </div>
-                            ) : (
-                              <div style={{ marginTop: '4px', color: 'var(--text2)' }}>
-                                {lang === 'ko' ? '현재 운영 중인 대안 서비스가 없습니다' : 'No operational alternatives currently available'}
-                              </div>
-                            )}
-                          </div>
-                        )
-                      })()}
                     </div>
                   )
                 })}
+
+                {/* Contextual fallback recommendation — one per service group */}
+                {showFallback && (
+                  <div className="mono text-[10px]" style={{ marginTop: '10px', padding: '8px 10px', background: 'var(--bg1)', borderRadius: '6px', borderLeft: '3px solid var(--amber)' }}>
+                    <span style={{ color: 'var(--text1)', fontWeight: 600 }}>🔄 {lang === 'ko' ? '대안 서비스' : 'Alternatives'}</span>
+                    {fallbacks.length > 0 ? (
+                      <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                        {fallbacks.map(f => (
+                          <span key={f.id} style={{ color: 'var(--text1)' }}>
+                            • {f.name}{f.aiwatchScore != null ? ` (Score: ${f.aiwatchScore})` : ''}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <div style={{ marginTop: '4px', color: 'var(--text2)' }}>
+                        {lang === 'ko' ? '현재 운영 중인 대안 서비스가 없습니다' : 'No operational alternatives currently available'}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )
           })}

--- a/tests/analysis-modal-grouping.spec.js
+++ b/tests/analysis-modal-grouping.spec.js
@@ -1,0 +1,261 @@
+import { test, expect } from '@playwright/test'
+
+// Same service, two distinct incidents — exercises the per-svcId merge path in AnalysisModal.
+// Regression guard for #315 (duplicate service name + duplicate fallback list).
+
+const INC_NETWORK = {
+  id: 'tog-inc-network',
+  title: 'Network Maintenance',
+  status: 'investigating',
+  impact: 'major',
+  startedAt: new Date(Date.now() - 7200_000).toISOString(),
+  resolvedAt: null,
+  duration: null,
+  timeline: [],
+}
+
+const INC_MODEL = {
+  id: 'tog-inc-model',
+  title: 'OpenAI GPT OSS 120B — down',
+  status: 'investigating',
+  impact: 'minor',
+  startedAt: new Date(Date.now() - 3600_000).toISOString(),
+  resolvedAt: null,
+  duration: null,
+  timeline: [],
+}
+
+const ANALYSIS_NETWORK = {
+  incidentId: 'tog-inc-network',
+  summary: 'Scheduled network maintenance affecting Together AI connectivity.',
+  estimatedRecovery: 'Exceeded typical pattern',
+  affectedScope: ['Network Connectivity', 'API Availability'],
+  needsFallback: true,
+  analyzedAt: new Date().toISOString(),
+}
+
+const ANALYSIS_MODEL = {
+  incidentId: 'tog-inc-model',
+  summary: 'OpenAI GPT OSS 120B model outage — recurring failure pattern.',
+  estimatedRecovery: '30m–1h',
+  affectedScope: ['OpenAI GPT OSS 120B model'],
+  needsFallback: true,
+  analyzedAt: new Date().toISOString(),
+}
+
+const MOCK = {
+  services: [
+    { id: 'together', category: 'api', name: 'Together AI', provider: 'Together', status: 'operational', latency: 150, incidents: [INC_NETWORK, INC_MODEL] },
+    { id: 'groq', category: 'api', name: 'Groq Cloud', provider: 'Groq', status: 'operational', latency: 100, incidents: [], aiwatchScore: 92 },
+    { id: 'fireworks', category: 'api', name: 'Fireworks AI', provider: 'Fireworks', status: 'operational', latency: 110, incidents: [], aiwatchScore: 87 },
+  ],
+  aiAnalysis: {
+    together: [ANALYSIS_NETWORK, ANALYSIS_MODEL],
+  },
+  lastUpdated: new Date().toISOString(),
+}
+
+test.describe('AnalysisModal grouping — same service multi-incident', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/status', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+    await page.route('**/api/status/cached', async (route) => {
+      await route.fulfill({ json: MOCK })
+    })
+  })
+
+  test('renders a single card with two incident sections (no duplicate service name)', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Together AI').first()).toBeVisible({ timeout: 20000 })
+
+    const analyzeBtn = page.locator('button').filter({ hasText: /Analyze|분석/ })
+    await analyzeBtn.click()
+
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    // Service header should render exactly once
+    await expect(modal.getByText('Together AI', { exact: true })).toHaveCount(1)
+
+    // Both incident summaries appear
+    await expect(modal.getByText(/Scheduled network maintenance/)).toBeVisible()
+    await expect(modal.getByText(/GPT OSS 120B model outage/)).toBeVisible()
+
+    // Multi-incident badge reflects the count
+    await expect(modal.getByText(/\(2 (incidents|건)\)/)).toBeVisible()
+  })
+
+  test('renders the fallback Alternatives block exactly once per card', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Together AI').first()).toBeVisible({ timeout: 20000 })
+
+    await page.locator('button').filter({ hasText: /Analyze|분석/ }).click()
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    const alternatives = modal.getByText(/🔄 (Alternatives|대안 서비스)/)
+    await expect(alternatives).toHaveCount(1)
+  })
+
+  test('shows isolated-issue badge when service is operational with active analyses', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Together AI').first()).toBeVisible({ timeout: 20000 })
+
+    await page.locator('button').filter({ hasText: /Analyze|분석/ }).click()
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    await expect(modal.getByText(/Isolated issue|부분 이슈/)).toBeVisible()
+  })
+})
+
+// All analyses resolved → card opacity drops, Resolved pill shows, Alternatives + isolated
+// badge both suppressed. Guards against regression where these surfaces bleed into a
+// fully-resolved group.
+const RESOLVED_MOCK = {
+  services: [
+    { id: 'together', category: 'api', name: 'Together AI', provider: 'Together', status: 'operational', latency: 150, incidents: [] },
+    { id: 'groq', category: 'api', name: 'Groq Cloud', provider: 'Groq', status: 'operational', latency: 100, incidents: [], aiwatchScore: 92 },
+  ],
+  aiAnalysis: {
+    together: [{
+      ...ANALYSIS_MODEL,
+      resolvedAt: new Date().toISOString(),
+    }],
+  },
+  lastUpdated: new Date().toISOString(),
+}
+
+test.describe('AnalysisModal — fully resolved group', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/status', (route) => route.fulfill({ json: RESOLVED_MOCK }))
+    await page.route('**/api/status/cached', (route) => route.fulfill({ json: RESOLVED_MOCK }))
+  })
+
+  test('hides Alternatives and Isolated issue, shows Resolved pill', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Together AI').first()).toBeVisible({ timeout: 20000 })
+
+    await page.locator('button').filter({ hasText: /Analyze|분석/ }).click()
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    await expect(modal.getByText(/🔄 (Alternatives|대안 서비스)/)).toHaveCount(0)
+    await expect(modal.getByText(/Isolated issue|부분 이슈/)).toHaveCount(0)
+    await expect(modal.getByText('Resolved')).toBeVisible()
+  })
+})
+
+// EXCLUDE_FALLBACK services (replicate/huggingface/pinecone/modal/etc.) must not render
+// the Alternatives block even when needsFallback=true — keeps suggestion list in sync with
+// constants.js.
+const EXCLUDED_SVC_MOCK = {
+  services: [
+    { id: 'huggingface', category: 'api', name: 'Hugging Face', provider: 'Hugging Face', status: 'operational', latency: 180, incidents: [INC_MODEL] },
+    { id: 'groq', category: 'api', name: 'Groq Cloud', provider: 'Groq', status: 'operational', latency: 100, incidents: [], aiwatchScore: 92 },
+  ],
+  aiAnalysis: {
+    huggingface: [{ ...ANALYSIS_MODEL, needsFallback: true }],
+  },
+  lastUpdated: new Date().toISOString(),
+}
+
+test.describe('AnalysisModal — EXCLUDE_FALLBACK service', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/status', (route) => route.fulfill({ json: EXCLUDED_SVC_MOCK }))
+    await page.route('**/api/status/cached', (route) => route.fulfill({ json: EXCLUDED_SVC_MOCK }))
+  })
+
+  test('does not render Alternatives for EXCLUDE_FALLBACK services', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Hugging Face').first()).toBeVisible({ timeout: 20000 })
+
+    await page.locator('button').filter({ hasText: /Analyze|분석/ }).click()
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    await expect(modal.getByText(/🔄 (Alternatives|대안 서비스)/)).toHaveCount(0)
+  })
+})
+
+// Mixed: shared incident across sibling services + a service-private incident on one of them.
+// Guard against the cross-service-bleed regression — the private incident must not appear
+// under the multi-svc sibling card.
+const SHARED_INC = {
+  id: 'anthropic-admin-api',
+  title: 'Admin API degraded',
+  status: 'investigating',
+  impact: 'major',
+  startedAt: new Date(Date.now() - 7200_000).toISOString(),
+  resolvedAt: null,
+  duration: null,
+  timeline: [],
+}
+const CLAUDE_PRIVATE_INC = {
+  id: 'claude-opus-46',
+  title: 'Opus 4.6 elevated errors',
+  status: 'investigating',
+  impact: 'minor',
+  startedAt: new Date(Date.now() - 1800_000).toISOString(),
+  resolvedAt: null,
+  duration: null,
+  timeline: [],
+}
+const SHARED_ANALYSIS = {
+  incidentId: 'anthropic-admin-api',
+  summary: 'Admin API endpoints are degraded across Anthropic surfaces.',
+  estimatedRecovery: '30m–2h',
+  affectedScope: ['Admin API'],
+  needsFallback: false,
+  analyzedAt: new Date().toISOString(),
+}
+const CLAUDE_PRIVATE_ANALYSIS = {
+  incidentId: 'claude-opus-46',
+  summary: 'Opus 4.6 model error rate elevated — API-only surface.',
+  estimatedRecovery: '15m–45m',
+  affectedScope: ['Opus 4.6'],
+  needsFallback: true,
+  analyzedAt: new Date().toISOString(),
+}
+const MIXED_MOCK = {
+  services: [
+    { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'degraded', latency: 120, incidents: [SHARED_INC, CLAUDE_PRIVATE_INC] },
+    { id: 'claudeai', category: 'app', name: 'claude.ai', provider: 'Anthropic', status: 'degraded', latency: 0, incidents: [SHARED_INC] },
+    { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', latency: 200, incidents: [], aiwatchScore: 90 },
+  ],
+  aiAnalysis: {
+    claude: [SHARED_ANALYSIS, CLAUDE_PRIVATE_ANALYSIS],
+    claudeai: [SHARED_ANALYSIS],
+  },
+  lastUpdated: new Date().toISOString(),
+}
+
+test.describe('AnalysisModal — mixed sibling-shared + service-private', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/status', (route) => route.fulfill({ json: MIXED_MOCK }))
+    await page.route('**/api/status/cached', (route) => route.fulfill({ json: MIXED_MOCK }))
+  })
+
+  test('renders shared incident in one card and private incident in a separate Claude-only card', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Claude API').first()).toBeVisible({ timeout: 20000 })
+
+    await page.locator('button').filter({ hasText: /Analyze|분석/ }).click()
+    const modal = page.locator('.fixed.inset-0').last()
+    await expect(modal).toBeVisible()
+
+    // Shared admin-api summary appears once
+    await expect(modal.getByText(/Admin API endpoints are degraded/)).toHaveCount(1)
+    // Private Opus 4.6 summary appears once — must NOT bleed onto the sibling card
+    await expect(modal.getByText(/Opus 4\.6 model error rate elevated/)).toHaveCount(1)
+
+    // Shared card must list claude.ai alongside Claude API (sibling grouping preserved)
+    const sharedSection = modal.getByText(/Admin API endpoints are degraded/).locator('xpath=ancestor::div[contains(@class, "rounded-lg")][1]')
+    await expect(sharedSection.getByText('claude.ai')).toBeVisible()
+
+    // Private card must be Claude-only — claude.ai must not leak into this card
+    const privateSection = modal.getByText(/Opus 4\.6 model error rate elevated/).locator('xpath=ancestor::div[contains(@class, "rounded-lg")][1]')
+    await expect(privateSection.getByText('claude.ai')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
closes #315

## Summary
- Restore two-level grouping in `AnalysisModal.jsx` so the same service with multiple active incidents collapses into one card with multiple incident sections (regression from #245).
- Hoist the fallback Alternatives block out of the per-analysis loop so it renders once per card, not once per incident.
- Add an "Isolated issue" / "부분 이슈" badge on single-service groups where every surface is operational but active analyses remain — reconciles the BetterStack <30% resource-churn threshold with active AI-analyzed per-model incidents (Together AI showing operational while a single model is down).

## Approach
Two-pass grouping to avoid cross-service bleed:
1. Bucket analyses by `incidentId`, collecting every svcId affected.
2. Multi-svc buckets (sibling-shared incidents) become their own card; single-svc buckets merge by owner svcId. A service-private incident can no longer land inside a sibling-shared card.

## Test plan
- [x] `npm run test:src` — 21/21 pass
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — 934ms, no errors
- [x] `npx playwright test` (full suite) — 84/84 pass
- [x] New `tests/analysis-modal-grouping.spec.js` (6 cases): single card + 2 incidents, single Alternatives block, Isolated issue badge, fully-resolved suppression, EXCLUDE_FALLBACK suppression, mixed sibling-shared + service-private (anti-bleed)
- [x] Existing `tests/multi-service-incident.spec.js` + `tests/analysis-fallback.spec.js` still green
- [x] PR review auto-loop — 2 rounds, converged (0 Critical, 0 Important)
- [x] Local browser verify — confirmed by user on http://localhost:5173 with live Together AI data

🤖 Generated with [Claude Code](https://claude.com/claude-code)