### PR TITLE
fix: enrich OSV security alerts via two-phase fetch (#323)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,7 @@ worker/
     detection.ts # Detection Lead entry parsing + incident-aware reset logic
     detection-lead-log.ts # Detection Lead audit log — per-day KV array (#256), tagged AppendResult, 24h sliding window for daily summary
     reddit.ts   # Reddit r/ChatGPT + r/netsec + r/cybersecurity monitoring
-    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities)
+    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities — two-phase flow: querybatch bulk scan + per-vuln GET enrichment, capped at OSV_MAX_DETAIL_FETCH=15/cycle to protect the Workers subrequest budget; overflow re-offered next cron since seen-markers are only written for surfaced alerts)
     parsers/    # Platform-specific parsers (statuspage, incident-io, gcloud, aistudio, instatus, betterstack, aws)
                 # dailyImpact support: statuspage (uptimeData), incident-io (component impacts), betterstack (status_history from index.json)
                 # impact-weights.ts: shared MAJOR_WEIGHT=1.0, MINOR_WEIGHT=0.3 — used by both statuspage.ts (official) and incident-io.ts (estimate from durations) for Atlassian-aligned uptime%
@@ -439,7 +439,7 @@ Cron Trigger (*/5 min)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
-  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan → Discord digest on findings
+  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323) → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed
 
 Web Vitals Pipeline (per-request, 100% collection):

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts } from '../security-monitor'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts } from '../security-monitor'
 import type { SecurityAlert, SecurityAlertMeta } from '../security-monitor'
 
 describe('mapOSVSeverity', () => {
@@ -61,6 +61,245 @@ describe('detectSecurityAlerts', () => {
   it('returns empty when kv is null', async () => {
     const result = await detectSecurityAlerts(null)
     expect(result).toEqual([])
+  })
+})
+
+// Regression guard for #323: OSV's /v1/querybatch only returns { id, modified } —
+// summary/severity/references/affected are NOT in the batch response. Without a
+// Phase-2 detail fetch, titles fall back to "GHSA-...: PyPI/name" and severity
+// defaults to 'medium' regardless of the real CVSS score. These tests lock in the
+// two-phase flow: querybatch → dedup → per-vuln GET.
+describe('fetchOSVAlerts — two-phase flow (#323)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  // Minimal response factory — matches what the Workers runtime passes back from fetch().
+  function resp(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  // Routes fetch by URL so both querybatch (POST) and per-vuln GET share one stub.
+  function stubFetchByUrl(routes: Record<string, unknown>): ReturnType<typeof vi.fn> {
+    const mock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      for (const [pattern, body] of Object.entries(routes)) {
+        if (url.includes(pattern)) return resp(body)
+      }
+      throw new Error(`unmocked fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', mock)
+    return mock
+  }
+
+  it('enriches alerts with summary/severity/patch via per-vuln GET', async () => {
+    const nowISO = new Date().toISOString()
+    // Place the vuln under whatever position OSV_PACKAGES has the Anthropic-PyPI entry,
+    // so a future reorder of that array doesn't silently point this test at a different package.
+    const ANTHROPIC_PYPI_IDX = 1
+    const mock = stubFetchByUrl({
+      'querybatch': {
+        results: Array.from({ length: ANTHROPIC_PYPI_IDX + 1 }, (_, i) =>
+          i === ANTHROPIC_PYPI_IDX
+            ? { vulns: [{ id: 'GHSA-w828-4qhx-vxx3', modified: nowISO }] }
+            : {},
+        ),
+      },
+      'GHSA-w828-4qhx-vxx3': {
+        id: 'GHSA-w828-4qhx-vxx3',
+        modified: nowISO,
+        summary: 'Claude SDK for Python: Memory Tool Path Validation Race Condition Allows Sandbox Escape',
+        severity: [{ type: 'CVSS_V3', score: '7.1' }],
+        references: [
+          { type: 'ADVISORY', url: 'https://github.com/anthropics/anthropic-sdk-python/security/advisories/GHSA-w828-4qhx-vxx3' },
+          { type: 'WEB', url: 'https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.87.0' },
+        ],
+        affected: [{
+          package: { name: 'anthropic', ecosystem: 'PyPI' },
+          ranges: [{ type: 'ECOSYSTEM', events: [{ introduced: '0.81.0' }, { fixed: '0.87.0' }] }],
+        }],
+        database_specific: { severity: 'HIGH', cwe_ids: ['CWE-367'] },
+      },
+    })
+
+    const alerts = await fetchOSVAlerts(null)
+
+    expect(alerts).toHaveLength(1)
+    const a = alerts[0]!
+    expect(a.title).toBe('Claude SDK for Python: Memory Tool Path Validation Race Condition Allows Sandbox Escape')
+    expect(a.severity).toBe('high') // CVSS 7.1 → high, NOT the 'medium' fallback
+    expect(a.service).toBe('Anthropic (Claude)')
+    expect(a.affectedPackage).toBe('PyPI/anthropic')
+    expect(a.affectedRange).toBe('>= 0.81.0')
+    expect(a.fixedVersion).toBe('0.87.0')
+    expect(a.patchUrl).toBe('https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.87.0')
+    expect(a.cweIds).toEqual(['CWE-367'])
+    // Two HTTP calls: one querybatch + one detail fetch.
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips Phase-2 detail fetch for candidates already in KV dedup', async () => {
+    const nowISO = new Date().toISOString()
+    const mock = stubFetchByUrl({
+      'querybatch': {
+        results: [
+          {},
+          { vulns: [
+            { id: 'GHSA-already-seen', modified: nowISO },
+            { id: 'GHSA-new-one', modified: nowISO },
+          ] },
+        ],
+      },
+      'GHSA-new-one': {
+        id: 'GHSA-new-one',
+        modified: nowISO,
+        summary: 'New vuln',
+        severity: [{ type: 'CVSS_V3', score: '5.0' }],
+      },
+    })
+
+    // Mark one as seen; the dedup pre-filter must skip its detail fetch.
+    const kv = {
+      async get(key: string) {
+        return key === 'security:seen:osv:GHSA-already-seen' ? '1' : null
+      },
+    } as unknown as KVNamespace
+
+    const alerts = await fetchOSVAlerts(kv)
+
+    expect(alerts.map(a => a.id)).toEqual(['GHSA-new-one'])
+    // 1 querybatch + 1 detail fetch (the seen one is skipped). If the skip were
+    // broken, the stub would throw on 'GHSA-already-seen' (no route defined).
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('filters vulns older than 7 days before any detail fetch', async () => {
+    const old = new Date(Date.now() - 10 * 86400 * 1000).toISOString()
+    const mock = stubFetchByUrl({
+      'querybatch': { results: [{ vulns: [{ id: 'GHSA-old', modified: old }] }] },
+    })
+
+    const alerts = await fetchOSVAlerts(null)
+    expect(alerts).toEqual([])
+    // Only the querybatch call — no detail fetch for the aged-out vuln.
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a single failed detail fetch without failing the batch', async () => {
+    const nowISO = new Date().toISOString()
+    // Route the successful detail but leave 'GHSA-broken' unmocked so it throws.
+    const mock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('querybatch')) {
+        return resp({ results: [
+          {},
+          { vulns: [
+            { id: 'GHSA-broken', modified: nowISO },
+            { id: 'GHSA-good', modified: nowISO },
+          ] },
+        ] })
+      }
+      if (url.includes('GHSA-good')) {
+        return resp({ id: 'GHSA-good', modified: nowISO, summary: 'Recoverable' })
+      }
+      throw new Error('simulated network error')
+    })
+    vi.stubGlobal('fetch', mock)
+
+    const alerts = await fetchOSVAlerts(null)
+    expect(alerts.map(a => a.id)).toEqual(['GHSA-good'])
+  })
+
+  it('throws when querybatch itself fails so detectSecurityAlerts can log it', async () => {
+    // Returning [] here would be indistinguishable from a legitimate quiet day;
+    // throwing lets Promise.allSettled in detectSecurityAlerts surface the failure.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('server error', { status: 500 })))
+    await expect(fetchOSVAlerts(null)).rejects.toThrow(/HTTP 500/)
+  })
+
+  it('returns [] with no detail fetches when querybatch yields zero vulns', async () => {
+    // Quiet day — all tracked packages return empty result blocks. Must short-circuit
+    // before Phase 2 so the cron doesn't burn subrequests on nothing.
+    const mock = stubFetchByUrl({ 'querybatch': { results: [{}, {}, {}] } })
+    const alerts = await fetchOSVAlerts(null)
+    expect(alerts).toEqual([])
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a KV.get rejection during pre-dedup as unseen and proceeds to detail fetch', async () => {
+    // Fail-open: a transient KV outage must not mask new CVEs. Regression guard — if a
+    // future refactor flipped the ternary, rejected reads would be silently marked "seen".
+    const nowISO = new Date().toISOString()
+    const mock = stubFetchByUrl({
+      'querybatch': { results: [{}, { vulns: [{ id: 'GHSA-kv-error', modified: nowISO }] }] },
+      'GHSA-kv-error': { id: 'GHSA-kv-error', modified: nowISO, summary: 'Recovered after KV error' },
+    })
+    const kv = {
+      async get() { throw new Error('KV read failed') },
+    } as unknown as KVNamespace
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const alerts = await fetchOSVAlerts(kv)
+
+    expect(alerts.map(a => a.id)).toEqual(['GHSA-kv-error'])
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('OSV pre-dedup KV read failed for GHSA-kv-error'),
+      expect.anything(),
+    )
+  })
+
+  it('caps detail fetches to OSV_MAX_DETAIL_FETCH and warns on overflow', async () => {
+    // Post-deploy / post-KV-wipe scenario: many candidates pass dedup on the first cycle.
+    // Cap keeps the Workers subrequest budget safe; overflow vulns are re-offered next cycle
+    // since the seen-marker is only written for alerts that are actually surfaced.
+    const nowISO = new Date().toISOString()
+    const manyVulns = Array.from({ length: 20 }, (_, i) => ({ id: `GHSA-many-${i}`, modified: nowISO }))
+    const routes: Record<string, unknown> = { 'querybatch': { results: [{ vulns: manyVulns }] } }
+    for (let i = 0; i < 20; i++) {
+      routes[`GHSA-many-${i}`] = { id: `GHSA-many-${i}`, modified: nowISO, summary: `Vuln ${i}` }
+    }
+    const mock = stubFetchByUrl(routes)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const alerts = await fetchOSVAlerts(null)
+
+    expect(alerts.length).toBe(15)
+    // 1 querybatch + 15 detail fetches (not 20)
+    expect(mock).toHaveBeenCalledTimes(16)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('capped at 15'))
+  })
+})
+
+describe('detectSecurityAlerts — HN dedup integration (#323 refactor)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  // Regression guard: the #323 refactor moved OSV dedup upstream into fetchOSVAlerts,
+  // leaving detectSecurityAlerts responsible only for HN dedup. This test makes sure
+  // the HN path still filters against KV and doesn't break under the new structure.
+  it('filters HN alerts whose kvKey is already in KV', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('hn.algolia.com')) {
+        return new Response(JSON.stringify({
+          hits: [
+            { objectID: 'hn-seen', title: 'OpenAI breach disclosed', url: 'https://example.com/a', points: 10, created_at_i: Math.floor(Date.now() / 1000) },
+            { objectID: 'hn-new',  title: 'Anthropic vulnerability CVE', url: 'https://example.com/b', points: 20, created_at_i: Math.floor(Date.now() / 1000) },
+          ],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      // OSV path: return zero candidates so this test isolates the HN dedup behavior.
+      if (url.includes('querybatch')) {
+        return new Response(JSON.stringify({ results: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      throw new Error(`unmocked: ${url}`)
+    }))
+
+    const kv = {
+      async get(key: string) {
+        return key === 'security:seen:hn:hn-seen' ? '1' : null
+      },
+    } as unknown as KVNamespace
+
+    const alerts = await detectSecurityAlerts(kv)
+    expect(alerts.map(a => a.id)).toEqual(['hn-new'])
   })
 })
 

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -140,10 +140,22 @@ export function mapOSVSeverity(vuln: OSVVuln): SecurityAlert['severity'] {
   return 'medium'
 }
 
-export async function fetchOSVAlerts(): Promise<SecurityAlert[]> {
+// Phase-1 candidate — see fetchOSVAlerts for the two-phase rationale.
+// `modified` is consumed by the 7-day filter inside listOSVCandidates and
+// intentionally not carried forward (candidates only need routing info).
+interface OSVCandidate {
+  id: string
+  packageIndex: number
+}
+
+// Phase 1 — single batch request instead of N per-package calls; OSV's querybatch
+// is designed for bulk dedup/scan and avoids per-package rate-limit pressure.
+// Throws on HTTP error so the outer Promise.allSettled in detectSecurityAlerts
+// logs it via `[security] OSV.dev fetch failed` — a silent `return []` would be
+// indistinguishable from a legitimate "no vulns this cycle".
+export async function listOSVCandidates(): Promise<OSVCandidate[]> {
   const sevenDaysAgo = new Date(Date.now() - 7 * 86400 * 1000).toISOString()
 
-  // Use batch endpoint — single request for all packages
   const queries = OSV_PACKAGES.map(pkg => ({ package: { name: pkg.name, ecosystem: pkg.ecosystem } }))
 
   const res = await fetch('https://api.osv.dev/v1/querybatch', {
@@ -154,50 +166,133 @@ export async function fetchOSVAlerts(): Promise<SecurityAlert[]> {
   })
 
   if (!res.ok) {
-    console.error(`[security] OSV.dev returned HTTP ${res.status}`)
     res.body?.cancel()
-    return []
+    throw new Error(`OSV querybatch HTTP ${res.status}`)
   }
 
-  const json = await res.json() as { results?: Array<{ vulns?: OSVVuln[] }> }
+  const json = await res.json() as { results?: Array<{ vulns?: Array<{ id: string; modified: string }> }> }
   if (!json.results) return []
 
-  const alerts: SecurityAlert[] = []
+  const candidates: OSVCandidate[] = []
   for (let i = 0; i < json.results.length; i++) {
     const vulns = json.results[i]?.vulns
     if (!vulns) continue
-    const pkg = OSV_PACKAGES[i]
-
     for (const v of vulns) {
       if (v.modified < sevenDaysAgo) continue
-
-      // Extract remediation info from affected ranges
-      const aff = v.affected?.[0]
-      const range = aff?.ranges?.[0]
-      const introduced = range?.events?.find(e => e.introduced)?.introduced
-      const fixed = range?.events?.find(e => e.fixed)?.fixed
-      const patchUrl = v.references?.find(r =>
-        r.url.includes('/commit/') || r.url.includes('/releases/tag/'),
-      )?.url
-
-      alerts.push({
-        source: 'osv' as const,
-        id: v.id,
-        title: v.summary || `${v.id}: ${pkg.ecosystem}/${pkg.name}`,
-        url: v.references?.find(r => r.type === 'WEB' || r.type === 'ADVISORY')?.url
-          || `https://osv.dev/vulnerability/${v.id}`,
-        severity: mapOSVSeverity(v),
-        kvKey: `security:seen:osv:${v.id}`,
-        service: pkg.service,
-        affectedPackage: `${pkg.ecosystem}/${pkg.name}`,
-        affectedRange: introduced ? `>= ${introduced}` : undefined,
-        fixedVersion: fixed,
-        patchUrl,
-        cweIds: v.database_specific?.cwe_ids,
-      })
+      candidates.push({ id: v.id, packageIndex: i })
     }
   }
+  return candidates
+}
 
+// Phase 2 — fetch the full vuln document for a single candidate.
+// Returns null on network/HTTP failure so the orchestrator can drop just this alert
+// rather than fail the whole batch (Promise.allSettled also catches throws).
+export async function fetchOSVVulnDetails(candidate: OSVCandidate): Promise<SecurityAlert | null> {
+  const res = await fetch(`https://api.osv.dev/v1/vulns/${candidate.id}`, {
+    headers: { 'User-Agent': 'AIWatch/1.0 (ai-watch.dev; security monitoring)' },
+    signal: AbortSignal.timeout(8000),
+  })
+
+  if (!res.ok) {
+    console.error(`[security] OSV.dev vuln fetch returned HTTP ${res.status} for ${candidate.id}`)
+    res.body?.cancel()
+    return null
+  }
+
+  const v = await res.json() as OSVVuln
+  const pkg = OSV_PACKAGES[candidate.packageIndex]
+  if (!pkg) {
+    console.error(`[security] OSV_PACKAGES index ${candidate.packageIndex} out of bounds for ${candidate.id}`)
+    return null
+  }
+
+  const aff = v.affected?.[0]
+  const range = aff?.ranges?.[0]
+  const introduced = range?.events?.find(e => e.introduced)?.introduced
+  const fixed = range?.events?.find(e => e.fixed)?.fixed
+  const patchUrl = v.references?.find(r =>
+    r.url.includes('/commit/') || r.url.includes('/releases/tag/'),
+  )?.url
+
+  return {
+    source: 'osv' as const,
+    id: v.id,
+    title: v.summary || `${v.id}: ${pkg.ecosystem}/${pkg.name}`,
+    url: v.references?.find(r => r.type === 'WEB' || r.type === 'ADVISORY')?.url
+      || `https://osv.dev/vulnerability/${v.id}`,
+    severity: mapOSVSeverity(v),
+    kvKey: `security:seen:osv:${v.id}`,
+    service: pkg.service,
+    affectedPackage: `${pkg.ecosystem}/${pkg.name}`,
+    affectedRange: introduced ? `>= ${introduced}` : undefined,
+    fixedVersion: fixed,
+    patchUrl,
+    cweIds: v.database_specific?.cwe_ids,
+  }
+}
+
+// Cap per-cycle detail fetches to protect the Workers subrequest budget on first
+// deploy, KV wipe, or post-outage catch-up (where `unseen` can be a large batch).
+// Over-cap vulns aren't lost — the `security:seen:*` write happens in the caller
+// (worker/src/index.ts cron handler) only for surfaced alerts, so truncated
+// candidates stay unseen and re-appear next cycle. If dedup-write ever moves
+// inside fetchOSVAlerts, this guarantee breaks — update both sides together.
+const OSV_MAX_DETAIL_FETCH = 15
+
+// Two-phase OSV fetch (#323): querybatch returns only id + modified, so we must
+// GET /v1/vulns/{id} per candidate to get summary/severity/references/affected.
+// Dedup runs between phases so vulns already marked seen by a prior cron cycle
+// skip the per-vuln detail fetch.
+// `kv = null` default is for test ergonomics; production always passes env.STATUS_CACHE.
+export async function fetchOSVAlerts(kv: KVNamespace | null = null): Promise<SecurityAlert[]> {
+  const candidates = await listOSVCandidates()
+  if (candidates.length === 0) return []
+
+  // Phase 1.5 — pre-dedup against seen-markers from prior cycles.
+  let unseen: OSVCandidate[] = candidates
+  if (kv) {
+    const seenFlags = await Promise.allSettled(
+      candidates.map(c => kv.get(`security:seen:osv:${c.id}`)),
+    )
+    unseen = candidates.filter((c, i) => {
+      const r = seenFlags[i]
+      if (r?.status === 'rejected') {
+        // Fail open: treat as unseen so transient KV outages don't mask new CVEs,
+        // but surface the failure — silent fail-open hides prolonged KV issues.
+        console.error(
+          `[security] OSV pre-dedup KV read failed for ${c.id}; treating as unseen:`,
+          r.reason instanceof Error ? r.reason.message : r.reason,
+        )
+        return true
+      }
+      return !(r?.status === 'fulfilled' && r.value)
+    })
+  }
+  if (unseen.length === 0) return []
+
+  if (unseen.length > OSV_MAX_DETAIL_FETCH) {
+    console.warn(`[security] OSV unseen=${unseen.length} capped at ${OSV_MAX_DETAIL_FETCH} for this cycle; overflow retried next cron`)
+    unseen = unseen.slice(0, OSV_MAX_DETAIL_FETCH)
+  }
+
+  // Phase 2 — parallel per-vuln detail fetch. allSettled so one failure doesn't drop the batch.
+  const settled = await Promise.allSettled(unseen.map(fetchOSVVulnDetails))
+  const alerts: SecurityAlert[] = []
+  let droppedHttp = 0
+  let droppedThrew = 0
+  for (const r of settled) {
+    if (r.status === 'fulfilled' && r.value) alerts.push(r.value)
+    else if (r.status === 'fulfilled') droppedHttp++  // null → HTTP error already logged in fetchOSVVulnDetails
+    else {
+      droppedThrew++
+      console.error('[security] OSV.dev vuln fetch threw:', r.reason instanceof Error ? r.reason.message : r.reason)
+    }
+  }
+  // Single aggregate line so a scatter of per-id HTTP errors produces one actionable signal.
+  if (droppedHttp + droppedThrew > 0) {
+    console.warn(`[security] OSV detail fetch dropped ${droppedHttp + droppedThrew}/${unseen.length} (http=${droppedHttp}, threw=${droppedThrew})`)
+  }
   return alerts
 }
 
@@ -208,9 +303,12 @@ export async function detectSecurityAlerts(
 ): Promise<SecurityAlert[]> {
   if (!kv) return []
 
+  // OSV alerts are pre-deduped inside fetchOSVAlerts (avoids per-vuln detail fetches
+  // for already-seen entries). HN still needs dedup here since fetchHNSecurityPosts
+  // doesn't touch KV.
   const [hnAlerts, osvAlerts] = await Promise.allSettled([
     fetchHNSecurityPosts(),
-    fetchOSVAlerts(),
+    fetchOSVAlerts(kv),
   ])
 
   if (hnAlerts.status === 'rejected') {
@@ -220,23 +318,22 @@ export async function detectSecurityAlerts(
     console.error('[security] OSV.dev fetch failed:', osvAlerts.reason instanceof Error ? osvAlerts.reason.message : osvAlerts.reason)
   }
 
-  const allAlerts = [
-    ...(hnAlerts.status === 'fulfilled' ? hnAlerts.value : []),
-    ...(osvAlerts.status === 'fulfilled' ? osvAlerts.value : []),
-  ]
-
-  // KV dedup
-  const newAlerts: SecurityAlert[] = []
-  for (const alert of allAlerts) {
-    const seen = await kv.get(alert.kvKey).catch((err) => {
-      console.error('[security] KV dedup read failed:', alert.kvKey, err instanceof Error ? err.message : err)
-      return null
-    })
-    if (seen) continue
-    newAlerts.push(alert)
+  const hnFinal: SecurityAlert[] = []
+  if (hnAlerts.status === 'fulfilled') {
+    for (const alert of hnAlerts.value) {
+      const seen = await kv.get(alert.kvKey).catch((err) => {
+        console.error('[security] KV dedup read failed:', alert.kvKey, err instanceof Error ? err.message : err)
+        return null
+      })
+      if (seen) continue
+      hnFinal.push(alert)
+    }
   }
 
-  return newAlerts
+  return [
+    ...hnFinal,
+    ...(osvAlerts.status === 'fulfilled' ? osvAlerts.value : []),
+  ]
 }
 
 // ---------- Discord formatting ----------


### PR DESCRIPTION
closes #323

## Summary
- OSV's `/v1/querybatch` returns only `{id, modified}` per vuln, so `fetchOSVAlerts` silently degraded every OSV alert — title fell back to `GHSA-...: PyPI/name`, severity defaulted to 🟡 `'medium'`, and no `pip install …` remediation line ever rendered in Discord.
- Refactor into a two-phase flow: `listOSVCandidates` (bulk scan) → KV pre-dedup → `fetchOSVVulnDetails` (per-vuln GET) → enriched `SecurityAlert`.
- Dashboard service detail, Discord security digest, and `security:monthly:{YYYY-MM}` archive all benefit automatically.

## Observability + safety
- `listOSVCandidates` throws on HTTP error (was silently `[]`) — `detectSecurityAlerts` Promise.allSettled now logs querybatch outages via the existing `[security] OSV.dev fetch failed` path.
- `OSV_MAX_DETAIL_FETCH = 15` cap on Phase 2 fan-out — protects the Workers subrequest budget on first deploy / KV wipe / post-outage catch-up. Overflow is re-offered next cron cycle (seen-marker is written by the caller only for surfaced alerts).
- Aggregate `console.warn` after Phase 2 summarizes drops: `OSV detail fetch dropped X/Y (http=A, threw=B)`.
- Pre-dedup `kv.get` rejection logs + fails open (better to re-alert than miss a new CVE).
- Invalid `OSV_PACKAGES` index logs instead of returning null silently.

## Stale KV entries (one-time)
The two entries already in prod KV (`security:seen:osv:GHSA-q5f5-3gjm-7mfm`, `security:seen:osv:GHSA-w828-4qhx-vxx3`) still carry the old low-signal titles until their 7-day TTL expires. Recommend after deploy:
```
npx wrangler kv key delete --binding=STATUS_CACHE --remote "security:seen:osv:GHSA-q5f5-3gjm-7mfm"
npx wrangler kv key delete --binding=STATUS_CACHE --remote "security:seen:osv:GHSA-w828-4qhx-vxx3"
```
Next cron cycle re-detects them with the correct severity (🟠 high) and full summary.

## Test plan
- [x] `cd worker && npm test` — 944/944 pass (9 new tests across two describe blocks)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — passes (2727.06 KiB / gzip 1008.17 KiB)
- [x] Local `npx wrangler dev` → `/api/status` HTTP 200, no regression, `securityAlerts` key still emitted
- [x] PR review auto-loop — Round 1 (2 Critical / 4 Important / 3 Suggestions from 4 agents) → fixes → Round 2 (0 Critical / 0 Important, 2 minor suggestions only = converged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)