### PR TITLE
feat: expand OSV_PACKAGES to voice/inference SDKs + Langchain subpackages (#325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,7 +331,7 @@ worker/
     detection.ts # Detection Lead entry parsing + incident-aware reset logic
     detection-lead-log.ts # Detection Lead audit log — per-day KV array (#256), tagged AppendResult, 24h sliding window for daily summary
     reddit.ts   # Reddit r/ChatGPT + r/netsec + r/cybersecurity monitoring
-    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities — two-phase flow: querybatch bulk scan + per-vuln GET enrichment, capped at OSV_MAX_DETAIL_FETCH=15/cycle to protect the Workers subrequest budget; overflow re-offered next cron since seen-markers are only written for surfaced alerts)
+    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities — 24 tracked packages across PyPI + npm including Langchain ecosystem adapters, see OSV_PACKAGES; two-phase flow: querybatch bulk scan + per-vuln GET enrichment, capped at OSV_MAX_DETAIL_FETCH=15/cycle to protect the Workers subrequest budget; overflow re-offered next cron since seen-markers are only written for surfaced alerts)
     parsers/    # Platform-specific parsers (statuspage, incident-io, gcloud, aistudio, instatus, betterstack, aws)
                 # dailyImpact support: statuspage (uptimeData), incident-io (component impacts), betterstack (status_history from index.json)
                 # impact-weights.ts: shared MAJOR_WEIGHT=1.0, MINOR_WEIGHT=0.3 — used by both statuspage.ts (official) and incident-io.ts (estimate from durations) for Atlassian-aligned uptime%
@@ -441,7 +441,7 @@ Cron Trigger (*/5 min)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
-  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323) → EPSS enrichment via GitHub Advisories (24h KV cache, #326) → Discord digest on findings
+  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (24 AI SDK packages · two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323/#325) → EPSS enrichment via GitHub Advisories (24h KV cache, #326) → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed
 
 Web Vitals Pipeline (per-request, 100% collection):

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,7 +47,7 @@
 - **랜딩 페이지** — Product Hunt 랜딩 페이지(`/intro`), 대시보드 프리뷰 mock, KO/EN 이중 언어, Flow 애니메이션, GA4 트래킹
 - **Web Vitals 모니터링** — 실사용자 LCP, FCP, TTFB, CLS, INP 수집, p75 집계 및 Discord Daily Report 임계값 알림
 - **주간 브리핑** — 매주 일요일 Discord 다이제스트: AI 서비스 변경 감지(OpenAI, Google, Anthropic), 인시던트 요약, 안정성 트렌드
-- **보안 모니터링** — Hacker News, Reddit(r/netsec, r/cybersecurity), OSV.dev를 통한 AI 서비스 보안 사고 감지 및 SDK 취약점 스캔, 대시보드 알림 + Discord 다이제스트
+- **보안 모니터링** — Hacker News, Reddit(r/netsec, r/cybersecurity), OSV.dev를 통한 AI 서비스 보안 사고 감지 및 24개 AI SDK 패키지(PyPI + npm, Langchain 에코시스템 어댑터 포함) 취약점 스캔, 대시보드 알림 + Discord 다이제스트
 - **상태 페이지 교차 검증** — Probe RTT + 플랫폼 쿼럼 + metastatuspage 모니터링으로 상태 페이지 인프라 장애 시 오탐 방지
 
 ## 모니터링 서비스
@@ -320,7 +320,7 @@ worker/
     ai-analysis.ts # 하이브리드 AI 장애 분석 (Gemma 4 primary + Sonnet fallback)
     changelog.ts # 변경사항/뉴스 수집 (OpenAI RSS, Google RSS, Anthropic HTML)
     weekly-briefing.ts # 주간 Discord 브리핑 (변경사항 + 인시던트 + 안정성)
-    security-monitor.ts # AI 서비스 보안 모니터링 (HN Algolia, OSV.dev SDK 취약점)
+    security-monitor.ts # AI 서비스 보안 모니터링 (HN Algolia, OSV.dev SDK 취약점 — 24개 추적 패키지)
     daily-summary.ts # 일일 Discord 리포트 (가동률, 지연시간, AI 사용량)
     monthly-archive.ts # 월간 안정성 아카이브 (영구 KV 보존)
     vitals.ts    # Web Vitals 집계 (p75, Discord 포맷)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Real-time monitoring dashboard for **31 AI services** — track status, latency,
 - **Landing page** — Product Hunt landing page (`/intro`) with dashboard preview mock, KO/EN i18n, flow animation, and GA4 tracking
 - **Web Vitals monitoring** — Real user LCP, FCP, TTFB, CLS, INP collection with p75 aggregation and threshold-based alerts in Discord Daily Report
 - **Weekly briefing** — Sunday Discord digest with AI service changelog detection (OpenAI, Google, Anthropic), incident summary, and stability trends
-- **Security monitoring** — AI service security incident detection via Hacker News, Reddit (r/netsec, r/cybersecurity), and OSV.dev SDK vulnerability scanning with dashboard alerts + Discord digest
+- **Security monitoring** — AI service security incident detection via Hacker News, Reddit (r/netsec, r/cybersecurity), and OSV.dev SDK vulnerability scanning across 24 AI SDK packages (PyPI + npm, including Langchain ecosystem adapters) with dashboard alerts + Discord digest
 - **Status page cross-validation** — Probe RTT + platform quorum + metastatuspage monitoring to prevent false positives during status page infrastructure outages
 
 ## Monitored Services
@@ -321,7 +321,7 @@ worker/
     ai-analysis.ts # Hybrid AI incident analysis (Gemma 4 primary + Sonnet fallback)
     changelog.ts # Changelog/news collection (OpenAI RSS, Google RSS, Anthropic HTML)
     weekly-briefing.ts # Weekly Discord briefing (changelog + incidents + stability)
-    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities)
+    security-monitor.ts # AI service security monitoring (HN Algolia, OSV.dev SDK vulnerabilities — 24 tracked packages)
     daily-summary.ts # Daily Discord report (uptime, latency, AI usage)
     monthly-archive.ts # Monthly reliability archive (permanent KV)
     vitals.ts    # Web Vitals aggregation (p75, Discord formatting)

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -933,7 +933,10 @@ export default function ServiceDetails({ serviceId }) {
         // Keep in sync with OSV_PACKAGES in worker/src/security-monitor.ts
         const OSV_SERVICE_MAP = {
           'OpenAI': 'openai', 'Anthropic (Claude)': 'claude', 'Google (Gemini)': 'gemini',
-          'Cohere': 'cohere', 'Mistral': 'mistral', 'Hugging Face': 'huggingface', 'LangChain': '',
+          'Cohere': 'cohere', 'Mistral': 'mistral', 'Hugging Face': 'huggingface',
+          'Together': 'together', 'Groq': 'groq', 'Replicate': 'replicate',
+          'AssemblyAI': 'assemblyai', 'Deepgram': 'deepgram',
+          'LangChain': '', // no dedicated service page — subpackage CVEs surface only in the banner
         }
         const filtered = securityAlerts.filter(a => {
           // OSV: match by mapped service ID (e.g., "Anthropic (Claude)" → only "claude", not "claudeai")

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,6 +1,58 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED } from '../security-monitor'
+import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED, OSV_PACKAGES } from '../security-monitor'
 import type { SecurityAlert, SecurityAlertMeta } from '../security-monitor'
+
+// #325: OSV_PACKAGES drives both querybatch input and the post-fetch enrichment
+// via OSV_PACKAGES[candidate.packageIndex]. A duplicated (name, ecosystem) would
+// issue redundant queries and inflate querybatch cost; an invalid ecosystem
+// silently yields zero results from OSV. Cheap guard — runs in <1ms.
+describe('OSV_PACKAGES invariants', () => {
+  it('has no duplicate (name, ecosystem) pairs', () => {
+    const keys = OSV_PACKAGES.map(p => `${p.ecosystem}/${p.name}`)
+    const unique = new Set(keys)
+    expect(keys.length).toBe(unique.size)
+  })
+
+  it('uses only OSV-recognized ecosystems (PyPI or npm)', () => {
+    // OSV supports more (Go, Maven, crates.io, etc.), but this project currently
+    // scans Python + JavaScript AI SDKs only. A typo like "pypi" (lowercase) would
+    // silently yield zero vulns across all queries — hence the strict allowlist.
+    const valid = new Set(['PyPI', 'npm'])
+    for (const pkg of OSV_PACKAGES) {
+      expect(valid.has(pkg.ecosystem)).toBe(true)
+    }
+  })
+
+  it('has a non-empty name and service label for every entry', () => {
+    for (const pkg of OSV_PACKAGES) {
+      expect(pkg.name).toBeTruthy()
+      expect(pkg.service).toBeTruthy()
+    }
+  })
+
+  it('every service label is also a key in the frontend OSV_SERVICE_MAP', () => {
+    // Cross-layer invariant: adding a `service` label here without also adding it
+    // to OSV_SERVICE_MAP in src/pages/ServiceDetails.jsx silently drops those
+    // alerts from the Security Alerts card — the filter there evaluates
+    // `OSV_SERVICE_MAP[a.service] === service.id`, which is `undefined === id`
+    // (false) for unmapped labels. This mirror enforces the sync at test time.
+    const KNOWN_SERVICE_LABELS = new Set([
+      'OpenAI', 'Anthropic (Claude)', 'Google (Gemini)', 'Cohere', 'Mistral',
+      'Hugging Face', 'LangChain',
+      'Together', 'Groq', 'Replicate', 'AssemblyAI', 'Deepgram',
+    ])
+    for (const pkg of OSV_PACKAGES) {
+      expect(KNOWN_SERVICE_LABELS.has(pkg.service)).toBe(true)
+    }
+  })
+
+  it('has at least 20 entries (tripwire for accidental mass removal)', () => {
+    // Current count is 24 (2026-04). The lower bound protects against a bad
+    // merge or truncation that would silently shrink OSV coverage — the other
+    // invariants pass for any subset, so a length floor is the only guard.
+    expect(OSV_PACKAGES.length).toBeGreaterThanOrEqual(20)
+  })
+})
 
 describe('mapOSVSeverity', () => {
   it('maps critical (>= 9.0)', () => {

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -93,17 +93,45 @@ export async function fetchHNSecurityPosts(): Promise<SecurityAlert[]> {
 
 // ---------- OSV.dev (AI SDK vulnerabilities) ----------
 
-const OSV_PACKAGES = [
+// Keep the OSV_SERVICE_MAP in src/pages/ServiceDetails.jsx in sync when editing
+// — its keys must cover every `service` label used here or the Security Alerts
+// card will silently drop entries for the unmapped service.
+// Exported for invariant tests only; production callers never import it directly.
+export const OSV_PACKAGES = [
+  // Major LLM providers — PyPI
   { name: 'openai', ecosystem: 'PyPI', service: 'OpenAI' },
   { name: 'anthropic', ecosystem: 'PyPI', service: 'Anthropic (Claude)' },
   { name: 'google-generativeai', ecosystem: 'PyPI', service: 'Google (Gemini)' },
   { name: 'cohere', ecosystem: 'PyPI', service: 'Cohere' },
   { name: 'mistralai', ecosystem: 'PyPI', service: 'Mistral' },
+  // Inference / cloud LLM — PyPI
+  { name: 'together', ecosystem: 'PyPI', service: 'Together' },
+  { name: 'groq', ecosystem: 'PyPI', service: 'Groq' },
+  { name: 'replicate', ecosystem: 'PyPI', service: 'Replicate' },
+  // Voice — PyPI
+  { name: 'assemblyai', ecosystem: 'PyPI', service: 'AssemblyAI' },
+  { name: 'deepgram-sdk', ecosystem: 'PyPI', service: 'Deepgram' },
+  // LangChain ecosystem — per-provider adapters live in separate PyPI packages
+  // since LangChain 0.1; tracking the meta-package alone misses CVEs like
+  // GHSA-3hjh-jh2h-vrg6 (DoS in langchain-community, 2024-06).
   { name: 'langchain', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'langchain-community', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'langchain-core', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'langchain-openai', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'langchain-anthropic', ecosystem: 'PyPI', service: 'LangChain' },
+  { name: 'langchain-google-genai', ecosystem: 'PyPI', service: 'LangChain' },
+  // ML infra — PyPI
   { name: 'transformers', ecosystem: 'PyPI', service: 'Hugging Face' },
+  // npm
   { name: 'openai', ecosystem: 'npm', service: 'OpenAI' },
   { name: '@anthropic-ai/sdk', ecosystem: 'npm', service: 'Anthropic (Claude)' },
   { name: '@google/generative-ai', ecosystem: 'npm', service: 'Google (Gemini)' },
+  { name: 'replicate', ecosystem: 'npm', service: 'Replicate' },
+  { name: 'groq-sdk', ecosystem: 'npm', service: 'Groq' },
+  { name: 'assemblyai', ecosystem: 'npm', service: 'AssemblyAI' },
+  { name: '@deepgram/sdk', ecosystem: 'npm', service: 'Deepgram' },
+  // Intentionally NOT included: `npm/together` — that name is a pre-existing
+  // unrelated HTML utility, not the Together AI SDK (as of 2026-04).
 ]
 
 interface OSVVuln {


### PR DESCRIPTION
closes #325

## Summary
- Grow OSV.dev coverage from **10 → 24 tracked AI SDK packages** so disclosures in Together / Groq / Replicate / AssemblyAI / Deepgram and Langchain per-provider subpackages no longer escape AIWatch's security monitoring.
- Front-end `OSV_SERVICE_MAP` extended in lockstep so the 5 new voice/inference services route to the right service detail page. Langchain subpackage CVEs continue aggregating via the existing `''` mapping.
- Pure data change + cross-layer invariant test — no fetch or alert-logic modifications.

## What's new
| Ecosystem | Packages added |
|---|---|
| PyPI inference/voice | `together`, `groq`, `replicate`, `assemblyai`, `deepgram-sdk` |
| PyPI Langchain adapters | `langchain-community`, `langchain-core`, `langchain-openai`, `langchain-anthropic`, `langchain-google-genai` |
| npm | `replicate`, `groq-sdk`, `assemblyai`, `@deepgram/sdk` |

**Intentionally skipped**: `npm/together` — that name is a pre-existing unrelated HTML utility, not the Together AI SDK (verified against npm registry, 2026-04).

### Why Langchain subpackages matter

Per-provider adapters became separate PyPI packages in Langchain 0.1+. Tracking the `langchain` meta-package alone missed CVEs like `GHSA-3hjh-jh2h-vrg6` (DoS in `langchain-community`, 2024-06) — which is exactly the blind spot this PR closes.

## Cost impact

- OSV querybatch is a **single POST** regardless of package count → Phase 1 cost unchanged.
- Phase 2 per-vuln fetches scale only with *new disclosures*, not the list size. Safely under the existing `OSV_MAX_DETAIL_FETCH = 15` cap (from #323 / PR #324).
- KV writes bounded by `security:seen:osv:{id}` — 7d TTL, incremental.

## Test plan

- [x] `cd worker && npm test` — 940/940 pass (5 new invariant tests)
- [x] `npm run build` — frontend builds clean
- [x] `npm run test:src` — 21/21 pass
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — passes (2726.22 KiB / gzip 1008.01 KiB)
- [x] Local verify at `localhost:5173` — user confirmed service detail pages for new services render normally
- [x] PR review auto-loop — Round 1 (1 Critical + 2 Important from test-analyzer) → fixes → Round 2 converged (0 Critical / 0 Important)

## New invariant tests

1. **No duplicate `(name, ecosystem)` pairs** — a duplicate would double-bill querybatch and duplicate alerts.
2. **Only PyPI/npm ecosystems** — catches the `"pypi"` lowercase typo that silently returns zero vulns.
3. **Non-empty name + service label** — tripwire for blank-row paste errors.
4. **Every `service` label is a key in the frontend `OSV_SERVICE_MAP`** — cross-layer invariant guarding the silent-drop regression where an unmapped service label makes alerts invisible on the service detail page.
5. **≥ 20 entries tripwire** — guards against a bad merge or mass-truncation that the other invariants would pass on any subset.

## Relationship to other PRs

- Branched from `main`, so this lands independent of PR #324 (two-phase fetch). Both edits touch `OSV_PACKAGES`; merging both will resolve cleanly since the additions here only append entries.
- #326 (EPSS enrichment) will build on top of whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)