### PR TITLE
feat: include security alerts in permanent monthly archive (#290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ When adding a new monitored service, update ALL of the following:
 | `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 | `incidents:monthly:{YYYY-MM}` | `MonthlyIncidents` JSON | 60d | 1/day | Monthly incident accumulation (deduped by ID, updated in daily summary cron) |
-| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service) |
+| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service). Also embeds optional `security: MonthlySecuritySummary \| null` (#290) — snapshotted from `security:monthly:*` before its 60d TTL expires, so historical reports retain security counts/top findings indefinitely. `null` on pre-#290 archives or when KV read/parse fails. |
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 
@@ -437,7 +437,7 @@ Cron Trigger (*/5 min)
   → alert count tracked in KV (alert:count:{date}) for Daily Summary
   → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75 + Detection Lead audit log (24h sliding window from today + yesterday keys)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
-  → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
+  → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* + security:monthly:* (#290) → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
   → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -7,8 +7,10 @@ import {
   buildMonthlyArchive,
   accumulateMonthlyIncidents,
   parseDurationMin,
+  summarizeSecurityMonth,
 } from '../monthly-archive'
 import type { ServiceStatus } from '../types'
+import type { SecurityAlertMeta } from '../security-monitor'
 
 // ── parseDurationMin ─────────────────────────────────────────────────
 
@@ -275,6 +277,103 @@ describe('accumulateMonthlyIncidents', () => {
   })
 })
 
+// ── summarizeSecurityMonth (#290) ───────────────────────────────────
+
+describe('summarizeSecurityMonth', () => {
+  function meta(partial: Partial<SecurityAlertMeta> & { title: string; url: string; source: string }): SecurityAlertMeta {
+    return { ...partial }
+  }
+
+  it('returns zeroed summary for empty input', () => {
+    const s = summarizeSecurityMonth([])
+    expect(s.totalAlerts).toBe(0)
+    expect(s.bySource).toEqual({ osv: 0, hackernews: 0 })
+    expect(s.bySeverity).toEqual({ critical: 0, high: 0, medium: 0, low: 0 })
+    expect(s.byService).toEqual({})
+    expect(s.topFindings).toEqual([])
+  })
+
+  it('counts by source, severity, and service', () => {
+    const alerts: SecurityAlertMeta[] = [
+      meta({ title: 'a', url: 'u1', source: 'osv', severity: 'critical', service: 'OpenAI', detectedAt: '2026-04-01T00:00:00Z' }),
+      meta({ title: 'b', url: 'u2', source: 'osv', severity: 'high', service: 'OpenAI', detectedAt: '2026-04-02T00:00:00Z' }),
+      meta({ title: 'c', url: 'u3', source: 'hackernews', severity: 'medium', service: 'Anthropic (Claude)', detectedAt: '2026-04-03T00:00:00Z' }),
+    ]
+    const s = summarizeSecurityMonth(alerts)
+    expect(s.totalAlerts).toBe(3)
+    expect(s.bySource).toEqual({ osv: 2, hackernews: 1 })
+    expect(s.bySeverity).toEqual({ critical: 1, high: 1, medium: 1, low: 0 })
+    expect(s.byService).toEqual({ 'OpenAI': 2, 'Anthropic (Claude)': 1 })
+  })
+
+  it('orders topFindings by severity desc, then by detectedAt desc', () => {
+    const alerts: SecurityAlertMeta[] = [
+      meta({ title: 'old-critical',   url: 'u1', source: 'osv', severity: 'critical', detectedAt: '2026-04-01T00:00:00Z' }),
+      meta({ title: 'new-critical',   url: 'u2', source: 'osv', severity: 'critical', detectedAt: '2026-04-15T00:00:00Z' }),
+      meta({ title: 'low',            url: 'u3', source: 'osv', severity: 'low',      detectedAt: '2026-04-20T00:00:00Z' }),
+      meta({ title: 'mid',            url: 'u4', source: 'osv', severity: 'medium',   detectedAt: '2026-04-10T00:00:00Z' }),
+    ]
+    const titles = summarizeSecurityMonth(alerts).topFindings.map(f => f.title)
+    expect(titles).toEqual(['new-critical', 'old-critical', 'mid', 'low'])
+  })
+
+  it('truncates topFindings to 10 entries even with more alerts present', () => {
+    // Generate 15 alerts — the constant is 10, so 5 must be dropped.
+    const alerts: SecurityAlertMeta[] = Array.from({ length: 15 }, (_, i) => meta({
+      title: `alert-${i}`,
+      url: `https://osv.dev/${i}`,
+      source: 'osv',
+      severity: 'high',
+      detectedAt: `2026-04-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    const s = summarizeSecurityMonth(alerts)
+    expect(s.totalAlerts).toBe(15)     // full count preserved
+    expect(s.topFindings).toHaveLength(10)
+  })
+
+  it('skips unknown severity and source values without throwing', () => {
+    // Defensive: a future schema might introduce a new severity label. We drop it
+    // from the counter buckets but still include it in topFindings with raw string.
+    const alerts: SecurityAlertMeta[] = [
+      meta({ title: 'x', url: 'u', source: 'osv', severity: 'bogus', detectedAt: '2026-04-01T00:00:00Z' }),
+      meta({ title: 'y', url: 'u2', source: 'new-source' as string, severity: 'low', detectedAt: '2026-04-02T00:00:00Z' }),
+    ]
+    const s = summarizeSecurityMonth(alerts)
+    expect(s.totalAlerts).toBe(2)
+    expect(s.bySource).toEqual({ osv: 1, hackernews: 0 }) // new-source dropped
+    expect(s.bySeverity.low).toBe(1)
+    expect(s.bySeverity.critical).toBe(0) // 'bogus' dropped, not mis-bucketed
+    // Low severity sorts above unknown in topFindings.
+    expect(s.topFindings[0].severity).toBe('low')
+  })
+
+  it('handles missing severity + service fields gracefully', () => {
+    const alerts: SecurityAlertMeta[] = [
+      meta({ title: 'no-sev', url: 'u', source: 'hackernews', detectedAt: '2026-04-01T00:00:00Z' }),
+    ]
+    const s = summarizeSecurityMonth(alerts)
+    expect(s.bySource).toEqual({ osv: 0, hackernews: 1 })
+    expect(s.byService).toEqual({})
+    expect(s.topFindings).toHaveLength(1)
+    expect(s.topFindings[0].severity).toBeUndefined()
+  })
+
+  it('sorts deterministically when one alert has no detectedAt (guards against localeCompare(undefined))', () => {
+    // `localeCompare` throws if its argument is literally `undefined` in some JS engines.
+    // The implementation uses `a.detectedAt ?? ''` so this is currently safe — this test
+    // is the tripwire if a future refactor drops the nullish coalescing.
+    const alerts: SecurityAlertMeta[] = [
+      meta({ title: 'timestamped', url: 'u1', source: 'osv', severity: 'high', detectedAt: '2026-04-10T00:00:00Z' }),
+      meta({ title: 'no-date',     url: 'u2', source: 'osv', severity: 'high' }), // detectedAt omitted
+    ]
+    expect(() => summarizeSecurityMonth(alerts)).not.toThrow()
+    const findings = summarizeSecurityMonth(alerts).topFindings
+    // Real timestamp sorts above '' under localeCompare desc — proves the fallback applies.
+    expect(findings[0].title).toBe('timestamped')
+    expect(findings[1].detectedAt).toBe('') // omitted becomes '' in the emitted shape
+  })
+})
+
 // ── buildMonthlyArchive ──────────────────────────────────────────────
 
 describe('buildMonthlyArchive', () => {
@@ -379,6 +478,104 @@ describe('buildMonthlyArchive', () => {
     expect(archive.period).toBe('2026-12')
     expect(archive.services.claude.incidents).toBe(2)
     expect(archive.services.claude.uptime).toBe(100)
+  })
+
+  it('populates security summary when security:monthly:{period} is present', async () => {
+    // Regression guard for #290: archive schema now carries the security summary.
+    // Verifies the KV read path + JSON parse + summarizeSecurityMonth all compose.
+    const kvWithSec = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-04') return JSON.stringify([
+          { title: 'Critical RCE in anthropic', url: 'https://osv.dev/1', source: 'osv', severity: 'critical', service: 'Anthropic (Claude)', detectedAt: '2026-04-05T10:00:00Z' },
+          { title: 'HN breach rumor', url: 'https://news.ycombinator.com/item?id=1', source: 'hackernews', detectedAt: '2026-04-10T08:00:00Z' },
+          { title: 'Medium path traversal', url: 'https://osv.dev/2', source: 'osv', severity: 'medium', service: 'OpenAI', detectedAt: '2026-04-02T14:00:00Z' },
+        ])
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(kvWithSec, 2026, 4)
+    expect(archive.security).not.toBeNull()
+    expect(archive.security?.totalAlerts).toBe(3)
+    expect(archive.security?.bySource).toEqual({ osv: 2, hackernews: 1 })
+    expect(archive.security?.bySeverity.critical).toBe(1)
+    expect(archive.security?.bySeverity.medium).toBe(1)
+    // Critical should sort above medium in topFindings
+    expect(archive.security?.topFindings[0].severity).toBe('critical')
+  })
+
+  it('sets security to null when security:monthly key is missing', async () => {
+    // Older archives (pre-#290) never wrote the key; the archive build must still succeed.
+    const noSecKV = {
+      get: async (key: string) => {
+        if (key === 'history:2026-04-01') return JSON.stringify({ claude: { ok: 288, total: 288 } })
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(noSecKV, 2026, 4)
+    expect(archive.security).toBeNull()
+    // Rest of the archive still populates normally.
+    expect(archive.daysCollected).toBe(1)
+  })
+
+  it('sets security to null when KV value is malformed JSON', async () => {
+    // Don't fail the whole monthly archive over optional security data.
+    const badSecKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-04') return '{corrupt'
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(badSecKV, 2026, 4)
+    expect(archive.security).toBeNull()
+  })
+
+  it('sets security to null when security:monthly KV.get rejects', async () => {
+    // The .catch(() => null) at the read site must swallow transient KV outages
+    // so the monthly archive — a once-a-month, foundational cron — still ships.
+    // Other archive fields (uptime/latency/incidents) should populate normally.
+    const rejectSecKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-04') throw new Error('KV temporarily unavailable')
+        if (key === 'history:2026-04-01') return JSON.stringify({ claude: { ok: 288, total: 288 } })
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(rejectSecKV, 2026, 4)
+    expect(archive.security).toBeNull()
+    expect(archive.daysCollected).toBe(1) // other reads succeeded
+  })
+
+  it('sets security to null when KV value is valid JSON but not an array', async () => {
+    // Future schema drift where someone writes an object-shaped payload must not
+    // crash on `.map` / `.sort` inside summarizeSecurityMonth.
+    const objSecKV = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-04') return '{"not":"an array"}'
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(objSecKV, 2026, 4)
+    expect(archive.security).toBeNull()
   })
 
   it('sets avgResolutionMin to null when totalMinutes is 0', async () => {

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -7,6 +7,7 @@
 // incident counts, unlike services:latest which is a point-in-time snapshot.
 
 import type { ProbeDailyData } from './probe-archival'
+import type { SecurityAlertMeta } from './security-monitor'
 import type { ServiceStatus, Incident } from './types'
 
 export type ScoreGrade = 'excellent' | 'good' | 'fair' | 'degrading' | 'unstable'
@@ -25,6 +26,88 @@ export interface MonthlyArchive {
   generatedAt: string            // ISO timestamp
   daysCollected: number          // number of days with actual uptime data
   services: Record<string, MonthlyServiceData>
+  // #290: nullable so archives generated before this feature shipped stay valid.
+  // null signals "no security data available" (missing KV, corrupt JSON, or
+  // pre-#290 archive); omit vs empty summary lets report renderers distinguish
+  // "truly 0 findings" (zeros in a populated summary) from "data unavailable".
+  security?: MonthlySecuritySummary | null
+}
+
+// ── Security summary (#290) ──────────────────────────────────────────
+
+export interface MonthlySecurityTopFinding {
+  title: string
+  url: string
+  source: string        // 'osv' | 'hackernews' (upstream `SecurityAlertMeta.source` is loosely typed)
+  severity?: string     // 'critical' | 'high' | 'medium' | 'low'
+  service?: string
+  detectedAt: string
+}
+
+export interface MonthlySecuritySummary {
+  totalAlerts: number
+  bySource: { osv: number; hackernews: number }
+  bySeverity: { critical: number; high: number; medium: number; low: number }
+  byService: Record<string, number>
+  topFindings: MonthlySecurityTopFinding[]   // sorted by severity desc, max 10
+}
+
+// Severity ordering for topFindings sort. Missing/unknown severity sorts lowest
+// so well-classified findings surface first in the monthly report.
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+}
+
+const TOP_FINDINGS_LIMIT = 10
+
+/**
+ * Pure aggregator: turn a month's worth of accumulated security alert metadata
+ * into the shape persisted into the permanent archive. Handles unknown
+ * `severity` and `source` values defensively (counts dropped, topFindings
+ * preserved with raw strings) so upstream schema drift never crashes the
+ * archive job — we'd rather ship a partial summary than no summary.
+ */
+export function summarizeSecurityMonth(alerts: SecurityAlertMeta[]): MonthlySecuritySummary {
+  const summary: MonthlySecuritySummary = {
+    totalAlerts: alerts.length,
+    bySource: { osv: 0, hackernews: 0 },
+    bySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    byService: {},
+    topFindings: [],
+  }
+
+  for (const a of alerts) {
+    if (a.source === 'osv' || a.source === 'hackernews') summary.bySource[a.source]++
+    if (a.severity && a.severity in summary.bySeverity) {
+      summary.bySeverity[a.severity as keyof typeof summary.bySeverity]++
+    }
+    if (a.service) {
+      summary.byService[a.service] = (summary.byService[a.service] ?? 0) + 1
+    }
+  }
+
+  summary.topFindings = [...alerts]
+    .sort((a, b) => {
+      const sa = SEVERITY_RANK[a.severity ?? ''] ?? 0
+      const sb = SEVERITY_RANK[b.severity ?? ''] ?? 0
+      if (sa !== sb) return sb - sa
+      // Severity tie: newest first so recent activity sorts above old stale findings.
+      return (b.detectedAt ?? '').localeCompare(a.detectedAt ?? '')
+    })
+    .slice(0, TOP_FINDINGS_LIMIT)
+    .map(a => ({
+      title: a.title,
+      url: a.url,
+      source: a.source,
+      severity: a.severity,
+      service: a.service,
+      detectedAt: a.detectedAt ?? '',
+    }))
+
+  return summary
 }
 
 // ── Incident accumulation (written daily by daily summary cron) ──────
@@ -232,6 +315,21 @@ export async function buildMonthlyArchive(
     }
   }
 
+  // #290: read accumulated security alerts (60d TTL) — null-safe because older
+  // archives never wrote this key. Parse errors degrade to null, not a throw;
+  // the rest of the archive is too valuable to sacrifice for optional data.
+  const secRaw = await kv.get(`security:monthly:${period}`).catch(() => null)
+  let security: MonthlySecuritySummary | null = null
+  if (secRaw) {
+    try {
+      const alerts = JSON.parse(secRaw) as SecurityAlertMeta[]
+      if (Array.isArray(alerts)) security = summarizeSecurityMonth(alerts)
+      else console.warn(`[monthly-archive] security:monthly:${period} is not an array, skipping`)
+    } catch (err) {
+      console.warn(`[monthly-archive] corrupt security accumulation for ${period}:`, err instanceof Error ? err.message : err)
+    }
+  }
+
   const uptimeMap = computeMonthlyUptime(dailyData)
   const latencyMap = computeMonthlyLatency(probeData)
 
@@ -275,6 +373,7 @@ export async function buildMonthlyArchive(
     generatedAt: new Date().toISOString(),
     daysCollected,
     services,
+    security,
   }
 }
 


### PR DESCRIPTION
refs #290

## Summary
- `security:monthly:{YYYY-MM}` (60d TTL) holds the running accumulation of HN + OSV security alerts for a given month, but its TTL means historical months lose their security data permanently.
- Extend `MonthlyArchive` (permanent, no TTL) to embed `security: MonthlySecuritySummary | null`, snapshotted at archive-generation time. Historical monthly reports can now render a security section indefinitely.
- Pure aggregator `summarizeSecurityMonth()` is independently testable and defensive against upstream schema drift — partial summary ships rather than crashing on unknown `severity` / `source`.

## Why `closes #290` was downgraded to `refs #290`
The issue's last checklist item — "Monthly reports template renders the new section" — lives in the `aiwatch-reports` repo (Jekyll site), not this repo. This PR delivers the full archive schema + generation + tests + docs; the reports template update is a follow-up PR against `aiwatch-reports`. Keeping the issue open until that lands.

## Shape

```ts
interface MonthlyArchive {
  period: string
  generatedAt: string
  daysCollected: number
  services: Record<string, MonthlyServiceData>
  security?: MonthlySecuritySummary | null  // NEW
}

interface MonthlySecuritySummary {
  totalAlerts: number
  bySource:   { osv: number; hackernews: number }
  bySeverity: { critical: number; high: number; medium: number; low: number }
  byService:  Record<string, number>
  topFindings: MonthlySecurityTopFinding[]  // severity desc, then detectedAt desc, max 10
}
```

**null vs populated-with-zeros** is a meaningful distinction: null = "data unavailable / pre-#290 archive / corrupt read"; zeros in a populated summary = "truly 0 findings this month". Report renderers consume both correctly via a single `if (archive.security) { … }` guard.

## Defensive behavior

| Input | `archive.security` |
|---|---|
| KV key missing (pre-#290 month) | `null` |
| `JSON.parse` throws (corrupt) | `null` |
| Valid JSON but not an array | `null` |
| `kv.get` rejects (transient outage) | `null` — other archive fields still populate |
| Unknown `severity` / `source` in alerts | Dropped from counts, preserved in `topFindings` raw |

## Cost impact
- One extra `kv.get('security:monthly:{period}')` per monthly archive build (1/month). Negligible.
- No new KV writes. The archive itself is already written 1/month at ~10-20 KB.

## Test plan
- [x] `cd worker && npm test` — 947/947 pass (12 new tests)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — passes (2726.49 KiB / gzip 1008.10 KiB)
- [x] Local `npx wrangler dev` → `/api/status` HTTP 200, `/api/report?month=YYYY-MM` unchanged read path (returns raw archive, field is append-only backward compatible)
- [x] PR review auto-loop — Round 1 (0 Critical + 2 Important from test-analyzer) → fixes → Round 2 converged (0/0)

## New tests (12)

**Unit — `summarizeSecurityMonth` (8)**:
- zeroed summary for empty input
- counts by source / severity / service
- sorts topFindings by severity desc, then detectedAt desc
- truncates to 10 with 15 input
- unknown severity + source values dropped without throwing
- missing severity + service fields handled
- undefined detectedAt tie-break (guards the `?? ''` fallback)

**Integration — `buildMonthlyArchive` (5)**:
- populated when `security:monthly:{period}` present
- null when key missing (pre-#290 months)
- null when malformed JSON
- null when non-array JSON
- null when `kv.get` rejects — other archive fields still populate

## Follow-up

- `aiwatch-reports` Jekyll template update to render the new Security section (separate PR against that repo)
- #291 (OSV-only per-alert timeline tracking) can now land on top of this schema — `MonthlySecurityTopFinding` will gain an optional `timeline?` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)