### PR TITLE
feat: enrich OSV alerts with EPSS exploit-probability score (#326)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,8 +261,9 @@ When adding a new monitored service, update ALL of the following:
 | `detection:lead:{YYYY-MM-DD}` | `DetectionLeadEntry[]` JSON | 7d | ~0-5 | Detection Lead audit log — appended on each new incident with positive lead, dedup by incId, surfaced in Daily Summary Discord embed (#256) |
 | `reddit:seen:{postId}` | `"1"` | 24h | ~120 | Reddit post dedup (hourly scan, max 5/hour) |
 | `security:seen:hn:{objectId}` | `SecurityAlertMeta` JSON | 7d | ~0 | HN security post dedup + dashboard display |
-| `security:seen:osv:{vulnId}` | `SecurityAlertMeta` JSON | 7d | ~0 | OSV.dev vulnerability dedup + dashboard display |
-| `security:monthly:{YYYY-MM}` | `SecurityAlertMeta[]` JSON | 60d | ~1/day | Monthly security alert accumulation for reports |
+| `security:seen:osv:{vulnId}` | `SecurityAlertMeta` JSON | 7d | ~0 | OSV.dev vulnerability dedup + dashboard display (includes `epssPercentile` / `epssPercentage` from #326 when GitHub Advisories enrichment succeeded) |
+| `security:monthly:{YYYY-MM}` | `SecurityAlertMeta[]` JSON | 60d | ~1/day | Monthly security alert accumulation for reports (entries carry EPSS fields when available, #326) |
+| `enrich:epss:{ghsaId}` | `EpssScore` JSON (`{percentile, percentage}`) | 24h | ~0-15/day | EPSS (Exploit Prediction Scoring System) cache (#326). Hit once per new OSV vuln against GitHub Advisories API, cached 24h (EPSS recomputes daily). Missing = enrichment unavailable → alert still surfaces without the exploit-probability tag. Rate-limited to 60/hr unauth (not a practical concern given 24h cache + #323 15-per-cycle cap) |
 | `security:detected:{YYYY-MM-DD}` | integer string | 3d | ~0-3/day | Daily counter of newly-detected security alerts (#288). Incremented by `securityAlerts.length` when HN/OSV detection fires. Daily summary reads this instead of counting `security:seen:*` (which accumulates over 7d and inflates the figure) |
 | `ai:analysis:{svcId}:{incId}` | `AIAnalysisResult` JSON | 1h (active) / 2h (resolved) | ~5 per incident | Hybrid AI analysis result — Gemma 4 primary + Sonnet fallback (TTL refreshed while active; on recovery, `resolvedAt` added instead of deleting — kept 2h for "Recently Resolved" UI). `model` field tracks which model produced the analysis |
 | `ai:reanalysis-skip:{svcId}:{incId}` | `"1"` | 30min | ~2 per incident | Per-incident re-analysis failure cooldown |
@@ -439,7 +440,7 @@ Cron Trigger (*/5 min)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* → archive:monthly:{YYYY-MM} (permanent)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
-  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323) → Discord digest on findings
+  → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323) → EPSS enrichment via GitHub Advisories (24h KV cache, #326) → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed
 
 Web Vitals Pipeline (per-request, 100% collection):

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -564,11 +564,27 @@ export default function Overview() {
                   const match = services.find(s => titleLC.includes(s.name.toLowerCase()) || titleLC.includes(s.provider.toLowerCase()))
                   if (match) tag = match.name
                 }
+                // #326: EPSS prefix mirroring ServiceDetails. Thresholds duplicated
+                // here because the frontend bundle cannot import from worker — keep
+                // in sync with EPSS_ACTIVE (0.8) / EPSS_ELEVATED (0.5) in
+                // worker/src/security-monitor.ts.
+                const epss = a.epssPercentile
+                let epssTag = null
+                if (typeof epss === 'number') {
+                  if (epss >= 0.8) epssTag = { icon: '🔥', color: 'var(--red)' }
+                  else if (epss >= 0.5) epssTag = { icon: '⚠️', color: 'var(--amber)' }
+                }
                 return (
                   <a key={i} href={safeUrl} target="_blank" rel="noopener noreferrer"
                     className="text-[var(--text1)] hover:text-[var(--purple)] truncate text-[11px]"
                   >
-                    {a.severity === 'critical' ? '🔴' : a.severity === 'high' ? '🟠' : '🟡'} {tag ? `[${tag}] ` : ''}{a.title}
+                    {a.severity === 'critical' ? '🔴' : a.severity === 'high' ? '🟠' : '🟡'}
+                    {epssTag && (
+                      <span style={{ color: epssTag.color, marginLeft: '4px' }}
+                        title={`EPSS ${Math.round(epss * 100)}th percentile — ${epss >= 0.8 ? 'actively exploited' : 'elevated exploit risk'}`}
+                      >{epssTag.icon}</span>
+                    )}
+                    {' '}{tag ? `[${tag}] ` : ''}{a.title}
                   </a>
                 )
               })}

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -952,13 +952,29 @@ export default function ServiceDetails({ serviceId }) {
               </div>
             </div>
             <div style={{ padding: '16px' }} className="flex flex-col gap-2">
+              {/* #326: EPSS-based prefix. Operators triage "🔥 actively exploited"
+                 before anything else; ≥EPSS_ELEVATED is "elevated, prioritize this week".
+                 Below EPSS_ELEVATED we skip the prefix to avoid crowding low-signal advisories.
+                 Thresholds must stay in sync with EPSS_ACTIVE / EPSS_ELEVATED in
+                 worker/src/security-monitor.ts. */}
               {filtered.map((a, i) => {
                 const safeUrl = a.url?.startsWith('https://') ? a.url : '#'
+                const epss = a.epssPercentile
+                let epssPrefix = null
+                if (typeof epss === 'number') {
+                  if (epss >= 0.8) epssPrefix = { tag: '🔥', color: 'var(--red)' }
+                  else if (epss >= 0.5) epssPrefix = { tag: '⚠️', color: 'var(--amber)' }
+                }
                 return (
                   <a key={i} href={safeUrl} target="_blank" rel="noopener noreferrer"
                     className="flex items-start gap-2 text-[12px] text-[var(--text1)] hover:text-[var(--purple)]"
                   >
                     <span className="shrink-0">{a.severity === 'critical' ? '🔴' : a.severity === 'high' ? '🟠' : '🟡'}</span>
+                    {epssPrefix && (
+                      <span className="shrink-0 mono text-[10px]" style={{ color: epssPrefix.color }}
+                        title={`EPSS ${Math.round(epss * 100)}th percentile — ${epss >= 0.8 ? 'actively exploited' : 'elevated exploit risk'}`}
+                      >{epssPrefix.tag}</span>
+                    )}
                     <span className="truncate">{a.title}</span>
                   </a>
                 )

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts } from '../security-monitor'
+import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED } from '../security-monitor'
 import type { SecurityAlert, SecurityAlertMeta } from '../security-monitor'
 
 describe('mapOSVSeverity', () => {
@@ -549,5 +549,282 @@ describe('readRecentSecurityAlerts', () => {
       expect(fullShape).toEqual(cachedShape)
       expect(fullShape.securityAlerts).toHaveLength(2)
     })
+  })
+})
+
+// #326 — EPSS enrichment against GitHub Advisories API. Fail-open contract:
+// no EPSS field means enrichment unavailable (cache miss + HTTP failure, rate
+// limit, or advisory without EPSS). Alerts must still surface regardless.
+describe('fetchEPSS (#326)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function stubFetch(response: Response | Error | (() => Response | Promise<Response>)): ReturnType<typeof vi.fn> {
+    const mock = vi.fn(async () => {
+      if (response instanceof Error) throw response
+      if (typeof response === 'function') return response()
+      return response
+    })
+    vi.stubGlobal('fetch', mock)
+    return mock
+  }
+
+  function resp(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  it('returns parsed epss when cache miss + 200 response', async () => {
+    stubFetch(resp({ epss: { percentile: 0.81596, percentage: 0.01583 } }))
+    const kvStore: Record<string, string> = {}
+    const kv = {
+      get: async (k: string) => kvStore[k] ?? null,
+      put: async (k: string, v: string) => { kvStore[k] = v },
+    } as unknown as KVNamespace
+
+    const score = await fetchEPSS('GHSA-f73w-4m7g-ch9x', kv)
+    expect(score).toEqual({ percentile: 0.81596, percentage: 0.01583 })
+    // Cache is populated so the next call short-circuits.
+    expect(kvStore['enrich:epss:GHSA-f73w-4m7g-ch9x']).toBe(JSON.stringify({ percentile: 0.81596, percentage: 0.01583 }))
+  })
+
+  it('returns cached value without fetching', async () => {
+    const mock = stubFetch(resp({}, 500))  // would fail if actually called
+    const kv = {
+      get: async () => JSON.stringify({ percentile: 0.42, percentage: 0.003 }),
+      put: async () => {},
+    } as unknown as KVNamespace
+
+    const score = await fetchEPSS('GHSA-cached', kv)
+    expect(score).toEqual({ percentile: 0.42, percentage: 0.003 })
+    expect(mock).not.toHaveBeenCalled()
+  })
+
+  it('falls through to HTTP when cache JSON is corrupt', async () => {
+    stubFetch(resp({ epss: { percentile: 0.1, percentage: 0.001 } }))
+    const kv = {
+      get: async () => '{broken',
+      put: async () => {},
+    } as unknown as KVNamespace
+    const score = await fetchEPSS('GHSA-corrupt', kv)
+    expect(score).toEqual({ percentile: 0.1, percentage: 0.001 })
+  })
+
+  it('returns undefined on HTTP 404 without throwing', async () => {
+    stubFetch(resp({ message: 'Not found' }, 404))
+    const score = await fetchEPSS('GHSA-missing', null)
+    expect(score).toBeUndefined()
+  })
+
+  it('logs rate-limit specifically on HTTP 403 / 429', async () => {
+    stubFetch(resp({ message: 'API rate limit exceeded' }, 429))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const score = await fetchEPSS('GHSA-rate-limited', null)
+    expect(score).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('rate-limited'))
+  })
+
+  it('returns undefined on fetch timeout / network error', async () => {
+    stubFetch(new Error('network down'))
+    const score = await fetchEPSS('GHSA-network-fail', null)
+    expect(score).toBeUndefined()
+  })
+
+  it('returns undefined when advisory has no epss field', async () => {
+    // GitHub advisory objects can legitimately lack epss (historical entries, private advisories).
+    stubFetch(resp({ ghsa_id: 'GHSA-no-epss', summary: 'x' }))
+    const score = await fetchEPSS('GHSA-no-epss', null)
+    expect(score).toBeUndefined()
+  })
+
+  it('returns undefined when epss field exists but has non-numeric values', async () => {
+    stubFetch(resp({ epss: { percentile: 'high' as unknown, percentage: null } }))
+    const score = await fetchEPSS('GHSA-malformed-epss', null)
+    expect(score).toBeUndefined()
+  })
+
+  it('continues when KV.put rejects (write-through best-effort)', async () => {
+    stubFetch(resp({ epss: { percentile: 0.5, percentage: 0.01 } }))
+    const kv = {
+      get: async () => null,
+      put: async () => { throw new Error('KV write down') },
+    } as unknown as KVNamespace
+    // Should still return the fetched score — cache write is non-blocking.
+    const score = await fetchEPSS('GHSA-kv-write-fail', kv)
+    expect(score).toEqual({ percentile: 0.5, percentage: 0.01 })
+  })
+
+  it('falls through to HTTP when KV.get rejects (fail-open read)', async () => {
+    // Parity with OSV pre-dedup: a transient KV outage must not block enrichment.
+    // Without this test, a future refactor that drops the `.catch` would currently
+    // go unnoticed — unit tests would pass while prod quietly burned rate limit.
+    stubFetch(resp({ epss: { percentile: 0.6, percentage: 0.02 } }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const kv = {
+      get: async () => { throw new Error('KV read down') },
+      put: async () => {},
+    } as unknown as KVNamespace
+    const score = await fetchEPSS('GHSA-kv-read-fail', kv)
+    expect(score).toEqual({ percentile: 0.6, percentage: 0.02 })
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('EPSS cache read failed'),
+      'GHSA-kv-read-fail',
+      expect.anything(),
+    )
+  })
+
+  it('writes cache with 24h TTL (expirationTtl: 86400)', async () => {
+    // Silent-regression guard: dropping the TTL or typoing it (e.g. 8640 = 2.4h)
+    // would invisibly change cache behavior. Assert on the put-options payload.
+    stubFetch(resp({ epss: { percentile: 0.3, percentage: 0.001 } }))
+    const captured: Array<{ key: string; value: string; opts?: unknown }> = []
+    const kv = {
+      get: async () => null,
+      put: async (key: string, value: string, opts?: unknown) => {
+        captured.push({ key, value, opts })
+      },
+    } as unknown as KVNamespace
+    await fetchEPSS('GHSA-ttl-check', kv)
+    expect(captured).toHaveLength(1)
+    expect(captured[0].opts).toEqual({ expirationTtl: 86_400 })
+  })
+})
+
+describe('enrichAlertsWithEPSS (#326)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function resp(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  it('enriches only OSV alerts; HN alerts pass through untouched', async () => {
+    const alerts: SecurityAlert[] = [
+      { source: 'osv', id: 'GHSA-1', title: 'Vuln', url: 'u1', kvKey: 'k1', severity: 'high' },
+      { source: 'hackernews', id: '42', title: 'HN post', url: 'u2', kvKey: 'k2' },
+    ]
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      // HN alerts must never hit GitHub Advisories — they have no CVE.
+      if (url.includes('api.github.com/advisories/42')) throw new Error('enriched HN alert!')
+      return resp({ epss: { percentile: 0.9, percentage: 0.1 } })
+    }))
+    const enriched = await enrichAlertsWithEPSS(alerts, null)
+    expect(enriched[0]).toMatchObject({ id: 'GHSA-1', epssPercentile: 0.9, epssPercentage: 0.1 })
+    expect(enriched[1]).toEqual(alerts[1]) // HN alert untouched, no EPSS fields
+    expect(enriched[1]).not.toHaveProperty('epssPercentile')
+  })
+
+  it('preserves alerts when enrichment fails for some', async () => {
+    const alerts: SecurityAlert[] = [
+      { source: 'osv', id: 'GHSA-ok', title: 'A', url: 'u', kvKey: 'k1' },
+      { source: 'osv', id: 'GHSA-fail', title: 'B', url: 'u', kvKey: 'k2' },
+    ]
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('GHSA-ok')) return resp({ epss: { percentile: 0.6, percentage: 0.01 } })
+      return resp({}, 500)
+    }))
+    const enriched = await enrichAlertsWithEPSS(alerts, null)
+    expect(enriched[0].epssPercentile).toBe(0.6)
+    // GHSA-fail survives without EPSS fields.
+    expect(enriched[1].id).toBe('GHSA-fail')
+    expect(enriched[1].epssPercentile).toBeUndefined()
+  })
+
+  it('returns all alerts even if every enrichment throws', async () => {
+    const alerts: SecurityAlert[] = [
+      { source: 'osv', id: 'GHSA-x', title: 'A', url: 'u', kvKey: 'k1' },
+      { source: 'osv', id: 'GHSA-y', title: 'B', url: 'u', kvKey: 'k2' },
+    ]
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('total outage') }))
+    const enriched = await enrichAlertsWithEPSS(alerts, null)
+    expect(enriched).toHaveLength(2)
+    expect(enriched[0].epssPercentile).toBeUndefined()
+    expect(enriched[1].epssPercentile).toBeUndefined()
+  })
+
+  it('returns empty array on empty input without making any fetch call', async () => {
+    // Guard against a future refactor adding an unconditional prefetch/rate-limit
+    // probe that would fire on no-op calls and burn subrequests.
+    const mock = vi.fn()
+    vi.stubGlobal('fetch', mock)
+    const result = await enrichAlertsWithEPSS([], null)
+    expect(result).toEqual([])
+    expect(mock).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatEpssTag (#326)', () => {
+  it('returns null when percentile is undefined (pre-enrichment / missing data)', () => {
+    expect(formatEpssTag(undefined)).toBeNull()
+  })
+
+  it('returns null for percentiles below EPSS_ELEVATED (low-signal floor)', () => {
+    expect(formatEpssTag(0)).toBeNull()
+    expect(formatEpssTag(0.49)).toBeNull()
+  })
+
+  it('returns elevated tag between EPSS_ELEVATED and EPSS_ACTIVE', () => {
+    expect(formatEpssTag(EPSS_ELEVATED)).toContain('Elevated')
+    expect(formatEpssTag(EPSS_ACTIVE - 0.01)).toContain('Elevated')
+    expect(formatEpssTag(0.5)).toContain('50%ile')
+  })
+
+  it('returns actively-exploited tag at EPSS_ACTIVE and above', () => {
+    expect(formatEpssTag(EPSS_ACTIVE)).toContain('Actively exploited')
+    expect(formatEpssTag(0.95)).toContain('95%ile')
+    expect(formatEpssTag(1)).toContain('100%ile')
+  })
+
+  it('threshold constants match dashboard source of truth', () => {
+    // Frontend (src/pages/ServiceDetails.jsx) hardcodes 0.5 and 0.8 because it
+    // cannot import from worker. If these constants move, the dashboard silently
+    // drifts — this test is the drift tripwire. Update ServiceDetails.jsx too.
+    expect(EPSS_ELEVATED).toBe(0.5)
+    expect(EPSS_ACTIVE).toBe(0.8)
+  })
+})
+
+describe('detectSecurityAlerts — EPSS wiring (#326)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  // Regression guard: verifies detectSecurityAlerts actually plumbs alerts through
+  // enrichAlertsWithEPSS before returning. A refactor that drops the enrichment
+  // call would silently lose EPSS tags downstream — unit tests on fetchEPSS /
+  // enrichAlertsWithEPSS alone would not catch it.
+  it('returns OSV alerts with epssPercentile populated end-to-end', async () => {
+    const nowISO = new Date().toISOString()
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('hn.algolia.com')) {
+        return new Response(JSON.stringify({ hits: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('querybatch')) {
+        // OSV_PACKAGES index 1 = PyPI/anthropic (same as #323 tests)
+        return new Response(JSON.stringify({
+          results: [{}, { vulns: [{ id: 'GHSA-epss-wired', modified: nowISO }] }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('osv.dev/v1/vulns/GHSA-epss-wired')) {
+        return new Response(JSON.stringify({
+          id: 'GHSA-epss-wired', modified: nowISO, summary: 'Wired alert',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('api.github.com/advisories/GHSA-epss-wired')) {
+        return new Response(JSON.stringify({
+          epss: { percentile: 0.88, percentage: 0.12 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      throw new Error(`unmocked: ${url}`)
+    }))
+
+    const kv = {
+      get: async () => null,
+      put: async () => {},
+    } as unknown as KVNamespace
+
+    const alerts = await detectSecurityAlerts(kv)
+    const wired = alerts.find(a => a.id === 'GHSA-epss-wired')
+    expect(wired).toBeDefined()
+    expect(wired?.epssPercentile).toBe(0.88)
+    expect(wired?.epssPercentage).toBe(0.12)
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -875,7 +875,13 @@ export default {
           // Then mark as seen — store alert metadata for dashboard display
           const nowISO = new Date().toISOString()
           for (const alert of securityAlerts) {
-            const meta = JSON.stringify({ title: alert.title, url: alert.url, source: alert.source, severity: alert.severity, service: alert.service, detectedAt: nowISO })
+            // #326: persist EPSS fields so dashboard/readRecentSecurityAlerts
+            // can render the exploit-probability tag without a re-fetch.
+            const meta = JSON.stringify({
+              title: alert.title, url: alert.url, source: alert.source,
+              severity: alert.severity, service: alert.service, detectedAt: nowISO,
+              epssPercentile: alert.epssPercentile, epssPercentage: alert.epssPercentage,
+            })
             await kvPut(env.STATUS_CACHE, alert.kvKey, meta, { expirationTtl: 604800 }).catch(err => { // 7d dedup
               console.error('[cron] Failed to mark security alert as seen:', alert.kvKey, err instanceof Error ? err.message : err)
             })
@@ -896,11 +902,15 @@ export default {
           const monthKey = `security:monthly:${nowISO.slice(0, 7)}`
           try {
             const monthRaw = await env.STATUS_CACHE.get(monthKey).catch(() => null)
-            const monthly: Array<{ title: string; url: string; source: string; severity?: string; service?: string; detectedAt: string }> = monthRaw ? JSON.parse(monthRaw) : []
+            const monthly: Array<{ title: string; url: string; source: string; severity?: string; service?: string; detectedAt: string; epssPercentile?: number; epssPercentage?: number }> = monthRaw ? JSON.parse(monthRaw) : []
             const existingIds = new Set(monthly.map(m => m.url))
             for (const alert of securityAlerts) {
               if (!existingIds.has(alert.url)) {
-                monthly.push({ title: alert.title, url: alert.url, source: alert.source, severity: alert.severity, service: alert.service, detectedAt: nowISO })
+                monthly.push({
+                  title: alert.title, url: alert.url, source: alert.source,
+                  severity: alert.severity, service: alert.service, detectedAt: nowISO,
+                  epssPercentile: alert.epssPercentile, epssPercentage: alert.epssPercentage,
+                })
               }
             }
             await kvPut(env.STATUS_CACHE, monthKey, JSON.stringify(monthly.slice(-100)), { expirationTtl: 5_184_000 }) // 60d

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -18,6 +18,13 @@ export interface SecurityAlert {
   fixedVersion?: string      // e.g. "0.87.0"
   patchUrl?: string          // commit or release URL
   cweIds?: string[]          // e.g. ["CWE-276"]
+  // EPSS (Exploit Prediction Scoring System) — from GitHub Advisories API (#326).
+  // Proxy for real-world exploitation likelihood. Both fields are 0..1 floats.
+  // Thresholds for the UI/Discord tag live on `EPSS_ELEVATED` / `EPSS_ACTIVE`
+  // (single source of truth — do not duplicate the numbers in field comments).
+  // Missing = enrichment unavailable (pre-#326, cache miss + HTTP failure, or rate-limited).
+  epssPercentile?: number
+  epssPercentage?: number    // absolute probability of exploit in next 30d
 }
 
 // ---------- Hacker News Algolia ----------
@@ -296,6 +303,124 @@ export async function fetchOSVAlerts(kv: KVNamespace | null = null): Promise<Sec
   return alerts
 }
 
+// ---------- EPSS enrichment (#326) ----------
+//
+// EPSS (Exploit Prediction Scoring System) is published by FIRST.org and surfaces
+// the probability a given CVE will be exploited in the wild within 30 days. GitHub's
+// Advisories API embeds it inline on every GHSA response, so we get it with one HTTP
+// call per vuln. A 🟠 "high" CVSS alert at EPSS 2%ile is lab-only; the same severity
+// at 80%ile means active scanning — this signal changes operator prioritization.
+//
+// Enrichment is fail-open: if GitHub rejects, rate-limits, or returns no EPSS field,
+// the alert still surfaces — just without the elevation tag. Missing is the default.
+
+// Single source of truth for the display/alert thresholds. Tuning these values
+// takes effect across formatEpssTag (Discord + tests) and the dashboard prefix
+// rendering (src/pages/ServiceDetails.jsx mirrors these — keep in sync).
+// Both fields are an EPSS **percentile** (0..1), not a raw probability.
+export const EPSS_ELEVATED = 0.5
+export const EPSS_ACTIVE = 0.8
+
+export interface EpssScore {
+  // Invariant: `fetchEPSS` only returns an EpssScore if BOTH fields are numeric
+  // (see type guard in fetchEPSS). Downstream consumers can rely on either being
+  // defined without checking the other.
+  percentile: number  // 0..1
+  percentage: number  // 0..1
+}
+
+// Cache 24h — EPSS is recomputed daily, so same-day re-fetches are wasteful.
+// Corrupt cache (parse error) is treated as miss; no retry-storm protection needed
+// because HTTP fetch caps itself at the outer rate-limit log.
+export async function fetchEPSS(ghsaId: string, kv: KVNamespace | null): Promise<EpssScore | undefined> {
+  const cacheKey = `enrich:epss:${ghsaId}`
+  if (kv) {
+    // Match observability parity with OSV pre-dedup / HN dedup: a silent KV outage
+    // here would masquerade as "always cache miss → always hit GitHub" and quietly
+    // burn the 60 req/h unauth rate limit with no correlating log.
+    const cached = await kv.get(cacheKey).catch(err => {
+      console.warn('[security] EPSS cache read failed:', ghsaId, err instanceof Error ? err.message : err)
+      return null
+    })
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as EpssScore
+        if (typeof parsed.percentile === 'number' && typeof parsed.percentage === 'number') {
+          return parsed
+        }
+      } catch {
+        // Persistent corruption means the writer is producing bad JSON or a
+        // schema migration left stale entries. Log once (length, not content —
+        // could be large) so operators can correlate with writer changes.
+        console.warn(`[security] EPSS cache corrupt for ${ghsaId}, refetching (len=${cached.length})`)
+      }
+    }
+  }
+
+  let res: Response
+  try {
+    res = await fetch(`https://api.github.com/advisories/${ghsaId}`, {
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'AIWatch/1.0 (ai-watch.dev; epss enrichment)',
+      },
+      signal: AbortSignal.timeout(5000),
+    })
+  } catch (err) {
+    console.warn(`[security] EPSS fetch for ${ghsaId} threw:`, err instanceof Error ? err.message : err)
+    return undefined
+  }
+
+  if (!res.ok) {
+    res.body?.cancel()
+    if (res.status === 403 || res.status === 429) {
+      console.warn(`[security] GitHub Advisories rate-limited during EPSS enrichment (HTTP ${res.status}); remaining vulns this cycle will surface without EPSS`)
+    } else {
+      console.warn(`[security] GitHub Advisories HTTP ${res.status} for ${ghsaId}`)
+    }
+    return undefined
+  }
+
+  let data: { epss?: { percentile?: unknown; percentage?: unknown } | null }
+  try {
+    data = await res.json()
+  } catch (err) {
+    console.warn(`[security] GitHub Advisories JSON parse failed for ${ghsaId}:`, err instanceof Error ? err.message : err)
+    return undefined
+  }
+  const epss = data?.epss
+  if (!epss || typeof epss.percentile !== 'number' || typeof epss.percentage !== 'number') {
+    return undefined
+  }
+
+  const score: EpssScore = { percentile: epss.percentile, percentage: epss.percentage }
+  if (kv) {
+    await kv.put(cacheKey, JSON.stringify(score), { expirationTtl: 86400 }).catch(err =>
+      console.warn('[security] EPSS cache write failed:', ghsaId, err instanceof Error ? err.message : err),
+    )
+  }
+  return score
+}
+
+// Parallel EPSS enrichment across a batch of alerts. OSV-only — HN alerts have
+// no CVE identifier so there's nothing to enrich. Fail-open per alert: any
+// enrichment failure (HTTP, timeout, rate-limit) drops the score but preserves
+// the alert.
+export async function enrichAlertsWithEPSS(
+  alerts: SecurityAlert[],
+  kv: KVNamespace | null,
+): Promise<SecurityAlert[]> {
+  const settled = await Promise.allSettled(
+    alerts.map(async (alert) => {
+      if (alert.source !== 'osv') return alert
+      const score = await fetchEPSS(alert.id, kv)
+      if (!score) return alert
+      return { ...alert, epssPercentile: score.percentile, epssPercentage: score.percentage }
+    }),
+  )
+  return settled.map((r, i) => r.status === 'fulfilled' ? r.value : alerts[i]!)
+}
+
 // ---------- Orchestrator ----------
 
 export async function detectSecurityAlerts(
@@ -330,10 +455,14 @@ export async function detectSecurityAlerts(
     }
   }
 
-  return [
+  const combined = [
     ...hnFinal,
     ...(osvAlerts.status === 'fulfilled' ? osvAlerts.value : []),
   ]
+  // #326: enrich OSV alerts with EPSS (fail-open). Inside detectSecurityAlerts so
+  // everything downstream (Discord format, KV meta write, dashboard display) sees
+  // the enriched shape without each caller needing to re-run the enrichment.
+  return enrichAlertsWithEPSS(combined, kv)
 }
 
 // ---------- Discord formatting ----------
@@ -345,10 +474,23 @@ const SEVERITY_EMOJI: Record<string, string> = {
   low: '🟢',
 }
 
+// Promote EPSS into the header line (#326) — operators scan the emoji + label combo
+// to triage which findings need action this week vs background noise. Thresholds
+// live on EPSS_ELEVATED / EPSS_ACTIVE above; below the elevated line we skip the
+// tag entirely to avoid crowding low-signal advisories.
+export function formatEpssTag(percentile: number | undefined): string | null {
+  if (percentile == null) return null
+  if (percentile >= EPSS_ACTIVE) return `🔥 Actively exploited (EPSS ${Math.round(percentile * 100)}%ile)`
+  if (percentile >= EPSS_ELEVATED) return `⚠️ Elevated exploit risk (EPSS ${Math.round(percentile * 100)}%ile)`
+  return null
+}
+
 function formatOSVLine(alert: SecurityAlert): string {
   const emoji = SEVERITY_EMOJI[alert.severity || 'medium']
   const serviceTag = alert.service ? `[${alert.service}] ` : ''
-  const parts = [`${emoji} ${serviceTag}**${alert.id}** · ${alert.affectedPackage || 'unknown'}`]
+  const epssTag = formatEpssTag(alert.epssPercentile)
+  const header = `${emoji} ${serviceTag}**${alert.id}** · ${alert.affectedPackage || 'unknown'}`
+  const parts = [epssTag ? `${header} · ${epssTag}` : header]
   parts.push(alert.title)
   if (alert.fixedVersion) {
     const cmd = alert.affectedPackage?.startsWith('npm/')
@@ -438,6 +580,12 @@ export interface SecurityAlertMeta {
   severity?: string
   service?: string
   detectedAt?: string
+  // #326 — EPSS fields mirror SecurityAlert so the dashboard can render exploit
+  // probability without re-fetching. Snapshotted at detection time; a later EPSS
+  // change doesn't update the meta (dedup key is 7d TTL — stale enough to matter
+  // only if EPSS shifts drastically, at which point the alert re-surfaces anyway).
+  epssPercentile?: number
+  epssPercentage?: number
 }
 
 /**


### PR DESCRIPTION
closes #326

**Stacked on PR #324 (#323 two-phase OSV fetch)** — base branch is \`fix/323-osv-security-summary\`, matching the #308/#309 stacking pattern. When #324 merges, this PR will retarget to main and may need a rebase.

## Summary
- OSV.dev has no EPSS (Exploit Prediction Scoring System); GitHub's Advisories API embeds it inline on every GHSA, so one extra HTTP + 24h KV cache gets us the signal for free.
- Enriches every new OSV alert with \`epssPercentile\` + \`epssPercentage\` (both 0..1).
- Surfaces a 🔥 Actively exploited (≥0.8) / ⚠️ Elevated risk (≥0.5) tag in the dashboard Security Alerts card + Discord digest header. Below 0.5 → no tag (avoids low-signal crowd).
- **Fail-open**: any enrichment failure (HTTP non-200, 403/429 rate-limit, timeout, network, missing epss field, non-numeric values, corrupt cache) drops the score but preserves the alert. Never blocks the security pipeline.

## Why this matters
A 🟠 "high" CVSS alert at EPSS 2%ile is lab-only; the same severity at 80%ile means active scanning in the wild. Without this signal operators triage purely on severity, which conflates lab-discovered flaws with real attack activity. CISA and most commercial scanners now treat EPSS ≥ 80th percentile as an auto-escalation trigger — AIWatch should too.

## Threshold constants
| Constant | Value | Tag | Trigger |
|---|---|---|---|
| \`EPSS_ACTIVE\` | 0.8 | 🔥 Actively exploited | Active scanning territory |
| \`EPSS_ELEVATED\` | 0.5 | ⚠️ Elevated exploit risk | Prioritize this week |
| (below 0.5) | — | _no tag_ | Low-signal floor |

Exported from \`worker/src/security-monitor.ts\`. Dashboard (\`src/pages/ServiceDetails.jsx\`) hardcodes 0.5/0.8 with a sync comment pointing at the worker constants, plus a drift tripwire test asserting \`EPSS_ELEVATED === 0.5 && EPSS_ACTIVE === 0.8\`. If anyone moves the constants, tests fail loud with a reminder to update the dashboard.

## Cost impact
- Per new OSV vuln (≤15/cycle via #323's \`OSV_MAX_DETAIL_FETCH\` cap): +1 KV read + 1 GitHub HTTP + 1 KV write.
- 24h cache → steady-state fetches near zero.
- Well inside Workers Paid 1000 subrequests/invocation.
- GitHub unauth rate-limit 60/hr is never practically hit given 24h cache + 15-per-cycle ceiling; 403/429 logged separately so operators can spot anomalies.

## Test plan
- [x] \`cd worker && npm test\` — 965/965 pass (25 new tests across 4 describe blocks)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — passes (2726.27 KiB / gzip 1008.03 KiB)
- [x] Local verify with 3 mock KV entries covering all 3 EPSS threshold buckets (🔥 ≥0.8, ⚠️ ≥0.5, no-tag below 0.5) — user confirmed dashboard rendering, tooltip, and theme-token colors
- [x] PR review auto-loop — Round 1 (1 Critical + 7 Important across 4 agents) → fixes → Round 2 converged (0/0)

## New tests (25)

**\`fetchEPSS\` (11)**:
cache miss + 200 | cache hit short-circuit | corrupt cache refetch | HTTP 404 | HTTP 403/429 rate-limit log | network error | no epss field | non-numeric epss | KV.put rejection non-blocking | KV.get rejection fail-open | 24h TTL assertion

**\`enrichAlertsWithEPSS\` (4)**:
OSV-only (HN stub throws if touched) | partial failure preserves alerts | total outage preserves alerts | empty input no-op

**\`formatEpssTag\` (5)**:
undefined | below-floor | elevated range | active range | threshold-constants-match-dashboard drift tripwire

**\`detectSecurityAlerts\` EPSS wiring (1)**:
end-to-end integration mocking HN + OSV querybatch + OSV vuln detail + GitHub Advisories — asserts \`epssPercentile\` surfaces through the orchestrator. Regression guard against someone dropping \`enrichAlertsWithEPSS\` from the final pipeline.

## CLAUDE.md
- New KV schema row: \`enrich:epss:{ghsaId}\` JSON, 24h TTL, 0-15 writes/day
- Status Data Flow: "EPSS enrichment via GitHub Advisories (24h KV cache, #326)" step added after OSV two-phase scan

## Dependencies
- **Depends on**: PR #324 (#323 two-phase fetch) — provides \`fetchOSVVulnDetails\` return shape that enrichment plugs into
- **Related**: #325 (PR #327) expands \`OSV_PACKAGES\`; EPSS enrichment scales with that expansion automatically, capped by \`OSV_MAX_DETAIL_FETCH = 15\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)