### PR TITLE
feat: admin endpoint to force Sonnet analysis on an active incident (#299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,9 +264,10 @@ When adding a new monitored service, update ALL of the following:
 | `security:seen:osv:{vulnId}` | `SecurityAlertMeta` JSON | 7d | ~0 | OSV.dev vulnerability dedup + dashboard display |
 | `security:monthly:{YYYY-MM}` | `SecurityAlertMeta[]` JSON | 60d | ~1/day | Monthly security alert accumulation for reports |
 | `security:detected:{YYYY-MM-DD}` | integer string | 3d | ~0-3/day | Daily counter of newly-detected security alerts (#288). Incremented by `securityAlerts.length` when HN/OSV detection fires. Daily summary reads this instead of counting `security:seen:*` (which accumulates over 7d and inflates the figure) |
-| `ai:analysis:{svcId}:{incId}` | `AIAnalysisResult` JSON | 1h (active) / 2h (resolved) | ~5 per incident | Hybrid AI analysis result — Gemma 4 primary + Sonnet fallback (TTL refreshed while active; on recovery, `resolvedAt` added instead of deleting — kept 2h for "Recently Resolved" UI). `model` field tracks which model produced the analysis |
+| `ai:analysis:{svcId}:{incId}` | `AIAnalysisResult` JSON | 1h (active) / 2h (resolved) | ~5 per incident | Hybrid AI analysis result — Gemma 4 primary + Sonnet fallback (TTL refreshed while active; on recovery, `resolvedAt` added instead of deleting — kept 2h for "Recently Resolved" UI). `model` field tracks which model produced the analysis. `sticky: true` (#299) marks a manual operator override — cron skips re-analysis and only refreshes TTL; cleared naturally when incident resolves |
 | `ai:reanalysis-skip:{svcId}:{incId}` | `"1"` | 30min | ~2 per incident | Per-incident re-analysis failure cooldown |
-| `ai:usage:{YYYY-MM-DD}` | `{ calls, success, failed, gemma?, sonnet? }` JSON | 2d | ~5 | Daily AI analysis usage counter (includes re-analysis, model breakdown) |
+| `ai:usage:{YYYY-MM-DD}` | `{ calls, success, failed, gemma?, sonnet? }` JSON | 2d | ~5 | Daily AI analysis usage counter (includes re-analysis, model breakdown). Manual `/api/admin/analyze` (#299) calls also increment here so the daily summary attributes them |
+| `admin:ratelimit:{hash}` | `"1"` | 60s | ~0-10/day | Per-incident rate limit for `POST /api/admin/analyze` (#299). `hash` = first 128 bits of SHA-256 of `{svcId}:{incidentId}`. Hashed rather than raw to avoid leaking incident IDs via `kv list` even though the endpoint is secret-gated |
 | `fetch-fail:{svcId}` | counter string | 30min | ~0 (spikes on outage) | RSS fetch consecutive failure counter (3+ → degraded, capped writes) |
 | `component-missing:{svcId}` | counter string | 30min | ~0 (spikes on migration) | Component ID consecutive miss counter (3+ → Discord alert) |
 | `alerted:component-missing:{svcId}` | `"1"` | 24h | ~0 | Component ID mismatch alert dedup |
@@ -482,7 +483,26 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
     npm run deploy:worker
     ```
   - Verify the output says `Uploaded aiwatch-worker` (not `aiwatch`)
-  - Endpoints: `GET /api/status`, `GET /api/status/cached` (KV-only, includes probe24h, for SSR + initial load), `GET /api/uptime?days=30`, `GET /api/probe/history?days=30` (daily probe RTT summaries, 90d max), `GET /api/report?month=YYYY-MM` (monthly archive JSON, permanent), `POST /api/alert`, `GET /badge/:serviceId`, `GET /api/og` (dynamic OG image PNG), `GET /api/v1/status`
+  - Endpoints: `GET /api/status`, `GET /api/status/cached` (KV-only, includes probe24h, for SSR + initial load), `GET /api/uptime?days=30`, `GET /api/probe/history?days=30` (daily probe RTT summaries, 90d max), `GET /api/report?month=YYYY-MM` (monthly archive JSON, permanent), `POST /api/alert`, `POST /api/admin/analyze` (#299 — operator Sonnet override, `X-Admin-Key` required, sets `sticky: true` so cron doesn't auto-replace), `GET /badge/:serviceId`, `GET /api/og` (dynamic OG image PNG), `GET /api/v1/status`
+  - **Operator tools — `POST /api/admin/analyze` (#299)**: Force a Sonnet analysis on a specific active incident when the cron's default (Gemma-first) produced low-signal output. Motivated by the 2026-04-20 ChatGPT outage where Gemma called a systemic infra failure a "service availability issue". Before this endpoint the override required hand-editing a local Node script + `wrangler kv key put --remote`.
+
+    ```bash
+    # One-time secret setup (do NOT commit the value anywhere)
+    npx wrangler secret put ADMIN_API_KEY --config worker/wrangler.toml
+
+    # During an outage — force a Sonnet analysis on the active incident
+    export ADMIN_API_KEY=...  # paste locally from 1Password / keychain
+    curl -X POST https://aiwatch-worker.p2c2kbf.workers.dev/api/admin/analyze \
+      -H "X-Admin-Key: $ADMIN_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"svcId":"chatgpt","incidentId":"01KPNN2V2SMP3TAN3MCJK87W50"}'
+    ```
+
+    **Request body** (JSON): `svcId` (required), `incidentId` (required, must be an active incident present in `services:latest`), `model` (`'sonnet' | 'gemma'`, default `'sonnet'`), `sticky` (default `true` — cron skips re-analysis until the incident resolves).
+
+    **Response**: `{ ok: true, wrote, ttl, analysis }` on 200. Failure modes: 401 `unauthorized` (missing/wrong `X-Admin-Key` — never leaks whether the secret is even configured), 400 (malformed body), 404 (IDs don't match an active incident — scope guard against arbitrary KV writes), 429 (1-req-per-60s-per-incident rate limit via `admin:ratelimit:{hash}`), 502 (upstream model failure or unparseable response), 503 (`ANTHROPIC_API_KEY` not configured).
+
+    **Security posture**: the endpoint accepts only IDs that match an active incident in `services:latest`, so a leaked secret can't be used to write arbitrary `ai:analysis:*` keys. Per-incident rate limit bounds damage to ~1 Sonnet call per incident per minute ≈ $0.01-level cost. Rotate `ADMIN_API_KEY` independently of `ANTHROPIC_API_KEY` if ever suspected compromised. Never paste the secret value into issues, PR bodies, or commit messages — only the variable name `$ADMIN_API_KEY` should appear in docs.
   - **Cron Trigger**: `*/5 * * * *` — alert detection runs every 5 minutes via scheduled handler (not per-request). Uses KV ID-based dedup (`alerted:new/res:` keys 7d TTL, `alerted:down/degraded/recovered:` keys 2h TTL). Fallback recommendations only included when service status is degraded/down (not operational). AI analysis runs inline with 8s timeout — Gemma 4 26B (Workers AI) primary, Sonnet (AI Gateway) fallback — results stored in `ai:analysis:{svcId}:{incId}` (1h TTL, per-incident). Daily alert counts tracked in `alert:count:{date}` for Daily Summary
 - **Frontend deployment**: Vercel, domain ai-watch.dev — `git push origin main` triggers auto-deploy. `npm run build` is local only; changes are not live until pushed
 - **PWA**: `public/manifest.json` + `public/sw.js` (stale-while-revalidate). CACHE_NAME in `sw.js` must be bumped manually when static assets change. SW excludes `/is-*` (Edge SSR) and `/api/*` (real-time data) from caching

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -6,3 +6,8 @@ DISCORD_WEBHOOK_URL=
 
 # Anthropic API key for AI incident analysis (optional — analysis disabled if empty)
 ANTHROPIC_API_KEY=
+
+# Operator secret for POST /api/admin/analyze (#299). Leave empty to disable the
+# endpoint (requests will 401). Rotate independently of ANTHROPIC_API_KEY.
+# Production: `npx wrangler secret put ADMIN_API_KEY`
+ADMIN_API_KEY=

--- a/worker/src/__tests__/admin-analyze.test.ts
+++ b/worker/src/__tests__/admin-analyze.test.ts
@@ -1,0 +1,384 @@
+// #299 — admin-only endpoint to force a Sonnet analysis on a specific active
+// incident. Tests cover the four documented failure modes (auth, scope, rate
+// limit, upstream fail) plus happy path.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import workerModule, { constantTimeEqual, adminRateLimitKey, isStickyExistingAnalysis } from '../index'
+import type { ServiceStatus, Incident } from '../types'
+
+// In-memory KV with spies for assertion.
+function makeKV(initial: Record<string, string> = {}) {
+  const store = { ...initial }
+  return {
+    store,
+    kv: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string, _opts?: unknown) => { store[k] = v }),
+      delete: vi.fn(async (k: string) => { delete store[k] }),
+      list: vi.fn(async () => ({ keys: Object.keys(store).map(name => ({ name })), list_complete: true, cacheStatus: null })),
+    } as unknown as KVNamespace,
+  }
+}
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  return {
+    id: 'inc-abc',
+    title: 'Elevated error rates',
+    status: 'investigating',
+    impact: 'major',
+    startedAt: '2026-04-20T10:00:00Z',
+    resolvedAt: null,
+    duration: null,
+    timeline: [{ stage: 'investigating', text: 'Initial report', at: '2026-04-20T10:00:00Z' }],
+    ...overrides,
+  }
+}
+
+function makeService(overrides: Partial<ServiceStatus> = {}): ServiceStatus {
+  return {
+    id: 'chatgpt',
+    name: 'ChatGPT',
+    provider: 'OpenAI',
+    status: 'degraded',
+    latency: null,
+    lastChecked: '2026-04-20T10:00:00Z',
+    incidents: [makeIncident()],
+    ...overrides,
+  }
+}
+
+function seedServicesLatest(store: Record<string, string>, services: ServiceStatus[]) {
+  store['services:latest'] = JSON.stringify({ services, cachedAt: new Date().toISOString() })
+}
+
+function envWith(opts: { adminKey?: string; anthropicKey?: string; kv: KVNamespace }) {
+  return {
+    ALLOWED_ORIGIN: '*',
+    STATUS_CACHE: opts.kv,
+    ANTHROPIC_API_KEY: opts.anthropicKey,
+    ADMIN_API_KEY: opts.adminKey,
+  } as Parameters<typeof workerModule.fetch>[1]
+}
+
+function req(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/admin/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  })
+}
+
+const mockSonnetResult = {
+  summary: 'Systemic infrastructure failure across API Platform',
+  estimatedRecovery: '1–2h',
+  estimatedRecoveryHours: 2,
+  affectedScope: ['API', 'ChatGPT'],
+  needsFallback: true,
+  analyzedAt: '2026-04-20T10:15:00Z',
+  incidentId: 'inc-abc',
+  model: 'sonnet' as const,
+}
+
+describe('constantTimeEqual (#299)', () => {
+  it('returns true for equal strings', () => {
+    expect(constantTimeEqual('secret-xyz', 'secret-xyz')).toBe(true)
+  })
+  it('returns false for length mismatch', () => {
+    expect(constantTimeEqual('abc', 'abcd')).toBe(false)
+  })
+  it('returns false for same-length different strings', () => {
+    expect(constantTimeEqual('secret-xyz', 'secret-abc')).toBe(false)
+  })
+  it('returns true for two empty strings', () => {
+    // Defensive: env.ADMIN_API_KEY missing would be rejected earlier; but the
+    // comparator itself should handle the edge case without special-casing.
+    expect(constantTimeEqual('', '')).toBe(true)
+  })
+})
+
+describe('isStickyExistingAnalysis (#299)', () => {
+  // Guard for the cron new-incident write path (symmetric with refreshOrReanalyze).
+  // Without this check, a manual /api/admin/analyze call that lands between two
+  // cron cycles for a brand-new incident would get clobbered by the cron's
+  // default Gemma-first write.
+  it('returns true when existing analysis has sticky=true', () => {
+    expect(isStickyExistingAnalysis(JSON.stringify({ summary: 'x', sticky: true }))).toBe(true)
+  })
+  it('returns false when existing analysis is sticky=false', () => {
+    expect(isStickyExistingAnalysis(JSON.stringify({ summary: 'x', sticky: false }))).toBe(false)
+  })
+  it('returns false when sticky field is absent (not a truthy check)', () => {
+    expect(isStickyExistingAnalysis(JSON.stringify({ summary: 'x' }))).toBe(false)
+  })
+  it('returns false on null/empty input (no existing analysis)', () => {
+    expect(isStickyExistingAnalysis(null)).toBe(false)
+    expect(isStickyExistingAnalysis('')).toBe(false)
+  })
+  it('returns false on corrupt JSON — does not lock the key during parse failures', () => {
+    // Safer default: if JSON is corrupt we DON'T want to be stuck with a dead-sticky
+    // payload that can never be overwritten. Treat as non-sticky and let the cron
+    // proceed with its normal write.
+    expect(isStickyExistingAnalysis('{not json')).toBe(false)
+  })
+  it('ignores truthy but non-literal-true values (sticky: "yes" not equal to true)', () => {
+    // Strict `=== true` — avoids accidentally sticking on typos or legacy payloads
+    // where the field might be 1 / "true" / "yes".
+    expect(isStickyExistingAnalysis(JSON.stringify({ sticky: 1 }))).toBe(false)
+    expect(isStickyExistingAnalysis(JSON.stringify({ sticky: 'true' }))).toBe(false)
+  })
+})
+
+describe('adminRateLimitKey (#299)', () => {
+  it('produces a stable admin:ratelimit: prefixed key', async () => {
+    const k = await adminRateLimitKey('chatgpt', 'inc-abc')
+    expect(k.startsWith('admin:ratelimit:')).toBe(true)
+    // 32 hex chars after prefix (we truncate to 128-bit — 32 hex digits).
+    expect(k.length).toBe('admin:ratelimit:'.length + 32)
+  })
+  it('is deterministic for the same input', async () => {
+    const a = await adminRateLimitKey('svc', 'inc')
+    const b = await adminRateLimitKey('svc', 'inc')
+    expect(a).toBe(b)
+  })
+  it('differs for different inputs', async () => {
+    const a = await adminRateLimitKey('svc', 'inc-1')
+    const b = await adminRateLimitKey('svc', 'inc-2')
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('POST /api/admin/analyze (#299)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns 401 when ADMIN_API_KEY is not configured', async () => {
+    const { kv } = makeKV()
+    const env = envWith({ kv })
+    const res = await workerModule.fetch(req({}), env, {} as ExecutionContext)
+    expect(res.status).toBe(401)
+    const body = await res.json() as { ok: boolean; error: string }
+    expect(body).toEqual({ ok: false, error: 'unauthorized' })
+  })
+
+  it('returns 401 when X-Admin-Key is missing or wrong', async () => {
+    const { kv } = makeKV()
+    const env = envWith({ adminKey: 'correct-key', kv })
+    // Missing header
+    const res1 = await workerModule.fetch(req({}), env, {} as ExecutionContext)
+    expect(res1.status).toBe(401)
+    // Wrong header
+    const res2 = await workerModule.fetch(req({}, { 'X-Admin-Key': 'wrong' }), env, {} as ExecutionContext)
+    expect(res2.status).toBe(401)
+  })
+
+  it('returns 503 when ANTHROPIC_API_KEY is missing', async () => {
+    const { kv } = makeKV()
+    const env = envWith({ adminKey: 'k', kv })  // no anthropicKey
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(503)
+  })
+
+  it('returns 400 when svcId or incidentId is missing', async () => {
+    const { kv } = makeKV()
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when incident is not in services:latest (scope guard)', async () => {
+    // Scope guard: prevent admin endpoint from writing arbitrary KV keys even if
+    // the secret leaks — the IDs must match something the cron is actively tracking.
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])  // only inc-abc is active
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'FAKE-ID' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(404)
+
+    // Rate-limit key MUST NOT be written for non-accepting paths — a future
+    // refactor that moved the write above the scope guard would let an attacker
+    // enumerate incident IDs by watching for 429s.
+    const rlKey = await adminRateLimitKey('chatgpt', 'FAKE-ID')
+    expect(store[rlKey]).toBeUndefined()
+  })
+
+  it('returns 404 when services:latest is missing (cold KV)', async () => {
+    const { kv } = makeKV()  // no services:latest seeded
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when incident is already resolved (must be active)', async () => {
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService({ incidents: [makeIncident({ status: 'resolved' })] })])
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 429 when rate limit key is already present', async () => {
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    // Pre-seed the rate-limit key for this svcId+incidentId.
+    const rlKey = await adminRateLimitKey('chatgpt', 'inc-abc')
+    store[rlKey] = '1'
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(429)
+  })
+
+  it('happy path — writes analysis with sticky=true and bumps ai:usage counter', async () => {
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    // Stub the Sonnet fetch so we don't hit AI Gateway.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({
+        summary: mockSonnetResult.summary,
+        estimatedRecovery: mockSonnetResult.estimatedRecovery,
+        affectedScope: mockSonnetResult.affectedScope,
+        needsFallback: mockSonnetResult.needsFallback,
+      }) }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { ok: boolean; wrote: string; ttl: number; analysis: { sticky?: boolean; model?: string } }
+    expect(body.ok).toBe(true)
+    expect(body.wrote).toBe('ai:analysis:chatgpt:inc-abc')
+    expect(body.ttl).toBe(3600)
+    expect(body.analysis.sticky).toBe(true)
+    expect(body.analysis.model).toBe('sonnet')
+
+    // KV assertions — analysis persisted, rate-limit key written, ai:usage incremented.
+    expect(store['ai:analysis:chatgpt:inc-abc']).toContain('sticky')
+    const rlKey = await adminRateLimitKey('chatgpt', 'inc-abc')
+    expect(store[rlKey]).toBe('1')
+    const usageKey = Object.keys(store).find(k => k.startsWith('ai:usage:'))
+    expect(usageKey).toBeDefined()
+    const usage = JSON.parse(store[usageKey!])
+    expect(usage.calls).toBe(1)
+    expect(usage.success).toBe(1)
+    expect(usage.sonnet).toBe(1)
+  })
+
+  it('honors sticky=false override — writes analysis without sticky field', async () => {
+    // Operator can opt out if they want the analysis to be auto-refreshable by the cron.
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({
+        summary: 'S', estimatedRecovery: '1h', affectedScope: ['API'], needsFallback: false,
+      }) }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(
+      req({ svcId: 'chatgpt', incidentId: 'inc-abc', sticky: false }, { 'X-Admin-Key': 'k' }),
+      env, {} as ExecutionContext,
+    )
+    expect(res.status).toBe(200)
+    const persisted = JSON.parse(store['ai:analysis:chatgpt:inc-abc'])
+    // `sticky` should be undefined (not persisted), NOT set to false — matches the
+    // "absent = not sticky" convention already used on other optional boolean fields.
+    expect(persisted.sticky).toBeUndefined()
+  })
+
+  it('returns 502 when Sonnet returns null (upstream parse failure)', async () => {
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    // Respond with garbage that will fail parseAnalysisResponse.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: 'not-json' }],
+    }), { status: 200 })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(502)
+  })
+
+  it('preserves pre-seeded ai:usage counters — increments rather than overwrites', async () => {
+    // Regression guard: `usage = usageRaw ? JSON.parse(raw) : {...}` must read
+    // existing counts. A regression to always-init would erase the day's running
+    // tally from the cron's own AI calls.
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    const today = new Date().toISOString().slice(0, 10)
+    store[`ai:usage:${today}`] = JSON.stringify({ calls: 5, success: 4, failed: 1, gemma: 2, sonnet: 2 })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({
+        summary: 'S', estimatedRecovery: '1h', affectedScope: [], needsFallback: false,
+      }) }],
+    }), { status: 200 })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(req({ svcId: 'chatgpt', incidentId: 'inc-abc' }, { 'X-Admin-Key': 'k' }), env, {} as ExecutionContext)
+    expect(res.status).toBe(200)
+    const usage = JSON.parse(store[`ai:usage:${today}`])
+    expect(usage.calls).toBe(6)    // 5 + 1
+    expect(usage.success).toBe(5)  // 4 + 1
+    expect(usage.sonnet).toBe(3)   // 2 + 1
+    expect(usage.failed).toBe(1)   // unchanged
+    expect(usage.gemma).toBe(2)    // unchanged
+  })
+
+  it('falls back to sonnet on unrecognized model value (not strict enum)', async () => {
+    // `body.model === 'gemma' ? 'gemma' : 'sonnet'` — any non-'gemma' value
+    // defaults to sonnet. Intentional (operator typos don't fail the call),
+    // but untested until now.
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({
+        summary: 'S', estimatedRecovery: '1h', affectedScope: [], needsFallback: false,
+      }) }],
+    }), { status: 200 })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(
+      req({ svcId: 'chatgpt', incidentId: 'inc-abc', model: 'sonnet4' }, { 'X-Admin-Key': 'k' }),
+      env, {} as ExecutionContext,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as { analysis: { model?: string } }
+    expect(body.analysis.model).toBe('sonnet')
+  })
+
+  it('accepts explicit sticky=true identically to default', async () => {
+    // Default is `sticky === false ? false : true` — explicit `true` must take
+    // the same branch so a future refactor to tri-state doesn't silently change
+    // the operator-facing contract.
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({
+        summary: 'S', estimatedRecovery: '1h', affectedScope: [], needsFallback: false,
+      }) }],
+    }), { status: 200 })))
+
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(
+      req({ svcId: 'chatgpt', incidentId: 'inc-abc', sticky: true }, { 'X-Admin-Key': 'k' }),
+      env, {} as ExecutionContext,
+    )
+    expect(res.status).toBe(200)
+    const persisted = JSON.parse(store['ai:analysis:chatgpt:inc-abc'])
+    expect(persisted.sticky).toBe(true)
+  })
+
+  it('returns 400 on malformed JSON body', async () => {
+    const { kv, store } = makeKV()
+    seedServicesLatest(store, [makeService()])
+    const env = envWith({ adminKey: 'k', anthropicKey: 'sk-test', kv })
+    const res = await workerModule.fetch(
+      new Request('https://example.com/api/admin/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Admin-Key': 'k' },
+        body: 'not-json',
+      }),
+      env, {} as ExecutionContext,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string }
+    expect(body.error).toBe('invalid JSON body')
+  })
+})

--- a/worker/src/__tests__/ai-analysis.test.ts
+++ b/worker/src/__tests__/ai-analysis.test.ts
@@ -1291,3 +1291,102 @@ describe('analyzeIncident — hybrid fallback', () => {
     expect(result).toBeNull()
   })
 })
+
+// #299 — sticky flag: manual operator overrides must survive the cron's
+// Gemma-first re-analysis path. refreshOrReanalyze should only refresh TTL.
+describe('refreshOrReanalyze — sticky analyses (#299)', () => {
+  it('skips re-analysis when existing analysis has sticky=true (only refreshes TTL)', async () => {
+    // 3h-old analysis would normally trigger the 2h age-based re-analysis branch.
+    // sticky=true must short-circuit BEFORE that check.
+    const stickyAnalysis = {
+      ...mockAnalysis,
+      analyzedAt: '2026-03-27T03:00:00Z',  // 3h old
+      sticky: true,
+      model: 'sonnet',
+    }
+    const store: Record<string, string> = {
+      [analysisKey('claude', 'inc-1')]: JSON.stringify(stickyAnalysis),
+    }
+    const kv = mockKV(store)
+    const svc = mockService('claude', [{
+      id: 'inc-1', status: 'investigating',
+      // New timeline entry that would normally trigger re-analysis.
+      timeline: [{ stage: 'identified', text: 'Root cause: pool exhaustion', at: '2026-03-27T05:30:00Z' }],
+    }])
+    const analyzeFn = vi.fn()
+
+    const now = new Date('2026-03-27T06:00:00Z').getTime()
+    const result = await refreshOrReanalyze([svc], kv, 'api-key', analyzeFn, 2, now)
+
+    expect(analyzeFn).not.toHaveBeenCalled()
+    expect(result.refreshed).toEqual(['claude'])
+    expect(result.reanalyzed).toEqual([])
+    // Persisted payload still sticky + no overwrite of summary/model.
+    const persisted = JSON.parse(store[analysisKey('claude', 'inc-1')])
+    expect(persisted.sticky).toBe(true)
+    expect(persisted.model).toBe('sonnet')
+    expect(persisted.summary).toBe('Test analysis')
+  })
+
+  it('still updates _lastRefresh when sticky', async () => {
+    // Even though we skip re-analysis, the 1h TTL needs refreshing so the key
+    // doesn't expire mid-incident.
+    const stickyAnalysis = { ...mockAnalysis, sticky: true }
+    const store: Record<string, string> = {
+      [analysisKey('chatgpt', 'inc-x')]: JSON.stringify(stickyAnalysis),
+    }
+    const kv = mockKV(store)
+    const svc = mockService('chatgpt', [{ id: 'inc-x', status: 'investigating' }])
+
+    await refreshOrReanalyze([svc], kv, 'key', vi.fn(), 2)
+
+    const persisted = JSON.parse(store[analysisKey('chatgpt', 'inc-x')])
+    expect(persisted._lastRefresh).toBeDefined()
+    // Assert the KV.put was called with the 1h TTL so the key can't silently leak past resolution.
+    expect(kv.put).toHaveBeenCalledWith(
+      analysisKey('chatgpt', 'inc-x'),
+      expect.stringContaining('sticky'),
+      { expirationTtl: 3600 },
+    )
+  })
+
+  it('non-sticky analyses follow the existing re-analysis path (regression guard)', async () => {
+    // If someone accidentally inverts the sticky check, non-sticky would be
+    // treated as sticky and never re-analyzed — this test catches that.
+    const oldAnalysis = { ...mockAnalysis, analyzedAt: '2026-03-27T03:00:00Z' } // 3h old, no sticky
+    const store: Record<string, string> = {
+      [analysisKey('claude', 'inc-1')]: JSON.stringify(oldAnalysis),
+    }
+    const kv = mockKV(store)
+    const svc = mockService('claude', [{
+      id: 'inc-1', status: 'investigating',
+      timeline: [{ stage: 'identified', text: 'Root cause identified', at: '2026-03-27T05:30:00Z' }],
+    }])
+    const analyzeFn = vi.fn().mockResolvedValue({ ...mockAnalysis, model: 'gemma' })
+
+    const now = new Date('2026-03-27T06:00:00Z').getTime()
+    await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2, now)
+
+    expect(analyzeFn).toHaveBeenCalledOnce()
+  })
+
+  it('corrupt sticky-analysis JSON falls through to normal re-analysis (does not lock incident)', async () => {
+    // Defensive: if stored JSON is corrupt we already log+fallthrough in the
+    // existing parse catch, but sticky adds a new branch BEFORE that — confirm
+    // corruption still routes through the existing recovery path rather than
+    // hanging on the sticky check.
+    const store: Record<string, string> = {
+      [analysisKey('claude', 'inc-1')]: '{corrupt',
+    }
+    const kv = mockKV(store)
+    const svc = mockService('claude', [{ id: 'inc-1', status: 'investigating' }])
+    const analyzeFn = vi.fn().mockResolvedValue({ ...mockAnalysis, model: 'gemma' })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await refreshOrReanalyze([svc], kv, 'key', analyzeFn, 2)
+
+    // The corrupt JSON should trigger re-analysis (not early-return).
+    expect(analyzeFn).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+})

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -68,6 +68,12 @@ export interface AIAnalysisResult {
   model?: 'gemma' | 'sonnet'  // which model produced this analysis
   resolvedAt?: string
   timelineHash?: string  // latest timeline entry timestamp — used to skip re-analysis when unchanged
+  // #299: when true, refreshOrReanalyze skips re-analysis for this incident and only
+  // refreshes the 1h TTL. Set by the /api/admin/analyze endpoint so an operator's
+  // manual Sonnet override doesn't get auto-clobbered by the cron's Gemma-first path
+  // on the next timeline update. Cleared naturally when incident resolves (the
+  // resolution flow overwrites this key with a 2h TTL + resolvedAt marker).
+  sticky?: boolean
 }
 
 /**
@@ -277,7 +283,10 @@ async function analyzeWithGemma(
 /**
  * Analyze incident using Claude Sonnet via AI Gateway (fallback).
  */
-async function analyzeWithSonnet(
+// Exported for the /api/admin/analyze endpoint (#299) so operators can force a
+// Sonnet analysis on an incident where Gemma produced low-signal output. Production
+// cron still reaches it via the analyzeIncident fallback path below.
+export async function analyzeWithSonnet(
   apiKey: string,
   prompt: string,
   incidentId: string,
@@ -392,6 +401,16 @@ export async function refreshOrReanalyze(
       if (raw) {
         try {
           const parsed = JSON.parse(raw)
+          // #299: sticky analyses (manual operator overrides) are never re-analyzed
+          // while the incident is active — only TTL-refreshed. Clears naturally on
+          // incident resolution (resolvedAt write overwrites this key with 2h TTL).
+          if (parsed.sticky === true) {
+            parsed._lastRefresh = new Date(now).toISOString()
+            await kvPut(kv, key, JSON.stringify(parsed), { expirationTtl: 3600 })
+            analyzedIncidents.set(inc.id, key)
+            result.refreshed.push(svc.id)
+            continue
+          }
           // Time-based re-analysis: if 2h+ old, attempt update without deleting old analysis first
           const analysisAge = now - new Date(parsed.analyzedAt).getTime()
           if (analysisAge >= 7_200_000 && (apiKey || ai) && reAnalysisCount < cap) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5,7 +5,7 @@
 import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type ServiceStatus } from './services'
 import { calculateAIWatchScore, classifyProbe } from './score'
 import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop, isFlapSuppressible, flapSuppressionKey } from './alerts'
-import { analyzeIncident, refreshOrReanalyze, analysisKey, formatRecoveryDisplay, type AIAnalysisResult } from './ai-analysis'
+import { analyzeIncident, analyzeWithSonnet, refreshOrReanalyze, analysisKey, buildAnalysisPrompt, findSimilarIncidents, formatRecoveryDisplay, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
@@ -14,6 +14,10 @@ interface Env {
   ALLOWED_ORIGIN: string
   DISCORD_WEBHOOK_URL?: string
   ANTHROPIC_API_KEY?: string
+  // #299: operator-only shared secret for POST /api/admin/analyze. Set via
+  // `wrangler secret put ADMIN_API_KEY`. Separate from ANTHROPIC_API_KEY so it
+  // can be rotated independently; absent secret → endpoint always 401.
+  ADMIN_API_KEY?: string
   AI?: Ai
   STATUS_CACHE: KVNamespace
 }
@@ -568,7 +572,15 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
               usage.success++
               if (analysis.model === 'gemma') usage.gemma = (usage.gemma ?? 0) + 1
               else if (analysis.model === 'sonnet') usage.sonnet = (usage.sonnet ?? 0) + 1
-              const kvOk = await kvPut(env.STATUS_CACHE, analysisKey(svc.id, inc.id), JSON.stringify(analysis), { expirationTtl: 3600 })
+              // #299: preserve sticky operator overrides — if an admin already wrote
+              // this key via /api/admin/analyze between two cron cycles, don't
+              // clobber it here. Symmetric with refreshOrReanalyze's guard.
+              const existingRaw = await env.STATUS_CACHE.get(analysisKey(svc.id, inc.id)).catch(() => null)
+              const skipWrite = isStickyExistingAnalysis(existingRaw)
+              if (skipWrite) console.log(`[cron] Preserving sticky analysis for ${svc.id}:${inc.id}; not overwriting`)
+              const kvOk = skipWrite
+                ? true
+                : await kvPut(env.STATUS_CACHE, analysisKey(svc.id, inc.id), JSON.stringify(analysis), { expirationTtl: 3600 })
               if (kvOk) {
                 analysisSection = `\n${DIV}\n🤖 **AI ANALYSIS** [Beta]\n${analysis.summary}\n⏱ Est. recovery: ${formatRecoveryDisplay(analysis.estimatedRecovery)}${analysis.affectedScope.length > 0 ? `\n📡 Scope: ${analysis.affectedScope.join(', ')}` : ''}`
               }
@@ -713,9 +725,203 @@ import { collectChangelogs, getStaleSources } from './changelog'
 import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary } from './weekly-briefing'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, cacheProbeSummaries, getCachedProbeSummaries, type ProbeDailyData } from './probe-archival'
-import type { ProbeSummary } from './types'
+import type { ProbeSummary, Incident } from './types'
 import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
 import { checkPlatformStatus, formatPlatformOutageAlert, formatPlatformRecoveryAlert, platformStatusKey, platformAlertKey, countPlatformServices, type PlatformStatus } from './platform-monitor'
+
+// ── #299: sticky-aware analysis write ─────────────────────────
+
+/**
+ * Inspect an existing raw JSON payload at `ai:analysis:{svcId}:{incId}` and
+ * return true if it's a sticky operator override that must NOT be overwritten.
+ * Corrupt JSON is treated as non-sticky (proceed with overwrite) — that's the
+ * safer default since a stuck-sticky corrupt payload would lock the key for the
+ * full incident lifetime.
+ */
+export function isStickyExistingAnalysis(rawJson: string | null): boolean {
+  if (!rawJson) return false
+  try {
+    const existing = JSON.parse(rawJson) as { sticky?: unknown }
+    return existing.sticky === true
+  } catch {
+    return false
+  }
+}
+
+// ── #299: POST /api/admin/analyze ─────────────────────────────
+
+/**
+ * Constant-time string comparison. Prevents timing-side-channel leaks of the
+ * admin secret. Short-circuits on length mismatch (that's already observable
+ * from the 401 anyway); diverges only on same-length different strings.
+ * Workers runtime doesn't expose `crypto.timingSafeEqual`, so we roll our own.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+/** SHA-256 hex of svcId:incidentId — used as rate-limit KV key suffix. */
+export async function adminRateLimitKey(svcId: string, incidentId: string): Promise<string> {
+  const data = new TextEncoder().encode(`${svcId}:${incidentId}`)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  const hex = [...new Uint8Array(hash)].map(b => b.toString(16).padStart(2, '0')).join('')
+  return `admin:ratelimit:${hex.slice(0, 32)}` // 128-bit prefix is plenty
+}
+
+interface AdminAnalyzeRequest {
+  svcId?: unknown
+  incidentId?: unknown
+  model?: unknown
+  sticky?: unknown
+}
+
+/**
+ * Look up the active incident matching svcId + incidentId in `services:latest`.
+ * Reading from the cache (5min TTL) avoids a 5-10s live fetch on every admin
+ * request; the operator's "I need this now" is still same-cron-cycle fresh.
+ * Returns null if service or incident not found — caller translates to 404.
+ */
+async function findActiveIncident(kv: KVNamespace, svcId: string, incidentId: string): Promise<{ service: ServiceStatus; incident: Incident } | null> {
+  const raw = await kv.get(CACHE_KEY).catch(err => {
+    console.warn('[admin/analyze] services:latest KV read failed:', err instanceof Error ? err.message : err)
+    return null
+  })
+  if (!raw) return null
+  let payload: { services?: ServiceStatus[] }
+  try {
+    payload = JSON.parse(raw)
+  } catch (err) {
+    // Parity with other JSON.parse sites in this file — corrupt `services:latest`
+    // is never expected and should be visible in logs, not silently collapsed to 404.
+    console.error('[admin/analyze] services:latest corrupt JSON:', err instanceof Error ? err.message : err)
+    return null
+  }
+  const service = payload.services?.find(s => s.id === svcId)
+  if (!service) return null
+  const incident = (service.incidents ?? []).find(i => i.id === incidentId && i.status !== 'resolved')
+  if (!incident) return null
+  return { service, incident }
+}
+
+async function handleAdminAnalyze(request: Request, env: Env, cors: Record<string, string>): Promise<Response> {
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { ...cors, 'Content-Type': 'application/json' } })
+
+  if (!env.ADMIN_API_KEY) {
+    // Missing secret — same error surface as wrong key (no info leak about config state).
+    return json(401, { ok: false, error: 'unauthorized' })
+  }
+  const provided = request.headers.get('X-Admin-Key') ?? ''
+  if (!constantTimeEqual(provided, env.ADMIN_API_KEY)) {
+    return json(401, { ok: false, error: 'unauthorized' })
+  }
+
+  if (!env.ANTHROPIC_API_KEY) {
+    return json(503, { ok: false, error: 'ANTHROPIC_API_KEY not configured' })
+  }
+
+  let body: AdminAnalyzeRequest
+  try { body = await request.json() } catch { return json(400, { ok: false, error: 'invalid JSON body' }) }
+
+  const svcId = typeof body.svcId === 'string' ? body.svcId : ''
+  const incidentId = typeof body.incidentId === 'string' ? body.incidentId : ''
+  const model = body.model === 'gemma' ? 'gemma' : 'sonnet'  // default sonnet — manual trigger implies escalation
+  const sticky = body.sticky === false ? false : true        // default true — operator override should survive cron updates
+  if (!svcId || !incidentId) {
+    return json(400, { ok: false, error: 'svcId and incidentId are required' })
+  }
+
+  // Rate limit: 1 request per svcId+incidentId per 60s. KV-based so it survives
+  // isolate restarts (in-memory Map would not, which matters for a route an
+  // operator might hammer during an outage from multiple tabs).
+  const rlKey = await adminRateLimitKey(svcId, incidentId)
+  // Fail-open with a log: a silent KV outage here would let an operator bypass
+  // rate limiting entirely (burning Anthropic tokens during a retry storm). We
+  // prefer to know about it rather than silently degrade — but still serve the
+  // request rather than block legitimate operator work on a transient KV blip.
+  const rlHit = await env.STATUS_CACHE.get(rlKey).catch(err => {
+    console.warn('[admin/analyze] rate-limit KV read failed; bypassing:', err instanceof Error ? err.message : err)
+    return null
+  })
+  if (rlHit) return json(429, { ok: false, error: 'rate limited — try again in a moment' })
+
+  // Scope guard: only allow IDs that exist as active incidents. Prevents spraying
+  // arbitrary KV keys via the endpoint if the admin secret ever leaks.
+  const active = await findActiveIncident(env.STATUS_CACHE, svcId, incidentId)
+  if (!active) return json(404, { ok: false, error: `no active incident ${svcId}:${incidentId}` })
+
+  // Write rate-limit marker BEFORE the expensive call so two concurrent requests
+  // don't both get through. TTL is a hard 60s — if the analysis takes longer than
+  // that, a retry is allowed (which is fine — the worst case is a double-write).
+  await env.STATUS_CACHE.put(rlKey, '1', { expirationTtl: 60 }).catch(err =>
+    console.warn('[admin/analyze] rate-limit write failed:', err instanceof Error ? err.message : err),
+  )
+
+  const { service, incident } = active
+  const similar = findSimilarIncidents(incident.title, service.incidents ?? [])
+  const prompt = buildAnalysisPrompt(service.name, {
+    id: incident.id, title: incident.title, status: incident.status,
+    startedAt: incident.startedAt, impact: incident.impact, timeline: incident.timeline,
+  }, similar)
+  const timelineAt = incident.timeline?.at(-1)?.at ?? ''
+
+  let analysis: AIAnalysisResult | null
+  try {
+    if (model === 'sonnet') {
+      analysis = await analyzeWithSonnet(env.ANTHROPIC_API_KEY, prompt, incident.id, timelineAt)
+    } else {
+      // Gemma path: go via analyzeIncident (tries Gemma first, falls back to Sonnet).
+      // The operator picked 'gemma' explicitly, but if Workers AI returns null we'd
+      // rather ship a Sonnet result than error out.
+      analysis = await analyzeIncident(env.ANTHROPIC_API_KEY, service.name, {
+        id: incident.id, title: incident.title, status: incident.status,
+        startedAt: incident.startedAt, impact: incident.impact, timeline: incident.timeline,
+      }, service.incidents ?? [], undefined, env.AI)
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'analysis failed'
+    return json(502, { ok: false, error: 'analysis failed', detail: message })
+  }
+
+  if (!analysis) {
+    return json(502, { ok: false, error: 'analysis returned null — upstream model error or unparseable response' })
+  }
+
+  if (sticky) analysis.sticky = true
+
+  const key = analysisKey(svcId, incidentId)
+  const ttl = 3600
+  try {
+    await env.STATUS_CACHE.put(key, JSON.stringify(analysis), { expirationTtl: ttl })
+  } catch (err) {
+    return json(502, { ok: false, error: 'KV write failed', detail: err instanceof Error ? err.message : String(err) })
+  }
+
+  // Bump ai:usage:{date} counter so the Daily Summary attributes the manual call.
+  // Match the shape used elsewhere: { calls, success, failed, gemma?, sonnet? }.
+  try {
+    const today = new Date().toISOString().slice(0, 10)
+    const usageKey = `ai:usage:${today}`
+    const raw = await env.STATUS_CACHE.get(usageKey).catch(() => null)
+    const usage: { calls: number; success: number; failed: number; gemma?: number; sonnet?: number } =
+      raw ? JSON.parse(raw) : { calls: 0, success: 0, failed: 0 }
+    usage.calls++
+    usage.success++
+    if (analysis.model === 'gemma') usage.gemma = (usage.gemma ?? 0) + 1
+    else if (analysis.model === 'sonnet') usage.sonnet = (usage.sonnet ?? 0) + 1
+    await env.STATUS_CACHE.put(usageKey, JSON.stringify(usage), { expirationTtl: 172800 })
+  } catch (err) {
+    // Counter is bookkeeping — don't fail the request over it.
+    console.warn('[admin/analyze] ai:usage counter bump failed:', err instanceof Error ? err.message : err)
+  }
+
+  return json(200, { ok: true, wrote: key, ttl, analysis })
+}
 
 export default {
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
@@ -1394,6 +1600,15 @@ export default {
           status: 500, headers: { ...cors, 'Content-Type': 'application/json' },
         })
       }
+    }
+
+    // POST /api/admin/analyze — operator override to run Sonnet analysis on a specific
+    // incident (#299). Motivated by 2026-04-20 ChatGPT outage where Gemma produced a
+    // generic "service availability issue" analysis and Sonnet (same prompt/data) correctly
+    // identified a systemic infra failure. Before this endpoint the override required
+    // hand-editing a Node script + `wrangler kv key put --remote`, racing the cron.
+    if (request.method === 'POST' && url.pathname === '/api/admin/analyze') {
+      return handleAdminAnalyze(request, env, cors)
     }
 
     // POST/DELETE /api/webhook/ping — track active webhook registrations (hashed, no raw URLs stored)


### PR DESCRIPTION
closes #299

## Summary
- Operator-only \`POST /api/admin/analyze\` lets you force a Sonnet analysis on a specific active incident when Gemma (primary) produces low-signal output.
- Motivated by the **2026-04-20 ChatGPT outage**: Gemma called a systemic ChatGPT + Codex + API Platform infrastructure failure a generic "service availability issue"; a Sonnet run on identical input correctly identified the shared infra cause.
- Before this PR, the workaround was hand-editing a Node script + \`wrangler kv key put --remote\`, racing the cron's re-analysis path.

## Endpoint

\`\`\`
POST /api/admin/analyze
X-Admin-Key: \$ADMIN_API_KEY
Content-Type: application/json

{ "svcId": "chatgpt", "incidentId": "01KPNN...", "model": "sonnet", "sticky": true }
\`\`\`

Response: \`{ ok, wrote, ttl, analysis }\` on 200. Failure modes: 401 (missing/wrong key, no config-state leak), 400 (malformed body), 404 (scope guard — IDs must match an active incident in \`services:latest\`), 429 (1 req / 60s / incident), 502 (upstream model error), 503 (ANTHROPIC_API_KEY not configured).

## Sticky flag
\`AIAnalysisResult.sticky: true\` (default on manual trigger) protects the operator's override from being clobbered by the cron's Gemma-first path. Guarded in two places:
- \`refreshOrReanalyze\` (ai-analysis.ts) — skips re-analysis, TTL refresh only
- Cron's new-incident write path (index.ts) — reads existing key before write; \`isStickyExistingAnalysis()\` helper centralizes the invariant

Cleared naturally on incident resolution (2h TTL + \`resolvedAt\` overwrite).

## Security posture
- \`ADMIN_API_KEY\` is a Worker secret, rotated independently of \`ANTHROPIC_API_KEY\` via \`wrangler secret put ADMIN_API_KEY\`.
- Constant-time compare on the header (manual XOR — no \`crypto.subtle.timingSafeEqual\` in Workers).
- **Scope guard**: endpoint accepts only IDs matching an active incident — a leaked secret can't write arbitrary \`ai:analysis:*\` keys.
- **Rate limit**: 1 req / incident / 60s bounds max blast radius to ~\$0.01/min of Sonnet cost.
- Rate-limit key is hashed (SHA-256 prefix, 128-bit) so \`kv list\` can't leak incident IDs.
- Never paste the secret value anywhere — docs reference \`\$ADMIN_API_KEY\` by variable name only.

## Test plan
- [x] \`cd worker && npm test\` — 967/967 pass (30 new across 2 files)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — passes (2731 KiB / gzip 1009 KiB)
- [x] Local CLI smoke test: 401 (no key), 401 (wrong key), 400 (missing svcId), 404 (bogus IDs) — all match spec
- [x] PR review auto-loop — Round 1 (0 Critical + 6 Important across 3 agents) → fixes → Round 2 converged (0/0)

## New tests (30)

**\`admin-analyze.test.ts\` (22)**:
- Helpers: \`constantTimeEqual\` (4), \`adminRateLimitKey\` (3), \`isStickyExistingAnalysis\` (6)
- Endpoint (9): missing ADMIN_API_KEY, missing/wrong header, missing ANTHROPIC_API_KEY, missing body fields, scope guard 404 **+ rate-limit-key-absent assertion**, cold KV, resolved incident, rate-limit 429, happy path **+ ai:usage increment**, sticky=false opt-out, 502 upstream fail, **counter preservation (pre-seeded survives)**, **model='sonnet4' defaults to sonnet**, **explicit sticky:true**, **malformed JSON body 400**

**\`ai-analysis.test.ts\` (4)**: sticky skips re-analysis, TTL still refreshes when sticky, non-sticky regression guard, corrupt sticky falls through to normal re-analysis

## Deploy checklist
- [ ] Before deploy: \`npx wrangler secret put ADMIN_API_KEY --config worker/wrangler.toml\`
- [ ] Deploy: \`npm run deploy:worker\`
- [ ] Smoke test: auth-failure paths via curl (not ok-path — that hits live Anthropic)
- [ ] Store the secret in 1Password / keychain for the next outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)