### PR TITLE
fix: filter scheduled maintenance + future-dated entries from BetterStack RSS (#331)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -354,6 +354,196 @@ describe('parseRssIncidents', () => {
     const result = parseRssIncidents(`<rss>${items}</rss>`)
     expect(result).toHaveLength(20)
   })
+
+  // #331: Together's BetterStack RSS carries planned-maintenance announcements
+  // with a scheduled title + future pubDate. The old parser rendered these as
+  // phantom "Scheduled Network Maintenance — down" incidents. Regression tests:
+  describe('scheduled maintenance / future pubDate filter (#331)', () => {
+    it('skips entries titled "Scheduled Network Maintenance"', () => {
+      const xml = `
+        <item>
+          <guid>https://status.together.ai/incident/876784#hash</guid>
+          <title>Scheduled Network Maintenance</title>
+          <pubDate>Sat, 25 Apr 2026 12:00:01 GMT</pubDate>
+          <description>We will be performing scheduled network maintenance from April 25...</description>
+        </item>
+      `
+      // Use a `now` past the pubDate so the future-date filter can't short-circuit
+      // the test — we want to prove the TITLE filter specifically works.
+      const fixedNow = new Date('2026-04-30T00:00:00Z').getTime()
+      const result = parseRssIncidents(xml, fixedNow)
+      expect(result).toHaveLength(0)
+    })
+
+    it('skips entries titled "Scheduled Maintenance" (no "network")', () => {
+      const xml = `
+        <item>
+          <guid>https://status.example.com/m/1#h</guid>
+          <title>Scheduled maintenance</title>
+          <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Routine upgrade</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-15T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(0)
+    })
+
+    it('skips entries with pubDate in the future (> 60s past now)', () => {
+      // Future-dated announcement with a NON-matching title (just to prove the
+      // future-date filter works independently of the title regex).
+      const xml = `
+        <item>
+          <guid>https://status.example.com/future#1</guid>
+          <title>Database Upgrade Window</title>
+          <pubDate>Sat, 01 May 2026 10:00:00 GMT</pubDate>
+          <description>We'll be rotating the primary DB cluster next week.</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-04-20T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(0)
+    })
+
+    it('keeps entries with pubDate within the 60s clock-skew buffer', () => {
+      // pubDate is 30s in the future — within the clock-skew tolerance, so it
+      // should still render. Prevents false positives from minor NTP drift.
+      const pubDate = new Date('2026-03-01T10:00:30Z').toUTCString()
+      const xml = `
+        <item>
+          <guid>https://status.example.com/skew#1</guid>
+          <title>Service X went down</title>
+          <pubDate>${pubDate}</pubDate>
+          <description>Errors</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-01T10:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(1)
+    })
+
+    it('still processes a normal incident alongside a filtered maintenance entry', () => {
+      // Regression guard: a real incident in the same feed must not be affected
+      // by a sibling scheduled-maintenance item.
+      const xml = `
+        <item>
+          <guid>https://status.together.ai/incident/876784#hash1</guid>
+          <title>Scheduled Network Maintenance</title>
+          <pubDate>Sat, 25 Apr 2026 12:00:01 GMT</pubDate>
+          <description>We will be performing scheduled network maintenance</description>
+        </item>
+        <item>
+          <guid>https://status.together.ai/incident/999#hash2</guid>
+          <title>GPT OSS 120B went down</title>
+          <pubDate>Sun, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Model unavailable</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-04-30T00:00:00Z').getTime()
+      const result = parseRssIncidents(xml, fixedNow)
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toContain('GPT OSS 120B')
+    })
+
+    it('does not falsely match titles that mention "maintenance" without "scheduled"', () => {
+      // "Maintenance mode" alone is ambiguous — could be an unexpected degraded
+      // state. Only the scheduled+maintenance pair should trigger the skip.
+      const xml = `
+        <item>
+          <guid>https://status.example.com/m2#h</guid>
+          <title>Stuck in maintenance mode</title>
+          <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Deploy pipeline hung.</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-15T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(1)
+    })
+
+    it('defaults `now` to Date.now() when omitted (backwards-compatible signature)', () => {
+      // Existing callers pass no arg. Verify the default path still works without
+      // regressing to some pathological constant.
+      const recentPast = new Date(Date.now() - 3600_000).toUTCString()  // 1h ago
+      const xml = `
+        <item>
+          <guid>https://status.example.com/now#1</guid>
+          <title>Service went down</title>
+          <pubDate>${recentPast}</pubDate>
+          <description>Errors</description>
+        </item>
+      `
+      expect(parseRssIncidents(xml)).toHaveLength(1)
+    })
+
+    it('matches the second regex alternation: "Maintenance — scheduled for tonight"', () => {
+      // The regex has two alternations; the first matches "scheduled ... maintenance",
+      // the second matches "maintenance ... scheduled". Together's current title
+      // exercises branch 1. A future provider might use branch 2. Without this test
+      // a regex refactor could silently delete that branch.
+      const xml = `
+        <item>
+          <guid>https://status.example.com/m2branch#h</guid>
+          <title>Maintenance — scheduled for tonight</title>
+          <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Planned work</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-15T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(0)
+    })
+
+    it('does NOT skip "Planned maintenance" or "Scheduled upgrade" variants', () => {
+      // Explicit negative contract: the regex is narrowly scoped to the
+      // scheduled + maintenance pair. Titles like "Planned maintenance window
+      // failed" or "Scheduled upgrade broke DB" describe real incidents where
+      // the planned event went wrong — we must still surface them. Prevents
+      // future over-broadening from swallowing legitimate reports.
+      const xml = `
+        <item>
+          <guid>https://status.example.com/planned#1</guid>
+          <title>Planned maintenance window exceeded</title>
+          <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Still ongoing past the planned end</description>
+        </item>
+        <item>
+          <guid>https://status.example.com/upgrade#1</guid>
+          <title>Scheduled upgrade failed to roll forward</title>
+          <pubDate>Sat, 01 Mar 2026 11:00:00 GMT</pubDate>
+          <description>Rollback initiated</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-15T00:00:00Z').getTime()
+      const result = parseRssIncidents(xml, fixedNow)
+      expect(result).toHaveLength(2)
+      // Also assert which incidents survived — a future bug that returned 2
+      // different items would slip past the count-only check.
+      const titles = result.map(r => r.title)
+      expect(titles.some(t => t.includes('Planned maintenance window exceeded'))).toBe(true)
+      expect(titles.some(t => t.includes('Scheduled upgrade failed to roll forward'))).toBe(true)
+    })
+
+    it('title filter fires before the future-date filter (order-of-checks guard)', () => {
+      // Real Together case: title matches AND pubDate is in the future. Current
+      // order is title first; if a refactor flipped the order it would still
+      // function (same net result) but logs would mis-categorize. Spy on
+      // console.debug to confirm the specific skip-reason path.
+      // NOTE: test is coupled to the literal log strings "scheduled maintenance"
+      // and "future-dated" in parseRssIncidents. Update both sides together if
+      // the log wording changes.
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+      const xml = `
+        <item>
+          <guid>https://status.together.ai/incident/876784#hash</guid>
+          <title>Scheduled Network Maintenance</title>
+          <pubDate>Sat, 25 Apr 2026 12:00:01 GMT</pubDate>
+          <description>Planned</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-04-24T00:00:00Z').getTime()  // before pubDate
+      parseRssIncidents(xml, fixedNow)
+      const calls = debugSpy.mock.calls.map(c => String(c[0]))
+      expect(calls.some(m => m.includes('scheduled maintenance'))).toBe(true)
+      expect(calls.some(m => m.includes('future-dated'))).toBe(false)
+      debugSpy.mockRestore()
+    })
+  })
 })
 
 describe('parseXaiRssIncidents', () => {

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -14,7 +14,16 @@ function isValidDate(s: string): boolean {
   return !isNaN(new Date(s).getTime())
 }
 
-export function parseRssIncidents(xml: string): Incident[] {
+// #331: BetterStack RSS occasionally carries planned-maintenance announcements
+// that share the same item shape as real incidents. Detect them via two signals:
+// a "scheduled (network) maintenance" phrase in the title, or a future pubDate
+// (RSS entries describe things that have happened — recovered/went down — so a
+// future timestamp is structurally impossible for a real incident). Skip both
+// rather than rendering a phantom "— down" card.
+const SCHEDULED_MAINTENANCE_TITLE = /scheduled\s+(?:\w+\s+)?maintenance|maintenance[^a-z]{0,20}scheduled/i
+const FUTURE_PUBDATE_BUFFER_MS = 60_000  // clock-skew tolerance
+
+export function parseRssIncidents(xml: string, now = Date.now()): Incident[] {
   const items = xml.match(/<item>([\s\S]*?)<\/item>/g)
   if (!items) return []
 
@@ -49,6 +58,19 @@ export function parseRssIncidents(xml: string): Incident[] {
     const isResolved = /\brecover(?:ed)?\b|\bresolved\b|\bfixed\b|\brestor(?:ed)?\b|\bmitigated\b|\bhealthy again\b|\bis back\b|\bback to normal\b|\bback up\b|\boperational\b/.test(lastText)
     const startMs = new Date(first.date).getTime()
     const endMs = new Date(last.date).getTime()
+
+    // #331: planned-maintenance / future announcements — not real incidents.
+    // Checked here (not at item-level) so a group legitimately named "maintenance"
+    // with a past pubDate and real downtime in its description wouldn't be dropped
+    // — title regex + future-date are AND-independent skip conditions.
+    if (SCHEDULED_MAINTENANCE_TITLE.test(first.title)) {
+      console.debug(`[parseRssIncidents] skipped scheduled maintenance: ${groupKey} ("${first.title}")`)
+      continue
+    }
+    if (startMs > now + FUTURE_PUBDATE_BUFFER_MS) {
+      console.debug(`[parseRssIncidents] skipped future-dated announcement: ${groupKey} ("${first.title}" at ${new Date(startMs).toISOString()})`)
+      continue
+    }
 
     // Filter out micro-incidents (resolved in < 60s) — automated monitoring noise
     if (isResolved && (endMs - startMs) >= 0 && (endMs - startMs) < 60_000) {


### PR DESCRIPTION
closes #331

## Summary
- Together AI's BetterStack RSS feed was serving a planned-maintenance announcement that our parser rendered as a **phantom \"Scheduled Network Maintenance — down\" incident** with a future \`startedAt\` (2026-04-25).
- Root cause: \`parseRssIncidents\` treated every RSS \`<item>\` as an active incident and appended the \" — down\" suffix. Latent across HuggingFace / Fireworks / Modal / xAI (all 5 share the parser).
- Fix: two early-\`continue\` filters in the per-group loop — title regex + future \`pubDate\` (60s clock-skew buffer).

## Live verification

| | Before | After |
|---|---|---|
| Together \`scheduled-titled\` incidents | 1 | 0 |
| Together \`future-dated\` incidents | 1 | 0 |
| Together real incidents | 19 | 19 |

## Filter design

Both checks short-circuit independently — defense in depth if Together changes the title pattern but keeps the future \`pubDate\`, or vice versa.

1. **Title regex** — \`/scheduled\\s+(?:\\w+\\s+)?maintenance|maintenance[^a-z]{0,20}scheduled/i\`
   - Matches: \"Scheduled Network Maintenance\", \"Scheduled Maintenance\", \"Maintenance — scheduled for tonight\"
   - Does NOT match: \"Planned maintenance window exceeded\", \"Scheduled upgrade failed\", \"Stuck in maintenance mode\" (narrow by design — real incidents where planned work went wrong should still surface)

2. **Future pubDate** — \`startMs > now + 60_000ms\`
   - Structurally impossible for a real incident (RSS describes past events)
   - 60s buffer tolerates minor NTP drift

3. **Injected \`now\` param** (default \`Date.now()\`) — tests pin time deterministically without \`vi.useFakeTimers\` global mutation.

## Test plan
- [x] \`cd worker && npm test\` — 945/945 pass (10 new)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — clean
- [x] Local \`wrangler dev\` against live Together RSS — phantom entry gone, real 19 incidents intact (user-confirmed in browser)
- [x] PR review auto-loop — Round 1 (0 Critical + 3 Important from test-analyzer — negative contracts + filter precedence) → fixes → Round 2 converged (0/0 + 2 minor suggestions applied)

## New tests (10 total, under \`scheduled maintenance / future pubDate filter (#331)\`)

**Positive (skip)**: scheduled-network-maintenance title · scheduled-maintenance no-\"network\" variant · future pubDate with non-matching title · second regex alternation (\"Maintenance — scheduled\") · mixed feed (maintenance skipped + real incident kept)

**Negative (keep)**: clock-skew 30s-future pubDate · \"Stuck in maintenance mode\" · \"Planned maintenance window exceeded\" / \"Scheduled upgrade failed\" regression guard (with exact title assertions)

**Observability**: title-filter precedence via \`console.debug\` spy — asserts \"scheduled maintenance\" log fires, \"future-dated\" does not (order-of-checks guard)

**Backwards compat**: \`now\` default path works without argument

## Out of scope

- Surfacing upcoming maintenance windows as a separate \"Maintenance\" banner. Filter-only resolves the immediate phantom-\"down\" bug; a user-facing maintenance UX is a separate UX decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)