### PR TITLE
feat: OSV-only per-alert timeline tracking (#291)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,8 @@ When adding a new monitored service, update ALL of the following:
 | `vitals:{YYYY-MM-DD}` | `{ count, allValues }` JSON | 3d | per visit (100%) | Web Vitals daily aggregation (LCP, FCP, TTFB, CLS, INP) |
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 | `incidents:monthly:{YYYY-MM}` | `MonthlyIncidents` JSON | 60d | 1/day | Monthly incident accumulation (deduped by ID, updated in daily summary cron) |
-| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service, optional `security` summary from `security:monthly:{YYYY-MM}` snapshot taken before its 60d TTL lapses — #290) |
+| `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, latency per service, optional `security` summary from `security:monthly:{YYYY-MM}` snapshot taken before its 60d TTL lapses — #290; OSV top findings also carry `timeline[]` from `security:timeline:osv:*` when available — #291) |
+| `security:timeline:osv:{vulnId}` | `OsvTimeline` JSON | none (permanent) | ~0-3/day | Per-alert OSV lifecycle tracking (#291). Entries: `detected` → `severity_changed` → `fix_released`. Written only on stage transitions by the hourly security cron, so steady-state KV writes are near zero. Archive reader attaches the entries to matching top findings |
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
 

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -8,9 +8,12 @@ import {
   accumulateMonthlyIncidents,
   parseDurationMin,
   summarizeSecurityAlerts,
+  extractOsvVulnId,
+  enrichTopFindingsWithTimelines,
 } from '../monthly-archive'
 import type { ServiceStatus } from '../types'
-import type { MonthlySecurityEntry } from '../monthly-archive'
+import type { MonthlySecurityEntry, MonthlySecuritySummary } from '../monthly-archive'
+import type { OsvTimeline } from '../security-monitor'
 
 // ── parseDurationMin ─────────────────────────────────────────────────
 
@@ -353,6 +356,97 @@ describe('summarizeSecurityAlerts', () => {
   })
 })
 
+// ── OSV vuln id extraction + archive timeline enrichment (#291) ──────
+
+describe('extractOsvVulnId', () => {
+  it('picks GHSA ids out of osv.dev URLs', () => {
+    expect(extractOsvVulnId('https://osv.dev/vulnerability/GHSA-abc-def-ghi')).toBe('GHSA-abc-def-ghi')
+  })
+
+  it('picks GHSA ids out of github.com advisory URLs', () => {
+    expect(extractOsvVulnId('https://github.com/advisories/GHSA-69w3-r845-3855')).toBe('GHSA-69w3-r845-3855')
+  })
+
+  it('picks CVE ids out of URLs', () => {
+    expect(extractOsvVulnId('https://nvd.nist.gov/vuln/detail/CVE-2026-12345')).toBe('CVE-2026-12345')
+  })
+
+  it('is case-insensitive on the GHSA/CVE prefix', () => {
+    // Some downstream tooling lowercases path segments; the regex uses /i to tolerate that.
+    expect(extractOsvVulnId('https://osv.dev/vulnerability/ghsa-aaa-bbb-ccc')).toBe('ghsa-aaa-bbb-ccc')
+    expect(extractOsvVulnId('https://example.com/cve-2026-12345')).toBe('cve-2026-12345')
+  })
+
+  it('returns null for URLs without a recognizable id', () => {
+    expect(extractOsvVulnId('https://example.com/advisory/random')).toBeNull()
+    expect(extractOsvVulnId(undefined)).toBeNull()
+    expect(extractOsvVulnId('')).toBeNull()
+  })
+})
+
+describe('enrichTopFindingsWithTimelines', () => {
+  const baseSummary: MonthlySecuritySummary = {
+    totalAlerts: 3,
+    bySource: { osv: 2, hackernews: 1 },
+    bySeverity: { critical: 0, high: 1, medium: 1, low: 0 },
+    byService: {},
+    topFindings: [
+      { title: 'OSV A', url: 'https://osv.dev/vulnerability/GHSA-aaa-bbb-ccc', source: 'osv',        severity: 'high',   detectedAt: '2026-03-01T00:00:00Z' },
+      { title: 'OSV B', url: 'https://osv.dev/vulnerability/GHSA-xxx-yyy-zzz', source: 'osv',        severity: 'medium', detectedAt: '2026-03-02T00:00:00Z' },
+      { title: 'HN C',  url: 'https://news.ycombinator.com/item?id=1',         source: 'hackernews',                     detectedAt: '2026-03-03T00:00:00Z' },
+    ],
+  }
+  const timelineA: OsvTimeline = {
+    vulnId: 'GHSA-aaa-bbb-ccc',
+    createdAt: '2026-03-01T00:00:00Z',
+    lastSeen: '2026-03-15T00:00:00Z',
+    entries: [
+      { stage: 'detected',     at: '2026-03-01T00:00:00Z', severity: 'medium' },
+      { stage: 'severity_changed', at: '2026-03-10T00:00:00Z', severity: 'high' },
+      { stage: 'fix_released', at: '2026-03-15T00:00:00Z', fixedVersion: '1.2.3' },
+    ],
+  }
+
+  it('attaches timeline entries to OSV findings when the KV key exists', async () => {
+    const kv = {
+      get: async (key: string) => key === 'security:timeline:osv:GHSA-aaa-bbb-ccc' ? JSON.stringify(timelineA) : null,
+    } as unknown as KVNamespace
+    const enriched = await enrichTopFindingsWithTimelines(kv, baseSummary)
+    expect(enriched.topFindings[0].timeline).toHaveLength(3)
+    expect(enriched.topFindings[0].timeline![2].stage).toBe('fix_released')
+    // Findings without a KV entry pass through unchanged
+    expect(enriched.topFindings[1].timeline).toBeUndefined()
+    // HN findings never get enriched
+    expect(enriched.topFindings[2].timeline).toBeUndefined()
+  })
+
+  it('skips enrichment on missing / malformed / empty timeline', async () => {
+    const kv = {
+      get: async (key: string) => {
+        if (key === 'security:timeline:osv:GHSA-aaa-bbb-ccc') return '{not valid json'
+        if (key === 'security:timeline:osv:GHSA-xxx-yyy-zzz') return JSON.stringify({ ...timelineA, entries: [] })
+        return null
+      },
+    } as unknown as KVNamespace
+    const enriched = await enrichTopFindingsWithTimelines(kv, baseSummary)
+    expect(enriched.topFindings[0].timeline).toBeUndefined()  // malformed
+    expect(enriched.topFindings[1].timeline).toBeUndefined()  // empty entries array
+  })
+
+  it('tolerates KV get rejection per finding (one failure does not poison the batch)', async () => {
+    const kv = {
+      get: async (key: string) => {
+        if (key === 'security:timeline:osv:GHSA-aaa-bbb-ccc') throw new Error('KV read failed')
+        if (key === 'security:timeline:osv:GHSA-xxx-yyy-zzz') return JSON.stringify({ ...timelineA, vulnId: 'GHSA-xxx-yyy-zzz' })
+        return null
+      },
+    } as unknown as KVNamespace
+    const enriched = await enrichTopFindingsWithTimelines(kv, baseSummary)
+    expect(enriched.topFindings[0].timeline).toBeUndefined()
+    expect(enriched.topFindings[1].timeline).toHaveLength(3)
+  })
+})
+
 // ── buildMonthlyArchive ──────────────────────────────────────────────
 
 describe('buildMonthlyArchive', () => {
@@ -501,6 +595,40 @@ describe('buildMonthlyArchive', () => {
 
     const archive = await buildMonthlyArchive(corruptSecurityKV, 2026, 3)
     expect(archive.security).toBeNull()
+  })
+
+  it('archive.security enriches OSV top findings with per-alert timelines (#291)', async () => {
+    const secEntries: MonthlySecurityEntry[] = [
+      { title: 'OSV with timeline', url: 'https://osv.dev/vulnerability/GHSA-aaa-bbb-ccc', source: 'osv', severity: 'high', detectedAt: '2026-03-10T00:00:00Z' },
+      { title: 'HN no timeline',    url: 'https://news.ycombinator.com/item?id=99',          source: 'hackernews',             detectedAt: '2026-03-11T00:00:00Z' },
+    ]
+    const timeline: OsvTimeline = {
+      vulnId: 'GHSA-aaa-bbb-ccc',
+      createdAt: '2026-03-10T00:00:00Z',
+      lastSeen: '2026-03-20T00:00:00Z',
+      entries: [
+        { stage: 'detected',     at: '2026-03-10T00:00:00Z', severity: 'medium' },
+        { stage: 'fix_released', at: '2026-03-20T00:00:00Z', fixedVersion: '2.0.0' },
+      ],
+    }
+    const kv = {
+      get: async (key: string) => {
+        if (key === 'security:monthly:2026-03') return JSON.stringify(secEntries)
+        if (key === 'security:timeline:osv:GHSA-aaa-bbb-ccc') return JSON.stringify(timeline)
+        return null
+      },
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(kv, 2026, 3)
+    expect(archive.security).not.toBeNull()
+    const osvFinding = archive.security!.topFindings.find(f => f.source === 'osv')
+    const hnFinding = archive.security!.topFindings.find(f => f.source === 'hackernews')
+    expect(osvFinding?.timeline).toHaveLength(2)
+    expect(osvFinding?.timeline?.[1].stage).toBe('fix_released')
+    expect(hnFinding?.timeline).toBeUndefined()
   })
 
   it('leaves archive.security = null when the security:monthly KV get rejects', async () => {

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED, OSV_PACKAGES } from '../security-monitor'
-import type { SecurityAlert, SecurityAlertMeta } from '../security-monitor'
+import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED, OSV_PACKAGES, shouldAppendTimeline, appendTimelineEntry, osvTimelineKey, planOsvTimelineCycle } from '../security-monitor'
+import type { SecurityAlert, SecurityAlertMeta, OsvTimeline } from '../security-monitor'
 
 // #325: OSV_PACKAGES drives both querybatch input and the post-fetch enrichment
 // via OSV_PACKAGES[candidate.packageIndex]. A duplicated (name, ecosystem) would
@@ -878,5 +878,221 @@ describe('detectSecurityAlerts — EPSS wiring (#326)', () => {
     expect(wired).toBeDefined()
     expect(wired?.epssPercentile).toBe(0.88)
     expect(wired?.epssPercentage).toBe(0.12)
+  })
+})
+
+// ── OSV timeline tracking (#291) ─────────────────────────────────────
+
+describe('osvTimelineKey', () => {
+  it('scopes the key to the vuln id', () => {
+    expect(osvTimelineKey('GHSA-abc-123')).toBe('security:timeline:osv:GHSA-abc-123')
+    expect(osvTimelineKey('CVE-2026-0001')).toBe('security:timeline:osv:CVE-2026-0001')
+  })
+})
+
+describe('shouldAppendTimeline', () => {
+  const baseAlert: SecurityAlert = {
+    source: 'osv',
+    id: 'GHSA-test-001',
+    title: 'Test vuln',
+    url: 'https://osv.dev/vulnerability/GHSA-test-001',
+    severity: 'high',
+    kvKey: 'security:seen:osv:GHSA-test-001',
+    service: 'OpenAI',
+    affectedPackage: 'PyPI/openai',
+  }
+
+  it('emits a detected entry on first observation (existing is null)', () => {
+    const entry = shouldAppendTimeline(null, baseAlert, '2026-04-22T10:00:00Z')
+    expect(entry).not.toBeNull()
+    expect(entry!.stage).toBe('detected')
+    expect(entry!.at).toBe('2026-04-22T10:00:00Z')
+    expect(entry!.severity).toBe('high')
+  })
+
+  it('returns null when nothing changed since last observation', () => {
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    expect(shouldAppendTimeline(existing, baseAlert, '2026-04-22T10:00:00Z')).toBeNull()
+  })
+
+  it('emits severity_changed when the current severity differs from the last observed', () => {
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'medium' }],
+    }
+    const entry = shouldAppendTimeline(existing, { ...baseAlert, severity: 'critical' }, '2026-04-22T10:00:00Z')
+    expect(entry).not.toBeNull()
+    expect(entry!.stage).toBe('severity_changed')
+    expect(entry!.severity).toBe('critical')
+  })
+
+  it('emits fix_released when a fixedVersion appears where none was known', () => {
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    const entry = shouldAppendTimeline(existing, { ...baseAlert, fixedVersion: '1.2.3' }, '2026-04-22T10:00:00Z')
+    expect(entry).not.toBeNull()
+    expect(entry!.stage).toBe('fix_released')
+    expect(entry!.fixedVersion).toBe('1.2.3')
+  })
+
+  it('does not re-emit fix_released when the fix was already recorded', () => {
+    // Prevents a runaway timeline — once a fixedVersion is known, later observations with
+    // the same fix should be a no-op, not a second fix_released entry.
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [
+        { stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' },
+        { stage: 'fix_released', at: '2026-04-21T00:00:00Z', fixedVersion: '1.2.3' },
+      ],
+    }
+    expect(shouldAppendTimeline(existing, { ...baseAlert, fixedVersion: '1.2.3' }, '2026-04-22T10:00:00Z')).toBeNull()
+  })
+
+  it('severity_changed preempts fix_released when both would fire in the same cycle', () => {
+    // Current implementation checks severity first; the single-entry-per-cycle model
+    // means the next cycle's observation still sees the new fixedVersion as "newly present"
+    // and emits fix_released then. This test locks that ordering.
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    const entry = shouldAppendTimeline(existing, { ...baseAlert, severity: 'critical', fixedVersion: '1.2.3' }, '2026-04-22T10:00:00Z')
+    expect(entry!.stage).toBe('severity_changed')
+    // On the next cycle, severity matches; fix_released fires.
+    const after = appendTimelineEntry(existing, baseAlert, entry!, '2026-04-22T10:00:00Z')
+    const second = shouldAppendTimeline(after, { ...baseAlert, severity: 'critical', fixedVersion: '1.2.3' }, '2026-04-22T11:00:00Z')
+    expect(second!.stage).toBe('fix_released')
+  })
+
+  it('walks the timeline back when the most recent entry lacks the field being compared', () => {
+    // A severity is recorded on `detected`, then a later `fix_released` entry omits severity.
+    // When a severity observation arrives and equals the last KNOWN severity (not the most
+    // recent-entry severity, which is undefined), we must NOT emit a spurious severity_changed.
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-21T00:00:00Z',
+      entries: [
+        { stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' },
+        { stage: 'fix_released', at: '2026-04-21T00:00:00Z', fixedVersion: '1.2.3' },  // no severity field
+      ],
+    }
+    expect(shouldAppendTimeline(existing, { ...baseAlert, severity: 'high', fixedVersion: '1.2.3' }, '2026-04-22T10:00:00Z')).toBeNull()
+  })
+
+  it('treats a missing current severity as "no change" (does not spurious-emit)', () => {
+    // Some OSV fetches may return an entry without a numeric CVSS or a readable text label —
+    // in that case mapOSVSeverity falls back to 'medium'. But if the alert object is built
+    // without a severity field at all, we must not spuriously emit severity_changed.
+    const existing: OsvTimeline = {
+      vulnId: baseAlert.id,
+      createdAt: '2026-04-20T00:00:00Z',
+      lastSeen: '2026-04-22T09:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    const noSevAlert = { ...baseAlert, severity: undefined }
+    expect(shouldAppendTimeline(existing, noSevAlert, '2026-04-22T10:00:00Z')).toBeNull()
+  })
+})
+
+describe('appendTimelineEntry', () => {
+  const baseAlert: SecurityAlert = {
+    source: 'osv', id: 'GHSA-001', title: 't', url: 'u', kvKey: 'k',
+    service: 'OpenAI', affectedPackage: 'PyPI/openai',
+  }
+
+  it('constructs a new timeline with createdAt = lastSeen when no prior exists', () => {
+    const entry = { stage: 'detected' as const, at: '2026-04-22T10:00:00Z', severity: 'high' as const }
+    const timeline = appendTimelineEntry(null, baseAlert, entry, '2026-04-22T10:00:00Z')
+    expect(timeline.vulnId).toBe('GHSA-001')
+    expect(timeline.createdAt).toBe('2026-04-22T10:00:00Z')
+    expect(timeline.lastSeen).toBe('2026-04-22T10:00:00Z')
+    expect(timeline.entries).toHaveLength(1)
+    expect(timeline.service).toBe('OpenAI')
+    expect(timeline.affectedPackage).toBe('PyPI/openai')
+  })
+
+  it('appends to an existing timeline and updates only lastSeen', () => {
+    const existing: OsvTimeline = {
+      vulnId: 'GHSA-001', service: 'OpenAI', affectedPackage: 'PyPI/openai',
+      createdAt: '2026-04-20T00:00:00Z', lastSeen: '2026-04-21T00:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    const entry = { stage: 'severity_changed' as const, at: '2026-04-22T10:00:00Z', severity: 'critical' as const }
+    const next = appendTimelineEntry(existing, baseAlert, entry, '2026-04-22T10:00:00Z')
+    expect(next.createdAt).toBe('2026-04-20T00:00:00Z')  // preserved
+    expect(next.lastSeen).toBe('2026-04-22T10:00:00Z')   // updated
+    expect(next.entries).toHaveLength(2)
+    expect(next.entries[1].stage).toBe('severity_changed')
+  })
+})
+
+describe('planOsvTimelineCycle', () => {
+  const alertA: SecurityAlert = {
+    source: 'osv', id: 'GHSA-aaa', title: 't', url: 'u', severity: 'high',
+    kvKey: 'security:seen:osv:GHSA-aaa', service: 'S', affectedPackage: 'PyPI/a',
+  }
+  const alertB: SecurityAlert = {
+    source: 'osv', id: 'GHSA-bbb', title: 't', url: 'u', severity: 'medium',
+    kvKey: 'security:seen:osv:GHSA-bbb', service: 'S', affectedPackage: 'PyPI/b',
+  }
+
+  it('plans a `detected` write for each alert on first observation', async () => {
+    const reader = async () => null
+    const plans = await planOsvTimelineCycle([alertA, alertB], reader, '2026-04-22T10:00:00Z')
+    expect(plans).toHaveLength(2)
+    expect(plans[0].key).toBe('security:timeline:osv:GHSA-aaa')
+    expect(plans[0].next.entries[0].stage).toBe('detected')
+    expect(plans[1].key).toBe('security:timeline:osv:GHSA-bbb')
+  })
+
+  it('emits zero plans when no alerts transitioned', async () => {
+    const existing: OsvTimeline = {
+      vulnId: 'GHSA-aaa', createdAt: '2026-04-20T00:00:00Z', lastSeen: '2026-04-21T00:00:00Z',
+      entries: [{ stage: 'detected', at: '2026-04-20T00:00:00Z', severity: 'high' }],
+    }
+    const reader = async (key: string) => key === 'security:timeline:osv:GHSA-aaa' ? JSON.stringify(existing) : null
+    const plans = await planOsvTimelineCycle([alertA], reader, '2026-04-22T10:00:00Z')
+    expect(plans).toHaveLength(0)
+  })
+
+  it('skips the write entirely when the existing timeline is corrupt — preserves historical createdAt', async () => {
+    // Overwriting a corrupt blob with a fresh `detected` entry would reset createdAt to
+    // today, erasing the real first-detection timestamp the monthly report depends on.
+    const reader = async () => '{not valid json'
+    const parseFails: string[] = []
+    const plans = await planOsvTimelineCycle(
+      [alertA],
+      reader,
+      '2026-04-22T10:00:00Z',
+      (key) => parseFails.push(key),
+    )
+    expect(plans).toHaveLength(0)
+    expect(parseFails).toEqual(['security:timeline:osv:GHSA-aaa'])
+  })
+
+  it('ignores non-OSV alerts in the input mix', async () => {
+    const hnAlert: SecurityAlert = {
+      source: 'hackernews', id: '1', title: 't', url: 'u', kvKey: 'k',
+    }
+    const reader = async () => null
+    const plans = await planOsvTimelineCycle([hnAlert, alertA], reader, '2026-04-22T10:00:00Z')
+    expect(plans).toHaveLength(1)
+    expect(plans[0].key).toBe('security:timeline:osv:GHSA-aaa')
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -718,7 +718,7 @@ function corsHeaders(origin: string, allowedOrigin: string | undefined): Headers
 import { generateBadgeSvg } from './badge'
 import { generateOgSvg } from './og'
 import { detectRedditPosts, formatRedditAlert, formatCompetitiveAlert, formatSecurityAlert as formatRedditSecurityAlert, isPromotable } from './reddit'
-import { detectSecurityAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts } from './security-monitor'
+import { detectSecurityAlerts, fetchOSVAlerts, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, planOsvTimelineCycle } from './security-monitor'
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { collectChangelogs, getStaleSources } from './changelog'
@@ -1126,6 +1126,26 @@ export default {
         }
       } catch (err) {
         console.error('[cron] Security monitoring (HN/OSV) failed:', err instanceof Error ? err.message : err)
+      }
+
+      // OSV timeline tracking (#291) — runs hourly alongside the dedup path.
+      // Separate from detectSecurityAlerts because timeline needs the CURRENT state
+      // of every tracked OSV alert (to detect severity_changed / fix_released),
+      // not just the new-this-hour ones. Writes only on stage transitions, so
+      // steady-state KV cost is near zero.
+      try {
+        const osvAlerts = await fetchOSVAlerts()
+        const plans = await planOsvTimelineCycle(
+          osvAlerts,
+          (key) => env.STATUS_CACHE.get(key).catch(() => null),
+          new Date().toISOString(),
+          (key, err) => console.warn('[cron] OSV timeline parse failed, preserving blob:', key, err instanceof Error ? err.message : err),
+        )
+        for (const p of plans) {
+          await kvPut(env.STATUS_CACHE, p.key, JSON.stringify(p.next))
+        }
+      } catch (err) {
+        console.error('[cron] OSV timeline tracking failed:', err instanceof Error ? err.message : err)
       }
     }
 

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -8,6 +8,8 @@
 
 import type { ProbeDailyData } from './probe-archival'
 import type { ServiceStatus, Incident } from './types'
+import type { OsvTimeline, OsvTimelineEntry } from './security-monitor'
+import { osvTimelineKey } from './security-monitor'
 
 export type ScoreGrade = 'excellent' | 'good' | 'fair' | 'degrading' | 'unstable'
 
@@ -47,8 +49,10 @@ export interface MonthlySecurityEntry {
 }
 
 export interface MonthlySecurityTopFinding extends MonthlySecurityEntry {
-  // Identical fields to MonthlySecurityEntry today. Kept as a distinct type so #291 can
-  // extend only top findings with an optional `timeline` array without widening the raw entry.
+  // #291: optional per-alert timeline ("detected → fix_released → severity_changed").
+  // Populated only for OSV findings that have a permanent security:timeline:osv:{id} KV
+  // entry at archive build time; HN findings never carry this field.
+  timeline?: OsvTimelineEntry[]
 }
 
 export interface MonthlySecuritySummary {
@@ -234,6 +238,45 @@ export function summarizeSecurityAlerts(entries: MonthlySecurityEntry[]): Monthl
   return { totalAlerts: entries.length, bySource, bySeverity, byService, topFindings }
 }
 
+/**
+ * Extract the OSV vuln ID (GHSA-* or CVE-*) from a finding URL.
+ * Works for the two shapes our writer currently produces: osv.dev/vulnerability/{id}
+ * and github.com/advisories/{id}. Returns null if the URL doesn't carry a recognizable id.
+ */
+export function extractOsvVulnId(url: string | undefined): string | null {
+  if (!url) return null
+  const m = url.match(/(GHSA-[a-z0-9-]+|CVE-\d{4}-\d+)/i)
+  return m ? m[1] : null
+}
+
+/**
+ * For each OSV top finding, attach its permanent timeline (#291) when a
+ * security:timeline:osv:{id} KV entry exists. HN findings and findings without a
+ * resolvable vuln id pass through unchanged.
+ */
+export async function enrichTopFindingsWithTimelines(
+  kv: KVNamespace,
+  summary: MonthlySecuritySummary,
+): Promise<MonthlySecuritySummary> {
+  const enrichedTop = await Promise.all(
+    summary.topFindings.map(async (f): Promise<MonthlySecurityTopFinding> => {
+      if (f.source !== 'osv') return f
+      const vulnId = extractOsvVulnId(f.url)
+      if (!vulnId) return f
+      const raw = await kv.get(osvTimelineKey(vulnId)).catch(() => null)
+      if (!raw) return f
+      try {
+        const timeline = JSON.parse(raw) as OsvTimeline
+        if (Array.isArray(timeline.entries) && timeline.entries.length > 0) {
+          return { ...f, timeline: timeline.entries }
+        }
+      } catch { /* malformed timeline — skip enrichment, don't fail archive */ }
+      return f
+    }),
+  )
+  return { ...summary, topFindings: enrichedTop }
+}
+
 /** Get all dates in a given month (YYYY-MM-DD strings) */
 export function getMonthDates(year: number, month: number): string[] {
   const dates: string[] = []
@@ -318,6 +361,8 @@ export async function buildMonthlyArchive(
       const parsed = JSON.parse(secRaw) as MonthlySecurityEntry[]
       if (Array.isArray(parsed) && parsed.length > 0) {
         security = summarizeSecurityAlerts(parsed)
+        // Attach permanent per-alert timelines to OSV top findings (#291).
+        security = await enrichTopFindingsWithTimelines(kv, security)
       }
     } catch (err) {
       console.warn(`[monthly-archive] corrupt security accumulation for ${period}:`, err instanceof Error ? err.message : err)

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -639,3 +639,160 @@ export async function readRecentSecurityAlerts(kv: KVNamespace | null): Promise<
   } catch { /* security data is optional — don't fail the response */ }
   return alerts
 }
+
+// ── OSV per-alert timeline tracking (#291) ─────────────────────────────────
+//
+// Captures real transitions — patch availability, severity shifts — against an
+// OSV alert so the monthly report can show progression ("T+0 detected → T+6h
+// fix released → T+26h severity raised"). Stored under security:timeline:osv:{id}
+// with NO TTL (permanent); the dedup-oriented security:seen:osv:* key (7d TTL)
+// is unchanged and kept separate.
+
+export type OsvTimelineStage = 'detected' | 'severity_changed' | 'fix_released' | 'cve_merged' | 'withdrawn'
+
+export interface OsvTimelineEntry {
+  stage: OsvTimelineStage
+  at: string                      // ISO 8601 — when AIWatch observed the transition
+  severity?: SecurityAlert['severity']
+  fixedVersion?: string
+  cveIds?: string[]
+  osvModified?: string            // OSV's own modified timestamp at snapshot time
+}
+
+export interface OsvTimeline {
+  vulnId: string
+  affectedPackage?: string
+  service?: string
+  createdAt: string               // first AIWatch observation
+  lastSeen: string                // refreshed when a new entry is appended
+  entries: OsvTimelineEntry[]     // chronological, at least one (the initial `detected`)
+}
+
+/** KV key for the permanent per-alert OSV timeline (#291). */
+export function osvTimelineKey(vulnId: string): string {
+  return `security:timeline:osv:${vulnId}`
+}
+
+/**
+ * Walk the timeline backwards to find the most recently observed severity.
+ * Returns undefined if no entry ever recorded one.
+ */
+function lastKnownSeverity(timeline: OsvTimeline): SecurityAlert['severity'] | undefined {
+  for (let i = timeline.entries.length - 1; i >= 0; i--) {
+    const sev = timeline.entries[i].severity
+    if (sev) return sev
+  }
+  return undefined
+}
+
+/** Same walk for fixedVersion — treats empty string as "no fix yet known". */
+function lastKnownFixedVersion(timeline: OsvTimeline): string | undefined {
+  for (let i = timeline.entries.length - 1; i >= 0; i--) {
+    const fv = timeline.entries[i].fixedVersion
+    if (fv) return fv
+  }
+  return undefined
+}
+
+/**
+ * Decide whether the current observation of an OSV alert warrants a new timeline entry.
+ * Pure function — callers provide existing timeline (null on first sight), the current
+ * alert payload, and the current ISO timestamp.
+ *
+ * Stages this function emits today:
+ *   - `detected`          existing is null (first observation)
+ *   - `severity_changed`  current severity differs from the last observed severity
+ *   - `fix_released`      current has a fixedVersion where the last observation had none
+ *
+ * `cve_merged` and `withdrawn` are reserved in the type for forward compat but not
+ * detected yet — they require fetch-layer fields (OSV aliases, withdrawn) the current
+ * SecurityAlert doesn't carry. Extend the fetcher first, then add branches here.
+ */
+export function shouldAppendTimeline(
+  existing: OsvTimeline | null,
+  current: SecurityAlert,
+  now: string,
+): OsvTimelineEntry | null {
+  if (!existing) {
+    return {
+      stage: 'detected',
+      at: now,
+      severity: current.severity,
+      fixedVersion: current.fixedVersion,
+    }
+  }
+  const lastSeverity = lastKnownSeverity(existing)
+  if (current.severity && current.severity !== lastSeverity) {
+    return { stage: 'severity_changed', at: now, severity: current.severity }
+  }
+  const lastFixed = lastKnownFixedVersion(existing)
+  if (current.fixedVersion && !lastFixed) {
+    return { stage: 'fix_released', at: now, fixedVersion: current.fixedVersion }
+  }
+  return null
+}
+
+/**
+ * Append a new entry to an existing timeline, or construct a new one. Pure — the
+ * cron integration handles the KV write.
+ */
+export function appendTimelineEntry(
+  existing: OsvTimeline | null,
+  alert: SecurityAlert,
+  entry: OsvTimelineEntry,
+  now: string,
+): OsvTimeline {
+  if (existing) {
+    return { ...existing, lastSeen: now, entries: [...existing.entries, entry] }
+  }
+  return {
+    vulnId: alert.id,
+    affectedPackage: alert.affectedPackage,
+    service: alert.service,
+    createdAt: now,
+    lastSeen: now,
+    entries: [entry],
+  }
+}
+
+/**
+ * Plan the KV writes for a full cycle of OSV timeline updates. Pure — callers provide
+ * the current OSV alert list and a reader for existing timelines; receive the list of
+ * timelines that need to be persisted. Extracted from the cron loop so the branching
+ * (no-op, first observation, transition, corrupt-existing) is directly testable.
+ *
+ * Corrupt existing timelines (parse failure) are preserved, NOT overwritten: resetting
+ * `createdAt` on corruption would erase the historical first-detection timestamp that
+ * the monthly report depends on. A skip+log stance favors manual repair.
+ */
+export interface TimelineCyclePlan {
+  key: string
+  next: OsvTimeline
+}
+
+export async function planOsvTimelineCycle(
+  alerts: SecurityAlert[],
+  readExisting: (key: string) => Promise<string | null>,
+  now: string,
+  onParseFail?: (key: string, err: unknown) => void,
+): Promise<TimelineCyclePlan[]> {
+  const plans: TimelineCyclePlan[] = []
+  for (const alert of alerts) {
+    if (alert.source !== 'osv') continue
+    const key = osvTimelineKey(alert.id)
+    const raw = await readExisting(key)
+    let existing: OsvTimeline | null = null
+    let corrupt = false
+    if (raw) {
+      try { existing = JSON.parse(raw) as OsvTimeline } catch (err) {
+        corrupt = true
+        onParseFail?.(key, err)
+      }
+    }
+    if (corrupt) continue  // preserve the blob for manual repair; don't overwrite createdAt
+    const entry = shouldAppendTimeline(existing, alert, now)
+    if (!entry) continue
+    plans.push({ key, next: appendTimelineEntry(existing, alert, entry, now) })
+  }
+  return plans
+}


### PR DESCRIPTION
closes #291

(Re-opened after the stacked parent PR #308 merged — the old PR #309 auto-closed when its base branch was deleted. Rebased cleanly onto main with #308's commits dropped since they're already upstream.)

## Summary
Captures real lifecycle transitions against each OSV alert — \`detected\` → \`severity_changed\` → \`fix_released\` — so the monthly report can show progression (\"T+0 detected → T+6h fix released → T+26h severity raised\") instead of a single \`detectedAt\` timestamp.

- **Storage**: \`security:timeline:osv:{vulnId}\`, **permanent** (no TTL). Kept separate from the 7d-TTL \`security:seen:osv:*\` dedup key.
- **Planner**: pure \`planOsvTimelineCycle(alerts, readExisting, now, onParseFail?)\` returns \`TimelineCyclePlan[]\` — only the keys that need writing this cycle. Corrupt existing timelines are preserved (skip + log), not overwritten, so a parse failure never erases historical \`createdAt\`.
- **Cron integration**: hourly block at \`now.getUTCMinutes() < 5\`, alongside the existing dedup path. Steady-state KV writes are near zero (only on transitions).
- **Archive integration** (#290): \`MonthlySecurityTopFinding\` gains optional \`timeline: OsvTimelineEntry[]\`, populated via \`enrichTopFindingsWithTimelines\` at archive build time for OSV findings only. HN findings never get enriched.

\`withdrawn\` and \`cve_merged\` stages are reserved in the \`OsvTimelineStage\` enum for forward compatibility but not detected yet.

## Test plan
- [x] Worker tests — 1042/1042 pass after rebase (16 new + everything else in main)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — clean
- [x] PR review (pre-rebase, in PR #309) — 2 rounds, converged 0 Critical / 0 Important

## References
- Issue #291 design + acceptance criteria
- #290 archive schema (merged as commit 85ef957c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)