### PR TITLE
fix: auto-bump sitemap <lastmod> on every build (#337)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ When adding a new monitored service, update ALL of the following:
 18. `api/is-down.ts` — add service to `SERVICES` map
 19. `api/is-down/html-template.ts` — if needed
 20. `vercel.json` — add rewrite rule `/is-{service}-down`
-21. `public/sitemap.xml` — add URL entry
+21. `public/sitemap.xml` — add URL entry (`lastmod` is auto-bumped to build date by `scripts/bump-sitemap-lastmod.mjs` via `prebuild` hook — #337 — so any placeholder date works for the initial commit)
 
 #### Reports site (aiwatch-reports) — commit + push to deploy (GitHub Pages auto-build)
 22. `README.md` — service count, category breakdown (e.g., "N LLM APIs, N voice & inference")

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/bump-sitemap-lastmod.mjs",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "npm run build && wrangler dev",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,87 +11,87 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-03-29</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-04-18</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-04-20</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-03-29</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -99,7 +99,7 @@
   <!-- Monthly Reports (external) -->
   <url>
     <loc>https://reports.ai-watch.dev/</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/bump-sitemap-lastmod.mjs
+++ b/scripts/bump-sitemap-lastmod.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// #337: bump <lastmod> in public/sitemap.xml to today's UTC date.
+// Runs as `prebuild` on every Vercel deploy so Googlebot sees fresh re-crawl
+// priority signals. Without this, `lastmod` silently drifts (we saw 4-32 day
+// staleness in production on 2026-04-24).
+//
+// Node-based rather than sed so the same script works on BSD (macOS local)
+// and GNU (Vercel Linux) without flag quirks.
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SITEMAP_PATH = path.resolve(process.cwd(), 'public/sitemap.xml')
+const today = new Date().toISOString().slice(0, 10)
+
+if (!fs.existsSync(SITEMAP_PATH)) {
+  console.error(`[bump-sitemap] ${SITEMAP_PATH} not found — skipping (not a fatal build error)`)
+  process.exit(0)
+}
+
+const before = fs.readFileSync(SITEMAP_PATH, 'utf8')
+// Strict YYYY-MM-DD match — won't touch any other timestamps elsewhere in the file.
+const matches = before.match(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g) ?? []
+if (matches.length === 0) {
+  // Genuine schema drift — no YYYY-MM-DD <lastmod> entries at all. Warn so a
+  // future contributor who changes the sitemap format (e.g. to ISO datetime)
+  // updates this script too instead of silently deploying with stale signals.
+  console.error(`[bump-sitemap] WARNING: no <lastmod>YYYY-MM-DD</lastmod> entries in ${SITEMAP_PATH} — schema may have changed, update this script`)
+  process.exit(0)  // non-fatal so builds don't break on a docs edit
+}
+
+const after = before.replace(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g, `<lastmod>${today}</lastmod>`)
+if (after === before) {
+  console.log(`[bump-sitemap] ${matches.length} entries already at ${today} — no change`)
+  process.exit(0)
+}
+
+fs.writeFileSync(SITEMAP_PATH, after)
+console.log(`[bump-sitemap] updated ${matches.length} <lastmod> entries → ${today}`)


### PR DESCRIPTION
closes #337

## Summary
- \`public/sitemap.xml\` had hardcoded \`<lastmod>\` values **4-32 days stale** as of 2026-04-24. Every 29 \`/is-X-down\` URL declared \`<changefreq>hourly</changefreq>\` alongside a month-old date — Googlebot treats that contradictory signal as "deprioritize re-crawl".
- Direct symptom: Google Search Console's \"Googlebot-rendered page\" tab served a month-old snapshot of \`is-claude-down\` today, even though production HTML has been fresh for weeks (verified via \`curl\`).
- Fix: \`scripts/bump-sitemap-lastmod.mjs\` wired as \`prebuild\` so every Vercel deploy rewrites \`<lastmod>\` to today's UTC date before \`vite build\` runs.

## Design notes
- **Node, not sed** — BSD (macOS local) and GNU (Vercel Linux) \`sed -i\` differ; Node runs identically on both.
- **Regex strictly anchored** to \`<lastmod>YYYY-MM-DD</lastmod>\` — won't silently corrupt an ISO-datetime variant if the schema ever migrates. On format drift it prints a \"schema may have changed\" warning instead.
- **UTC date** per sitemaps.org spec. KST would be up to 9h ahead of real UTC publish time — worse than stale.
- **Non-fatal exits** (exit 0 on missing file / schema drift) — a docs-only PR accidentally moving the sitemap shouldn't break the build. Counter-case (fail-loud in production) addressed in review as \`VERCEL === '1'\` gate if ever needed.

## Test plan
- [x] Fresh run: \"updated 32 <lastmod> entries → 2026-04-24\"
- [x] Idempotent re-run: \"32 entries already at 2026-04-24 — no change\"
- [x] Artificial stale (2025-01-01): correctly matched + bumped
- [x] \`npm run build\` — prebuild fires, vite build succeeds
- [x] \`npm run test:src\` — 47/47 pass (no regression)
- [x] PR review — 0 Critical / 0 Important

## Expected outcome after merge
1. Vercel auto-deploy writes today's date into all 32 \`<lastmod>\` entries.
2. Google re-crawls within 24-72h (signal matches actual content freshness).
3. Search Console \"Googlebot-rendered\" snapshots catch up to current production HTML.

## Docs
CLAUDE.md \"Adding a new service\" checklist item #21 now notes that \`lastmod\` is auto-bumped on build — future contributors adding a \`/is-X-down\` URL only need to add the entry; any placeholder date works.

## Out of scope
- Per-URL \`lastmod\` reflecting each service's last incident (would need an Edge Function — defer unless Google re-crawl signal proves insufficient)
- Changing \`changefreq\` values — current \`hourly\` (for \`is-X-down\`) and \`daily\` (for home) are semantically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)