### PR TITLE
feat: proxy /reports/* to reports.ai-watch.dev for SEO consolidation (refs #264)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 
 Is X Down pages (Edge SSR) and Landing page use inline `gtag()` calls directly since they don't use React.
 
-**Reports site** (`reports.ai-watch.dev`) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
+**Reports site** (served at `ai-watch.dev/reports/` via Vercel rewrite to `reports.ai-watch.dev` — SEO consolidation #264; direct subdomain visits self-redirect via JS in `aiwatch-reports/_includes/head.html`) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
 
 | Event | Parameters | Trigger | Purpose |
 |---|---|---|---|

--- a/api/intro/html-template.ts
+++ b/api/intro/html-template.ts
@@ -6,7 +6,7 @@ interface LandingOptions {
 
 export function renderLandingPage(opts: LandingOptions): string {
   const phDisplay = opts.showPHBanner ? 'block' : 'none'
-  const reportUrl = 'https://reports.ai-watch.dev/'
+  const reportUrl = 'https://ai-watch.dev/reports/'
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -482,7 +482,7 @@ export function renderLandingPage(opts: LandingOptions): string {
     <div class="nav-links">
       <a href="#how" data-i18n="nav.how">동작 방식</a>
       <a href="#features" data-i18n="nav.features">기능</a>
-      <a href="https://reports.ai-watch.dev" data-i18n="nav.report">월간 리포트</a>
+      <a href="https://ai-watch.dev/reports" data-i18n="nav.report">월간 리포트</a>
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
     </div>
     <div class="lang-toggle">
@@ -1116,7 +1116,7 @@ export function renderLandingPage(opts: LandingOptions): string {
     <div class="footer-left">© 2026 AIWatch · AGPL-3.0</div>
     <div class="footer-links">
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
-      <a href="https://reports.ai-watch.dev" data-i18n="footer.report">월간 리포트</a>
+      <a href="https://ai-watch.dev/reports" data-i18n="footer.report">월간 리포트</a>
       <a href="https://ai-watch.dev/#settings" data-i18n="footer.alert">알림 설정</a>
       <a href="https://ai-watch.dev/is-claude-down">Is Claude Down?</a>
     </div>

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -329,7 +329,7 @@ function renderStatusHeader(service: ServiceData | null, seo: ServiceSEO): strin
 <p class="meta mono">${metaParts.join(' &middot; ')}</p>
 ${lastIncident ? `<p class="meta">Last incident: ${esc(formatDate(lastIncident.startedAt))} &mdash; ${esc(lastIncident.title)}${lastIncident.duration ? ` (${esc(lastIncident.duration)})` : ' (ongoing)'}</p>` : '<p class="meta">No recent incidents</p>'}
 ${/* TODO: update report URL monthly (currently hardcoded to latest report) */ ''}
-${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="https://reports.ai-watch.dev/2026-03/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">March 2026 Report &rarr;</a></p>` : ''}
+${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="https://ai-watch.dev/reports/2026-03/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">March 2026 Report &rarr;</a></p>` : ''}
 </div>`
 }
 
@@ -512,7 +512,7 @@ function renderFallbacks(seo: ServiceSEO, fallbacks: Fallback[], fromId?: string
 ${items}
 <div class="links" style="margin-top:12px">
 <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'alternatives'})">Reliability rankings &rarr;</a>
-<a href="https://reports.ai-watch.dev/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'alternatives'})">Monthly reports &rarr;</a>
+<a href="https://ai-watch.dev/reports/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'alternatives'})">Monthly reports &rarr;</a>
 </div>
 </div>`
 }
@@ -679,7 +679,7 @@ function renderFooter(slug: string): string {
 
   return `<div class="footer">
 <p style="margin-bottom:12px"><a href="https://ai-watch.dev" class="btn" onclick="typeof gtag==='function'&&gtag('event','click_dashboard',{location:'is_down_page',source:'footer'})">View Full Dashboard</a></p>
-<p><a href="https://ai-watch.dev/#${esc(seoEntry?.id ?? slug)}" onclick="typeof gtag==='function'&&gtag('event','click_service_detail',{location:'is_down_page',service_id:'${esc(seoEntry?.id ?? slug)}'})">Detailed service page</a> &middot; <a href="https://reports.ai-watch.dev/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'footer'})">Monthly reports</a> &middot; <a href="https://ai-watch.dev/#settings" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'footer'})">Set up alerts</a></p>
+<p><a href="https://ai-watch.dev/#${esc(seoEntry?.id ?? slug)}" onclick="typeof gtag==='function'&&gtag('event','click_service_detail',{location:'is_down_page',service_id:'${esc(seoEntry?.id ?? slug)}'})">Detailed service page</a> &middot; <a href="https://ai-watch.dev/reports/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'footer'})">Monthly reports</a> &middot; <a href="https://ai-watch.dev/#settings" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'footer'})">Set up alerts</a></p>
 ${relatedLinks ? `<p style="margin-top:12px;font-size:13px">Related: ${relatedLinks}</p>` : ''}
 ${otherLinks ? `<p style="margin-top:8px;font-size:12px">Also check: ${otherLinks}</p>` : ''}
 <p style="margin-top:12px">&copy; 2026 AIWatch. Real-time AI service status monitoring.</p>

--- a/docs/aiwatch-landing.html
+++ b/docs/aiwatch-landing.html
@@ -460,7 +460,7 @@
     <div class="nav-links">
       <a href="#how" data-i18n="nav.how">동작 방식</a>
       <a href="#features" data-i18n="nav.features">기능</a>
-      <a href="https://reports.ai-watch.dev" data-i18n="nav.report">월간 리포트</a>
+      <a href="https://ai-watch.dev/reports" data-i18n="nav.report">월간 리포트</a>
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
     </div>
     <div class="lang-toggle">
@@ -1045,10 +1045,10 @@
   <text x="120" y="164" text-anchor="end" fill="#768390" font-size="11">OpenAI API</text>
   <rect x="128" y="150" width="258" height="16" rx="3" fill="#3b82f6"/>
   <text x="392" y="163" fill="#adbac7" font-size="11">86  Good</text>
-  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 31개 서비스 보기 → reports.ai-watch.dev</text>
+  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 31개 서비스 보기 → ai-watch.dev/reports/</text>
 </svg>
   </div>
-  <a href="https://reports.ai-watch.dev/" class="report-link" target="_blank" rel="noopener noreferrer" onclick="gtag('event','click_reports',{location:'landing_report',source:'intro'})">
+  <a href="https://ai-watch.dev/reports/" class="report-link" target="_blank" rel="noopener noreferrer" onclick="gtag('event','click_reports',{location:'landing_report',source:'intro'})">
     <span data-i18n="report.link">전체 리포트 보기 →</span>
   </a>
   </div>
@@ -1085,7 +1085,7 @@
     <div class="footer-left">© 2026 AIWatch · AGPL-3.0</div>
     <div class="footer-links">
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
-      <a href="https://reports.ai-watch.dev" data-i18n="footer.report">월간 리포트</a>
+      <a href="https://ai-watch.dev/reports" data-i18n="footer.report">월간 리포트</a>
       <a href="https://ai-watch.dev/#settings" data-i18n="footer.alert">알림 설정</a>
       <a href="https://ai-watch.dev/is-claude-down">Is Claude Down?</a>
     </div>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -96,9 +96,9 @@
     <priority>0.8</priority>
   </url>
 
-  <!-- Monthly Reports (external) -->
+  <!-- Monthly Reports (Vercel proxy to reports.ai-watch.dev, #264) -->
   <url>
-    <loc>https://reports.ai-watch.dev/</loc>
+    <loc>https://ai-watch.dev/reports/</loc>
     <lastmod>2026-04-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -201,7 +201,7 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
           )
         })}
         <a
-          href="https://reports.ai-watch.dev/"
+          href="https://ai-watch.dev/reports/"
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => { trackEvent('click_reports', {}); onNavigate?.() }}

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -35,7 +35,7 @@ test.describe('Sidebar navigation', () => {
     const reportsLink = sidebar.getByRole('link', { name: 'Reports' })
 
     await expect(reportsLink).toBeVisible()
-    await expect(reportsLink).toHaveAttribute('href', 'https://reports.ai-watch.dev/')
+    await expect(reportsLink).toHaveAttribute('href', 'https://ai-watch.dev/reports/')
     await expect(reportsLink).toHaveAttribute('target', '_blank')
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -32,6 +32,8 @@
     { "source": "/is-character-ai-down", "destination": "/api/is-down?slug=character-ai" },
     { "source": "/is-codex-down", "destination": "/api/is-down?slug=codex" },
     { "source": "/intro", "destination": "/api/intro" },
+    { "source": "/reports", "destination": "https://reports.ai-watch.dev/" },
+    { "source": "/reports/:path*", "destination": "https://reports.ai-watch.dev/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
refs #264

## Summary
- Step 2 of 2 for the monthly-reports domain migration. Serves reports at \`ai-watch.dev/reports/...\` via Vercel rewrite proxy to the existing \`reports.ai-watch.dev\` Jekyll origin.
- All user-facing internal links migrated to the main-domain path so backlinks/click-through accumulate authority on \`ai-watch.dev\` rather than the subdomain.
- Depends on Step 1 (separate commit in \`aiwatch-reports\` repo) to finalize canonical URLs + subdomain self-redirect.

## ⚠️ Deploy order requirement

**Step 1 (aiwatch-reports) must land and rebuild BEFORE this PR merges to main.** Without Step 1, Jekyll still generates \`<link rel="canonical" href="https://reports.ai-watch.dev/...">\` and asset paths at root (\`/assets/*\`), which would miss this PR's rewrite and fall through to the SPA catch-all → CSS/JS 404 on \`ai-watch.dev/reports/*\`.

### Step 1 checklist (user-side, \`aiwatch-reports\` repo)

1. **\`_config.yml\`** — 2 line change:
   \`\`\`yaml
   baseurl: "/reports"
   url: https://ai-watch.dev
   \`\`\`
2. **\`_includes/head.html\`** — prepend JS redirect block before \`{%- seo -%}\`:
   \`\`\`html
   <script>
   if (location.hostname === 'reports.ai-watch.dev') {
     location.replace('https://ai-watch.dev/reports' + location.pathname + location.search + location.hash);
   }
   </script>
   \`\`\`
3. Commit → GH Pages auto-rebuilds → verify \`curl -s https://reports.ai-watch.dev/2026-03/ | grep canonical\` returns main-domain canonical.

## What this PR changes

| File | Change |
|---|---|
| \`vercel.json\` | Two rewrites before SPA catch-all: \`/reports\` + \`/reports/:path*\` → \`reports.ai-watch.dev/...\` |
| \`src/components/Sidebar.jsx\` | Nav link: subdomain → main |
| \`api/intro/html-template.ts\` | 3 refs (\`reportUrl\` const + 2 nav links in i18n) |
| \`api/is-down/html-template.ts\` | 3 refs (rank meta, alternatives card, footer) |
| \`docs/aiwatch-landing.html\` | 3 refs in design mockup — not deployed but kept in sync |
| \`public/sitemap.xml\` | Single \`/reports/\` entry as main-domain sitemap signpost (Jekyll sitemap after Step 1 covers individual months) |
| \`tests/navigation.spec.js\` | Playwright href assertion updated |
| \`CLAUDE.md\` | \"Reports site\" description captures rewrite + JS redirect |

## Local verification

- Jekyll build on \`aiwatch-reports\` with proposed \`_config.yml\` changes (tested on 2026-04-24 then reverted) confirmed:
  - \`<link rel="canonical" href="https://ai-watch.dev/reports/2026-03/" />\`
  - \`<meta property="og:url" content="https://ai-watch.dev/reports/2026-03/" />\`
  - \`sitemap.xml\` emits all main-domain URLs
  - Internal asset links: \`/reports/assets/main.css\` (consistent with Vercel rewrite path)
- JS redirect in \`_includes/head.html\` lands at top of \`<head>\` before \`<meta charset>\` — fires before CSS/assets load.
- \`npm run build\` clean.
- \`npm run test:src\` 47/47 pass.
- Code review (Round 1) — 0 Critical / 0 Important.

## Step 3 (deferred)

Subdomain 301 redirect at DNS/Cloudflare level — wait 2-3 months for Google to absorb main-domain canonicals, then retire the subdomain origin entirely.

## Why \`refs\` not \`closes\`
Issue #264's acceptance criteria include:
- [x] Decide between option 1/2/3 (Option 1, Vercel rewrite)
- [x] Implement chosen approach (this PR + Step 1)
- [ ] \`ai-watch.dev/reports/2026-04/\` resolves to current monthly report — **pending Step 1 + production deploy**
- [ ] Canonical points to new ai-watch.dev URL — **pending Step 1**
- [ ] Old subdomain URLs 301 redirect — **deferred as Step 3**
- [x] Sitemap updated
- [x] No broken internal links

Keeping open until post-deploy verification + Step 3 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)