### PR TITLE
revert: #264 Vercel rewrite + internal link updates — rewrite not functional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 
 Is X Down pages (Edge SSR) and Landing page use inline `gtag()` calls directly since they don't use React.
 
-**Reports site** (served at `ai-watch.dev/reports/` via Vercel rewrite to `reports.ai-watch.dev` — SEO consolidation #264; direct subdomain visits self-redirect via JS in `aiwatch-reports/_includes/head.html`) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
+**Reports site** (`reports.ai-watch.dev`) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
 
 | Event | Parameters | Trigger | Purpose |
 |---|---|---|---|

--- a/api/intro/html-template.ts
+++ b/api/intro/html-template.ts
@@ -6,7 +6,7 @@ interface LandingOptions {
 
 export function renderLandingPage(opts: LandingOptions): string {
   const phDisplay = opts.showPHBanner ? 'block' : 'none'
-  const reportUrl = 'https://ai-watch.dev/reports/'
+  const reportUrl = 'https://reports.ai-watch.dev/'
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -482,7 +482,7 @@ export function renderLandingPage(opts: LandingOptions): string {
     <div class="nav-links">
       <a href="#how" data-i18n="nav.how">동작 방식</a>
       <a href="#features" data-i18n="nav.features">기능</a>
-      <a href="https://ai-watch.dev/reports" data-i18n="nav.report">월간 리포트</a>
+      <a href="https://reports.ai-watch.dev" data-i18n="nav.report">월간 리포트</a>
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
     </div>
     <div class="lang-toggle">
@@ -1116,7 +1116,7 @@ export function renderLandingPage(opts: LandingOptions): string {
     <div class="footer-left">© 2026 AIWatch · AGPL-3.0</div>
     <div class="footer-links">
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
-      <a href="https://ai-watch.dev/reports" data-i18n="footer.report">월간 리포트</a>
+      <a href="https://reports.ai-watch.dev" data-i18n="footer.report">월간 리포트</a>
       <a href="https://ai-watch.dev/#settings" data-i18n="footer.alert">알림 설정</a>
       <a href="https://ai-watch.dev/is-claude-down">Is Claude Down?</a>
     </div>

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -329,7 +329,7 @@ function renderStatusHeader(service: ServiceData | null, seo: ServiceSEO): strin
 <p class="meta mono">${metaParts.join(' &middot; ')}</p>
 ${lastIncident ? `<p class="meta">Last incident: ${esc(formatDate(lastIncident.startedAt))} &mdash; ${esc(lastIncident.title)}${lastIncident.duration ? ` (${esc(lastIncident.duration)})` : ' (ongoing)'}</p>` : '<p class="meta">No recent incidents</p>'}
 ${/* TODO: update report URL monthly (currently hardcoded to latest report) */ ''}
-${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="https://ai-watch.dev/reports/2026-03/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">March 2026 Report &rarr;</a></p>` : ''}
+${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="https://reports.ai-watch.dev/2026-03/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">March 2026 Report &rarr;</a></p>` : ''}
 </div>`
 }
 
@@ -512,7 +512,7 @@ function renderFallbacks(seo: ServiceSEO, fallbacks: Fallback[], fromId?: string
 ${items}
 <div class="links" style="margin-top:12px">
 <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'alternatives'})">Reliability rankings &rarr;</a>
-<a href="https://ai-watch.dev/reports/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'alternatives'})">Monthly reports &rarr;</a>
+<a href="https://reports.ai-watch.dev/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'alternatives'})">Monthly reports &rarr;</a>
 </div>
 </div>`
 }
@@ -679,7 +679,7 @@ function renderFooter(slug: string): string {
 
   return `<div class="footer">
 <p style="margin-bottom:12px"><a href="https://ai-watch.dev" class="btn" onclick="typeof gtag==='function'&&gtag('event','click_dashboard',{location:'is_down_page',source:'footer'})">View Full Dashboard</a></p>
-<p><a href="https://ai-watch.dev/#${esc(seoEntry?.id ?? slug)}" onclick="typeof gtag==='function'&&gtag('event','click_service_detail',{location:'is_down_page',service_id:'${esc(seoEntry?.id ?? slug)}'})">Detailed service page</a> &middot; <a href="https://ai-watch.dev/reports/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'footer'})">Monthly reports</a> &middot; <a href="https://ai-watch.dev/#settings" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'footer'})">Set up alerts</a></p>
+<p><a href="https://ai-watch.dev/#${esc(seoEntry?.id ?? slug)}" onclick="typeof gtag==='function'&&gtag('event','click_service_detail',{location:'is_down_page',service_id:'${esc(seoEntry?.id ?? slug)}'})">Detailed service page</a> &middot; <a href="https://reports.ai-watch.dev/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'footer'})">Monthly reports</a> &middot; <a href="https://ai-watch.dev/#settings" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'footer'})">Set up alerts</a></p>
 ${relatedLinks ? `<p style="margin-top:12px;font-size:13px">Related: ${relatedLinks}</p>` : ''}
 ${otherLinks ? `<p style="margin-top:8px;font-size:12px">Also check: ${otherLinks}</p>` : ''}
 <p style="margin-top:12px">&copy; 2026 AIWatch. Real-time AI service status monitoring.</p>

--- a/docs/aiwatch-landing.html
+++ b/docs/aiwatch-landing.html
@@ -460,7 +460,7 @@
     <div class="nav-links">
       <a href="#how" data-i18n="nav.how">동작 방식</a>
       <a href="#features" data-i18n="nav.features">기능</a>
-      <a href="https://ai-watch.dev/reports" data-i18n="nav.report">월간 리포트</a>
+      <a href="https://reports.ai-watch.dev" data-i18n="nav.report">월간 리포트</a>
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
     </div>
     <div class="lang-toggle">
@@ -1045,10 +1045,10 @@
   <text x="120" y="164" text-anchor="end" fill="#768390" font-size="11">OpenAI API</text>
   <rect x="128" y="150" width="258" height="16" rx="3" fill="#3b82f6"/>
   <text x="392" y="163" fill="#adbac7" font-size="11">86  Good</text>
-  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 31개 서비스 보기 → ai-watch.dev/reports/</text>
+  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 31개 서비스 보기 → reports.ai-watch.dev</text>
 </svg>
   </div>
-  <a href="https://ai-watch.dev/reports/" class="report-link" target="_blank" rel="noopener noreferrer" onclick="gtag('event','click_reports',{location:'landing_report',source:'intro'})">
+  <a href="https://reports.ai-watch.dev/" class="report-link" target="_blank" rel="noopener noreferrer" onclick="gtag('event','click_reports',{location:'landing_report',source:'intro'})">
     <span data-i18n="report.link">전체 리포트 보기 →</span>
   </a>
   </div>
@@ -1085,7 +1085,7 @@
     <div class="footer-left">© 2026 AIWatch · AGPL-3.0</div>
     <div class="footer-links">
       <a href="https://github.com/bentleypark/aiwatch">GitHub</a>
-      <a href="https://ai-watch.dev/reports" data-i18n="footer.report">월간 리포트</a>
+      <a href="https://reports.ai-watch.dev" data-i18n="footer.report">월간 리포트</a>
       <a href="https://ai-watch.dev/#settings" data-i18n="footer.alert">알림 설정</a>
       <a href="https://ai-watch.dev/is-claude-down">Is Claude Down?</a>
     </div>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -96,9 +96,9 @@
     <priority>0.8</priority>
   </url>
 
-  <!-- Monthly Reports (Vercel proxy to reports.ai-watch.dev, #264) -->
+  <!-- Monthly Reports (external) -->
   <url>
-    <loc>https://ai-watch.dev/reports/</loc>
+    <loc>https://reports.ai-watch.dev/</loc>
     <lastmod>2026-04-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -201,7 +201,7 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
           )
         })}
         <a
-          href="https://ai-watch.dev/reports/"
+          href="https://reports.ai-watch.dev/"
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => { trackEvent('click_reports', {}); onNavigate?.() }}

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -35,7 +35,7 @@ test.describe('Sidebar navigation', () => {
     const reportsLink = sidebar.getByRole('link', { name: 'Reports' })
 
     await expect(reportsLink).toBeVisible()
-    await expect(reportsLink).toHaveAttribute('href', 'https://ai-watch.dev/reports/')
+    await expect(reportsLink).toHaveAttribute('href', 'https://reports.ai-watch.dev/')
     await expect(reportsLink).toHaveAttribute('target', '_blank')
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -32,8 +32,6 @@
     { "source": "/is-character-ai-down", "destination": "/api/is-down?slug=character-ai" },
     { "source": "/is-codex-down", "destination": "/api/is-down?slug=codex" },
     { "source": "/intro", "destination": "/api/intro" },
-    { "source": "/reports", "destination": "https://reports.ai-watch.dev/" },
-    { "source": "/reports/:path*", "destination": "https://reports.ai-watch.dev/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Hotfix revert of PR #339. External URL rewrite in vercel.json did not proxy `/reports/*` to `reports.ai-watch.dev` — Vercel instead served the SPA catch-all for all `/reports/*` requests. With internal links (Sidebar, intro, is-down) already pointing to `ai-watch.dev/reports/*`, users clicking them saw the dashboard homepage instead of their expected report.

Reverting restores all internal links to `reports.ai-watch.dev` (working) and removes the non-functional Vercel rewrite. Re-approach: implement `api/reports.ts` Edge Function as an internal proxy, then re-point internal links.