### PR TITLE
feat: Discord ping when monthly archive lands (refs aiwatch-reports#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,7 @@ When adding a new monitored service, update ALL of the following:
 | `vitals:history:{YYYY-MM-DD}` | `{ count, p75 }` JSON | 90d | 1 | Archived yesterday's vitals p75 summary |
 | `incidents:monthly:{YYYY-MM}` | `MonthlyIncidents` JSON | 60d | 1/day | Monthly incident accumulation (deduped by ID, updated in daily summary cron) |
 | `archive:monthly:{YYYY-MM}` | `MonthlyArchive` JSON | none (permanent) | 1/month | Monthly reliability snapshot (uptime, score, incidents, totalDowntimeMin, longestIncidentMin, avgResolutionMin, avgLatencyMs per service — downtime/longest fields surfaced from `incidents:monthly:*` before its 60d TTL lapses so aiwatch-reports#10 can render full Incident Summary columns; optional `security` summary from `security:monthly:{YYYY-MM}` snapshot — #290; OSV top findings also carry `timeline[]` from `security:timeline:osv:*` when available — #291) |
+| `archive:notified:{YYYY-MM}` | `"1"` | 60d | 1/month | Dedup marker for the "monthly archive ready" Discord ping that links to the `aiwatch-reports/generate-report.yml` workflow_dispatch page (aiwatch-reports#4). Written only after a successful send so a transient webhook failure on the 00:00 archive cycle retries on the 01:00 catch-up cycle. 60d TTL purely for dedup (archive itself is permanent) |
 | `security:timeline:osv:{vulnId}` | `OsvTimeline` JSON | none (permanent) | ~0-3/day | Per-alert OSV lifecycle tracking (#291). Entries: `detected` → `severity_changed` → `fix_released`. Written only on stage transitions by the hourly security cron, so steady-state KV writes are near zero. Archive reader attaches the entries to matching top findings |
 | `platform:status:{platformId}` | `PlatformStatus` JSON | 10min | ~288 | Status page platform health (metastatuspage.com for Atlassian) |
 | `alerted:platform:{platformId}` | `"1"` | 2h | ~1 | Platform outage alert dedup |
@@ -442,6 +443,7 @@ Cron Trigger (*/5 min)
   → daily summary at UTC 09:00 (KST 18:00) with alert count aggregation + Web Vitals p75 + Detection Lead audit log (24h sliding window from today + yesterday keys)
   → daily summary also accumulates incidents:monthly:{YYYY-MM} (dedup by incident ID, 60d TTL)
   → monthly archive on 1st of month (UTC 00:00) → aggregate history:* + probe:daily:* + incidents:monthly:* + security:monthly:* → archive:monthly:{YYYY-MM} (permanent)
+  → archive-ready Discord ping → links to `aiwatch-reports/generate-report.yml` workflow_dispatch so operator clicks "Run workflow" to open draft PR; dedup via archive:notified:{YYYY-MM} (aiwatch-reports#4)
   → changelog RSS/HTML collection (hourly at :00) → KV accumulate new entries from OpenAI/Google/Anthropic
   → security monitoring (hourly at :00) → HN Algolia + OSV.dev SDK vulnerability scan (24 AI SDK packages · two-phase: querybatch → KV dedup → per-vuln GET enrichment; #323/#325) → EPSS enrichment via GitHub Advisories (24h KV cache, #326) → Discord digest on findings
   → weekly briefing on Sunday UTC 00:00 (KST 09:00) → aggregate changelog + incidents + stability → Discord embed

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -10,6 +10,9 @@ import {
   summarizeSecurityAlerts,
   extractOsvVulnId,
   enrichTopFindingsWithTimelines,
+  buildArchiveReadyEmbed,
+  archiveNotifiedKey,
+  REPORTS_WORKFLOW_URL,
 } from '../monthly-archive'
 import type { ServiceStatus } from '../types'
 import type { MonthlySecurityEntry, MonthlySecuritySummary } from '../monthly-archive'
@@ -705,5 +708,74 @@ describe('buildMonthlyArchive', () => {
     const archive = await buildMonthlyArchive(kvWithUnresolved, 2026, 4)
     expect(archive.services.claude.incidents).toBe(2)
     expect(archive.services.claude.avgResolutionMin).toBeNull()
+  })
+})
+
+// ── Phase 2: Archive-ready notification (aiwatch-reports#4) ──────────
+
+describe('archiveNotifiedKey', () => {
+  it('returns the stable archive:notified:{period} form', () => {
+    expect(archiveNotifiedKey('2026-04')).toBe('archive:notified:2026-04')
+  })
+})
+
+describe('buildArchiveReadyEmbed', () => {
+  it('renders a full English month label for a valid YYYY-MM', () => {
+    const embed = buildArchiveReadyEmbed('2026-04', 31, 30)
+    expect(embed.title).toBe('📦 Monthly Archive Ready — 2026-04')
+    expect(embed.color).toBe(0x9B59B6)
+    expect(embed.description).toContain('**April 2026** archive')
+    expect(embed.description).toContain('Services: 31')
+    expect(embed.description).toContain('Days collected: 30')
+  })
+
+  it('links to the generate-report.yml workflow_dispatch page', () => {
+    const embed = buildArchiveReadyEmbed('2026-04', 31, 30)
+    expect(embed.description).toContain(REPORTS_WORKFLOW_URL)
+    expect(REPORTS_WORKFLOW_URL).toBe(
+      'https://github.com/bentleypark/aiwatch-reports/actions/workflows/generate-report.yml',
+    )
+  })
+
+  it('spells out the month input the operator must enter', () => {
+    const embed = buildArchiveReadyEmbed('2026-04', 31, 30)
+    expect(embed.description).toMatch(/enter month `2026-04`/)
+  })
+
+  it('formats December correctly (month = 12 edge)', () => {
+    const embed = buildArchiveReadyEmbed('2026-12', 31, 31)
+    expect(embed.description).toContain('**December 2026** archive')
+  })
+
+  it('formats January correctly (single-digit month with zero padding)', () => {
+    const embed = buildArchiveReadyEmbed('2027-01', 31, 31)
+    expect(embed.description).toContain('**January 2027** archive')
+  })
+
+  it('renders a usable embed when the archive has zero services or days', () => {
+    const embed = buildArchiveReadyEmbed('2026-04', 0, 0)
+    expect(embed.title).toBe('📦 Monthly Archive Ready — 2026-04')
+    expect(embed.description).toContain('**April 2026** archive')
+    expect(embed.description).toContain('Services: 0')
+    expect(embed.description).toContain('Days collected: 0')
+    expect(embed.description).not.toContain('Invalid Date')
+  })
+
+  it('falls back to the raw period when the format is malformed', () => {
+    const embed = buildArchiveReadyEmbed('not-a-month', 0, 0)
+    expect(embed.title).toBe('📦 Monthly Archive Ready — not-a-month')
+    expect(embed.description).toContain('**not-a-month** archive')
+    expect(embed.description).not.toContain('Invalid Date')
+  })
+
+  it('falls back to the raw period when the month component is out of range', () => {
+    const embed = buildArchiveReadyEmbed('2026-13', 0, 0)
+    expect(embed.description).toContain('**2026-13** archive')
+    expect(embed.description).not.toContain('Invalid Date')
+  })
+
+  it('always embeds the archive KV key path for traceability', () => {
+    const embed = buildArchiveReadyEmbed('2026-04', 31, 30)
+    expect(embed.description).toContain('`archive:monthly:2026-04`')
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -265,7 +265,7 @@ import { sanitize } from './utils'
 
 // ── Discord Webhook Alerts (Cron-based, no isolate concurrency) ──
 
-async function sendDiscordAlert(webhookUrl: string, embed: { title: string; description: string; color: number }) {
+async function sendDiscordAlert(webhookUrl: string, embed: { title: string; description: string; color: number }): Promise<boolean> {
   try {
     const resp = await fetch(webhookUrl, {
       method: 'POST',
@@ -280,11 +280,13 @@ async function sendDiscordAlert(webhookUrl: string, embed: { title: string; desc
     })
     if (!resp.ok) {
       console.error(`[discord] webhook returned ${resp.status}: ${await resp.text().catch(() => '')}`)
-    } else {
-      resp.body?.cancel()
+      return false
     }
+    resp.body?.cancel()
+    return true
   } catch (err) {
     console.error('[discord] webhook failed:', err instanceof Error ? err.message : err)
+    return false
   }
 }
 
@@ -299,6 +301,40 @@ async function alertWorkerError(env: Env, error: string) {
     description: `\`fetchAllServices()\` 전체 실패\n\`\`\`${sanitize(error)}\`\`\``,
     color: 0xED4245,
   })
+}
+
+// Dedup marker is written only after the Discord send returns true. A 5xx / network
+// failure on the 00:00 cycle leaves the marker unset so the 01:00 catch-up cycle retries.
+// Corrupt archive JSON bails without sending so operators don't get a misleading
+// "Services: 0" ping that also locks out retries for 60 days.
+async function maybeNotifyArchiveReady(env: Env, archiveKey: string, period: string): Promise<void> {
+  if (!env.DISCORD_WEBHOOK_URL || !env.STATUS_CACHE) return
+  const notifiedKey = archiveNotifiedKey(period)
+  const already = await env.STATUS_CACHE.get(notifiedKey).catch(() => null)
+  if (already) return
+
+  const archiveRaw = await env.STATUS_CACHE.get(archiveKey).catch(() => null)
+  if (!archiveRaw) return // archive not yet written this cycle; catch-up or next month handles it
+
+  let serviceCount: number
+  let daysCollected: number
+  try {
+    const parsed = JSON.parse(archiveRaw)
+    serviceCount = Object.keys(parsed.services ?? {}).length
+    daysCollected = typeof parsed.daysCollected === 'number' ? parsed.daysCollected : 0
+  } catch (err) {
+    console.error(`[monthly-archive] corrupt archive JSON for ${period} — skipping notification:`, err instanceof Error ? err.message : err)
+    return
+  }
+
+  const sent = await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, buildArchiveReadyEmbed(period, serviceCount, daysCollected))
+  if (!sent) {
+    console.warn(`[monthly-archive] notification send failed for ${period} — will retry next cron cycle`)
+    return
+  }
+  // 60d TTL — purely for dedup (the archive itself is permanent). Any TTL ≥ 2h would
+  // cover the catch-up window; 60d matches the surrounding monthly-ops retention feel.
+  await kvPut(env.STATUS_CACHE, notifiedKey, '1', { expirationTtl: 60 * 24 * 60 * 60 })
 }
 
 // ── Cron-based Alert Detection ──
@@ -726,7 +762,7 @@ import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyB
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, cacheProbeSummaries, getCachedProbeSummaries, type ProbeDailyData } from './probe-archival'
 import type { ProbeSummary, Incident } from './types'
-import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
+import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, buildArchiveReadyEmbed, archiveNotifiedKey, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
 import { checkPlatformStatus, formatPlatformOutageAlert, formatPlatformRecoveryAlert, platformStatusKey, platformAlertKey, countPlatformServices, type PlatformStatus } from './platform-monitor'
 
 // ── #299: sticky-aware analysis write ─────────────────────────
@@ -1334,6 +1370,15 @@ export default {
         } catch (err) {
           console.error('[monthly-archive] Failed:', err)
         }
+      }
+
+      // Sits outside the `if (!existing)` archive-build branch so the 01:00 catch-up
+      // cycle can still ping if the 00:00 cycle built the archive but the Discord send
+      // failed. Dedup via archive:notified:{period}.
+      if (env.DISCORD_WEBHOOK_URL) {
+        await maybeNotifyArchiveReady(env, archiveKey, `${prevYear}-${String(prevMon).padStart(2, '0')}`).catch((err) => {
+          console.error('[monthly-archive] notification failed:', err instanceof Error ? err.message : err)
+        })
       }
     }
 

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -437,3 +437,57 @@ export function isInMonthlyArchiveWindow(
   if (!isNormal && !isCatchUp) return { inWindow: false, isCatchUp: false }
   return { inWindow: true, isCatchUp: !isNormal }
 }
+
+// ── Archive-ready Discord notification (aiwatch-reports#4) ───────────
+//
+// The aiwatch-reports `generate-report.yml` workflow is `workflow_dispatch`-only,
+// so operators have to remember to click "Run workflow" on the 1st. This hook fires
+// a one-shot Discord ping with the workflow URL the moment the monthly archive lands.
+
+export const REPORTS_WORKFLOW_URL =
+  'https://github.com/bentleypark/aiwatch-reports/actions/workflows/generate-report.yml'
+
+export function archiveNotifiedKey(period: string): string {
+  return `archive:notified:${period}`
+}
+
+/**
+ * Build the Discord embed for "monthly archive ready — go generate the draft" pings.
+ * Pure function for testability; the cron handler owns KV dedup + the send itself.
+ *
+ * `period` is the YYYY-MM covered by the archive (e.g. `"2026-04"` for April).
+ * Invalid periods fall back to the raw string so a malformed call still produces a
+ * readable embed rather than `"Invalid Date"`.
+ */
+export function buildArchiveReadyEmbed(
+  period: string,
+  serviceCount: number,
+  daysCollected: number,
+): { title: string; description: string; color: number } {
+  let monthLabel = period
+  const match = /^(\d{4})-(\d{2})$/.exec(period)
+  if (match) {
+    const y = Number(match[1])
+    const m = Number(match[2])
+    if (m >= 1 && m <= 12) {
+      monthLabel = new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString('en-US', {
+        month: 'long', year: 'numeric', timeZone: 'UTC',
+      })
+    }
+  }
+  const description = [
+    `**${monthLabel}** archive is now available in KV (\`archive:monthly:${period}\`).`,
+    ``,
+    `• Services: ${serviceCount}`,
+    `• Days collected: ${daysCollected}`,
+    ``,
+    `🚀 [**Generate report draft →**](${REPORTS_WORKFLOW_URL})`,
+    ``,
+    `*Click the link, press "Run workflow", enter month \`${period}\`, and a draft PR will open for review.*`,
+  ].join('\n')
+  return {
+    title: `📦 Monthly Archive Ready — ${period}`,
+    description,
+    color: 0x9B59B6, // purple — consistent with daily summary / monthly ops
+  }
+}


### PR DESCRIPTION
## Summary

- Discord ping fires immediately after the monthly `archive:monthly:{YYYY-MM}` KV write, embedding the `aiwatch-reports/generate-report.yml` workflow link so the operator no longer has to remember to manually run the draft generator on the 1st.
- `sendDiscordAlert` now returns `Promise<boolean>` so the dedup marker (`archive:notified:{YYYY-MM}`, 60d TTL) is only written on a 2xx response — a transient 5xx on the 00:00 cron cycle is safely retried on the 01:00 catch-up cycle.
- Corrupt archive JSON bails without sending or marking, so operators never get a misleading "Services: 0" ping that locks out retries.
- 9 new unit tests covering Jan/Apr/Dec/13/malformed-period fallback, zero-stats embed, workflow URL, KV key, operator-input phrasing.

End-to-end verified against a real Discord webhook with an in-memory KV stub:

```
[1] Fresh archive, no marker — result: sent  (marker: 1)
[2] Re-invoke with marker present — result: dedup
[3] Corrupt archive JSON — result: corrupt  (marker: UNSET, 01:00 retry preserved)
```

## Test plan

- [x] `npm run test:worker` — 1058 passed (was 1049 before this PR; +9 new)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean build
- [x] Live Discord webhook smoke test — embed rendered with correct month label, working workflow link, purple color
- [x] PR review auto-loop converged (Round 1 raised 1 Critical + 2 Important; Round 2 confirmed all addressed, no new Critical/Important)
- [ ] First real cron firing on 2026-05-01 UTC 00:00 — operator receives ping for the April archive
- [ ] After deploy, manual `wrangler kv key delete archive:notified:2026-04` if a re-test is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)