### PR TITLE
fix: BetterStack maintenance state misclassified as degraded (closes #349)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -623,9 +623,71 @@ describe('parseBetterStackStatus', () => {
     })).toBe('degraded')
   })
 
-  it('returns degraded for "degraded" and "maintenance" without resource data', () => {
+  it('returns degraded for "degraded" without resource data', () => {
     expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'degraded' } } })).toBe('degraded')
-    expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'maintenance' } } })).toBe('degraded')
+  })
+
+  it('returns operational for "maintenance" without resource data (planned, no real impact)', () => {
+    // #349 — pure maintenance with no resource breakdown should not surface as degraded.
+    expect(parseBetterStackStatus({ data: { attributes: { aggregate_state: 'maintenance' } } })).toBe('operational')
+  })
+
+  it('returns operational for "maintenance" when all non-op resources are also maintenance (#349)', () => {
+    // Live Together AI scenario on 2026-04-26: 11/31 resources in `maintenance` state,
+    // 0 in `degraded`/`downtime`. Was misclassified as degraded; should be operational.
+    const resources = Array.from({ length: 31 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'operational' },
+    }))
+    for (let i = 0; i < 11; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'maintenance' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'maintenance' } },
+      included: resources,
+    })).toBe('operational')
+  })
+
+  it('returns operational for "maintenance" when real issues are below 30% of the non-maintenance fleet', () => {
+    // 8 maintenance + 1 downtime + 11 operational = 20 resources.
+    // Threshold against non-maintenance peers: realIssues / (20 - 8) = 1/12 = 8.3% < 30%
+    // → individual model blip during maintenance, parser stays operational so users don't
+    // see a false-positive amber tile.
+    const resources: Array<{ type: string; attributes: { status: string } }> = []
+    for (let i = 0; i < 8; i++) resources.push({ type: 'status_page_resource', attributes: { status: 'maintenance' } })
+    resources.push({ type: 'status_page_resource', attributes: { status: 'downtime' } })
+    for (let i = 0; i < 11; i++) resources.push({ type: 'status_page_resource', attributes: { status: 'operational' } })
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'maintenance' } },
+      included: resources,
+    })).toBe('operational')
+  })
+
+  it('returns degraded for "maintenance" when ≥30% of NON-maintenance resources are real issues', () => {
+    // Maintenance announcement coexisting with widespread real outage. The threshold is
+    // applied against non-maintenance peers only — counting against the full fleet would
+    // let widespread maintenance dilute the signal of a coexisting real outage.
+    // 4 downtime / (10 - 0 maintenance) = 40% → escalate.
+    const resources = Array.from({ length: 10 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'maintenance' as string },
+    }))
+    for (let i = 0; i < 4; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'maintenance' } },
+      included: resources,
+    })).toBe('degraded')
+  })
+
+  it('returns degraded when real issues are ≥30% of non-maintenance peers despite being a small fraction overall', () => {
+    // Worst-case scenario flagged by review: 25/31 in maintenance, 5/31 in downtime, 1 operational.
+    // Naive ratio 5/31 = 16% would underflag the genuine 5-resource outage. Correct ratio uses
+    // the non-maintenance denominator: 5/(31-25) = 5/6 = 83% → escalate.
+    const resources = Array.from({ length: 31 }, () => ({
+      type: 'status_page_resource', attributes: { status: 'maintenance' as string },
+    }))
+    for (let i = 0; i < 5; i++) resources[i] = { type: 'status_page_resource', attributes: { status: 'downtime' } }
+    resources[5] = { type: 'status_page_resource', attributes: { status: 'operational' } }
+    expect(parseBetterStackStatus({
+      data: { attributes: { aggregate_state: 'maintenance' } },
+      included: resources,
+    })).toBe('degraded')
   })
 
   it('returns operational for "degraded" when <30% of resources are non-operational (#162)', () => {

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -220,7 +220,30 @@ export function parseBetterStackStatus(data: BetterStackIndex): 'operational' | 
   )
   const nonOpCount = resources.filter((r) => r.attributes?.status !== 'operational').length
 
-  if (state === 'degraded' || state === 'maintenance') {
+  if (state === 'maintenance') {
+    // Planned maintenance is not an outage on its own — escalate to `degraded` only when real
+    // unplanned issues (degraded/downtime resources) coexist AND those issues exceed the 30%
+    // threshold against the *non-maintenance* fleet. Counting against `resources.length`
+    // would let widespread maintenance (e.g. 25/31 in maintenance) dilute a coexisting real
+    // outage to a noise-band ratio. The intent — treat planned maintenance as not-an-outage —
+    // matches `parseBetterStackDailyImpact` which separately excludes zero-downtime maintenance
+    // from per-day impact totals (different signal, same product principle).
+    // Closes #349 — Together AI was misclassified as degraded during pure-maintenance windows.
+    const realIssues = resources.filter(
+      (r) => r.attributes?.status === 'degraded' || r.attributes?.status === 'downtime'
+    ).length
+    if (realIssues === 0) return 'operational'
+    const maintenanceCount = resources.filter(
+      (r) => r.attributes?.status === 'maintenance'
+    ).length
+    const nonMaintenanceTotal = resources.length - maintenanceCount
+    // Defensive: realIssues > 0 implies nonMaintenanceTotal > 0 (a resource can't be both
+    // maintenance and downtime simultaneously). Explicit guard makes the safety obvious.
+    if (nonMaintenanceTotal === 0) return 'operational'
+    if (realIssues / nonMaintenanceTotal < 0.3) return 'operational'
+    return 'degraded'
+  }
+  if (state === 'degraded') {
     if (resources.length > 0 && nonOpCount / resources.length < 0.3) return 'operational'
     return 'degraded'
   }


### PR DESCRIPTION
## Summary

- BetterStack-backed services (Together, Fireworks, HuggingFace, Modal) rendered as `degraded` during planned maintenance windows when ≥30% of resources were in `maintenance` status. Live verification on 2026-04-26: Together AI showed 11/31 (35.5%) resources in `maintenance`, 0 in actual `degraded`/`downtime`, dashboard tile was amber.
- Root cause: `parseBetterStackStatus` shared a branch for `aggregate_state === 'degraded'` and `'maintenance'`. The 30% non-operational threshold counted maintenance resources as non-operational, tipping the service into `degraded` for any maintenance window touching enough monitors.
- Fix: split `maintenance` into its own branch. Returns `operational` for pure-maintenance windows; only escalates to `degraded` when real (`degraded`/`downtime`) resources coexist AND those issues exceed 30% of the **non-maintenance** fleet (worst case flagged in review: 25-maintenance + 5-downtime would underflag at 5/31 = 16% naive ratio; correct 5/6 = 83% → escalate).
- Existing `degraded` and `downtime` branches kept byte-identical.
- The same file's `parseBetterStackDailyImpact` already excludes zero-downtime maintenance from per-day impact totals — this fix brings the status path into the same product stance.

## Test plan

- [x] `npm run test:worker` — 1053 passed (was 1048; +5 new tests, +1 revised)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean build
- [x] PR review auto-loop converged (Round 1: 1 HIGH silent-failure + 1 MEDIUM comment accuracy; Round 2: both addressed, no new findings)
- [ ] After merge + Worker deploy, verify Together AI tile flips to operational on the next 5-min cron cycle (`/api/status` for `together` should show `"status": "operational"` while upstream is in maintenance)
- [ ] Spot-check Fireworks / HuggingFace / Modal tiles unchanged

## Affected services

BetterStack-backed only: `together`, `fireworks`, `huggingface`, `modal`. Other parsers (Statuspage, incident.io, gcloud, etc.) don't expose a comparable `maintenance` aggregate state and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)