### PR TITLE
fix: Overview Recent Incidents — sort ongoing → monitoring → resolved (closes #354)

### DIFF
--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -8,6 +8,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
+import { STATUS_PRIORITY, getResolvedTime, compareIncidents } from '../utils/incidentSort'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -36,31 +37,11 @@ const PERIODS = [7, 30, 90]
 const TABLE_COLS = ['col.time', 'col.title', 'col.service', 'col.duration', 'col.status']
 
 // ── Helpers ──────────────────────────────────────────────────
-
-/** Status group priority: investigating/identified → monitoring → resolved */
-const STATUS_PRIORITY = { ongoing: 0, monitoring: 1, resolved: 2 }
-
-/** Get resolved time: resolvedAt field, or last resolved timeline entry, or null */
-function getResolvedTime(inc) {
-  if (inc.resolvedAt) return inc.resolvedAt
-  const tl = inc.timeline ?? []
-  const resolvedEntry = [...tl].reverse().find(t => t.stage === 'resolved')
-  return resolvedEntry?.at ?? null
-}
+// STATUS_PRIORITY / getResolvedTime / getLatestActivity / compareIncidents
+// live in src/utils/incidentSort.js — shared with Overview "Recent Incidents".
 
 /** Last element of array (ES5-safe) */
 function last(arr) { return arr && arr.length > 0 ? arr[arr.length - 1] : undefined }
-
-/** Get the most recent activity time for sorting */
-function getLatestActivity(inc) {
-  if (inc.status === 'resolved') {
-    const resolved = getResolvedTime(inc)
-    if (resolved) return new Date(resolved).getTime()
-  }
-  const lastTimeline = last(inc.timeline)
-  if (lastTimeline?.at) return new Date(lastTimeline.at).getTime()
-  return new Date(inc.startedAt).getTime()
-}
 
 /** Get contextual timestamp label and date based on status */
 function getContextualTime(inc, t) {
@@ -413,14 +394,7 @@ export default function Incidents() {
       .filter((inc) => serviceFilter === 'all' || inc.serviceId === serviceFilter)
       .filter((inc) => statusFilter  === 'all' || inc.status    === statusFilter)
       .filter((inc) => !cutoff || inc.status !== 'resolved' || new Date(inc.startedAt).getTime() >= cutoff)
-      .sort((a, b) => {
-        // Priority 1: status group (ongoing → monitoring → resolved)
-        const aPri = STATUS_PRIORITY[a.status] ?? 2
-        const bPri = STATUS_PRIORITY[b.status] ?? 2
-        if (aPri !== bPri) return aPri - bPri
-        // Priority 2: most recent activity (timeline last update, resolvedAt, or startedAt)
-        return getLatestActivity(b) - getLatestActivity(a)
-      })
+      .sort(compareIncidents)
   }, [allIncidents, serviceFilter, statusFilter, period])
 
   // groupIncidents re-sorts purely by date — re-apply STATUS_PRIORITY so ongoing

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -10,6 +10,7 @@ import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, EXCLUDE_FALLBACK, API_TIER, getFallbacks } from '../utils/constants'
 import { buildCalendarFromIncidents } from '../utils/calendar'
+import { compareIncidents } from '../utils/incidentSort'
 import { formatTime, formatDate } from '../utils/time'
 import SkeletonUI from '../components/SkeletonUI'
 import StatusPill from '../components/StatusPill'
@@ -491,12 +492,7 @@ export default function Overview() {
   }
   const recentIncidents = [...incMap.values()]
     .filter((inc) => inc.status !== 'resolved' || new Date(inc.startedAt).getTime() >= sevenDaysAgo)
-    .sort((a, b) => {
-      const aActive = a.status !== 'resolved' ? 1 : 0
-      const bActive = b.status !== 'resolved' ? 1 : 0
-      if (aActive !== bActive) return bActive - aActive
-      return new Date(b.startedAt) - new Date(a.startedAt)
-    })
+    .sort(compareIncidents)
     .slice(0, 5)
 
   const withLatency = catServices.filter((s) => s.latency != null)

--- a/src/utils/__tests__/incidentSort.test.js
+++ b/src/utils/__tests__/incidentSort.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STATUS_PRIORITY,
+  getResolvedTime,
+  getLatestActivity,
+  compareIncidents,
+} from '../incidentSort'
+
+function makeIncident({
+  id = 'inc',
+  status = 'ongoing',
+  startedAt = '2026-04-28T00:00:00Z',
+  resolvedAt,
+  timeline = [],
+}) {
+  return { id, status, startedAt, resolvedAt, timeline }
+}
+
+describe('STATUS_PRIORITY', () => {
+  it('ranks ongoing < monitoring < resolved', () => {
+    expect(STATUS_PRIORITY.ongoing).toBeLessThan(STATUS_PRIORITY.monitoring)
+    expect(STATUS_PRIORITY.monitoring).toBeLessThan(STATUS_PRIORITY.resolved)
+  })
+
+  it('treats raw upstream statuses (investigating/identified) as ongoing tier', () => {
+    // worker/src/types.ts emits 4 raw statuses — investigating/identified must NOT
+    // fall through to the resolved tier (regression check for the bug found in #354
+    // round-2 verification).
+    expect(STATUS_PRIORITY.investigating).toBe(STATUS_PRIORITY.ongoing)
+    expect(STATUS_PRIORITY.identified).toBe(STATUS_PRIORITY.ongoing)
+    expect(STATUS_PRIORITY.investigating).toBeLessThan(STATUS_PRIORITY.monitoring)
+    expect(STATUS_PRIORITY.identified).toBeLessThan(STATUS_PRIORITY.monitoring)
+  })
+})
+
+describe('getResolvedTime', () => {
+  it('prefers resolvedAt field when present', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      resolvedAt: '2026-04-28T03:00:00Z',
+      timeline: [{ stage: 'resolved', at: '2026-04-28T02:00:00Z' }],
+    })
+    expect(getResolvedTime(inc)).toBe('2026-04-28T03:00:00Z')
+  })
+
+  it('falls back to last resolved timeline entry', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      timeline: [
+        { stage: 'investigating', at: '2026-04-28T00:00:00Z' },
+        { stage: 'resolved',      at: '2026-04-28T02:00:00Z' },
+      ],
+    })
+    expect(getResolvedTime(inc)).toBe('2026-04-28T02:00:00Z')
+  })
+
+  it('returns null when no resolution evidence exists', () => {
+    const inc = makeIncident({
+      status: 'ongoing',
+      timeline: [{ stage: 'investigating', at: '2026-04-28T00:00:00Z' }],
+    })
+    expect(getResolvedTime(inc)).toBeNull()
+  })
+
+  it('handles missing timeline field', () => {
+    const inc = { status: 'ongoing', startedAt: '2026-04-28T00:00:00Z' }
+    expect(getResolvedTime(inc)).toBeNull()
+  })
+
+  it('picks the LAST resolved entry when multiple exist (re-opened incident)', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      timeline: [
+        { stage: 'resolved',      at: '2026-04-28T01:00:00Z' },
+        { stage: 'investigating', at: '2026-04-28T01:30:00Z' },
+        { stage: 'resolved',      at: '2026-04-28T02:00:00Z' },
+      ],
+    })
+    expect(getResolvedTime(inc)).toBe('2026-04-28T02:00:00Z')
+  })
+})
+
+describe('getLatestActivity', () => {
+  it('uses resolved time for resolved incidents', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      startedAt: '2026-04-28T00:00:00Z',
+      resolvedAt: '2026-04-28T02:00:00Z',
+    })
+    expect(getLatestActivity(inc)).toBe(new Date('2026-04-28T02:00:00Z').getTime())
+  })
+
+  it('uses last timeline entry for active incidents', () => {
+    const inc = makeIncident({
+      status: 'ongoing',
+      startedAt: '2026-04-28T00:00:00Z',
+      timeline: [
+        { stage: 'investigating', at: '2026-04-28T00:00:00Z' },
+        { stage: 'identified',    at: '2026-04-28T01:30:00Z' },
+      ],
+    })
+    expect(getLatestActivity(inc)).toBe(new Date('2026-04-28T01:30:00Z').getTime())
+  })
+
+  it('falls back to startedAt when timeline is empty', () => {
+    const inc = makeIncident({ status: 'ongoing', startedAt: '2026-04-28T00:00:00Z' })
+    expect(getLatestActivity(inc)).toBe(new Date('2026-04-28T00:00:00Z').getTime())
+  })
+
+  it('falls back to startedAt for resolved incidents without resolution evidence', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      startedAt: '2026-04-28T00:00:00Z',
+      // no resolvedAt, no resolved-stage timeline entry — degenerate but possible
+    })
+    expect(getLatestActivity(inc)).toBe(new Date('2026-04-28T00:00:00Z').getTime())
+  })
+})
+
+describe('compareIncidents', () => {
+  it('puts ongoing before monitoring', () => {
+    const ongoing    = makeIncident({ id: 'a', status: 'ongoing',    startedAt: '2026-04-28T00:00:00Z' })
+    const monitoring = makeIncident({ id: 'b', status: 'monitoring', startedAt: '2026-04-28T05:00:00Z' })
+    expect(compareIncidents(ongoing, monitoring)).toBeLessThan(0)
+    expect(compareIncidents(monitoring, ongoing)).toBeGreaterThan(0)
+  })
+
+  it('puts raw investigating/identified before monitoring', () => {
+    // Real worker payload uses investigating/identified — they must outrank
+    // monitoring even when monitoring started more recently.
+    const investigating = makeIncident({ id: 'a', status: 'investigating', startedAt: '2026-04-28T00:00:00Z' })
+    const identified    = makeIncident({ id: 'b', status: 'identified',    startedAt: '2026-04-28T01:00:00Z' })
+    const monitoring    = makeIncident({ id: 'c', status: 'monitoring',    startedAt: '2026-04-28T05:00:00Z' })
+    expect(compareIncidents(investigating, monitoring)).toBeLessThan(0)
+    expect(compareIncidents(identified, monitoring)).toBeLessThan(0)
+  })
+
+  it('puts monitoring before resolved', () => {
+    const monitoring = makeIncident({ id: 'a', status: 'monitoring', startedAt: '2026-04-28T00:00:00Z' })
+    const resolved   = makeIncident({ id: 'b', status: 'resolved',   startedAt: '2026-04-28T05:00:00Z', resolvedAt: '2026-04-28T06:00:00Z' })
+    expect(compareIncidents(monitoring, resolved)).toBeLessThan(0)
+  })
+
+  it('puts ongoing before resolved even when resolved is more recent', () => {
+    // The bug Overview had — recent monitoring/resolved should NOT outrank an older ongoing.
+    const ongoing  = makeIncident({ id: 'a', status: 'ongoing',  startedAt: '2026-04-28T00:00:00Z' })
+    const resolved = makeIncident({ id: 'b', status: 'resolved', startedAt: '2026-04-28T05:00:00Z', resolvedAt: '2026-04-28T06:00:00Z' })
+    expect(compareIncidents(ongoing, resolved)).toBeLessThan(0)
+  })
+
+  it('within same tier, sorts by latest activity desc', () => {
+    const newer = makeIncident({ id: 'a', status: 'ongoing', startedAt: '2026-04-28T05:00:00Z' })
+    const older = makeIncident({ id: 'b', status: 'ongoing', startedAt: '2026-04-28T00:00:00Z' })
+    expect(compareIncidents(newer, older)).toBeLessThan(0)
+  })
+
+  it('within same tier, timeline last update beats startedAt', () => {
+    const oldStartFreshUpdate = makeIncident({
+      id: 'a',
+      status: 'ongoing',
+      startedAt: '2026-04-28T00:00:00Z',
+      timeline: [{ stage: 'identified', at: '2026-04-28T05:00:00Z' }],
+    })
+    const newerStart = makeIncident({
+      id: 'b',
+      status: 'ongoing',
+      startedAt: '2026-04-28T03:00:00Z',
+    })
+    // oldStartFreshUpdate's last activity is later (05:00) than newerStart's (03:00)
+    expect(compareIncidents(oldStartFreshUpdate, newerStart)).toBeLessThan(0)
+  })
+
+  it('unknown status defaults to resolved tier so malformed entries do not outrank ongoing', () => {
+    const ongoing = makeIncident({ id: 'a', status: 'ongoing', startedAt: '2026-04-28T00:00:00Z' })
+    const weird   = makeIncident({ id: 'b', status: 'weird-future-status', startedAt: '2026-04-28T05:00:00Z' })
+    expect(compareIncidents(ongoing, weird)).toBeLessThan(0)
+  })
+
+  it('Array.sort yields the documented overall order', () => {
+    // Mix of raw worker statuses (investigating/identified) + monitoring + resolved
+    // mirrors the actual API response shape from /api/status.
+    const incidents = [
+      makeIncident({ id: '1-resolved-old',     status: 'resolved',      startedAt: '2026-04-27T00:00:00Z', resolvedAt: '2026-04-27T01:00:00Z' }),
+      makeIncident({ id: '2-monitoring-new',   status: 'monitoring',    startedAt: '2026-04-28T05:00:00Z' }),
+      makeIncident({ id: '3-investigating-old',status: 'investigating', startedAt: '2026-04-28T01:00:00Z' }),
+      makeIncident({ id: '4-identified-new',   status: 'identified',    startedAt: '2026-04-28T03:00:00Z' }),
+      makeIncident({ id: '5-resolved-recent',  status: 'resolved',      startedAt: '2026-04-28T04:00:00Z', resolvedAt: '2026-04-28T05:30:00Z' }),
+    ]
+    const sorted = [...incidents].sort(compareIncidents).map((i) => i.id)
+    expect(sorted).toEqual([
+      '4-identified-new',     // active tier, latest activity
+      '3-investigating-old',  // active tier, older
+      '2-monitoring-new',     // monitoring tier
+      '5-resolved-recent',    // resolved tier, latest resolved
+      '1-resolved-old',       // resolved tier, older
+    ])
+  })
+})

--- a/src/utils/incidentSort.js
+++ b/src/utils/incidentSort.js
@@ -1,0 +1,75 @@
+/**
+ * Incident sort helpers shared by the Incidents page and the Overview "Recent
+ * Incidents" section.
+ *
+ * Tier order: investigating/identified ("ongoing") → monitoring → resolved.
+ * Within a tier, most-recent-activity first (last timeline update, else
+ * resolvedAt, else startedAt). Unknown status falls through to the resolved
+ * tier so a malformed payload doesn't sort above real ongoing items.
+ *
+ * Status values mirror `worker/src/types.ts` Incident.status (4-state:
+ * investigating/identified/monitoring/resolved) plus the legacy "ongoing"
+ * alias retained for any caller that pre-normalizes. Keep this map aligned
+ * with `INC_BAR_CLASS` in `src/pages/Overview.jsx`.
+ *
+ * See issue #354.
+ */
+
+export const STATUS_PRIORITY = {
+  investigating: 0,
+  identified:    0,
+  ongoing:       0,  // legacy alias for pre-normalized data
+  monitoring:    1,
+  resolved:      2,
+}
+
+/**
+ * Resolved timestamp — `resolvedAt` field, or the last `resolved` timeline
+ * entry, or null when the incident hasn't resolved yet.
+ *
+ * @param {{ resolvedAt?: string, timeline?: { stage: string, at: string }[] }} inc
+ * @returns {string | null}
+ */
+export function getResolvedTime(inc) {
+  if (inc.resolvedAt) return inc.resolvedAt
+  const tl = inc.timeline ?? []
+  const resolvedEntry = [...tl].reverse().find((t) => t.stage === 'resolved')
+  return resolvedEntry?.at ?? null
+}
+
+/**
+ * Most-recent-activity timestamp (ms epoch) for sort ordering.
+ *
+ * Resolved incidents prefer the resolved time so a recently-resolved incident
+ * outranks an old resolved one. Active incidents prefer the last timeline
+ * update so an incident with a fresh status-page comment outranks a stale one
+ * that started earlier but hasn't moved.
+ *
+ * @param {{ status: string, resolvedAt?: string, startedAt: string, timeline?: { stage: string, at: string }[] }} inc
+ * @returns {number}
+ */
+export function getLatestActivity(inc) {
+  if (inc.status === 'resolved') {
+    const resolved = getResolvedTime(inc)
+    if (resolved) return new Date(resolved).getTime()
+  }
+  const tl = inc.timeline ?? []
+  const lastTimeline = tl.length > 0 ? tl[tl.length - 1] : undefined
+  if (lastTimeline?.at) return new Date(lastTimeline.at).getTime()
+  return new Date(inc.startedAt).getTime()
+}
+
+/**
+ * Comparator: tier first, latest-activity desc within tier. Stable on equal
+ * keys (relies on Array.prototype.sort being stable per ES2019+).
+ *
+ * @param {{ status: string }} a
+ * @param {{ status: string }} b
+ * @returns {number}
+ */
+export function compareIncidents(a, b) {
+  const aPri = STATUS_PRIORITY[a.status] ?? 2
+  const bPri = STATUS_PRIORITY[b.status] ?? 2
+  if (aPri !== bPri) return aPri - bPri
+  return getLatestActivity(b) - getLatestActivity(a)
+}


### PR DESCRIPTION
## Summary

Extract incident sort helpers from `Incidents.jsx` into `src/utils/incidentSort.js` and use them for the Overview "Recent Incidents" section. Closes a latent bug where raw worker statuses `investigating` / `identified` fell through to the resolved tier.

closes #354

## What changed

- **NEW** `src/utils/incidentSort.js` — `STATUS_PRIORITY`, `getResolvedTime`, `getLatestActivity`, `compareIncidents`. Map mirrors `INC_BAR_CLASS` in Overview.jsx (all 4 raw statuses from `worker/src/types.ts:12` + legacy `ongoing` alias).
- **NEW** `src/utils/__tests__/incidentSort.test.js` — 19 Vitest cases.
- **MODIFIED** `src/pages/Incidents.jsx` — locals removed, imports from new util. Sort line collapses to `.sort(compareIncidents)`. Grouped re-sort path keeps `STATUS_PRIORITY` direct (operates on group rows, not raw incidents).
- **MODIFIED** `src/pages/Overview.jsx` — `recentIncidents` 2-tier sort replaced with `.sort(compareIncidents)`.

## Why

Overview's old sort:
```js
const aActive = a.status !== 'resolved' ? 1 : 0
// 1 bucket for all non-resolved (investigating + identified + monitoring mixed),
// then startedAt desc within the bucket
```

→ A monitoring incident that started 3h ago could sort above a still-investigating incident that started yesterday.

New sort (mirrors Incidents page):
1. Tier: investigating/identified → monitoring → resolved
2. Within-tier: latest activity desc (timeline last update / resolvedAt / startedAt)

## Latent bug closed

Original `STATUS_PRIORITY = { ongoing: 0, monitoring: 1, resolved: 2 }` only mapped `ongoing`, but the worker emits raw `investigating` / `identified` (never `ongoing` — verified against live `/api/status` payload). So both fell through to `?? 2` and sorted into the resolved tier on Incidents page too. New map handles all 4 raw statuses + retains the legacy alias.

Discovered during local verification: the user noticed there were "no ongoing incidents" displayed, but `/api/status` showed 4 active incidents (2 investigating + 1 identified + 1 monitoring) at the time. Trace led to `STATUS_PRIORITY` missing the raw status keys.

## Test plan

- [x] `npm run test:src` — 66/66 passing (19 new cases in `incidentSort.test.js`)
- [x] `npm run lint` — 0 errors (7 unrelated warnings in `worker/coverage/`)
- [x] `npm run build` — clean
- [x] Local verify with live worker data: Overview Recent Incidents renders investigating/identified rows above monitoring above resolved (Gemini API + Deepgram active incidents on hand at verification time)

## Review history

`pr-review-toolkit:code-reviewer` — Round 1: 0 Critical / 0 Important / 2 Suggestions. Convergence reached.
- Suggestion 1 (out of scope): same class of bug in Incidents.jsx grouped re-sort path → tracked separately as #355.
- Suggestion 2 (trivial JSDoc clarification): skipped per low confidence.

## Out of scope

- Grouped re-sort path on Incidents.jsx (#355 follow-up)
- StatusBadge color mapping for non-`ongoing` raw statuses (separate visual concern, not surfaced by this fix)