### PR TITLE
feat: add Junie service monitoring

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 [English](README.md) | **한국어**
 
-**31개 AI 서비스**의 상태, 지연시간, 가동률, 인시던트를 실시간으로 모니터링하는 대시보드입니다.
+**32개 AI 서비스**의 상태, 지연시간, 가동률, 인시던트를 실시간으로 모니터링하는 대시보드입니다.
 
 **[대시보드](https://ai-watch.dev)** · **[랜딩 페이지](https://ai-watch.dev/intro)**
 
@@ -26,7 +26,7 @@
 
 ## 주요 기능
 
-- **실시간 상태 모니터링** — 31개 AI 서비스의 정상 / 성능 저하 / 장애 상태
+- **실시간 상태 모니터링** — 32개 AI 서비스의 정상 / 성능 저하 / 장애 상태
 - **PWA 지원** — 홈 화면 추가, Service Worker 오프라인 캐시
 - **지연시간 측정** — 19개 probe 대상 서비스의 API 엔드포인트 직접 RTT 측정, 나머지는 상태 페이지 응답 시간
 - **24시간 지연시간 추세** — Chart.js 라인 차트 (5분 간격 probe 스냅샷)
@@ -273,16 +273,16 @@ README, 문서, 블로그에 실시간 상태 배지를 임베드할 수 있습�
 | `mistral` | Mistral API | `copilot` | GitHub Copilot |
 | `cohere` | Cohere API | `cursor` | Cursor |
 | `groq` | Groq Cloud | `windsurf` | Windsurf |
-| `together` | Together AI | `deepseek` | DeepSeek API |
+| `together` | Together AI | `junie` | Junie |
+| `fireworks` | Fireworks AI | `deepseek` | DeepSeek API |
 | `perplexity` | Perplexity | `xai` | xAI (Grok) |
 | `huggingface` | Hugging Face | `replicate` | Replicate |
 | `elevenlabs` | ElevenLabs | `openrouter` | OpenRouter |
 | `bedrock` | Amazon Bedrock | `pinecone` | Pinecone |
 | `azureopenai` | Azure OpenAI | `stability` | Stability AI |
 | `assemblyai` | AssemblyAI | `deepgram` | Deepgram |
-| `characterai` | Character.AI | `fireworks` | Fireworks AI |
-| `voyageai` | Voyage AI | `modal` | Modal |
-| `codex` | Codex | | |
+| `characterai` | Character.AI | `modal` | Modal |
+| `voyageai` | Voyage AI | `codex` | Codex |
 
 ## 프로젝트 구조
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **English** | [한국어](README.ko.md)
 
-Real-time monitoring dashboard for **31 AI services** — track status, latency, uptime, and incidents across major AI providers.
+Real-time monitoring dashboard for **32 AI services** — track status, latency, uptime, and incidents across major AI providers.
 
 **[Dashboard](https://ai-watch.dev)** · **[Landing Page](https://ai-watch.dev/intro)**
 
@@ -27,7 +27,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 
 ## Features
 
-- **Real-time status** — Operational / Degraded / Down for 31 AI services
+- **Real-time status** — Operational / Degraded / Down for 32 AI services
 - **PWA support** — Add to home screen, offline cache with Service Worker
 - **Latency monitoring** — Direct API endpoint response time (RTT) for 19 probe-capable services, status page timing as fallback
 - **24h latency trend** — Chart.js line chart with 5-min probe snapshots
@@ -274,16 +274,16 @@ Embed real-time status badges in your README, docs, or blog.
 | `mistral` | Mistral API | `copilot` | GitHub Copilot |
 | `cohere` | Cohere API | `cursor` | Cursor |
 | `groq` | Groq Cloud | `windsurf` | Windsurf |
-| `together` | Together AI | `deepseek` | DeepSeek API |
+| `together` | Together AI | `junie` | Junie |
+| `fireworks` | Fireworks AI | `deepseek` | DeepSeek API |
 | `perplexity` | Perplexity | `xai` | xAI (Grok) |
 | `huggingface` | Hugging Face | `replicate` | Replicate |
 | `elevenlabs` | ElevenLabs | `openrouter` | OpenRouter |
 | `bedrock` | Amazon Bedrock | `pinecone` | Pinecone |
 | `azureopenai` | Azure OpenAI | `stability` | Stability AI |
 | `assemblyai` | AssemblyAI | `deepgram` | Deepgram |
-| `characterai` | Character.AI | `fireworks` | Fireworks AI |
-| `voyageai` | Voyage AI | `modal` | Modal |
-| `codex` | Codex | | |
+| `characterai` | Character.AI | `modal` | Modal |
+| `voyageai` | Voyage AI | `codex` | Codex |
 
 ## Project Structure
 

--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -501,6 +501,13 @@ const MOCK_SERVICES = [
         ] },
     ],
   },
+  {
+    id: 'junie', category: 'agent', name: 'Junie', provider: 'JetBrains', status: 'operational',
+    latency: null, uptime30d: null,
+    history30d: hist([]),
+    history3m: [],
+    incidents: [],
+  },
 ]
 
 // Mock AI analysis — must reference an incidentId matching an unresolved incident in MOCK_SERVICES

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -72,6 +72,7 @@ const STATUS_URL = {
   copilot:     'https://githubstatus.com',
   cursor:      'https://status.cursor.com',
   windsurf:    'https://status.windsurf.com',
+  junie:       'https://status.jetbrains.ai',
   codex:       'https://status.openai.com',
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,7 +22,7 @@ export const API_SERVICE_IDS = [
 export const APP_SERVICE_IDS = ['claudeai', 'chatgpt', 'characterai']
 
 // Coding agents
-export const AGENT_SERVICE_IDS = ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf']
+export const AGENT_SERVICE_IDS = ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie']
 
 // Display order: app → LLM → voice → inference → agent
 export const SERVICE_AND_APP_IDS = [
@@ -46,7 +46,7 @@ export const SERVICE_CATEGORIES = {
   apps:      { labelKey: 'filter.apps',      ids: ['claudeai', 'chatgpt', 'characterai'] },
   llm:       { labelKey: 'filter.llm',       ids: ['claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq', 'together', 'fireworks', 'perplexity', 'xai', 'deepseek', 'openrouter'] },
   inference: { labelKey: 'filter.inference', ids: ['elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone', 'stability', 'voyageai', 'modal'] },
-  agents:    { labelKey: 'filter.agents',    ids: ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf'] },
+  agents:    { labelKey: 'filter.agents',    ids: ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie'] },
 }
 
 // Services excluded from fallback recommendations (not interchangeable with LLM APIs)

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -98,6 +98,7 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2', statusComponentIds: ['pjmpxvq2cmr2', 'cnnb39dkkk82'] },
   // windsurf badge reflects worst-of: Cascade primary + Windsurf Tab (autocomplete agent surface) (#379).
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m', statusComponentIds: ['r5wf1ykd7y1m', '8q19cygxvshj'] },
+  { id: 'junie', name: 'Junie', provider: 'JetBrains', category: 'agent', statusUrl: 'https://status.jetbrains.ai', apiUrl: 'https://status.jetbrains.ai/api/v2/summary.json', statusComponentId: '9vbyyqkkjxl4' },
 ]
 
 /**


### PR DESCRIPTION
## Summary
Closes #336

Adds Junie as a monitored coding-agent service using JetBrains' Statuspage feed and Junie's component-scoped status.

## Changes
- Add Junie to the worker service configuration with `statusComponentId` scoping.
- Add Junie to dashboard agent service IDs, filters, mock data, and service detail status URL mapping.
- Update README/README.ko service counts and service ID tables.

## Test Plan
- `git diff --check`
- `npm run build`
- `npm run test:worker`
- `npm run test:src`

## Notes
Verified the live Statuspage summary reports Junie component id `9vbyyqkkjxl4` on page `hz9p6nl7pqtq`.
