### PR TITLE
fix: incident group sort drops investigating/identified into resolved tier (#355)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,87 +11,87 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-04-24</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-04-30</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -99,13 +99,13 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -8,7 +8,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
-import { STATUS_PRIORITY, getResolvedTime, compareIncidents } from '../utils/incidentSort'
+import { STATUS_PRIORITY, getResolvedTime, compareIncidents, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -201,15 +201,19 @@ function IncidentCard({ incident, isSelected, onClick, onClose, t, lang }) {
 // Desktop group row (collapsed): single grid row with [×N flaps] badge; click toggles entries.
 // Entries render as ordinary IncidentRows below in their own rowgroup.
 function IncidentGroupRow({ group, expanded, onToggle, selectedId, onSelect, onClose, t, lang }) {
-  const dominantStatus = group.uniformStatus
-    ? Object.keys(group.statusCounts)[0]
-    : (['ongoing', 'monitoring', 'resolved'].find(s => group.statusCounts[s]) ?? 'resolved')
+  const dominantStatus = dominantGroupStatus(group)
   const statusCls = STATUS_BADGE_CLASS[dominantStatus] ?? STATUS_BADGE_CLASS.resolved
   const statusLabel = group.uniformStatus
     ? t('incidents.group.statusUniform').replace('{status}', t(`incidents.status.${dominantStatus}`).toLowerCase())
     : Object.entries(group.statusCounts).map(([s, n]) => `${n} ${t(`incidents.status.${s}`).toLowerCase()}`).join(' · ')
   const firstEntry = group.entries[0]
   const serviceLabel = firstEntry.affectedNames?.length > 1 ? firstEntry.affectedNames.join(', ') : firstEntry.serviceName
+  const summed = sumGroupDuration(group)
+  const durationLabel = summed.resolvedCount === 0 && summed.hasOngoing
+    ? t('incidents.duration.ongoing')
+    : summed.hasOngoing
+      ? `${formatDurationMs(summed.totalMs)} + ${t('incidents.duration.ongoing')}`
+      : formatDurationMs(summed.totalMs)
   return (
     <>
       <div
@@ -226,7 +230,6 @@ function IncidentGroupRow({ group, expanded, onToggle, selectedId, onSelect, onC
           {formatDate(group.rangeStart, lang)} → {formatDate(group.rangeEnd, lang)}
         </span>
         <div role="cell" className="flex items-center gap-2 min-w-0">
-          <span className="text-[9px] text-[var(--text2)]" aria-hidden="true">{expanded ? '▾' : '▸'}</span>
           <span style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text0)' }} className="truncate">{group.normalizedTitle}</span>
           <span
             className="shrink-0 mono text-[var(--text2)] bg-[var(--bg2)]"
@@ -234,9 +237,10 @@ function IncidentGroupRow({ group, expanded, onToggle, selectedId, onSelect, onC
           >
             {t('incidents.group.flaps').replace('{n}', String(group.count))}
           </span>
+          <span className="shrink-0 text-[var(--text2)]" style={{ fontSize: '11px' }} aria-hidden="true">{expanded ? '▾' : '▸'}</span>
         </div>
         <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text1)' }}>{serviceLabel}</span>
-        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>—</span>
+        <span role="cell" className="mono" style={{ fontSize: '11px', color: 'var(--text2)' }}>{durationLabel}</span>
         <span role="cell" className={`mono ${statusCls}`} style={{ fontSize: '9px', letterSpacing: '0.04em', padding: '2px 6px', borderRadius: '3px', justifySelf: 'start' }}>
           {statusLabel}
         </span>
@@ -264,14 +268,18 @@ function IncidentGroupRow({ group, expanded, onToggle, selectedId, onSelect, onC
 }
 
 function IncidentGroupCard({ group, expanded, onToggle, selectedId, onSelect, onClose, t, lang }) {
-  const dominantStatus = group.uniformStatus
-    ? Object.keys(group.statusCounts)[0]
-    : (['ongoing', 'monitoring', 'resolved'].find(s => group.statusCounts[s]) ?? 'resolved')
+  const dominantStatus = dominantGroupStatus(group)
   const statusLabel = group.uniformStatus
     ? t('incidents.group.statusUniform').replace('{status}', t(`incidents.status.${dominantStatus}`).toLowerCase())
     : Object.entries(group.statusCounts).map(([s, n]) => `${n} ${t(`incidents.status.${s}`).toLowerCase()}`).join(' · ')
   const firstEntry = group.entries[0]
   const serviceLabel = firstEntry.affectedNames?.length > 1 ? firstEntry.affectedNames.join(', ') : firstEntry.serviceName
+  const summed = sumGroupDuration(group)
+  const durationLabel = summed.resolvedCount === 0 && summed.hasOngoing
+    ? t('incidents.duration.ongoing')
+    : summed.hasOngoing
+      ? `${formatDurationMs(summed.totalMs)} + ${t('incidents.duration.ongoing')}`
+      : formatDurationMs(summed.totalMs)
   return (
     <div>
       <button
@@ -299,8 +307,10 @@ function IncidentGroupCard({ group, expanded, onToggle, selectedId, onSelect, on
           <span>·</span>
           <span>{serviceLabel}</span>
           <span>·</span>
+          <span>{durationLabel}</span>
+          <span>·</span>
           <span>{statusLabel}</span>
-          <span className="ml-auto text-[var(--text2)]" aria-hidden="true">{expanded ? '▾' : '▸'}</span>
+          <span className="text-[var(--text2)]" style={{ marginLeft: 'auto' }} aria-hidden="true">{expanded ? '▾' : '▸'}</span>
         </div>
       </button>
       {expanded && (
@@ -402,9 +412,7 @@ export default function Incidents() {
   // newest-first ordering within the same status is preserved.
   const grouped = useMemo(() => {
     const rows = groupIncidents(filtered)
-    const statusOf = (r) => r.kind === 'single'
-      ? r.incident.status
-      : (['ongoing', 'monitoring', 'resolved'].find(s => r.statusCounts[s]) ?? 'resolved')
+    const statusOf = (r) => r.kind === 'single' ? r.incident.status : dominantGroupStatus(r)
     return rows.slice().sort((a, b) => (STATUS_PRIORITY[statusOf(a)] ?? 2) - (STATUS_PRIORITY[statusOf(b)] ?? 2))
   }, [filtered])
 

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -11,6 +11,7 @@ import { trackEvent } from '../utils/analytics'
 import { formatDate } from '../utils/time'
 import { buildCalendarFromIncidents } from '../utils/calendar'
 import { groupIncidents } from '../utils/incidentGrouping'
+import { dominantGroupStatus } from '../utils/incidentSort'
 import { SCORE_TEXT_CLASS } from '../utils/constants'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
@@ -303,11 +304,7 @@ function IncidentRow({ incident, detectedAt, isRecentlyRecovered, t, lang }) {
 
 function IncidentGroupRow({ group, t, lang }) {
   const [expanded, setExpanded] = useState(false)
-  // BetterStack-flap groups are always null-impact; the visible status is whatever the entries
-  // share. When mixed, render the highest-priority status.
-  const dominantStatus = group.uniformStatus
-    ? Object.keys(group.statusCounts)[0]
-    : (['investigating', 'identified', 'monitoring', 'resolved'].find(s => group.statusCounts[s]))
+  const dominantStatus = dominantGroupStatus(group)
   const STATUS_CLS = {
     investigating: 'text-[var(--red)]',
     identified:    'text-[var(--red)]',

--- a/src/utils/__tests__/incidentSort.test.js
+++ b/src/utils/__tests__/incidentSort.test.js
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import {
   STATUS_PRIORITY,
+  STATUS_ORDER,
   getResolvedTime,
   getLatestActivity,
   compareIncidents,
+  dominantGroupStatus,
+  formatDurationMs,
+  sumGroupDuration,
 } from '../incidentSort'
 
 function makeIncident({
@@ -194,5 +198,217 @@ describe('compareIncidents', () => {
       '5-resolved-recent',    // resolved tier, latest resolved
       '1-resolved-old',       // resolved tier, older
     ])
+  })
+})
+
+describe('STATUS_ORDER', () => {
+  it('puts ongoing first, then raw worker statuses in priority order', () => {
+    // STATUS_ORDER must include BOTH the normalized 'ongoing' alias used by
+    // Incidents.jsx (which collapses investigating/identified→ongoing before
+    // grouping) AND the raw worker statuses used by ServiceDetails.jsx (which
+    // does not pre-normalize). Putting 'ongoing' first lets the normalized
+    // path resolve correctly, while the raw-status path still falls through
+    // to investigating/identified when 'ongoing' is absent from statusCounts.
+    expect(STATUS_ORDER).toEqual(['ongoing', 'investigating', 'identified', 'monitoring', 'resolved'])
+  })
+})
+
+describe('dominantGroupStatus', () => {
+  it('returns the only key when group is uniform', () => {
+    const group = { uniformStatus: true, statusCounts: { investigating: 4 } }
+    expect(dominantGroupStatus(group)).toBe('investigating')
+  })
+
+  it('picks ongoing for the normalized Incidents.jsx shape (regression for #355)', () => {
+    // Incidents.jsx normalizes inc.status → 'ongoing' | 'monitoring' | 'resolved'
+    // before grouping, so production statusCounts keys for that page are exactly
+    // {ongoing, monitoring, resolved}. Pre-fix: a STATUS_ORDER without 'ongoing'
+    // dropped this case to the resolved tier with a green badge.
+    const group = {
+      uniformStatus: false,
+      statusCounts: { ongoing: 2, resolved: 5 },
+    }
+    expect(dominantGroupStatus(group)).toBe('ongoing')
+  })
+
+  it('picks investigating for the raw-status ServiceDetails.jsx shape', () => {
+    // ServiceDetails.jsx does NOT normalize before grouping, so its statusCounts
+    // keys are raw worker statuses (investigating/identified/monitoring/resolved).
+    // 'ongoing' is absent — find() must fall through to 'investigating'.
+    const group = {
+      uniformStatus: false,
+      statusCounts: { investigating: 2, monitoring: 1, resolved: 5 },
+    }
+    expect(dominantGroupStatus(group)).toBe('investigating')
+  })
+
+  it('picks identified over monitoring + resolved', () => {
+    const group = {
+      uniformStatus: false,
+      statusCounts: { identified: 1, monitoring: 3, resolved: 10 },
+    }
+    expect(dominantGroupStatus(group)).toBe('identified')
+  })
+
+  it('picks investigating over identified (priority order matches STATUS_ORDER)', () => {
+    const group = {
+      uniformStatus: false,
+      statusCounts: { investigating: 1, identified: 1 },
+    }
+    expect(dominantGroupStatus(group)).toBe('investigating')
+  })
+
+  it('falls back to resolved when group has only resolved entries', () => {
+    const group = {
+      uniformStatus: false,
+      statusCounts: { resolved: 5 },
+    }
+    expect(dominantGroupStatus(group)).toBe('resolved')
+  })
+
+  it('falls back to resolved on empty statusCounts (defensive)', () => {
+    const group = { uniformStatus: false, statusCounts: {} }
+    expect(dominantGroupStatus(group)).toBe('resolved')
+  })
+
+  it('integrates with STATUS_PRIORITY so a mostly-investigating group sorts above mostly-resolved', () => {
+    const investigatingGroup = {
+      uniformStatus: false,
+      statusCounts: { investigating: 1, resolved: 8 },
+    }
+    const resolvedGroup = {
+      uniformStatus: false,
+      statusCounts: { monitoring: 1, resolved: 8 },
+    }
+    expect(STATUS_PRIORITY[dominantGroupStatus(investigatingGroup)])
+      .toBeLessThan(STATUS_PRIORITY[dominantGroupStatus(resolvedGroup)])
+  })
+
+  it('integrates with STATUS_PRIORITY for the normalized Incidents.jsx shape (#355 regression)', () => {
+    // The actual production case for Incidents.jsx — a flap group with normalized
+    // 'ongoing' + 'resolved' entries must sort above a resolved-only group.
+    const ongoingGroup = {
+      uniformStatus: false,
+      statusCounts: { ongoing: 2, resolved: 5 },
+    }
+    const resolvedGroup = {
+      uniformStatus: false,
+      statusCounts: { resolved: 8 },
+    }
+    expect(STATUS_PRIORITY[dominantGroupStatus(ongoingGroup)])
+      .toBeLessThan(STATUS_PRIORITY[dominantGroupStatus(resolvedGroup)])
+  })
+})
+
+describe('formatDurationMs', () => {
+  it('renders sub-minute durations as 1m (round up, mirrors worker formatDuration)', () => {
+    expect(formatDurationMs(0)).toBe('1m')
+    expect(formatDurationMs(30_000)).toBe('1m')
+  })
+
+  it('renders minutes-only durations without hour prefix', () => {
+    expect(formatDurationMs(31 * 60_000)).toBe('31m')
+    expect(formatDurationMs(59 * 60_000)).toBe('59m')
+  })
+
+  it('renders hours-and-minutes for durations >= 1h', () => {
+    expect(formatDurationMs(60 * 60_000)).toBe('1h 0m')
+    expect(formatDurationMs(125 * 60_000)).toBe('2h 5m')
+  })
+
+  it('rounds partial minutes up (Math.ceil) to match worker', () => {
+    // 30s30ms → 1m, 60s30ms → 2m, etc. — same rounding as worker formatDuration
+    expect(formatDurationMs(30_500)).toBe('1m')
+    expect(formatDurationMs(60_500)).toBe('2m')
+  })
+
+  it('matches worker formatDuration output bit-for-bit (cross-language parity lock-in)', async () => {
+    // formatDurationMs and worker/src/utils.ts:formatDuration are sibling impls
+    // that MUST produce identical output for the same elapsed ms — group totals
+    // on the dashboard otherwise drift from per-incident `duration` strings the
+    // worker emits. This test imports the worker function and asserts equality
+    // across boundary inputs (sub-minute, minute boundaries, hour rollover,
+    // partial-minute round-up). Catches silent drift if either side migrates
+    // rounding (Math.ceil → Math.round, etc.) without updating the other.
+    const { formatDuration } = await import('../../../worker/src/utils')
+    const fixtures = [0, 1, 30_000, 60_000, 60_001, 60_500, 90_000, 120_000, 30 * 60_000, 59 * 60_000, 60 * 60_000, 125 * 60_000, 180 * 60_000]
+    for (const ms of fixtures) {
+      const epoch0 = new Date(0)
+      const later = new Date(ms)
+      expect(formatDurationMs(ms)).toBe(formatDuration(epoch0, later))
+    }
+  })
+})
+
+describe('sumGroupDuration', () => {
+  const start = (iso) => new Date(iso).toISOString()
+
+  it('sums durations across all resolved entries', () => {
+    const group = {
+      entries: [
+        { startedAt: start('2026-04-30T01:00:00Z'), resolvedAt: start('2026-04-30T01:10:00Z') },
+        { startedAt: start('2026-04-30T02:00:00Z'), resolvedAt: start('2026-04-30T02:30:00Z') },
+        { startedAt: start('2026-04-30T03:00:00Z'), resolvedAt: start('2026-04-30T03:05:00Z') },
+      ],
+    }
+    const result = sumGroupDuration(group)
+    expect(result.totalMs).toBe(45 * 60_000)
+    expect(result.hasOngoing).toBe(false)
+    expect(result.resolvedCount).toBe(3)
+    expect(formatDurationMs(result.totalMs)).toBe('45m')
+  })
+
+  it('flags hasOngoing when an entry is missing resolvedAt', () => {
+    const group = {
+      entries: [
+        { startedAt: start('2026-04-30T01:00:00Z'), resolvedAt: start('2026-04-30T01:10:00Z') },
+        { startedAt: start('2026-04-30T02:00:00Z') }, // ongoing
+      ],
+    }
+    const result = sumGroupDuration(group)
+    expect(result.totalMs).toBe(10 * 60_000)
+    expect(result.hasOngoing).toBe(true)
+    expect(result.resolvedCount).toBe(1)
+  })
+
+  it('returns zero totalMs and hasOngoing=false for empty entries (defensive)', () => {
+    const result = sumGroupDuration({ entries: [] })
+    expect(result.totalMs).toBe(0)
+    expect(result.hasOngoing).toBe(false)
+    expect(result.resolvedCount).toBe(0)
+  })
+
+  it('treats missing entries field as empty (defensive)', () => {
+    const result = sumGroupDuration({})
+    expect(result.totalMs).toBe(0)
+    expect(result.resolvedCount).toBe(0)
+  })
+
+  it('skips entries with end <= start (treats as ongoing)', () => {
+    // Malformed payload: resolvedAt earlier than startedAt — must not produce
+    // negative ms or crash. Treated as ongoing so the sum stays a lower bound.
+    const group = {
+      entries: [
+        { startedAt: start('2026-04-30T01:00:00Z'), resolvedAt: start('2026-04-30T00:50:00Z') },
+        { startedAt: start('2026-04-30T02:00:00Z'), resolvedAt: start('2026-04-30T02:15:00Z') },
+      ],
+    }
+    const result = sumGroupDuration(group)
+    expect(result.totalMs).toBe(15 * 60_000)
+    expect(result.hasOngoing).toBe(true)
+    expect(result.resolvedCount).toBe(1)
+  })
+
+  it('skips entries with invalid timestamps (treats as ongoing)', () => {
+    const group = {
+      entries: [
+        { startedAt: 'not-a-date', resolvedAt: start('2026-04-30T01:10:00Z') },
+        { startedAt: start('2026-04-30T02:00:00Z'), resolvedAt: start('2026-04-30T02:05:00Z') },
+      ],
+    }
+    const result = sumGroupDuration(group)
+    expect(result.totalMs).toBe(5 * 60_000)
+    expect(result.hasOngoing).toBe(true)
+    expect(result.resolvedCount).toBe(1)
   })
 })

--- a/src/utils/incidentSort.js
+++ b/src/utils/incidentSort.js
@@ -24,6 +24,103 @@ export const STATUS_PRIORITY = {
 }
 
 /**
+ * Statuses in priority order, used by `dominantGroupStatus` to derive a
+ * representative status for a flap group.
+ *
+ * Includes BOTH the normalized `'ongoing'` alias (used by `Incidents.jsx`,
+ * whose `allIncidents` useMemo collapses `investigating`/`identified` →
+ * `'ongoing'` before grouping) AND the raw worker statuses (used directly by
+ * `ServiceDetails.jsx`, which does not pre-normalize). Putting `'ongoing'`
+ * first makes the normalized path resolve correctly without breaking the
+ * raw-status path: when `statusCounts` carries raw statuses, `'ongoing'` is
+ * absent and `find` falls through to `investigating`/`identified` as
+ * intended.
+ *
+ * Within a priority tier, the array order is itself the tiebreaker (e.g.
+ * `investigating` is chosen over `identified` even though `STATUS_PRIORITY`
+ * ties them at 0). Adding a new status to `STATUS_PRIORITY` therefore also
+ * requires inserting it at the matching position here — `find()`
+ * short-circuits on the first match.
+ */
+export const STATUS_ORDER = ['ongoing', 'investigating', 'identified', 'monitoring', 'resolved']
+
+/**
+ * Pick the highest-priority raw status present in a flap group. Falls back
+ * to `resolved` only when `statusCounts` is empty or contains nothing in
+ * `STATUS_ORDER` (defensive).
+ *
+ * Used to drive group-row badge color, badge label, and sort tier on the
+ * Incidents page (issue #355). Without `STATUS_ORDER`, an investigating- or
+ * identified-only group would fall through to `resolved` and sort below
+ * monitoring + resolved rows.
+ *
+ * @param {{ uniformStatus?: boolean, statusCounts: Record<string, number> }} group
+ * @returns {string}
+ */
+export function dominantGroupStatus(group) {
+  if (group.uniformStatus) {
+    const keys = Object.keys(group.statusCounts)
+    return keys[0] ?? 'resolved'
+  }
+  return STATUS_ORDER.find((s) => group.statusCounts[s]) ?? 'resolved'
+}
+
+/**
+ * Format a millisecond duration as `Nh Mm` or `Mm`. Mirrors the worker's
+ * `formatDuration` (`worker/src/utils.ts`) so summed group durations on the
+ * Incidents page render in the same shape as per-incident `duration` strings
+ * coming from the API. Sub-minute durations round up to `1m` to avoid `0m`.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+export function formatDurationMs(ms) {
+  const totalMin = Math.max(1, Math.ceil(ms / 60_000))
+  const hours = Math.floor(totalMin / 60)
+  const minutes = totalMin % 60
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+}
+
+/**
+ * Sum the cumulative impacted time across a flap group's entries. Returns the
+ * total ms across resolved entries plus a flag indicating whether any entry
+ * is still active. Wall-clock range (`rangeEnd − rangeStart`) was rejected
+ * because it includes recovery gaps between flaps and overstates impact for
+ * SLO accounting.
+ *
+ * Defensive: skips entries with missing/invalid timestamps so a malformed
+ * payload doesn't crash the row render.
+ *
+ * @param {{ entries?: { startedAt?: string, resolvedAt?: string }[] }} group
+ * @returns {{ totalMs: number, hasOngoing: boolean, resolvedCount: number }}
+ */
+export function sumGroupDuration(group) {
+  let totalMs = 0
+  let hasOngoing = false
+  let resolvedCount = 0
+  for (const entry of group.entries ?? []) {
+    if (entry.resolvedAt && entry.startedAt) {
+      const start = new Date(entry.startedAt).getTime()
+      const end = new Date(entry.resolvedAt).getTime()
+      if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+        totalMs += end - start
+        resolvedCount += 1
+        continue
+      }
+      // Inverted or non-finite timestamps indicate an upstream parser/clock bug —
+      // unambiguously not a legitimate ongoing incident. Surface in dev so the
+      // engineer running `npm run dev` notices; production stays silent so a
+      // single bad payload doesn't crash the row render.
+      if (typeof console !== 'undefined' && import.meta?.env?.DEV) {
+        console.warn('[sumGroupDuration] malformed entry timestamps, treating as ongoing', { startedAt: entry.startedAt, resolvedAt: entry.resolvedAt })
+      }
+    }
+    hasOngoing = true
+  }
+  return { totalMs, hasOngoing, resolvedCount }
+}
+
+/**
  * Resolved timestamp — `resolvedAt` field, or the last `resolved` timeline
  * entry, or null when the incident hasn't resolved yet.
  *


### PR DESCRIPTION
## Summary
- **Sort fix (#355)**: Replace hardcoded status arrays in 3 `Incidents.jsx` call sites + 1 `ServiceDetails.jsx` call site with a shared `dominantGroupStatus()` helper. `STATUS_ORDER` now correctly handles both the normalized `Incidents.jsx` shape (`{ongoing, monitoring, resolved}`) and raw worker statuses on `ServiceDetails.jsx`. A flap group containing only `investigating`/`identified` (or normalized `ongoing`) entries no longer drops into the resolved tier with a green badge.
- **Arrow repositioning**: Group-row expand `▸` moved from before the title to after the `× N flaps` badge — title alignment now matches non-grouped rows. Mobile card uses inline `marginLeft:'auto'` because Tailwind's `ml-auto` fails under the unlayered `* { margin: 0 }` reset in `src/index.css` (CSS cascade-layer interaction — unlayered rules beat layered utility rules).
- **Duration sum**: The group-row Duration column previously showed a hardcoded em-dash. Now sums `resolvedAt − startedAt` across entries via `sumGroupDuration`, formatted as `Nh Mm` (or `Nh Mm + Ongoing` when any entry is still active). Wall-clock range was rejected because it includes recovery gaps and overstates impact. Malformed timestamps emit a dev-only warn (`import.meta.env.DEV`) so upstream parser drift surfaces during local dev without polluting the production console.
- **Cross-language parity test**: Locks `formatDurationMs` in step with the worker `formatDuration` (Math.ceil rounding) so a future change to either side gets caught.

## Acceptance criteria (from #355)
- [x] All three `['ongoing', 'monitoring', 'resolved']` literals in `src/pages/Incidents.jsx` replaced — now uses `dominantGroupStatus(group)`.
- [x] Test in `src/utils/__tests__/incidentSort.test.js` covering grouped row containing only `investigating`/`identified` sorts into the active tier — and the matching normalized `{ongoing, resolved}` shape.
- [x] Visual verify locally: Mistral API flap groups appear in the active tier when applicable; resolved-only groups stay at the bottom.
- [x] No regression in existing grouped-row sort behavior (Vitest 87/87, Playwright E2E 87/87).

## Test plan
- [x] `npm run test:src` — 87/87 passing (4 new STATUS_ORDER/dominantGroupStatus tests, 4 new formatDurationMs tests, 1 cross-language parity, 6 new sumGroupDuration tests)
- [x] `npm test` — Playwright E2E 87/87 passing
- [x] `npm run build` — clean
- [x] Local browser verify (Playwright MCP): flap rows show summed duration `24m` (= 2m + 4m + 18m), arrow renders after the `× 3 flaps` badge, mobile card metadata wraps cleanly with duration before status

🤖 Generated with [Claude Code](https://claude.com/claude-code)