### PR TITLE
chore: add concurrency control to Test workflow (#365)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,15 @@ on:
       - 'docs/**'
       - '.github/**/*.md'
 
+# Bound CI quota usage per branch / PR — a new push on the same head_ref
+# cancels the previous run instead of stacking. Mitigates abuse surface
+# after Vercel Git Fork Protection is disabled (#365). For push events,
+# github.head_ref is empty, so the fallback to github.ref keeps each main
+# push in its own group rather than collapsing them all together.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: Worker Unit Tests


### PR DESCRIPTION
## Summary
- Add a top-level \`concurrency:\` block to \`.github/workflows/test.yml\` so a new push on the same PR / branch cancels the previous run.
- Group key uses \`github.head_ref || github.ref\` — PR pushes share a group keyed by head ref, while \`main\` pushes fall back to \`github.ref\` and stay isolated from each other.

## Why now
- PR #357 (first external contributor PR) exposed friction with Vercel \"Authorization required to deploy\" — fixed by disabling Vercel team setting → **Git Fork Protection**.
- Disabling that setting slightly raises the abuse surface (a malicious fork could trigger many concurrent CI runs to consume Vercel quota / GitHub Actions minutes). Concurrency control bounds this: each PR can only occupy one CI slot at a time.

## Test plan
- [x] \`js-yaml\` parse confirms valid YAML and that \`jobs: unit, e2e, build\` are unchanged.
- [ ] After merge, push twice quickly to a test branch and verify the first run is auto-cancelled.
- [ ] Verify that two near-simultaneous pushes to \`main\` do NOT cancel each other (separate groups via \`github.ref\`).

closes #365
refs #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)