### PR TITLE
fix: codex/chatgpt uptime mismatches OpenAI's published group aggregates (#367)

### DIFF
--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -213,17 +213,28 @@ describe('ChatGPT without statusComponentId (#292)', () => {
 
   const chatgptConfig = SERVICES.find((s) => s.id === 'chatgpt') as ServiceConfig
 
-  it('config has no statusComponentId or incidentIoComponentId (post-migration)', () => {
-    // Guard against accidental reintroduction of the stale IDs. incidentExclude
-    // must stay absent too — the cross-contamination guard in fetchService
-    // relies on incidentKeywords being the sole filter.
+  it('config carries no statusComponentId / statusComponent / incidentExclude — cross-contamination guard depends on this (#292)', () => {
+    // The "no relevant unresolved incidents → operational" guard at the !statusComponent &&
+    // !statusComponentId branch in fetchService is what protects chatgpt from inheriting
+    // OpenAI API page-level non-operational states. Re-adding either of those fields would
+    // bypass that guard. incidentKeywords must remain the sole filter for incident
+    // selection, with no overriding incidentExclude list.
     expect(chatgptConfig).toBeDefined()
     expect(chatgptConfig.statusComponentId).toBeUndefined()
     expect(chatgptConfig.statusComponent).toBeUndefined()
-    expect(chatgptConfig.incidentIoComponentId).toBeUndefined()
     expect(chatgptConfig.incidentExclude).toBeUndefined()
     expect(chatgptConfig.incidentKeywords).toContain('chatgpt')
     expect(chatgptConfig.incidentKeywords).toContain('conversation')
+  })
+
+  it('config has incidentIoComponentId + incidentIoGroupId for uptime sourcing (#367)', () => {
+    // Separate code path from the cross-contamination guard above: the dashboard
+    // uptime number comes from parseIncidentIoUptime, which needs an incident.io
+    // group/component to read from. Without these, chatgpt.uptime30d was null.
+    // The guard above checks statusComponent / statusComponentId only, so adding
+    // incidentIoComponentId here does NOT defeat #292.
+    expect(chatgptConfig.incidentIoComponentId).toBe('01JMXBNJXGV1T5GT2M9XA83XNG')  // Conversations
+    expect(chatgptConfig.incidentIoGroupId).toBe('01K5H8S53SY1KMS4GQMNMZXTR1')      // ChatGPT group
   })
 
   it('keyword-matched ChatGPT incident → degraded', () => {
@@ -313,11 +324,13 @@ describe('OpenAI Codex without statusComponentId (#294)', () => {
     expect(codexConfig.statusComponentId).toBeUndefined()
     expect(codexConfig.statusComponent).toBeUndefined()
     expect(codexConfig.incidentExclude).toBeUndefined()
-    // incidentIoComponentId = Codex API (#301) — sourcing official uptime
-    // from the surface that backs CLI + VS Code extension. Guard against
-    // accidental removal; if this assertion ever fails, either the ID was
-    // renamed upstream or someone reverted #301.
+    // incidentIoComponentId = Codex API (#301) — kept as fallback if the group
+    // lookup ever fails. incidentIoGroupId = Codex group (#367) — primary uptime
+    // source, matching what OpenAI publishes on status.openai.com (Codex
+    // group aggregate ≈ 99.98%, vs the single Codex API component which read
+    // 100% and disagreed with the published number).
     expect(codexConfig.incidentIoComponentId).toBe('01KMP3KP5MGE23B80K1EK4S8PV')
+    expect(codexConfig.incidentIoGroupId).toBe('01KMKF9EBTCD8BN9PG8DJZXRSQ')
     expect(codexConfig.incidentKeywords).toContain('codex')
     expect(codexConfig.incidentKeywords).toContain('cli')
     expect(codexConfig.incidentKeywords).toContain('vs code')

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -56,26 +56,33 @@ export const SERVICES: ServiceConfig[] = [
   // AI Apps
   { id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude.ai', 'across surfaces', 'claude desktop'], statusComponent: 'claude.ai', statusComponentId: 'rwppv331jlwc' },
   { id: 'characterai', name: 'Character.AI', provider: 'Character AI', category: 'app', statusUrl: 'https://status.character.ai', apiUrl: 'https://status.character.ai/api/v2/summary.json', statusComponentId: 'fw8g76r7dqcl' },
-  // ChatGPT has no single umbrella component on status.openai.com; sub-components
-  // (Login/Feed/Video/Atlas) are too granular to represent the service. Status is
-  // resolved from the overall indicator + incidentKeywords filter, with the
-  // "no relevant unresolved incidents → operational" guard in fetchService
-  // preventing cross-contamination from OpenAI API incidents (#292).
-  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents' },
+  // ChatGPT has no single umbrella status-page component, but status.openai.com
+  // does publish a ChatGPT group aggregate over its sub-components — that's the
+  // user-facing uptime number on the page. Status determination still uses the
+  // overall indicator + incidentKeywords filter with the "no relevant unresolved
+  // incidents → operational" cross-contamination guard (#292); the new
+  // incidentIoComponentId / incidentIoGroupId pair only feeds parseIncidentIoUptime
+  // (#367), not the status path. Component fallback is Conversations
+  // (01JMXBNJXGV1T5GT2M9XA83XNG, 99.92% sample) — not perfect coverage but a
+  // reasonable proxy if OpenAI ever restructures the ChatGPT group.
+  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG', incidentIoGroupId: '01K5H8S53SY1KMS4GQMNMZXTR1' },
   // Coding Agents
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
   // OpenAI Codex (coding agent): published across 4 distinct surface components on
-  // status.openai.com (Codex Web / Codex API / CLI / VS Code extension) with no
-  // umbrella component. Same #292 pattern as chatgpt — overall indicator +
-  // incidentKeywords filter, cross-contamination guard in fetchService blocks
-  // OpenAI API / ChatGPT incidents from bleeding through.
+  // status.openai.com (Codex Web / Codex API / CLI / VS Code extension) with a
+  // Codex group aggregate over all four. Same #292 pattern as chatgpt — overall
+  // indicator + incidentKeywords filter, cross-contamination guard in fetchService
+  // blocks OpenAI API / ChatGPT incidents from bleeding through.
   //
-  // Uptime source: Codex API component only (#301). Chosen because it backs
-  // the CLI and VS Code extension — API availability is the strongest proxy
-  // for developer-use availability. Surface-specific outages (e.g., Codex Web
-  // frontend only) surface via incidentKeywords in Recent Incidents, not in
-  // the uptime%. Is Codex Down SEO page documents this scoping.
-  { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV' },
+  // Uptime source: Codex group aggregate (#367 — '01KMKF9EBTCD8BN9PG8DJZXRSQ').
+  // Matches what OpenAI publishes on status.openai.com. The original #301 scoping
+  // to the Codex API component alone produced 100% while OpenAI's published Codex
+  // group sat at 99.98%; the dashboard now mirrors what users see upstream.
+  // incidentIoComponentId stays set to Codex API as a fallback — if the group
+  // ID becomes invalid, the parser falls through to the per-component lookup
+  // rather than returning null. Surface-specific outages (e.g., Codex Web only)
+  // still surface via incidentKeywords in Recent Incidents.
+  { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV', incidentIoGroupId: '01KMKF9EBTCD8BN9PG8DJZXRSQ' },
   { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
   { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },


### PR DESCRIPTION
## Summary
- Add `incidentIoGroupId` to **codex** (`01KMKF9EBTCD8BN9PG8DJZXRSQ` — Codex group: API + Web + CLI) and to **chatgpt** (`01K5H8S53SY1KMS4GQMNMZXTR1` — ChatGPT group, alongside `incidentIoComponentId='01JMXBNJXGV1T5GT2M9XA83XNG'` as Conversations-fallback).
- Live `/api/status` will now return uptime numbers that match what OpenAI publishes on `status.openai.com`. Pre-fix: codex 100% vs published 99.98%; chatgpt null vs published 99.83%.

## Why
The original scoping decisions (#301 for codex, #292 for chatgpt) predated the team noticing incident.io publishes **group aggregates** that match the user-facing status-page number. The parser already supports group lookup via `incidentIoGroupId` (existing test at `worker/src/parsers/__tests__/incident-io.test.ts:41-48`); only the configs lagged. The cross-contamination guard from #292 is independent — it gates on `statusComponent`/`statusComponentId`, neither of which this PR touches.

## Test plan
- [x] `npm run test:worker` — 1082/1082 passing (was 1080; +2 from a split status-determination test that separates "cross-contamination guard preconditions" from "uptime sourcing fields")
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean
- [x] PR review (code-reviewer): 0 Critical, 0 Important, 1 Suggestion (stale comment on codex config — applied)
- [ ] Live verification post-deploy: `codex.uptime30d ≈ 99.98` and `chatgpt.uptime30d ≈ 99.83` (numbers track OpenAI's published values, refreshed at the next 5-min cron tick after deploy)

## Out of scope
- April 2026 monthly archive's poll-based 84.97% Codex aggregate — separate metric path (`computeMonthlyUptime` on daily counters), already addressed in `aiwatch-reports#14` with a partial-window caveat.
- Backfilling historical archives with incident.io group uptime — bigger architectural decision deferred.

closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)