### PR TITLE
fix: retune probe corroboration 1.5× / ±20m (closes #372)

### DIFF
--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -160,6 +160,45 @@ describe('isCorroboratedByProbe', () => {
     )).toBe(true)
   })
 
+  it('corroborates when RTT exceeds 1.5× median (boundary, retuned in #372)', () => {
+    // medianRtt = 185, 1.5× = 277.5 → rtt 280 is just above threshold
+    const snapshots: ProbeSnapshot[] = [
+      ...baseSnapshots,
+      { t: '2026-03-24T01:20:00Z', data: { mistral: { status: 401, rtt: 280 } } },
+    ]
+    expect(isCorroboratedByProbe(
+      snapshots, 'mistral',
+      '2026-03-24T01:18:00Z', '2026-03-24T01:22:00Z',
+      medianRtt,
+    )).toBe(true)
+  })
+
+  it('does NOT corroborate when RTT is just below 1.5× median (locks new threshold)', () => {
+    // 277 = 185 × 1.497 — just under the 1.5× threshold (277.5)
+    const snapshots: ProbeSnapshot[] = [
+      ...baseSnapshots,
+      { t: '2026-03-24T01:20:00Z', data: { mistral: { status: 401, rtt: 277 } } },
+    ]
+    expect(isCorroboratedByProbe(
+      snapshots, 'mistral',
+      '2026-03-24T01:18:00Z', '2026-03-24T01:22:00Z',
+      medianRtt,
+    )).toBe(false)
+  })
+
+  it('uses ±20-minute window — catches probes 15min outside the incident edge (retuned in #372)', () => {
+    // Incident at 01:30; probe with spike at 01:15 (15min before start)
+    // Old window (±10m) would exclude; new window (±20m) includes
+    const snapshots: ProbeSnapshot[] = [
+      { t: '2026-03-24T01:15:00Z', data: { mistral: { status: 401, rtt: 800 } } }, // spike 15min before
+    ]
+    expect(isCorroboratedByProbe(
+      snapshots, 'mistral',
+      '2026-03-24T01:30:00Z', '2026-03-24T01:32:00Z',
+      medianRtt,
+    )).toBe(true)
+  })
+
   it('returns true when probe failed (rtt=-1)', () => {
     const failSnapshots: ProbeSnapshot[] = [
       ...baseSnapshots,
@@ -206,7 +245,7 @@ describe('isCorroboratedByProbe', () => {
   })
 
   it('returns true when incidentEnd is null (ongoing)', () => {
-    // Ongoing incident — window is start ± 10min
+    // Ongoing incident — window is start ± 20min
     const spikeSnapshots: ProbeSnapshot[] = [
       ...baseSnapshots,
       { t: '2026-03-24T01:20:00Z', data: { mistral: { status: 401, rtt: 700 } } },

--- a/worker/src/probe.ts
+++ b/worker/src/probe.ts
@@ -126,10 +126,19 @@ export function computeMedianRtt(snapshots: ProbeSnapshot[], serviceId: string):
  * Check if a micro-incident is corroborated by probe data (RTT spike).
  * Returns true if the incident appears to be a real outage based on probe evidence.
  *
- * Logic: find probe snapshots within ±10 minutes of the incident window.
- * If any probe shows RTT > 3× median or a failed probe (rtt=-1), it's corroborated.
+ * Logic: find probe snapshots within ±20 minutes of the incident window.
+ * If any probe shows RTT > 1.5× median or a failed probe (rtt=-1), it's corroborated.
  * If no probes exist in the window, assume real (conservative — don't filter without evidence).
+ *
+ * Threshold tuning history (#372):
+ *   Original (#91 Phase 2, 2026-04-06): 3× / ±10m. 5/10 incidents corroborated at deploy time.
+ *   Retune (2026-05-04): 1.5× / ±20m. Original threshold dropped to 0/14 by May; data showed
+ *   real Mistral degradations only push RTT to ~2× baseline (not 3×). 1.5× restores ~57% pass rate
+ *   on the same data — a balance between filtering Checkly false-positives and over-filtering
+ *   genuine short outages. Long-term replacement: same-title incident grouping (#373).
  */
+export const PROBE_CORROBORATION_MULTIPLIER = 1.5
+export const PROBE_CORROBORATION_WINDOW_MS = 1_200_000 // ±20 minutes
 export function isCorroboratedByProbe(
   snapshots: ProbeSnapshot[],
   serviceId: string,
@@ -141,8 +150,8 @@ export function isCorroboratedByProbe(
     console.warn(`[isCorroboratedByProbe] no baseline RTT for ${serviceId}, assuming real`)
     return true
   }
-  const WINDOW_MS = 600_000 // ±10 minutes
-  const spikeThreshold = medianRtt * 3
+  const WINDOW_MS = PROBE_CORROBORATION_WINDOW_MS
+  const spikeThreshold = medianRtt * PROBE_CORROBORATION_MULTIPLIER
   const startMs = new Date(incidentStart).getTime()
   if (Number.isNaN(startMs)) {
     console.error(`[isCorroboratedByProbe] invalid incidentStart: "${incidentStart}"`)


### PR DESCRIPTION
## Summary

- Retune probe corroboration thresholds: `medianRtt × 3` → `× 1.5`, window `±10m` → `±20m`
- Extract magic numbers into exported constants `PROBE_CORROBORATION_MULTIPLIER` / `PROBE_CORROBORATION_WINDOW_MS`
- Document tuning history in JSDoc + reference long-term replacement (#373)
- 3 new unit tests lock the new threshold + window contract

## Why

\`isCorroboratedByProbe\` was added in #91 Phase 2 (PR #158, deployed 2026-04-06) to suppress Mistral's auto-monitoring noise. At deploy time it corroborated 5/10 incidents (50% pass rate) — judged effective.

By 2026-05-04, the same configuration was dropping **all 14** post-60s-filter Mistral incidents (0/14, 0%). Per-incident analysis on live data:

- Median Mistral probe RTT: 154ms
- Old threshold: 154 × 3 = 462ms
- All 14 incidents' max RTT in window: 162-319ms — RTT IS elevated (+5%~+107% over baseline) but never reaches 3×

Mistral's "Degraded" state pushes RTT to ~2× baseline, not 3×. The original 3× was over-tuned to one moment.

## Threshold simulation (current 14 incidents)

| Config | Pass | |
|---|---|---|
| 3× / ±10m (current) | 0 / 14 | broken |
| 2× / ±10m | 3 / 14 | partial |
| 2× / ±20m | 4 / 14 | window matters less than multiplier |
| **1.5× / ±20m** | **8 / 14** | **chosen — best balance** |

## Scope

This PR is an **interim retune** to restore dashboard signal. The Mistral-only special case and asymmetry with other services (Together AI 139 raw / Fireworks 30 raw shown as-is) is **out of scope** — see #373 for the long-term replacement (same-title incident grouping applied uniformly).

## Test plan

- [x] \`npm run test:worker\` — 1084/1084 pass (52 in probe.test.ts including 3 new boundary tests)
- [x] \`npx wrangler deploy --config worker/wrangler.toml --dry-run\` — clean
- [x] PR review converged round 2: 0 Critical / 0 Important
- [ ] After merge: deploy worker + verify Mistral dashboard shows ~8 incidents (matching simulation)

## New tests

- \`corroborates when RTT exceeds 1.5× median (boundary, retuned in #372)\` — locks threshold
- \`does NOT corroborate when RTT is just below 1.5× median\` — locks boundary tightly
- \`uses ±20-minute window — catches probes 15min outside the incident edge\` — locks window expansion

## Out of scope (tracked separately)

- #373: replace probe corroboration with same-title incident grouping (long-term)
- Mistral-only \`isMistralProbedEndpoint\` hardcode removal
- Probe endpoint change from \`/v1/models\` to \`/v1/chat/completions\`
- Monthly archive ↔ live dashboard count consistency (4월 보고서 97 vs dashboard ~8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)