### PR TITLE
feat: multi-component status tracking for coding agents (closes #379)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,12 +403,13 @@ Is X Down pages (Edge SSR) and Landing page use inline `gtag()` calls directly s
 
 ### Service Status Determination
 Per-service status is resolved in `services.ts` with this priority:
-1. **Component match** (`statusComponentId` or `statusComponent`): use that component's status
-2. **Component not found**: fall back to overall page indicator
-3. **No component configured**: use overall indicator, BUT if no relevant unresolved incidents matched after `incidentExclude`/`incidentKeywords` filtering, treat as `operational` (prevents cross-contamination from unrelated incidents on shared status pages, e.g., ChatGPT incident should not affect OpenAI API status)
-4. **`incidentExclude` component bypass** (#359): when an `incidentExclude` pattern matches the incident title, check if the incident's `componentNames` starts with `config.statusComponent` — if it does, include the incident anyway. Prevents "claude.ai and API unavailable" from being dropped from Claude API just because the title contains "claude.ai". Component tagging is more authoritative than title substring matching.
-5. **Component-status incident filter** (`filterByComponentStatus`): if component is `operational` but provider bulk-linked incidents to all components, remove unresolved incidents (keep resolved + monitoring). Prevents e.g., Anthropic admin API incident from showing on claude.ai/Claude Code when their components are healthy
-5. **Status page fetch failure cross-validation** (post-processing in `fetchAllServices`):
+1. **Multi-component worst-of** (`statusComponentIds`, #379): when configured, look up each id in the page's `components`, normalize each, and pick the worst (`down` > `degraded` > `operational`). Used for coding agents whose user-facing surface spans multiple components — e.g. Cursor IDE primary + Cloud Agents + Automations + CLI; Claude Code component + Claude API dependency. `statusComponentId` (singular) remains the *primary* component for uptime parsing, calendar days, and component-miss alerting; `statusComponentIds` is purely for badge resolution. Convention: list the primary as the first entry of `statusComponentIds`. If none of the ids resolve in the components list, falls through to step 2.
+2. **Component match** (`statusComponentId` or `statusComponent`): use that component's status
+3. **Component not found**: fall back to overall page indicator
+4. **No component configured**: use overall indicator, BUT if no relevant unresolved incidents matched after `incidentExclude`/`incidentKeywords` filtering, treat as `operational` (prevents cross-contamination from unrelated incidents on shared status pages, e.g., ChatGPT incident should not affect OpenAI API status)
+5. **`incidentExclude` component bypass** (#359): when an `incidentExclude` pattern matches the incident title, check if the incident's `componentNames` starts with `config.statusComponent` — if it does, include the incident anyway. Prevents "claude.ai and API unavailable" from being dropped from Claude API just because the title contains "claude.ai". Component tagging is more authoritative than title substring matching.
+6. **Component-status incident filter** (`filterByComponentStatus`): if component is `operational` but provider bulk-linked incidents to all components, remove unresolved incidents (keep resolved + monitoring). Prevents e.g., Anthropic admin API incident from showing on claude.ai/Claude Code when their components are healthy
+7. **Status page fetch failure cross-validation** (post-processing in `fetchAllServices`):
    - If service is `degraded` from fetch failure (no incidents) AND probe RTT is normal → override to `operational`
    - If 70%+ of services on the same platform (Atlassian/incident.io/etc.) fail simultaneously → platform outage → override all to `operational`
    - Conservative: only overrides when evidence is strong (≥2 recent probes healthy, or quorum failure detected)

--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { normalizeStatus } from '../parsers/statuspage'
-import { filterIncidents, SERVICES } from '../services'
+import { filterIncidents, SERVICES, worstStatus, resolveSvcStatus } from '../services'
 import type { Incident, ServiceConfig } from '../types'
 import { type KVLike } from '../utils'
 
@@ -13,6 +13,7 @@ import { type KVLike } from '../utils'
 interface StatusConfig {
   statusComponent?: string
   statusComponentId?: string
+  statusComponentIds?: string[]
 }
 
 interface SummaryData {
@@ -24,26 +25,10 @@ interface FilteredIncident {
   status: string
 }
 
-/**
- * Mirrors the svcStatus determination logic from services.ts lines 219-234
- */
-function determineSvcStatus(
-  config: StatusConfig,
-  summaryData: SummaryData,
-  filtered: FilteredIncident[],
-): string {
-  const overall = normalizeStatus(summaryData.status?.indicator ?? 'none')
-  if (!config.statusComponent && !config.statusComponentId) {
-    if (overall !== 'operational' && filtered.filter((i) => i.status !== 'resolved').length === 0) {
-      return 'operational'
-    }
-    return overall
-  }
-  const comp = config.statusComponent
-    ? summaryData.components?.find((c) => c.name.startsWith(config.statusComponent!))
-    : summaryData.components?.find((c) => c.id === config.statusComponentId!)
-  return comp ? normalizeStatus(comp.status) : overall
-}
+// Tests call the production resolver directly (no test mirror) so a future change
+// to status-resolution logic cannot pass the tests by drifting from runtime.
+const determineSvcStatus = (config: StatusConfig, summary: SummaryData, filtered: FilteredIncident[]): string =>
+  resolveSvcStatus(config, summary, filtered)
 
 describe('svcStatus determination', () => {
   describe('no component configured (e.g., OpenAI API after migration)', () => {
@@ -148,6 +133,164 @@ describe('svcStatus determination', () => {
       }
       expect(determineSvcStatus(config, summary, [])).toBe('degraded')
     })
+  })
+
+  describe('with statusComponentIds (multi-component, worst-of) — #379', () => {
+    // Models the cursor case: IDE primary + Cloud Agents + Automations
+    const config: StatusConfig = {
+      statusComponentId: 'ide',
+      statusComponentIds: ['ide', 'cloud-agents', 'automations'],
+    }
+
+    it('returns operational when all tracked components are operational', () => {
+      const summary: SummaryData = {
+        status: { indicator: 'none' },
+        components: [
+          { id: 'ide', name: 'IDE', status: 'operational' },
+          { id: 'cloud-agents', name: 'Cloud Agents', status: 'operational' },
+          { id: 'automations', name: 'Automations', status: 'operational' },
+          { id: 'marketplace', name: 'Marketplace', status: 'operational' },
+        ],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('operational')
+    })
+
+    it('flips to degraded when a non-primary component is partial_outage (the bug)', () => {
+      // Live cursor case 2026-05-04 23:32 UTC — IDE OK but Cloud Agents/Automations down.
+      // Pre-#379 single-statusComponentId logic returned operational; now must be degraded.
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [
+          { id: 'ide', name: 'IDE', status: 'operational' },
+          { id: 'cloud-agents', name: 'Cloud Agents', status: 'partial_outage' },
+          { id: 'automations', name: 'Automations', status: 'partial_outage' },
+        ],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('degraded')
+    })
+
+    it('returns down when any tracked component is major_outage (worst wins)', () => {
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [
+          { id: 'ide', name: 'IDE', status: 'partial_outage' },
+          { id: 'cloud-agents', name: 'Cloud Agents', status: 'major_outage' },
+          { id: 'automations', name: 'Automations', status: 'operational' },
+        ],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('down')
+    })
+
+    it('ignores untracked components (e.g. Marketplace status does not affect badge)', () => {
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [
+          { id: 'ide', name: 'IDE', status: 'operational' },
+          { id: 'cloud-agents', name: 'Cloud Agents', status: 'operational' },
+          { id: 'automations', name: 'Automations', status: 'operational' },
+          { id: 'marketplace', name: 'Marketplace', status: 'major_outage' }, // not tracked
+        ],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('operational')
+    })
+
+    it('falls back to overall indicator when none of the tracked ids resolve', () => {
+      // Configured ids drifted (page restructured) — nothing matches; fall back to overall.
+      // Component-miss alert path picks this up separately so operators can reconcile.
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [{ id: 'unknown-1', name: 'Renamed', status: 'operational' }],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('degraded')
+    })
+
+    it('partial id resolution still computes worst-of across the resolved subset', () => {
+      // Two of three ids found — worst-of those two is the result.
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [
+          { id: 'ide', name: 'IDE', status: 'operational' },
+          { id: 'cloud-agents', name: 'Cloud Agents', status: 'partial_outage' },
+          // 'automations' missing — drifted away
+        ],
+      }
+      expect(determineSvcStatus(config, summary, [])).toBe('degraded')
+    })
+
+    it('ignores empty statusComponentIds and falls back to single statusComponentId', () => {
+      const cfg: StatusConfig = { statusComponentId: 'ide', statusComponentIds: [] }
+      const summary: SummaryData = {
+        status: { indicator: 'minor' },
+        components: [{ id: 'ide', name: 'IDE', status: 'operational' }],
+      }
+      expect(determineSvcStatus(cfg, summary, [])).toBe('operational')
+    })
+  })
+})
+
+describe('worstStatus helper (#379)', () => {
+  it('returns operational for empty input (no components matched)', () => {
+    expect(worstStatus([])).toBe('operational')
+  })
+  it('returns operational when all are operational', () => {
+    expect(worstStatus(['operational', 'operational'])).toBe('operational')
+  })
+  it('promotes to degraded when any is degraded', () => {
+    expect(worstStatus(['operational', 'degraded', 'operational'])).toBe('degraded')
+  })
+  it('promotes to down when any is down (overrides degraded)', () => {
+    expect(worstStatus(['operational', 'degraded', 'down'])).toBe('down')
+  })
+  it('handles single-element list', () => {
+    expect(worstStatus(['degraded'])).toBe('degraded')
+  })
+})
+
+describe('SERVICES coding-agent multi-component config sanity (#379)', () => {
+  it('cursor tracks IDE primary + Cloud Agents + Automations + CLI', () => {
+    const cursor = SERVICES.find((s) => s.id === 'cursor')!
+    expect(cursor.statusComponentId).toBe('rflc60xp5jp2') // IDE — primary for uptime parsing
+    expect(cursor.statusComponentIds).toEqual([
+      'rflc60xp5jp2', // IDE
+      'mwv1g9sc7kdh', // Cloud Agents
+      'k0trcq273dr6', // Automations
+      'vsny1qv7v86c', // CLI
+    ])
+  })
+
+  it('claudecode intentionally stays single-component (dependency tracking would clash with incidentKeywords filter)', () => {
+    // Pre-merge review caught that adding Claude API as a second tracked component
+    // would flip the badge to degraded for API-only incidents that don't match
+    // claudecode's `incidentKeywords` (['claude code', 'across surfaces']) — leaving
+    // a degraded card with no visible incident. Claude API outages remain visible
+    // on the separate `claude` (Claude API) card. See #379 review.
+    const cc = SERVICES.find((s) => s.id === 'claudecode')!
+    expect(cc.statusComponentId).toBe('yyzkbfz2thpt') // Claude Code (only)
+    expect(cc.statusComponentIds).toBeUndefined()
+  })
+
+  it('copilot tracks Copilot + Copilot AI Model Providers', () => {
+    const cp = SERVICES.find((s) => s.id === 'copilot')!
+    expect(cp.statusComponentId).toBe('pjmpxvq2cmr2')
+    expect(cp.statusComponentIds).toEqual(['pjmpxvq2cmr2', 'cnnb39dkkk82'])
+  })
+
+  it('windsurf tracks Cascade + Windsurf Tab', () => {
+    const ws = SERVICES.find((s) => s.id === 'windsurf')!
+    expect(ws.statusComponentId).toBe('r5wf1ykd7y1m')
+    expect(ws.statusComponentIds).toEqual(['r5wf1ykd7y1m', '8q19cygxvshj'])
+  })
+
+  it('primary statusComponentId always appears as the first entry of statusComponentIds', () => {
+    // Convention: primary first so a reader can scan the array and immediately see
+    // which component drives uptime%/calendar/miss tracking. Enforce in the test
+    // so accidental reordering during config edits is caught.
+    for (const sid of ['cursor', 'copilot', 'windsurf']) {
+      const svc = SERVICES.find((s) => s.id === sid)!
+      if (svc.statusComponentIds && svc.statusComponentId) {
+        expect(svc.statusComponentIds[0]).toBe(svc.statusComponentId)
+      }
+    }
   })
 })
 

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -67,6 +67,14 @@ export const SERVICES: ServiceConfig[] = [
   // reasonable proxy if OpenAI ever restructures the ChatGPT group.
   { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG', incidentIoGroupId: '01K5H8S53SY1KMS4GQMNMZXTR1' },
   // Coding Agents
+  // claudecode intentionally tracks only the Claude Code component for the badge.
+  // Adding Claude API as a multi-component dependency would conflict with the
+  // existing `incidentKeywords` filter (`['claude code', 'across surfaces']`):
+  // an API-only incident would flip the badge to degraded but be dropped from
+  // the visible incident list, leaving users staring at a degraded card with no
+  // explanation. Track only Claude Code here; users see Claude API outages on
+  // the separate `claude` (Claude API) card. See #379 for the multi-component
+  // pattern and the review trade-off that kept claudecode single-component.
   { id: 'claudecode', name: 'Claude Code', provider: 'Anthropic', category: 'agent', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude code', 'across surfaces'], statusComponent: 'Claude Code', statusComponentId: 'yyzkbfz2thpt' },
   // OpenAI Codex (coding agent): published across 4 distinct surface components on
   // status.openai.com (Codex Web / Codex API / CLI / VS Code extension) with a
@@ -83,9 +91,13 @@ export const SERVICES: ServiceConfig[] = [
   // rather than returning null. Surface-specific outages (e.g., Codex Web only)
   // still surface via incidentKeywords in Recent Incidents.
   { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['codex', 'cli', 'vs code'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01KMP3KP5MGE23B80K1EK4S8PV', incidentIoGroupId: '01KMKF9EBTCD8BN9PG8DJZXRSQ' },
-  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2' },
-  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2' },
-  { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m' },
+  // cursor badge reflects worst-of: IDE primary + Cloud Agents + Automations + CLI (#379).
+  // Bugbot/cursor.com/Marketplace are auxiliary surfaces and intentionally excluded.
+  { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2', statusComponentIds: ['rflc60xp5jp2', 'mwv1g9sc7kdh', 'k0trcq273dr6', 'vsny1qv7v86c'] },
+  // copilot badge reflects worst-of: Copilot + Copilot AI Model Providers (direct upstream) (#379).
+  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2', statusComponentIds: ['pjmpxvq2cmr2', 'cnnb39dkkk82'] },
+  // windsurf badge reflects worst-of: Cascade primary + Windsurf Tab (autocomplete agent surface) (#379).
+  { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m', statusComponentIds: ['r5wf1ykd7y1m', '8q19cygxvshj'] },
 ]
 
 /**
@@ -128,6 +140,81 @@ export async function mergeAistudioIncidents(
     cancelBody()
     return { incidents: primary, merged: 0, parseErrors: 1 }
   }
+}
+
+type NormalizedStatus = 'operational' | 'degraded' | 'down'
+const STATUS_RANK: Record<NormalizedStatus, number> = { operational: 0, degraded: 1, down: 2 }
+
+/**
+ * Pick the worst status across multiple components (down > degraded > operational).
+ * Used for `statusComponentIds` multi-component badge resolution: when any tracked
+ * surface is degraded, the service's badge reflects the worst case.
+ */
+export function worstStatus(statuses: NormalizedStatus[]): NormalizedStatus {
+  return statuses.reduce<NormalizedStatus>(
+    (worst, s) => (STATUS_RANK[s] > STATUS_RANK[worst] ? s : worst),
+    'operational',
+  )
+}
+
+// Loose shape used by resolveSvcStatus so the same function can serve both the
+// production fetchService loop (where summaryData is StatuspageResponse) and
+// tests (where it's a hand-rolled fixture). Only the fields actually read are
+// declared — adding StatuspageResponse here would force the test to import
+// types from a parser module unnecessarily.
+type StatusResolverSummary = {
+  status?: { indicator?: string } | null
+  components?: Array<{ id: string; name: string; status: string }>
+}
+type StatusResolverConfig = Pick<ServiceConfig, 'statusComponent' | 'statusComponentId' | 'statusComponentIds'>
+
+/**
+ * Resolve a service's overall badge status from its config + status page summary.
+ *
+ * **Single source of truth** — production (`fetchService` loop) and the
+ * status-determination unit tests both call this directly so the test mirror
+ * cannot drift from the runtime logic.
+ *
+ * Branch order (each step is taken only if the prior didn't return):
+ *   1. **No component configured** — fall back to overall page indicator, but
+ *      if every matching incident is resolved, claim `operational` to suppress
+ *      cross-contamination from sibling services on shared status pages
+ *      (e.g. an OpenAI-API-only incident must not flip ChatGPT to degraded).
+ *   2. **`statusComponentIds` worst-of (#379)** — when configured AND non-empty
+ *      AND `components` is present, pick the worst normalized status across
+ *      the resolved subset (`down > degraded > operational`). If none of the
+ *      configured ids resolve in the page's components (drift), fall back to
+ *      the overall indicator; the separate component-miss alert path picks
+ *      the drift up so operators can reconcile.
+ *   3. **Single-component** (`statusComponent` name-prefix match OR
+ *      `statusComponentId` exact match) — use that component's status; fall
+ *      back to overall if neither matches.
+ */
+export function resolveSvcStatus(
+  config: StatusResolverConfig,
+  summaryData: StatusResolverSummary,
+  filtered: Array<{ status: string }>,
+): NormalizedStatus {
+  const overall = normalizeStatus(summaryData.status?.indicator ?? 'none')
+  if (!config.statusComponent && !config.statusComponentId && !config.statusComponentIds) {
+    if (overall !== 'operational' && filtered.filter((i) => i.status !== 'resolved').length === 0) {
+      return 'operational'
+    }
+    return overall
+  }
+  if (config.statusComponentIds && config.statusComponentIds.length > 0 && summaryData.components) {
+    const matched = config.statusComponentIds
+      .map((id) => summaryData.components!.find((c) => c.id === id))
+      .filter((c): c is NonNullable<typeof c> => c != null)
+    if (matched.length > 0) {
+      return worstStatus(matched.map((c) => normalizeStatus(c.status)))
+    }
+    return overall
+  }
+  const comp = config.statusComponent
+    ? summaryData.components?.find((c) => c.name.startsWith(config.statusComponent!))
+    : summaryData.components?.find((c) => c.id === config.statusComponentId)
+  return comp ? normalizeStatus(comp.status) : overall
 }
 
 export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {
@@ -326,22 +413,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
       // non-operational. Computing svcStatus first lets the no-component
       // branch detect the empty-filtered case and treat the service as
       // operational, suppressing untagged-include entirely.
-      const svcStatus = (() => {
-        const overall = normalizeStatus(summaryData.status?.indicator ?? 'none')
-        if (!config.statusComponent && !config.statusComponentId) {
-          // No specific component — use overall, but if no relevant unresolved incidents
-          // matched after filtering, treat as operational (avoids cross-contamination
-          // from unrelated incidents, e.g., ChatGPT incident affecting OpenAI API status)
-          if (overall !== 'operational' && filtered.filter((i) => i.status !== 'resolved').length === 0) {
-            return 'operational'
-          }
-          return overall
-        }
-        const comp = config.statusComponent
-          ? summaryData.components?.find((c) => c.name.startsWith(config.statusComponent))
-          : summaryData.components?.find((c) => c.id === config.statusComponentId)
-        return comp ? normalizeStatus(comp.status) : overall
-      })()
+      const svcStatus = resolveSvcStatus(config, summaryData, filtered)
 
       // Only fall back to untagged-include when this service is genuinely
       // non-operational. Operational services per the cross-contamination
@@ -388,7 +460,10 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
       // Filter out active incidents when component is operational (#228)
       filtered = filterByComponentStatus(filtered, svcStatus, config)
 
-      // Track component ID misses for migration detection (#135)
+      // Track component ID misses for migration detection (#135).
+      // Primary statusComponentId drives the alerted-on tracker. Additional ids
+      // from statusComponentIds (#379) are warn-logged so operators can reconcile
+      // without triggering Discord alerts that would fire repeatedly per surface.
       if (config.statusComponentId && summaryData.components) {
         const compFound = summaryData.components.some((c) => c.id === config.statusComponentId)
         if (!compFound) {
@@ -397,6 +472,14 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
           await trackComponentMiss(kv, config.id)
         } else {
           await resetComponentMiss(kv, config.id)
+        }
+      }
+      if (config.statusComponentIds && summaryData.components) {
+        const missing = config.statusComponentIds.filter(
+          (id) => id !== config.statusComponentId && !summaryData.components!.some((c) => c.id === id),
+        )
+        if (missing.length > 0) {
+          console.warn(`[fetchService] ${config.id} additional component ids missing: ${missing.join(', ')}`)
         }
       }
       // Augment dailyImpact with ongoing incidents (source data only includes resolved).

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -56,6 +56,20 @@ export interface ServiceConfig {
   incidentIoBaseUrl?: string
   statusComponent?: string
   statusComponentId?: string
+  // Optional: multiple components to track for the badge (worst-status wins).
+  // When set, the dashboard status is `down` if any component is `major_outage`,
+  // `degraded` if any is `partial_outage`/`degraded_performance`, else `operational`.
+  // `statusComponentId` remains the *primary* component used for uptime parsing,
+  // calendar days, and component-miss alerting; this list adds extra surfaces
+  // whose health should also flip the badge (e.g. Cursor IDE primary +
+  // Cloud Agents/Automations as user-impacting agentic surfaces).
+  // An empty array `[]` is treated as if the field were absent — the resolver
+  // falls through to the single-`statusComponentId` path. Only use this for
+  // sibling surfaces of the *same* product (cursor IDE + cursor Cloud Agents);
+  // dependency tracking (e.g. Claude Code → Claude API) creates badge/incident
+  // asymmetry when the dependency's incidents don't match the service's
+  // `incidentKeywords` filter. See #379 review for the trade-off.
+  statusComponentIds?: string[]
   incidentIoComponentId?: string
   incidentIoGroupId?: string       // incident.io group uptime (e.g. "APIs" aggregate)
   betterStackUrl?: string


### PR DESCRIPTION
## Summary

- Coding agents tracked only a single `statusComponentId` for the badge — when other user-impacting surfaces on the same status page were degraded but the tracked component stayed operational, the dashboard misleadingly showed `operational` while users hit broken behavior.
- Adds optional `statusComponentIds: string[]` to `ServiceConfig`; the badge picks the worst status across all listed components (`down > degraded > operational`). `statusComponentId` remains the *primary* component for uptime parsing, calendar days, and component-miss alerting.
- Live trigger: 2026-05-04 23:32 UTC Cursor "Cloud Agents degradation" — Cloud Agents + Automations both `partial_outage`, but Cursor card stayed green because IDE was healthy. Local verification confirmed the fix flips Cursor to `degraded` correctly against the live incident.

## Coding-agent updates

| Service | Components tracked | Rationale |
|---|---|---|
| **cursor** | IDE + Cloud Agents + Automations + CLI | Sibling surfaces of the same product. Bugbot/cursor.com/Marketplace excluded as auxiliary. |
| **copilot** | Copilot + Copilot AI Model Providers | Direct upstream — model provider outages break Copilot. |
| **windsurf** | Cascade + Windsurf Tab | Two AI-facing user surfaces. Netlify infra components excluded. |
| **claudecode** | _intentionally single-component_ | Adding Claude API as a dependency would clash with the existing `incidentKeywords` filter — API-only incidents would flip the badge to `degraded` while being dropped from the visible incident list. Users see Claude API outages on the separate `claude` card. (See review note in `services.ts:68`.) |
| **codex** | unchanged | Uses incident.io path with no `statusComponent`/`statusComponentId`, falls into the unchanged "no component configured" branch. Out of scope. |

## Implementation

- `worker/src/types.ts` — added `statusComponentIds?: string[]` with JSDoc covering empty-array semantics and the dependency-tracking trade-off.
- `worker/src/services.ts` — extracted `resolveSvcStatus(config, summary, filtered)` and `worstStatus(statuses[])` as exported helpers. Production and tests now call `resolveSvcStatus` directly so there is no test mirror to drift. Component-miss tracking continues on the primary `statusComponentId` only; additional ids in `statusComponentIds` are warn-logged so a multi-component restructure doesn't trigger Discord alert spam.
- `CLAUDE.md` — Service Status Determination priority list now leads with the multi-component step; subsequent steps renumbered to fix a pre-existing duplicate `5.`.

## Tests

1108/1108 worker tests pass. Notable additions in `worker/src/__tests__/status-determination.test.ts`:
- Worst-of resolution with 3 components, including the bug repro (IDE green + Cloud Agents/Automations partial_outage → `degraded`)
- `down` overrides `degraded` overrides `operational`
- Untracked components (e.g. Marketplace `major_outage` not in the configured list) are correctly ignored
- Partial id resolution — when 2 of 3 ids are present, worst-of computes across the resolved subset
- Drift fallback — when none of the configured ids resolve, falls back to overall indicator (component-miss alert path picks up the drift separately)
- Empty-array semantics — `statusComponentIds: []` is treated as if absent (single-component path)
- Per-service config sanity — primary-first convention, claudecode intentionally not multi-component
- `worstStatus()` unit tests (empty input, single, mixed, etc.)

## Local Verification

- `npx wrangler dev --config worker/wrangler.toml --port 8788` + `npm run dev`
- Live Cloud Agents incident on Cursor (`partial_outage` on `mwv1g9sc7kdh` + `k0trcq273dr6`)
- After cache stabilization (1 fetch cycle), `/api/status` consistently returned `cursor: degraded` (5/5 calls)
- Dashboard at `localhost:5174` showed Cursor card in degraded state — confirmed by Daisy
- Production (without fix) returned `cursor: operational` for the same live incident, confirming the asymmetry

## Test plan

- [x] All worker unit tests pass (1108/1108)
- [x] `wrangler deploy --dry-run` succeeds
- [x] Local dev with live Cloud Agents incident: cursor flips to degraded
- [ ] After deploy: verify cursor flips on production within ~1 minute (cache stabilization cycle — anti-flap may show one cycle of operational before settling on degraded)
- [ ] Verify other coding agents (copilot/windsurf) remain `operational` (no regressions on currently-healthy services)
- [ ] Verify claudecode still tracks Claude Code component only (single-component path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)