### PR TITLE
fix: switch /reports proxy to direct GH Pages so #264 redirect can land (refs #264)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ api/
   intro/
     html-template.ts # SSR HTML template (i18n, dashboard mock, GA4)
   is-down.ts        # "Is X Down?" Edge Function (30 services — excludes bedrock/azureopenai per #263)
-  reports.ts        # Monthly Reports proxy (/reports/* → reports.ai-watch.dev) with HTML path rewriting (#264)
+  reports.ts        # Monthly Reports proxy (/reports/* → bentleypark.github.io/aiwatch-reports/*, fetched directly to bypass the Cloudflare 301 on the public reports.ai-watch.dev hostname) with HTML path rewriting (#264)
 src/
   components/   # Shared UI: StatusPill, SkeletonUI, EmptyState, Modal, Sidebar, Topbar, CookieBanner, AnalysisModal
   pages/        # Overview, Latency, Incidents, Uptime, ServiceDetails, Settings, AboutScore, Ranking
@@ -394,7 +394,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 
 Is X Down pages (Edge SSR) and Landing page use inline `gtag()` calls directly since they don't use React.
 
-**Reports site** (`reports.ai-watch.dev`) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
+**Reports site** (served at `ai-watch.dev/reports/` via the `api/reports.ts` proxy; #264) uses the same GA4 ID (`G-D4ZWVHQ7JK`) with event delegation in `_includes/footer.html`:
 
 | Event | Parameters | Trigger | Purpose |
 |---|---|---|---|
@@ -523,4 +523,4 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
 - **PWA**: `public/manifest.json` + `public/sw.js` (stale-while-revalidate). CACHE_NAME in `sw.js` must be bumped manually when static assets change. SW excludes `/is-*` (Edge SSR) and `/api/*` (real-time data) from caching
 - **Edge SSR**: `api/is-down.ts` serves "Is X Down?" SEO pages (30 services — all monitored except bedrock + azureopenai which are estimate-only with no differentiated data) via Vercel Edge Functions. Uses `/api/status/cached` (KV-only) for fast SSR (~1.2s). Rank uses competition ranking (`Math.round(score)`-based `findIndex`, not id-based) and applies the same `uptimeSource === 'estimate' && incidents.length === 0` filter as the dashboard Ranking page so SEO rank numbers match what users see. Header meta omits the Uptime segment entirely when `uptime30d` is null (no "Uptime: N/A" surface). Dynamic OG image via Worker `/api/og` (PNG, resvg-wasm). Share buttons: X, Threads, KakaoTalk (SDK async), Copy Link. `vercel.json` rewrites route `/is-{service}-down` to the handler
 - **Landing page**: `api/intro.ts` + `api/intro/html-template.ts` — Product Hunt landing page via Vercel Edge Function. `/intro` route (or `?ref=producthunt` for PH banner). Self-contained SSR with inline CSS/JS, KO/EN i18n (client-side toggle), GA4 events, dashboard preview mock. No external data fetch (pure template render)
-- **Monthly Reports proxy**: `api/reports.ts` — Vercel Edge Function that proxies `/reports/*` on `ai-watch.dev` to the aiwatch-reports Jekyll origin at `reports.ai-watch.dev` (#264). Consolidates SEO + GA4 under a single apex domain. `vercel.json` needs four explicit rewrites (`/reports`, `/reports/`, `/reports/:rest*`, `/reports/:rest*/`) because path-to-regexp's `:rest*` does not match trailing-slash paths in Vercel's router. Denylist header filtering (strips `content-encoding`, upstream server IDs, hop-by-hop headers), 10s timeout, `s-maxage=600` edge cache when upstream omits a directive, 502 error page on upstream failure (does not fall back to the SPA so operators can distinguish "report missing" from "proxy broken")
+- **Monthly Reports proxy**: `api/reports.ts` — Vercel Edge Function that proxies `/reports/*` on `ai-watch.dev` to the aiwatch-reports Jekyll site (#264). Fetches directly from `bentleypark.github.io/aiwatch-reports/` rather than the public `reports.ai-watch.dev` subdomain so a Cloudflare Page Rule can 301 the public subdomain to `ai-watch.dev/reports/` without trapping the proxy in a redirect loop (proxy fetch and the 301'd public hostname must not share a hostname). The aiwatch-reports repo therefore must NOT carry a `CNAME` file pointing at `reports.ai-watch.dev`. Consolidates SEO + GA4 under a single apex domain. `vercel.json` needs four explicit rewrites (`/reports`, `/reports/`, `/reports/:rest*`, `/reports/:rest*/`) because path-to-regexp's `:rest*` does not match trailing-slash paths in Vercel's router. Denylist header filtering (strips `content-encoding`, upstream server IDs, hop-by-hop headers), 10s timeout, `s-maxage=600` edge cache when upstream omits a directive, 502 error page on upstream failure (does not fall back to the SPA so operators can distinguish "report missing" from "proxy broken")

--- a/api/__tests__/reports.test.ts
+++ b/api/__tests__/reports.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { toUpstreamPath } from '../reports'
+
+// Pure-function unit test for the path-stripping logic that maps Vercel
+// request paths onto the GH Pages upstream. A regex regression here would
+// silently break asset URLs / nested report paths in production, so the
+// four documented mappings (#264) are pinned by tests.
+describe('toUpstreamPath (#264)', () => {
+  it('maps the bare /reports root to /', () => {
+    expect(toUpstreamPath('/reports')).toBe('/')
+  })
+
+  it('maps /reports/ (trailing slash) to /', () => {
+    expect(toUpstreamPath('/reports/')).toBe('/')
+  })
+
+  it('strips the /reports prefix from a monthly report path', () => {
+    expect(toUpstreamPath('/reports/2026-03/')).toBe('/2026-03/')
+  })
+
+  it('strips the prefix from asset paths', () => {
+    expect(toUpstreamPath('/reports/assets/main.css')).toBe('/assets/main.css')
+  })
+
+  it('handles paths with explicit index.html', () => {
+    expect(toUpstreamPath('/reports/2026-03/index.html')).toBe('/2026-03/index.html')
+  })
+
+  it('handles deeply nested paths', () => {
+    expect(toUpstreamPath('/reports/2026-03/assets/charts/uptime.svg')).toBe(
+      '/2026-03/assets/charts/uptime.svg',
+    )
+  })
+
+  it('preserves a leading slash on the stripped result', () => {
+    // Defends against a regex that would strip /reports without preserving the
+    // path separator and produce something like 'assets/main.css' (no leading /).
+    expect(toUpstreamPath('/reports/anything')).toMatch(/^\//)
+  })
+})

--- a/api/reports.ts
+++ b/api/reports.ts
@@ -1,7 +1,10 @@
 // Vercel Edge Function — proxy /reports/* to the aiwatch-reports Jekyll/GH Pages
-// origin at reports.ai-watch.dev (#264). Replaces the prior external-URL rewrite
-// which fell through to the SPA catch-all in production (Vercel rewrites expect
-// internal destinations; external URLs are not reliably proxied).
+// origin (#264). Originally pointed at reports.ai-watch.dev; switched to fetch
+// GH Pages directly via bentleypark.github.io/aiwatch-reports/* so that a
+// Cloudflare Page Rule can 301 the public reports.ai-watch.dev hostname to
+// ai-watch.dev/reports/ without trapping the proxy in a redirect loop. With
+// the prior origin, a Page Rule on the public hostname would 301 the proxy's
+// own fetch back to ai-watch.dev/reports/ (= itself).
 //
 // vercel.json needs four rewrite sources for this to cover every Jekyll URL
 // shape — path-to-regexp's `:rest*` does not match requests with a trailing
@@ -9,17 +12,29 @@
 //   /reports, /reports/, /reports/:rest*, /reports/:rest*/
 //
 // URL mapping:
-//   /reports           → reports.ai-watch.dev/
-//   /reports/          → reports.ai-watch.dev/
-//   /reports/2026-03/  → reports.ai-watch.dev/2026-03/
-//   /reports/assets/x  → reports.ai-watch.dev/assets/x
+//   /reports           → bentleypark.github.io/aiwatch-reports/
+//   /reports/          → bentleypark.github.io/aiwatch-reports/
+//   /reports/2026-03/  → bentleypark.github.io/aiwatch-reports/2026-03/
+//   /reports/assets/x  → bentleypark.github.io/aiwatch-reports/assets/x
 
 export const config = { runtime: 'edge' }
 
-const UPSTREAM_ORIGIN = 'https://reports.ai-watch.dev'
+// Direct GH Pages URL — bypasses the public reports.ai-watch.dev hostname so
+// that Cloudflare's 301 Page Rule on that hostname can't trap the proxy in
+// a redirect loop. Requires the aiwatch-reports repo to NOT have a CNAME
+// file pointing at reports.ai-watch.dev (else GH Pages 301s every request
+// from this URL back to the public hostname, defeating the bypass).
+//
+// During the deploy gap between this proxy change landing and the
+// aiwatch-reports CNAME removal, GH Pages still 301s from this URL back to
+// reports.ai-watch.dev — the fetch's `redirect: 'follow'` (below) is what
+// keeps the proxy working in that interim. Don't change it to 'manual' or
+// 'error' without first verifying the CNAME has been removed.
+const UPSTREAM_ORIGIN = 'https://bentleypark.github.io/aiwatch-reports'
 
 // Strip /reports prefix and normalize: missing trailing slash on home becomes '/'.
-function toUpstreamPath(pathname: string): string {
+// Exported for unit testing; not imported anywhere in production code.
+export function toUpstreamPath(pathname: string): string {
   const stripped = pathname.replace(/^\/reports/, '') || '/'
   return stripped.startsWith('/') ? stripped : `/${stripped}`
 }
@@ -126,7 +141,7 @@ export default async function handler(req: Request): Promise<Response> {
     // so operators can tell the difference between "report not found" and
     // "proxy is broken". Status 502 is semantically correct for upstream fail.
     return new Response(
-      `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Reports unavailable</title></head><body style="background:#080c10;color:#e6edf3;font-family:sans-serif;text-align:center;padding:60px"><h1>Monthly reports temporarily unavailable</h1><p>The aiwatch-reports origin is unreachable. Try <a href="https://reports.ai-watch.dev" style="color:#58a6ff">reports.ai-watch.dev</a> directly, or return to the <a href="https://ai-watch.dev" style="color:#58a6ff">dashboard</a>.</p></body></html>`,
+      `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Reports unavailable</title></head><body style="background:#080c10;color:#e6edf3;font-family:sans-serif;text-align:center;padding:60px"><h1>Monthly reports temporarily unavailable</h1><p>The reports origin is unreachable. Please try again shortly, or return to the <a href="https://ai-watch.dev" style="color:#58a6ff">dashboard</a>.</p></body></html>`,
       { status: 502, headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' } },
     )
   }


### PR DESCRIPTION
## Summary

- #264's deferred 301-redirect step (public `reports.ai-watch.dev/*` → `ai-watch.dev/reports/*`) is blocked because `api/reports.ts` proxies via `reports.ai-watch.dev` itself — a Cloudflare Page Rule on that hostname would 301 the proxy's own fetch back to `ai-watch.dev/reports/` and trap it in a loop.
- Fix: route the proxy fetch directly through `bentleypark.github.io/aiwatch-reports/*`. That's a hostname Cloudflare doesn't 301, so the public subdomain can be redirected independently.
- Land first in a 3-step plan: (1) **this PR** flips the proxy upstream, (2) follow-up `aiwatch-reports` PR removes the `CNAME` file so GH Pages stops 301'ing, (3) operator-only Cloudflare Page Rule on the public hostname.

## Why this is safe to land first

While the `aiwatch-reports/CNAME` file remains in place, GH Pages 301s `bentleypark.github.io/aiwatch-reports/*` back to `reports.ai-watch.dev/*`. Vercel's `redirect: 'follow'` transparently chases that chain to a 200 from the existing public subdomain — the proxy keeps working through every step of the rollout. The header comment in `api/reports.ts` documents this and warns a future maintainer not to swap `redirect: 'follow'` for `'manual'` until step 2 has actually shipped.

## Files

- `api/reports.ts` — `UPSTREAM_ORIGIN` flipped, rationale comments expanded, `toUpstreamPath` exported for unit testing, fallback HTML's link to the now-301'd subdomain replaced with a generic dashboard return (would be circular post-redirect).
- `api/__tests__/reports.test.ts` — new — pins the four documented `/reports*` path mappings plus `/index.html` and deeply-nested-asset edge cases against regex regressions.
- `CLAUDE.md` — Directory Layout entry, Reports site GA4 header, and Monthly Reports proxy bullet all updated with the new origin and loop-prevention rationale.

## Test plan

- [x] `npm run test:worker` → 1109/1109 pass
- [x] `npm run test:src` → 95/95 pass
- [x] New `api/__tests__/reports.test.ts` → 7/7 pass
- [x] `wrangler deploy --dry-run` (worker untouched) → clean
- [ ] Vercel preview: visit `/reports/` and `/reports/2026-03/` on the preview URL — content should render correctly through the new GH Pages upstream
- [ ] After merge: same checks on production
- [ ] After follow-up PR + Cloudflare step: `curl -sI https://reports.ai-watch.dev/2026-03/` returns 301 to `https://ai-watch.dev/reports/2026-03/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)