### PR TITLE
chore: add 2026-04 monthly report to sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,87 +11,87 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-04</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-05</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -99,13 +99,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://ai-watch.dev/reports/2026-04/</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## Summary

- April 2026 monthly reliability report merged in [aiwatch-reports#14](https://github.com/bentleypark/aiwatch-reports/pull/14) and is now published at `ai-watch.dev/reports/2026-04/`.
- This PR adds the corresponding sitemap entry so Googlebot can discover and crawl the new report.
- The prebuild script (#337) auto-bumps every `<lastmod>` to today's UTC date on each Vercel deploy.

## Test plan

- [x] `npm run build` succeeds with the updated sitemap (prebuild hook ran cleanly)
- [ ] After merge: `curl https://ai-watch.dev/sitemap.xml | grep 2026-04` returns the new entry
- [ ] Submit updated sitemap in Google Search Console (manual operator step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)