### PR TITLE
fix: ongoing/monitoring incidents not pinned to top in ServiceDetails + Is X Down (closes #383)

### DIFF
--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -176,4 +176,66 @@ describe('renderIncidents — 30-day window + grouping', () => {
     expect(rows).toBeLessThanOrEqual(20)
     expect(rows).toBeGreaterThan(15) // sanity: we should fill up near the cap
   })
+
+  it('puts an investigating incident above newer resolved rows (#383 SSR regression)', () => {
+    // Mirrors the ServiceDetails.jsx fix on the SSR side. groupIncidents alone
+    // sorts purely by date — without compareGroupedRows the active incident's
+    // title would render below newer resolved rows in the SERP-visible HTML.
+    const svc = mkService({
+      incidents: [
+        mkInc({ id: 'r1',  title: 'Recent resolved A', status: 'resolved',      startedAt: '2026-05-05T00:29:00Z', duration: '1h 41m' }),
+        mkInc({ id: 'r2',  title: 'Recent resolved B', status: 'resolved',      startedAt: '2026-05-01T12:55:00Z', duration: '8m' }),
+        mkInc({ id: 'inv', title: 'Active partial outage', status: 'investigating', startedAt: '2026-04-30T06:59:00Z' }),
+      ],
+    })
+    const html = renderIncidents(svc)
+    const invIdx = html.indexOf('Active partial outage')
+    const r1Idx = html.indexOf('Recent resolved A')
+    const r2Idx = html.indexOf('Recent resolved B')
+    expect(invIdx).toBeGreaterThan(-1)
+    expect(invIdx).toBeLessThan(r1Idx)
+    expect(invIdx).toBeLessThan(r2Idx)
+  })
+
+  it('puts a monitoring incident above newer resolved rows (#383 SSR regression — monitoring tier)', () => {
+    const svc = mkService({
+      incidents: [
+        mkInc({ id: 'r1',  title: 'Recent resolved A', status: 'resolved',  startedAt: '2026-05-05T11:00:00Z', duration: '5m' }),
+        mkInc({ id: 'mon', title: 'Active fix verifying', status: 'monitoring', startedAt: '2026-05-04T08:00:00Z' }),
+      ],
+    })
+    const html = renderIncidents(svc)
+    const monIdx = html.indexOf('Active fix verifying')
+    const r1Idx = html.indexOf('Recent resolved A')
+    expect(monIdx).toBeGreaterThan(-1)
+    expect(monIdx).toBeLessThan(r1Idx)
+  })
+
+  it('row cap does not truncate an ongoing incident in favor of newer resolved rows (#383 SSR regression)', () => {
+    // 25 newer resolved rows + 1 older investigating row. Without sort-before-cap
+    // the investigating row would be discarded by .slice(0, 20).
+    const now = Date.now()
+    const svc = mkService({
+      incidents: [
+        ...Array.from({ length: 25 }, (_, i) => mkInc({
+          id: `r${i}`,
+          title: `Resolved title ${i}`,
+          status: 'resolved' as const,
+          startedAt: new Date(now - i * 3600_000).toISOString(),
+          duration: '5m',
+        })),
+        mkInc({ id: 'inv', title: 'Active investigation', status: 'investigating', startedAt: new Date(now - 26 * 3600_000).toISOString() }),
+      ],
+    })
+    const html = renderIncidents(svc)
+    expect(html).toContain('Active investigation')
+    // Strong guard: investigating must render BEFORE the newest resolved row,
+    // not just survive the cap. A bug placing investigating at index 19 would
+    // still leave it in the HTML but in the wrong position.
+    const invIdx = html.indexOf('Active investigation')
+    const newestResolvedIdx = html.indexOf('Resolved title 0')
+    expect(invIdx).toBeGreaterThan(-1)
+    expect(newestResolvedIdx).toBeGreaterThan(-1)
+    expect(invIdx).toBeLessThan(newestResolvedIdx)
+  })
 })

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -3,6 +3,7 @@
 import type { ServiceSEO } from './seo-content'
 import { SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE, RELATED_SLUGS } from './slug-map'
 import { groupIncidents, type GroupingIncident, type GroupRow, type SingleRow } from './incident-grouping'
+import { compareGroupedRows } from './incident-sort'
 
 /** Format recovery display — shared with worker/src/ai-analysis.ts */
 function formatRecoveryDisplay(recovery: string): string {
@@ -424,7 +425,13 @@ export function renderIncidents(service: ServiceData | null): string {
 <div class="card"><p style="color:#8b949e;font-size:13px;padding:8px 0">No incidents in the last 30 days</p></div>`
   }
 
-  const rows = groupIncidents(recent, { timeZone: 'UTC' }).slice(0, INCIDENT_ROW_CAP)
+  // Re-sort groupIncidents() output so ongoing/monitoring rows survive the
+  // INCIDENT_ROW_CAP slice — see compareGroupedRows. Sort must run before
+  // .slice() or a resolved-heavy 30-day window can truncate an active row.
+  const rows = groupIncidents(recent, { timeZone: 'UTC' })
+    .slice()
+    .sort(compareGroupedRows)
+    .slice(0, INCIDENT_ROW_CAP)
   const body = rows.map((row) => row.kind === 'group' ? renderIncidentGroup(row) : renderIncidentSingle((row as SingleRow).incident)).join('\n')
   return `${heading}
 <div class="card">${body}</div>`

--- a/api/is-down/incident-sort.ts
+++ b/api/is-down/incident-sort.ts
@@ -1,0 +1,48 @@
+// Server-side sort helper for /is-X-down SSR pages.
+//
+// Mirrors `compareGroupedRows` from `src/utils/incidentSort.js` — duplicated
+// rather than shared because Vercel Edge bundling cannot import from `src/`.
+// Tier semantics (investigating/identified/ongoing → monitoring → resolved)
+// must stay aligned with the SPA file. If you need other helpers from the
+// SPA file here, port them deliberately rather than re-deriving locally.
+//
+// Why this exists: `groupIncidents` re-sorts purely by representative date,
+// so an active investigating/monitoring incident can land below newer
+// resolved rows. `compareGroupedRows` lifts active rows back above resolved
+// by tier — keep this implementation in lockstep with the SPA copy.
+
+import type { GroupedRow } from './incident-grouping'
+
+const STATUS_PRIORITY: Record<string, number> = {
+  investigating: 0,
+  identified: 0,
+  ongoing: 0,
+  monitoring: 1,
+  resolved: 2,
+}
+
+// Includes both the normalized 'ongoing' alias and raw worker statuses so
+// `dominantGroupStatus` works whether the caller pre-normalizes or not.
+// Kept aligned with the SPA `STATUS_ORDER` for the same reason.
+const STATUS_ORDER = ['ongoing', 'investigating', 'identified', 'monitoring', 'resolved']
+
+function dominantGroupStatus(group: { uniformStatus?: boolean; statusCounts: Record<string, number> }): string {
+  if (group.uniformStatus) {
+    const keys = Object.keys(group.statusCounts)
+    return keys[0] ?? 'resolved'
+  }
+  return STATUS_ORDER.find((s) => group.statusCounts[s]) ?? 'resolved'
+}
+
+/**
+ * Comparator for `groupIncidents()` output rows. Sorts by tier
+ * (ongoing → monitoring → resolved). Within a tier, the spec-stable
+ * `Array.prototype.sort` (ES2019+) preserves input order — callers must
+ * therefore pass `groupIncidents()` output (already newest-first); sorting
+ * an unsorted list will not yield newest-first within tiers.
+ */
+export function compareGroupedRows(a: GroupedRow, b: GroupedRow): number {
+  const aStatus = a.kind === 'single' ? a.incident.status : dominantGroupStatus(a)
+  const bStatus = b.kind === 'single' ? b.incident.status : dominantGroupStatus(b)
+  return (STATUS_PRIORITY[aStatus] ?? 2) - (STATUS_PRIORITY[bStatus] ?? 2)
+}

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -8,7 +8,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
-import { STATUS_PRIORITY, getResolvedTime, compareIncidents, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
+import { getResolvedTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -37,8 +37,8 @@ const PERIODS = [7, 30, 90]
 const TABLE_COLS = ['col.time', 'col.title', 'col.service', 'col.duration', 'col.status']
 
 // ── Helpers ──────────────────────────────────────────────────
-// STATUS_PRIORITY / getResolvedTime / getLatestActivity / compareIncidents
-// live in src/utils/incidentSort.js — shared with Overview "Recent Incidents".
+// Sort/grouping helpers live in src/utils/incidentSort.js — shared with
+// Overview "Recent Incidents" and ServiceDetails.
 
 /** Last element of array (ES5-safe) */
 function last(arr) { return arr && arr.length > 0 ? arr[arr.length - 1] : undefined }
@@ -407,14 +407,12 @@ export default function Incidents() {
       .sort(compareIncidents)
   }, [allIncidents, serviceFilter, statusFilter, period])
 
-  // groupIncidents re-sorts purely by date — re-apply STATUS_PRIORITY so ongoing
-  // incidents stay above resolved flap groups. Sort is stable (ES2019+), so
-  // newest-first ordering within the same status is preserved.
-  const grouped = useMemo(() => {
-    const rows = groupIncidents(filtered)
-    const statusOf = (r) => r.kind === 'single' ? r.incident.status : dominantGroupStatus(r)
-    return rows.slice().sort((a, b) => (STATUS_PRIORITY[statusOf(a)] ?? 2) - (STATUS_PRIORITY[statusOf(b)] ?? 2))
-  }, [filtered])
+  // groupIncidents re-sorts purely by date; compareGroupedRows lifts ongoing
+  // rows back above newer resolved flap groups. See incidentSort.js.
+  const grouped = useMemo(
+    () => groupIncidents(filtered).slice().sort(compareGroupedRows),
+    [filtered]
+  )
 
   if (loading && services.length === 0) return <IncidentsSkeleton />
   if (!loading && services.length === 0 && error) return <EmptyState type="offline" onAction={refresh} />

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -11,7 +11,7 @@ import { trackEvent } from '../utils/analytics'
 import { formatDate } from '../utils/time'
 import { buildCalendarFromIncidents } from '../utils/calendar'
 import { groupIncidents } from '../utils/incidentGrouping'
-import { dominantGroupStatus } from '../utils/incidentSort'
+import { compareGroupedRows, dominantGroupStatus } from '../utils/incidentSort'
 import { SCORE_TEXT_CLASS } from '../utils/constants'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
@@ -691,12 +691,10 @@ export default function ServiceDetails({ serviceId }) {
   const cutoff7d = Date.now() - 7 * 86_400_000
   const recentIncidents = (service.incidents ?? []).filter(
     (inc) => inc.status !== 'resolved' || new Date(inc.startedAt).getTime() >= cutoff7d
-  ).sort((a, b) => {
-    const aOngoing = a.status !== 'resolved' ? 1 : 0
-    const bOngoing = b.status !== 'resolved' ? 1 : 0
-    if (aOngoing !== bOngoing) return bOngoing - aOngoing
-    return new Date(b.startedAt) - new Date(a.startedAt)
-  })
+  )
+  // groupIncidents re-sorts purely by date; compareGroupedRows lifts ongoing/
+  // monitoring rows back above newer resolved ones. See incidentSort.js.
+  const groupedIncidents = groupIncidents(recentIncidents).slice().sort(compareGroupedRows)
   const incidentCount = recentIncidents.length
   const totalIncidents = (service.incidents ?? []).length
   const isEstimateNoData = service.uptimeSource === 'estimate' && totalIncidents === 0
@@ -883,7 +881,7 @@ export default function ServiceDetails({ serviceId }) {
               </div>
             ) : (
               <div className="flex flex-col" style={{ gap: '8px' }}>
-                {groupIncidents(recentIncidents).map((row) => row.kind === 'group' ? (
+                {groupedIncidents.map((row) => row.kind === 'group' ? (
                   <IncidentGroupRow key={`group:${row.dayKey}:${row.normalizedTitle}`} group={row} t={t} lang={lang} />
                 ) : (
                   <IncidentRow key={row.incident.id} incident={row.incident} detectedAt={service.detectedAt} isRecentlyRecovered={!!(recentlyRecovered[service.id] ?? []).includes(row.incident.id)} t={t} lang={lang} />

--- a/src/utils/__tests__/incidentSort.test.js
+++ b/src/utils/__tests__/incidentSort.test.js
@@ -5,19 +5,25 @@ import {
   getResolvedTime,
   getLatestActivity,
   compareIncidents,
+  compareGroupedRows,
   dominantGroupStatus,
   formatDurationMs,
   sumGroupDuration,
 } from '../incidentSort'
+import { groupIncidents } from '../incidentGrouping'
 
 function makeIncident({
   id = 'inc',
+  title,
   status = 'ongoing',
   startedAt = '2026-04-28T00:00:00Z',
   resolvedAt,
+  impact = null,
   timeline = [],
 }) {
-  return { id, status, startedAt, resolvedAt, timeline }
+  // title defaults to id so groupIncidents doesn't accidentally merge
+  // distinct fixtures via empty-title same-day collisions.
+  return { id, title: title ?? id, status, startedAt, resolvedAt, impact, timeline }
 }
 
 describe('STATUS_PRIORITY', () => {
@@ -198,6 +204,77 @@ describe('compareIncidents', () => {
       '5-resolved-recent',    // resolved tier, latest resolved
       '1-resolved-old',       // resolved tier, older
     ])
+  })
+})
+
+describe('compareGroupedRows', () => {
+  // Helper: build a real `groupIncidents` output from a list of incidents,
+  // then sort it the way ServiceDetails.jsx / Incidents.jsx do at render time.
+  // Tests the *page-level composition*, not just the comparator in isolation —
+  // a regression like #383 (page calls groupIncidents but forgets the sort)
+  // would still pass an isolated comparator unit test.
+  const UTC = { timeZone: 'UTC' }
+
+  it('puts an investigating incident above newer resolved rows (ServiceDetails.jsx #383 regression)', () => {
+    // Real-world shape: ChatGPT detail page on 2026-05-05 had one investigating
+    // entry from Apr 30 06:59 buried under May 5 / May 1 resolved entries,
+    // because groupIncidents re-sorted purely by date.
+    const incidents = [
+      makeIncident({ id: 'r-may5', status: 'resolved',      startedAt: '2026-05-05T00:29:00Z', resolvedAt: '2026-05-05T02:10:00Z' }),
+      makeIncident({ id: 'r-may1', status: 'resolved',      startedAt: '2026-05-01T12:55:00Z', resolvedAt: '2026-05-01T13:03:00Z' }),
+      makeIncident({ id: 'inv',    status: 'investigating', startedAt: '2026-04-30T06:59:00Z' }),
+      makeIncident({ id: 'r-apr30',status: 'resolved',      startedAt: '2026-04-30T06:01:00Z', resolvedAt: '2026-04-30T07:24:00Z' }),
+    ]
+    const sortedIds = groupIncidents(incidents, UTC)
+      .slice()
+      .sort(compareGroupedRows)
+      .map((row) => row.kind === 'single' ? row.incident.id : `group:${row.normalizedTitle}`)
+    expect(sortedIds[0]).toBe('inv')
+  })
+
+  it('keeps newest-first ordering within the same status tier (stable sort)', () => {
+    const incidents = [
+      makeIncident({ id: 'r-old', status: 'resolved', startedAt: '2026-04-29T10:00:00Z', resolvedAt: '2026-04-29T10:10:00Z' }),
+      makeIncident({ id: 'r-new', status: 'resolved', startedAt: '2026-05-05T10:00:00Z', resolvedAt: '2026-05-05T10:10:00Z' }),
+    ]
+    const sortedIds = groupIncidents(incidents, UTC)
+      .slice()
+      .sort(compareGroupedRows)
+      .map((row) => row.incident.id)
+    expect(sortedIds).toEqual(['r-new', 'r-old'])
+  })
+
+  it('puts a mostly-resolved flap group BELOW a single investigating row (Mistral-flap parity)', () => {
+    // Together/Fireworks/Mistral flap into 2+ same-day same-title resolved rows.
+    // Even when the flap group's rangeEnd is more recent, an unrelated
+    // investigating incident must outrank it.
+    const incidents = [
+      makeIncident({ id: 'flap-1', title: 'Embedding API — recovered', status: 'resolved', startedAt: '2026-05-05T08:00:00Z', resolvedAt: '2026-05-05T08:05:00Z' }),
+      makeIncident({ id: 'flap-2', title: 'Embedding API — recovered', status: 'resolved', startedAt: '2026-05-05T09:00:00Z', resolvedAt: '2026-05-05T09:05:00Z' }),
+      makeIncident({ id: 'flap-3', title: 'Embedding API — recovered', status: 'resolved', startedAt: '2026-05-05T10:00:00Z', resolvedAt: '2026-05-05T10:05:00Z' }),
+      makeIncident({ id: 'inv',    title: 'API outage',                status: 'investigating', startedAt: '2026-05-04T12:00:00Z' }),
+    ]
+    const rows = groupIncidents(incidents, UTC).slice().sort(compareGroupedRows)
+    expect(rows[0].kind).toBe('single')
+    expect(rows[0].incident.id).toBe('inv')
+    expect(rows[1].kind).toBe('group')
+    expect(rows[1].count).toBe(3)
+  })
+
+  it('orders monitoring above resolved across mixed singles and groups', () => {
+    const incidents = [
+      makeIncident({ id: 'r-1', status: 'resolved', startedAt: '2026-05-05T11:00:00Z', resolvedAt: '2026-05-05T11:05:00Z' }),
+      makeIncident({ id: 'mon', status: 'monitoring', startedAt: '2026-05-05T08:00:00Z' }),
+      makeIncident({ id: 'r-2', status: 'resolved', startedAt: '2026-05-05T12:00:00Z', resolvedAt: '2026-05-05T12:05:00Z' }),
+    ]
+    const ids = groupIncidents(incidents, UTC).slice().sort(compareGroupedRows).map((r) => r.incident.id)
+    expect(ids[0]).toBe('mon')
+  })
+
+  it('treats unknown row status as resolved tier (defensive)', () => {
+    const a = { kind: 'single', incident: { id: 'a', status: 'weird', startedAt: '2026-05-05T00:00:00Z' } }
+    const b = { kind: 'single', incident: { id: 'b', status: 'monitoring', startedAt: '2026-05-04T00:00:00Z' } }
+    expect(compareGroupedRows(b, a)).toBeLessThan(0)
   })
 })
 

--- a/src/utils/incidentSort.js
+++ b/src/utils/incidentSort.js
@@ -170,3 +170,26 @@ export function compareIncidents(a, b) {
   if (aPri !== bPri) return aPri - bPri
   return getLatestActivity(b) - getLatestActivity(a)
 }
+
+/**
+ * Comparator for `groupIncidents()` output rows ({kind:'single'|'group'}).
+ * Sorts by tier (ongoing → monitoring → resolved). Within a tier, the
+ * spec-stable `Array.prototype.sort` (ES2019+) preserves input order — callers
+ * must therefore pass `groupIncidents()` output (already newest-first by
+ * representative date); sorting an unsorted list will not yield newest-first
+ * within tiers.
+ *
+ * Used by `Incidents.jsx` and `ServiceDetails.jsx` (refs #354/#355) and
+ * mirrored on the SSR side at `api/is-down/incident-sort.ts` because
+ * `groupIncidents` re-sorts purely by date and would otherwise bury an active
+ * incident under newer resolved rows.
+ *
+ * @param {{ kind: 'single', incident: { status: string } } | { kind: 'group', uniformStatus?: boolean, statusCounts: Record<string, number> }} a
+ * @param {{ kind: 'single', incident: { status: string } } | { kind: 'group', uniformStatus?: boolean, statusCounts: Record<string, number> }} b
+ * @returns {number}
+ */
+export function compareGroupedRows(a, b) {
+  const aStatus = a.kind === 'single' ? a.incident.status : dominantGroupStatus(a)
+  const bStatus = b.kind === 'single' ? b.incident.status : dominantGroupStatus(b)
+  return (STATUS_PRIORITY[aStatus] ?? 2) - (STATUS_PRIORITY[bStatus] ?? 2)
+}


### PR DESCRIPTION
## Summary
- `groupIncidents()` re-sorts purely by representative date, so an active investigating/monitoring incident could land below newer resolved rows. Surfaced on the ChatGPT detail page (2026-05-05: "Partial Disruption…" Apr 30 06:59 was buried under May 5/May 1 resolved entries). Same bug applies to the SSR `/is-X-down` pages, where the 30-day `INCIDENT_ROW_CAP=20` slice can also *truncate* an active row out of the SERP-visible HTML.
- Extracted the priority-based stable sort into `compareGroupedRows` (`src/utils/incidentSort.js`) and mirrored it server-side (`api/is-down/incident-sort.ts` — Vercel Edge cannot import from `src/`). `ServiceDetails.jsx`, `Incidents.jsx`, and `api/is-down/html-template.ts` all call the helper after `groupIncidents`; **SSR sort runs before the cap** so active rows survive truncation.
- Tier order remains: investigating/identified/ongoing → monitoring → resolved. Within a tier, `groupIncidents`' newest-first ordering is preserved by `Array.prototype.sort` stability (ES2019+).

## Test plan
- [x] `npm run test:src` — 96/96 pass (4 new SPA composition tests + 3 new SSR regression tests; existing 86 untouched)
- [x] `npm test` — 87/87 Playwright pass (no regression in dashboard/mobile/service-details/incidents/uptime/settings)
- [x] `npm run build` — clean
- [x] `npm run lint` — only pre-existing coverage warnings (no new findings)
- [x] Local verify (Vite + Worker): ChatGPT detail page shows the In Progress incident at top of Incident History
- [ ] Vercel Preview verify: ChatGPT detail page + an Is X Down page (e.g. `/is-chatgpt-down`) render active incidents above newer resolved entries
- [x] Multi-agent PR review converged (Round 3, Critical/Important = 0)

## Out of scope
- No change to `groupIncidents` itself (its date-only sort is correct for the Mistral/BetterStack flap-clustering use case).
- No new dev-only `console.warn` for unknown statuses (deferred — current `?? 2` fallback can never sort an unknown status above `ongoing`, and unit tests cover the documented status set).
- No automated SPA↔SSR `STATUS_PRIORITY` parity test (pre-existing concern; tests on both sides would catch end-to-end drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)