### PR TITLE
fix: allow Vercel Preview deployments through Worker CORS allowlist (closes #385)

### DIFF
--- a/worker/src/__tests__/cors.test.ts
+++ b/worker/src/__tests__/cors.test.ts
@@ -1,0 +1,175 @@
+// CORS allowlist tests — covers literal-origin, wildcard, and `*suffix`
+// matching (#385). The suffix pattern was added so Vercel Preview deployments
+// (per-branch URLs that can't be pre-listed) can call `/api/status` without
+// resorting to a global `*.vercel.app` allowlist. Vercel concatenates
+// project+branch+hash+team into a single hyphenated subdomain, hence
+// hyphen-anchored suffix matching rather than dot-anchored subdomain match.
+
+import { describe, it, expect } from 'vitest'
+import { matchOrigin, corsHeaders } from '../cors'
+
+const PROD = 'https://ai-watch.dev'
+const VERCEL_TEAM = '*-bentleys-projects-5f6a1a8c.vercel.app'
+const ALLOWLIST = `${PROD},https://www.ai-watch.dev,${VERCEL_TEAM}`
+
+describe('matchOrigin — exact-string allowlist', () => {
+  it('matches a listed origin verbatim', () => {
+    expect(matchOrigin(PROD, ALLOWLIST)).toBe(PROD)
+  })
+
+  it('matches the second allowlist entry', () => {
+    expect(matchOrigin('https://www.ai-watch.dev', ALLOWLIST)).toBe('https://www.ai-watch.dev')
+  })
+
+  it('rejects an origin that is a substring of an allowed entry', () => {
+    expect(matchOrigin('https://ai-watch.de', ALLOWLIST)).toBe('')
+  })
+
+  it('rejects an arbitrary origin', () => {
+    expect(matchOrigin('https://attacker.example', ALLOWLIST)).toBe('')
+  })
+
+  it('is case-sensitive (origins are normalized lowercase by the browser)', () => {
+    // Mirrors browser behavior — Origin header values are lowercased by the UA,
+    // so the allowlist comparison is case-sensitive by design.
+    expect(matchOrigin('https://AI-watch.dev', ALLOWLIST)).toBe('')
+  })
+})
+
+describe('matchOrigin — *suffix pattern (Vercel preview)', () => {
+  // Real-world shape: project + git branch slug + deploy hash + team slug,
+  // all concatenated with hyphens into a single subdomain.
+  const TEAM_PREVIEW = 'https://aiwatch-dev-git-fix-385-cors-abc123-bentleys-projects-5f6a1a8c.vercel.app'
+
+  it('matches a real per-branch Vercel preview URL', () => {
+    expect(matchOrigin(TEAM_PREVIEW, ALLOWLIST)).toBe(TEAM_PREVIEW)
+  })
+
+  it('matches a different branch under the same team suffix', () => {
+    const otherBranch = 'https://aiwatch-dev-git-feat-something-xyz789-bentleys-projects-5f6a1a8c.vercel.app'
+    expect(matchOrigin(otherBranch, ALLOWLIST)).toBe(otherBranch)
+  })
+
+  it('does NOT match an arbitrary *.vercel.app origin (different team)', () => {
+    // Critical: a global `*.vercel.app` allowlist would let any Vercel user
+    // call our Worker. The team-scoped suffix prevents that.
+    expect(matchOrigin('https://something-attacker-projects-deadbeef.vercel.app', ALLOWLIST)).toBe('')
+    expect(matchOrigin('https://random.vercel.app', ALLOWLIST)).toBe('')
+  })
+
+  it('does NOT match the bare suffix host (no prefix)', () => {
+    // `*-foo` should not match `foo` — the asterisk requires a non-empty
+    // prefix. (`bentleys-projects-5f6a1a8c.vercel.app` is the team's overview
+    // page on Vercel, never a deployment host.)
+    expect(matchOrigin('https://bentleys-projects-5f6a1a8c.vercel.app', ALLOWLIST)).toBe('')
+  })
+
+  it('matches even when the suffix entry is the only allowlist item', () => {
+    expect(matchOrigin('https://x-bentleys-projects-5f6a1a8c.vercel.app', VERCEL_TEAM)).toBe(
+      'https://x-bentleys-projects-5f6a1a8c.vercel.app',
+    )
+  })
+
+  it('rejects an origin that ends with the team slug but on a different TLD', () => {
+    expect(matchOrigin('https://x-bentleys-projects-5f6a1a8c.vercel.dev', ALLOWLIST)).toBe('')
+    expect(matchOrigin('https://x-bentleys-projects-5f6a1a8c.attacker.com', ALLOWLIST)).toBe('')
+  })
+
+  it('IGNORES a suffix pattern whose first non-asterisk char is not "-" or "." (typo guard)', () => {
+    // If an operator forgets the leading separator in wrangler.toml — e.g.
+    // writes `*bentleys-projects-5f6a1a8c.vercel.app` (no `-`) — `endsWith`
+    // would match `evilbentleys-projects-5f6a1a8c.vercel.app` from any
+    // attacker who registers that name. The matcher rejects suffixes that
+    // don't begin with a separator so this typo fails closed.
+    const TYPO = '*bentleys-projects-5f6a1a8c.vercel.app'
+    expect(matchOrigin('https://aiwatch-dev-git-x-bentleys-projects-5f6a1a8c.vercel.app', TYPO)).toBe('')
+    expect(matchOrigin('https://evilbentleys-projects-5f6a1a8c.vercel.app', TYPO)).toBe('')
+  })
+
+  it('accepts both "-" and "." as anchor characters', () => {
+    expect(matchOrigin('https://x-foo.example.com', '*-foo.example.com')).toBe('https://x-foo.example.com')
+    expect(matchOrigin('https://x.foo.example.com', '*.foo.example.com')).toBe('https://x.foo.example.com')
+  })
+})
+
+describe('matchOrigin — wildcard / undefined / empty', () => {
+  it('returns the literal "*" when allowedOrigin is "*" (open allowlist)', () => {
+    // Used by `worker/.dev.vars` for local development.
+    expect(matchOrigin('https://anything.example', '*')).toBe('*')
+  })
+
+  it('returns "*" even when origin is empty under wildcard mode', () => {
+    // Wildcard does not require an Origin header — that's what makes it useful
+    // for local curl tests.
+    expect(matchOrigin('', '*')).toBe('*')
+  })
+
+  it('returns empty string when allowedOrigin is undefined', () => {
+    expect(matchOrigin(PROD, undefined)).toBe('')
+  })
+
+  it('returns empty string when allowedOrigin is the empty string', () => {
+    expect(matchOrigin(PROD, '')).toBe('')
+  })
+
+  it('returns empty string when origin is empty and allowlist is non-wildcard', () => {
+    expect(matchOrigin('', ALLOWLIST)).toBe('')
+  })
+
+  it('tolerates extra whitespace in the comma-separated allowlist', () => {
+    expect(matchOrigin(PROD, `  ${PROD}  ,  https://www.ai-watch.dev  `)).toBe(PROD)
+  })
+
+  it('tolerates trailing commas / empty entries', () => {
+    expect(matchOrigin(PROD, `${PROD},,,`)).toBe(PROD)
+    expect(matchOrigin('https://attacker.example', `${PROD},,,`)).toBe('')
+  })
+
+  it('treats a bare "*" only as the top-level open-allowlist sentinel', () => {
+    // The `*` shortcut is recognized only when the ENTIRE allowlist is `*`.
+    // A bare `*` mid-list is silently ignored — it must not fall through to
+    // the suffix branch where slice(1)='' would make .endsWith('') always true
+    // for any non-empty string and silently turn the whole allowlist into
+    // universal allow. The `pattern.length > 1` guard in matchOrigin enforces
+    // this; keep this test as a regression lock.
+    expect(matchOrigin('https://attacker.example', '*')).toBe('*')
+    expect(matchOrigin('https://attacker.example', `${PROD},*`)).toBe('')
+    expect(matchOrigin(PROD, `${PROD},*`)).toBe(PROD)
+  })
+})
+
+describe('corsHeaders — full response shape', () => {
+  it('emits Access-Control-Allow-* and Vary headers when origin matches', () => {
+    const headers = corsHeaders(PROD, ALLOWLIST) as Record<string, string>
+    expect(headers['Access-Control-Allow-Origin']).toBe(PROD)
+    expect(headers['Access-Control-Allow-Methods']).toBe('GET, POST, DELETE, OPTIONS')
+    expect(headers['Access-Control-Allow-Headers']).toBe('Content-Type')
+    expect(headers['Access-Control-Max-Age']).toBe('86400')
+    expect(headers['Vary']).toBe('Origin')
+  })
+
+  it('emits "*" as the origin under wildcard mode', () => {
+    const headers = corsHeaders('https://anything.example', '*') as Record<string, string>
+    expect(headers['Access-Control-Allow-Origin']).toBe('*')
+  })
+
+  it('returns an empty object when origin is not allowed (fail closed)', () => {
+    // No headers means the browser's CORS check fails — exactly the
+    // behavior we want for an unrecognized origin.
+    expect(corsHeaders('https://attacker.example', ALLOWLIST)).toEqual({})
+  })
+
+  it('returns an empty object when allowedOrigin is missing', () => {
+    expect(corsHeaders(PROD, undefined)).toEqual({})
+  })
+
+  it('echoes the matched preview origin (not the pattern) in the response', () => {
+    // Per the CORS spec, Access-Control-Allow-Origin must be either '*' or a
+    // single origin — never a pattern. Make sure the helper returns the actual
+    // request origin, not the literal `*suffix` string.
+    const preview = 'https://aiwatch-dev-git-fix-385-cors-abc123-bentleys-projects-5f6a1a8c.vercel.app'
+    const headers = corsHeaders(preview, ALLOWLIST) as Record<string, string>
+    expect(headers['Access-Control-Allow-Origin']).toBe(preview)
+    expect(headers['Access-Control-Allow-Origin']).not.toContain('*')
+  })
+})

--- a/worker/src/cors.ts
+++ b/worker/src/cors.ts
@@ -1,0 +1,76 @@
+// CORS helpers for the AIWatch Worker.
+//
+// The allowlist is a comma-separated env var (`ALLOWED_ORIGIN`) of literal
+// origins plus optional `*suffix` patterns. Suffix patterns exist to cover
+// Vercel Preview deployments, which rotate per branch+commit and are not a
+// pure subdomain hierarchy — Vercel concatenates project + branch slug +
+// deploy hash + team slug with hyphens into a *single* subdomain
+// (`aiwatch-dev-git-{branch}-{hash}-{team}.vercel.app`), so a `*.suffix`
+// dot-anchor doesn't fit. We use literal-end-with matching, with the
+// operator responsible for choosing a suffix unique enough to be safe.
+//
+// For AIWatch the safe suffix is `-bentleys-projects-5f6a1a8c.vercel.app`
+// (team-scoped — Vercel won't issue this team slug to anyone else). A bare
+// `*.vercel.app` would let any Vercel user call the API and is never used.
+//
+// Match semantics:
+//   - `'*'`               → permissive, returns the wildcard origin literal
+//   - `'*-suffix'` /      → matches any origin whose host ends with the suffix.
+//     `'*.suffix'`          The character right after the `*` must be `-` or
+//                           `.` so a typo missing the separator (e.g.
+//                           `*bentleys-projects-...`) doesn't silently widen
+//                           the allowlist. Suffix matching is literal end-with
+//                           on the entire origin string; operator picks a
+//                           suffix unique enough to be unforgeable.
+//   - `'https://x.com'`   → exact match
+//
+// Returns `{}` (no headers) when origin doesn't match — the browser will then
+// block the request, which is the correct fail-closed behavior.
+
+/**
+ * Pure origin-matching helper, exported for unit testing.
+ *
+ * @param origin - The Origin header from the incoming request.
+ * @param allowedOrigin - Comma-separated allowlist (env var). May be `'*'`,
+ *   exact origins, or `*suffix` patterns.
+ * @returns The string to send back as `Access-Control-Allow-Origin`, or `''`
+ *   when the origin is not allowed.
+ */
+export function matchOrigin(origin: string, allowedOrigin: string | undefined): string {
+  if (!allowedOrigin) return ''
+  if (allowedOrigin === '*') return '*'
+  if (!origin) return ''
+  for (const raw of allowedOrigin.split(',')) {
+    const pattern = raw.trim()
+    if (!pattern) continue
+    if (pattern === origin) return origin
+    if (pattern.startsWith('*') && pattern.length > 1) {
+      const suffix = pattern.slice(1)
+      // Require a leading separator (`-` or `.`) on the suffix. This rejects
+      // typo'd patterns like `*bentleys-projects-…vercel.app` (missing `-`)
+      // that would otherwise match `evilbentleys-projects-…vercel.app` — the
+      // separator anchors the suffix to a real boundary in the origin string.
+      if (suffix[0] !== '-' && suffix[0] !== '.') continue
+      if (origin.endsWith(suffix)) return origin
+    }
+  }
+  return ''
+}
+
+/**
+ * CORS response headers for the matched origin, or `{}` when not allowed.
+ * `Vary: Origin` ensures CDN/proxy caches don't serve a response targeted
+ * at one origin to a different one.
+ */
+export function corsHeaders(origin: string, allowedOrigin: string | undefined): HeadersInit {
+  const allowOrigin = matchOrigin(origin, allowedOrigin)
+  if (!allowOrigin) return {}
+
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin',
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,6 +9,7 @@ import { analyzeIncident, analyzeWithSonnet, refreshOrReanalyze, analysisKey, bu
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
+import { corsHeaders } from './cors'
 
 interface Env {
   ALLOWED_ORIGIN: string
@@ -710,28 +711,7 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
   }
 }
 
-function corsHeaders(origin: string, allowedOrigin: string | undefined): HeadersInit {
-  let allowOrigin = ''
-  if (!allowedOrigin) {
-    allowOrigin = ''
-  } else if (allowedOrigin === '*') {
-    allowOrigin = '*'
-  } else {
-    const allowed = allowedOrigin.split(',').map((s) => s.trim())
-    if (allowed.includes(origin)) {
-      allowOrigin = origin
-    }
-  }
-  if (!allowOrigin) return {}
-
-  return {
-    'Access-Control-Allow-Origin': allowOrigin,
-    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Max-Age': '86400',
-    'Vary': 'Origin',
-  }
-}
+// corsHeaders moved to ./cors — also handles team-scoped suffix patterns for Vercel preview origins.
 
 import { generateBadgeSvg } from './badge'
 import { generateOgSvg } from './og'

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,7 +4,10 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 
 [vars]
-ALLOWED_ORIGIN = "https://ai-watch.dev,https://www.ai-watch.dev,https://aiwatch-dev.vercel.app"
+# Vercel preview deployments rotate per branch+commit, so they're matched via
+# a team-scoped suffix pattern — never use the global `*.vercel.app`, which
+# would let any Vercel tenant call the API.
+ALLOWED_ORIGIN = "https://ai-watch.dev,https://www.ai-watch.dev,https://aiwatch-dev.vercel.app,*-bentleys-projects-5f6a1a8c.vercel.app"
 # Local dev override: create worker/.dev.vars with ALLOWED_ORIGIN=*
 
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary
- Vercel Preview deployments use per-branch URLs (`aiwatch-dev-git-{branch}-{hash}-bentleys-projects-5f6a1a8c.vercel.app`) that can't be pre-listed in `ALLOWED_ORIGIN`. Every PR's preview SPA was stuck in the offline empty state. Surfaced while verifying #383's preview.
- Extracted CORS logic to `worker/src/cors.ts`. Added a `*suffix` pattern with mandatory `-` or `.` separator anchor — matches per-branch preview origins via team-scoped `*-bentleys-projects-5f6a1a8c.vercel.app` while keeping out the global `*.vercel.app` (which would let any Vercel tenant in).
- Hardened against operator typos: a suffix pattern whose first char isn't `-` or `.` is dropped, so missing the separator can't silently widen the match surface.

## Worker redeploy required
This change has no effect until the Worker is redeployed (`npm run deploy:worker`). Per CLAUDE.md, that is a manual step gated on the maintainer's approval.

## Test plan
- [x] `npm run test:worker` — 1135/1135 (26 new tests covering literal-match / suffix-anchor / wildcard / typo-guard / CORS-spec compliance / fail-closed)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — clean, env shows updated `ALLOWED_ORIGIN`
- [x] `npm run lint` — only pre-existing warnings
- [x] Multi-agent PR review converged (Round 2, Critical/Important = 0)
- [ ] After `npm run deploy:worker`: from any new PR's Vercel preview URL, dashboard loads service data instead of "Cannot fetch service status"
- [ ] Verify production (https://ai-watch.dev) still loads (regression check on the unchanged exact-match path)

## Out of scope (filed mentally for follow-up)
- **URL parsing** of the Origin header before suffix-matching. Current `endsWith` against the full string accepts technically-malformed origins (fragment/path appended) — but standards-conformant browsers never send those, and CORS is browser-enforced, so the bypass is theoretical. silent-failure-hunter agent flagged this and recommended deferring; would land as defense-in-depth in a separate hardening PR.
- **403 on rejected Origin for state-changing endpoints** (`POST /api/alert`, `POST /api/vitals`). Today the side effect runs even when the response has no Allow-Origin header (browsers block the read but the write already happened). Pre-existing behavior unchanged by this PR; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)