### PR TITLE
fix: suppress degraded alert during incident-resolution race (#394)

### DIFF
--- a/worker/src/__tests__/alerts.test.ts
+++ b/worker/src/__tests__/alerts.test.ts
@@ -180,7 +180,7 @@ describe('buildServiceAlerts', () => {
     expect(alerts).toHaveLength(0)
   })
 
-  it('does not suppress when all incidents are resolved', () => {
+  it('does not suppress when all incidents are resolved without resolvedAt', () => {
     const svc = mockService({
       status: 'degraded',
       incidents: [{ id: 'inc1', title: 'Fixed', status: 'resolved', startedAt: recentDate, duration: '10m', impact: 'minor' }],
@@ -188,6 +188,51 @@ describe('buildServiceAlerts', () => {
     const alerts = buildServiceAlerts([svc], new Map(), new Map())
     expect(alerts).toHaveLength(1)
     expect(alerts[0].key).toBe('alerted:degraded:openai')
+  })
+
+  // #394: Atlassian Statuspage clears incident.status before component status_indicator,
+  // producing a confusing 🟢 Resolved → 🟠 Degraded → 🟢 Recovered tail in the same window.
+  describe('resolved-race-window suppression (#394)', () => {
+    it('suppresses degraded alert when incident resolved within 15min', () => {
+      const resolvedAt = new Date(NOW - 5 * 60_000).toISOString() // 5min ago
+      const svc = mockService({
+        status: 'degraded',
+        incidents: [{ id: 'inc1', title: 'Fixed', status: 'resolved', startedAt: recentDate, resolvedAt, duration: '7m', impact: 'major' }],
+      })
+      expect(buildServiceAlerts([svc], new Map(), new Map(), NOW)).toHaveLength(0)
+    })
+
+    it('fires degraded alert when incident resolved more than 15min ago', () => {
+      const resolvedAt = new Date(NOW - 16 * 60_000).toISOString()
+      const svc = mockService({
+        status: 'degraded',
+        incidents: [{ id: 'inc1', title: 'Fixed', status: 'resolved', startedAt: recentDate, resolvedAt, duration: '7m', impact: 'major' }],
+      })
+      const alerts = buildServiceAlerts([svc], new Map(), new Map(), NOW)
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0].key).toBe('alerted:degraded:openai')
+    })
+
+    it('does NOT suppress down alert during race window (high-urgency)', () => {
+      const resolvedAt = new Date(NOW - 5 * 60_000).toISOString()
+      const svc = mockService({
+        status: 'down',
+        incidents: [{ id: 'inc1', title: 'Fixed', status: 'resolved', startedAt: recentDate, resolvedAt, duration: '7m', impact: 'major' }],
+      })
+      const alerts = buildServiceAlerts([svc], new Map(), new Map(), NOW)
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0].key).toBe('alerted:down:openai')
+    })
+
+    it('handles invalid resolvedAt without throwing — falls through to degraded fire', () => {
+      const svc = mockService({
+        status: 'degraded',
+        incidents: [{ id: 'inc1', title: 'Fixed', status: 'resolved', startedAt: recentDate, resolvedAt: 'not-a-date', duration: '7m', impact: 'major' }],
+      })
+      const alerts = buildServiceAlerts([svc], new Map(), new Map(), NOW)
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0].key).toBe('alerted:degraded:openai')
+    })
   })
 
   it('does not create alert for operational service', () => {

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -203,22 +203,42 @@ export function mergeTogetherAlerts(alerts: AlertCandidate[]): AlertCandidate[] 
   return [...rest, ...merged]
 }
 
+// #394: Atlassian Statuspage clears `incident.status` to `resolved` a few minutes before the
+// component-level `status_indicator` clears back to `operational`. Without suppression, a single
+// outage produces 🔴 New → 🟢 Resolved → 🟠 Degraded → 🟢 Recovered. 15min covers up to ~3 cron
+// cycles of component lag — narrower would re-allow the race; much wider would mask a fresh
+// degradation that follows a resolution within the window. Down alerts are not suppressed since
+// they are high-urgency and the lag is rare with major_outage indicators.
+const RESOLVED_RACE_WINDOW_MS = 15 * 60 * 1000
+
 /**
  * Build service status change alerts (degraded/down/recovered).
  * Suppresses status alerts when ongoing incidents already cover the service.
  * @param alertedDownMap Map of service ID → ISO timestamp when alerted as down
  * @param alertedDegradedMap Map of service ID → ISO timestamp when alerted as degraded
+ * @param now Epoch ms used to evaluate the resolved-race-window (#394). Defaults to Date.now().
  */
 export function buildServiceAlerts(
   services: ScoredService[],
   alertedDownMap: Map<string, string>,
   alertedDegradedMap: Map<string, string> = new Map(),
+  now: number = Date.now(),
 ): AlertCandidate[] {
   const alerts: AlertCandidate[] = []
 
   for (const svc of services) {
     // Suppress status alerts if ongoing incidents exist (incident alert already covers it)
     const hasOngoingIncident = (svc.incidents ?? []).some((i) => i.status !== 'resolved')
+
+    // #394: a 🟢 Resolved fired (or about to fire) in the last 15min on this service means
+    // the user already received the canonical "back to normal" signal — silence the
+    // 🟠 degraded that would otherwise fire from the still-stale component indicator.
+    const hasRecentlyResolvedIncident = (svc.incidents ?? []).some((inc) => {
+      if (inc.status !== 'resolved' || !inc.resolvedAt) return false
+      const resolvedMs = new Date(inc.resolvedAt).getTime()
+      if (Number.isNaN(resolvedMs)) return false
+      return now - resolvedMs < RESOLVED_RACE_WINDOW_MS
+    })
 
     if (svc.status === 'down' && !hasOngoingIncident) {
       alerts.push({
@@ -229,7 +249,7 @@ export function buildServiceAlerts(
         url: `https://ai-watch.dev/#${svc.id}`,
       })
     }
-    if (svc.status === 'degraded' && !hasOngoingIncident) {
+    if (svc.status === 'degraded' && !hasOngoingIncident && !hasRecentlyResolvedIncident) {
       alerts.push({
         key: `alerted:degraded:${svc.id}`,
         title: `🟠 ${svc.name} — Partially Degraded`,


### PR DESCRIPTION
closes #394

## Summary

- 🟠 **Partially Degraded** alert now silenced when a 🟢 **Resolved** for the same service fired within the last 15 min.
- 🔴 **Service Down** alert remains unsuppressed (high-urgency, component-lag rarer with `major_outage`).
- Side effect: `alerted:degraded:{svcId}` KV not written in the suppressed path → next-cycle 🟢 Service Recovered also skipped. The 🟢 Resolved embed is the canonical recovery signal — avoids tail-end double-recovery noise.

## Why

Real DeepSeek incident on 2026-05-06 produced this alert burst within ~10 min:

```
4:16 🔴 New Incident
4:21 🟢 Incident Resolved (7m)
4:21 🟠 Partially Degraded   ← unwanted
4:26 🟢 Service Recovered (5m)
```

Atlassian Statuspage flips `incident.status` to `resolved` a few cron cycles before the component-level `status_indicator` clears back to `operational`. In that window `hasOngoingIncident=false` and `svc.status='degraded'` are both true → `buildServiceAlerts` (worker/src/alerts.ts:232) treats it as a fresh degradation and fires.

## How

`buildServiceAlerts` gains an optional `now: number = Date.now()` for deterministic tests. New `hasRecentlyResolvedIncident` predicate guards the degraded branch using `inc.resolvedAt` recency. All parsers (`statuspage`/`betterstack`/`incident-io`/`gcloud`/`aws`/`aistudio`/`instatus`/`onlineornot`) already populate `resolvedAt`; `services.ts:724-728` provides a timeline-based fallback. Invalid `resolvedAt` strings safely fall through (test pinned).

## Test plan

- [x] `npm run test:worker` — 1147/1147 pass
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` — build OK
- [x] New cases in `worker/src/__tests__/alerts.test.ts` (`describe('resolved-race-window suppression (#394)')`):
  - suppresses degraded when incident resolved within 15min
  - fires degraded when resolved >15min ago
  - down alert NOT suppressed during race window
  - invalid `resolvedAt` falls through safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)