### PR TITLE
fix: scope GitHub Copilot incidents with incidentKeywords (closes #397)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ gh pr merge --squash --delete-branch
 When adding a new monitored service, update ALL of the following:
 
 #### Worker (backend)
-1. `worker/src/services.ts` — add `ServiceConfig` entry at correct position in `SERVICES` array (determines API response order: LLM → voice → infra → apps → agents)
+1. `worker/src/services.ts` — add `ServiceConfig` entry at correct position in `SERVICES` array (determines API response order: LLM → voice → infra → apps → agents). If the status page hosts unrelated components (multi-tenant Atlassian / incident.io / metastatuspage feeds — e.g. `githubstatus.com`, `status.openai.com`, `status.claude.com`), set `incidentKeywords` to scope the visible incident list — otherwise the service card will surface every incident on the page (#397)
 2. `worker/src/probe.ts` — add `ProbeTarget` if API endpoint exists for RTT measurement
 3. `worker/src/fallback.ts` — update ALL of:
    - `EXCLUDE_FALLBACK` — remove if fallback-eligible

--- a/worker/src/__tests__/filter-incidents.test.ts
+++ b/worker/src/__tests__/filter-incidents.test.ts
@@ -452,3 +452,90 @@ describe('fetchService cross-contamination guard (#361)', () => {
     expect(filtered.find((i) => i.id === 'db-1')).toBeUndefined()
   })
 })
+
+describe('filterIncidents — GitHub Copilot scoping (#397)', () => {
+  // The GitHub status page mixes incidents across many components (Pull Requests,
+  // Actions, Webhooks, Git Operations, Codespaces, Issues, Packages, Pages, Copilot…).
+  // Without `incidentKeywords: ['copilot']`, the Copilot service card surfaces every
+  // unrelated incident. These tests pin the filter behavior so a future config edit
+  // that removes the keywords list re-introduces the leak loudly.
+  const copilotConfig: ServiceConfig = {
+    id: 'copilot',
+    name: 'GitHub Copilot',
+    provider: 'Microsoft',
+    category: 'agent',
+    statusUrl: 'https://githubstatus.com',
+    apiUrl: 'https://www.githubstatus.com/api/v2/summary.json',
+    statusComponentId: 'pjmpxvq2cmr2',
+    statusComponentIds: ['pjmpxvq2cmr2', 'cnnb39dkkk82'],
+    incidentKeywords: ['copilot'],
+  }
+
+  it('keeps incident when "copilot" is in componentNames', () => {
+    const inc = mockIncident({
+      title: 'Incident with multiple GitHub services',
+      componentNames: ['Webhooks', 'Actions', 'Copilot'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(1)
+  })
+
+  it('keeps incident when "copilot" is in the title even with null componentNames', () => {
+    const inc = mockIncident({
+      title: 'Disruption with Copilot Coding Agent sessions',
+      componentNames: null,
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(1)
+  })
+
+  it('drops Pull Requests-only incident', () => {
+    const inc = mockIncident({
+      title: 'Incident with Pull Requests',
+      componentNames: ['Pull Requests'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+
+  it('drops Actions-only incident', () => {
+    const inc = mockIncident({
+      title: 'Incident with Actions, we are investigating reports of degraded availability',
+      componentNames: ['Actions'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+
+  it('drops Git Operations-only incident', () => {
+    const inc = mockIncident({
+      title: 'Increased Latency and Failures for SSH Git Operations',
+      componentNames: ['Git Operations'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+
+  it('drops Codespaces-only incident', () => {
+    const inc = mockIncident({
+      title: 'Errors starting and connecting to Codespaces',
+      componentNames: ['Codespaces'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+
+  it('drops multi-component incident that does NOT include Copilot', () => {
+    const inc = mockIncident({
+      title: 'Incident with Issues and Webhooks',
+      componentNames: ['Git Operations', 'Webhooks', 'Issues', 'Pull Requests', 'Actions', 'Packages', 'Pages', 'Codespaces'],
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+
+  it('drops generic GitHub incident with null componentNames and no Copilot mention in title', () => {
+    // Defensive default: when GitHub doesn't tag the affected components, we don't
+    // speculate that Copilot is impacted. The status determination still relies on
+    // the component-level operational/degraded signal, so a real Copilot impact would
+    // surface there even if the incident itself stays hidden.
+    const inc = mockIncident({
+      title: 'Disruption with some GitHub services',
+      componentNames: null,
+    })
+    expect(filterIncidents([inc], copilotConfig)).toHaveLength(0)
+  })
+})

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -95,7 +95,7 @@ export const SERVICES: ServiceConfig[] = [
   // Bugbot/cursor.com/Marketplace are auxiliary surfaces and intentionally excluded.
   { id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent', statusUrl: 'https://status.cursor.com', apiUrl: 'https://status.cursor.com/api/v2/summary.json', statusComponentId: 'rflc60xp5jp2', statusComponentIds: ['rflc60xp5jp2', 'mwv1g9sc7kdh', 'k0trcq273dr6', 'vsny1qv7v86c'] },
   // copilot badge reflects worst-of: Copilot + Copilot AI Model Providers (direct upstream) (#379).
-  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2', statusComponentIds: ['pjmpxvq2cmr2', 'cnnb39dkkk82'] },
+  { id: 'copilot', name: 'GitHub Copilot', provider: 'Microsoft', category: 'agent', statusUrl: 'https://githubstatus.com', apiUrl: 'https://www.githubstatus.com/api/v2/summary.json', statusComponentId: 'pjmpxvq2cmr2', statusComponentIds: ['pjmpxvq2cmr2', 'cnnb39dkkk82'], incidentKeywords: ['copilot'] },
   // windsurf badge reflects worst-of: Cascade primary + Windsurf Tab (autocomplete agent surface) (#379).
   { id: 'windsurf', name: 'Windsurf', provider: 'Codeium', category: 'agent', statusUrl: 'https://status.windsurf.com', apiUrl: 'https://status.windsurf.com/api/v2/summary.json', statusComponentId: 'r5wf1ykd7y1m', statusComponentIds: ['r5wf1ykd7y1m', '8q19cygxvshj'] },
   { id: 'junie', name: 'Junie', provider: 'JetBrains', category: 'agent', statusUrl: 'https://status.jetbrains.ai', apiUrl: 'https://status.jetbrains.ai/api/v2/summary.json', statusComponentId: '9vbyyqkkjxl4' },


### PR DESCRIPTION
## Summary

Closes #397. The GitHub Copilot service card surfaced every incident from the shared GitHub status page (Pull Requests, Issues, Webhooks, Actions, Git Operations, Codespaces, Pages, Packages) because \`copilot\` was the only shared-status-page service in \`worker/src/services.ts\` without an \`incidentKeywords\` filter. Status badge was correct (multi-component resolution via \`statusComponentIds\`, #379) — only the user-facing incident list leaked.

- **\`worker/src/services.ts:98\`** — added \`incidentKeywords: ['copilot']\`. \`filterIncidents()\` matches keyword against title OR componentNames, so this captures any incident referencing Copilot (incl. \"Copilot AI Model Providers\") while dropping Pull Requests-only / Actions-only / Git Ops-only / Codespaces-only and generic null-componentName incidents.
- **\`worker/src/__tests__/filter-incidents.test.ts\`** — 8 new tests pinning the behavior across keep / drop scenarios so a future config edit removing the keywords loudly breaks CI.
- **\`CLAUDE.md\`** — \"Adding a new service\" step now documents the multi-tenant status page rule explicitly (was implicit, only visible by inspecting existing entries).

## Test plan

- [x] Worker unit tests: 1151 passing (8 new) — \`npm run test:worker\`
- [x] \`wrangler deploy --dry-run\` clean
- [x] PR review converged round 1: zero Critical / Important
- [ ] After Worker deploy, \`/api/status\` Copilot \`incidents\` array contains only Copilot-relevant incidents (verified by spot-check against \`https://www.githubstatus.com/api/v2/incidents.json\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)