### PR TITLE
feat: Claude Code statusline integration guide page (refs #400 Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `region_switch_intent` | `service_id`, `recommended_region` | ServiceDetails (Regional) | Region guide link click |
 | `click_reports` | — | Sidebar | Monthly reports link click |
 | `click_request_service` | — | Sidebar (request link) | Service request link click |
-| `copy_statusline_snippet` | `preset` (degraded_only/compact_badge/full_list/scoped) | Statusline page (Copy buttons) | Statusline integration adoption signal (#400 Phase 0) |
+| `copy_statusline_snippet` | `preset` (degraded_only/compact_badge/full_list/scoped/clickable) | Statusline page (Copy buttons) | Statusline integration adoption signal (#400 Phase 0) |
 | `share` | `method` (x/threads/kakao/copy), `item_id` | Is X Down (share buttons) | Social share button click |
 | `click_dashboard` | `location`, `source` | Is X Down (header/footer) | Dashboard link click |
 | `click_cta_alerts` | `location`, `source?` | Is X Down (CTA/footer) | Set Up Alerts click |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `region_switch_intent` | `service_id`, `recommended_region` | ServiceDetails (Regional) | Region guide link click |
 | `click_reports` | — | Sidebar | Monthly reports link click |
 | `click_request_service` | — | Sidebar (request link) | Service request link click |
+| `copy_statusline_snippet` | `preset` (degraded_only/compact_badge/full_list/scoped) | Statusline page (Copy buttons) | Statusline integration adoption signal (#400 Phase 0) |
 | `share` | `method` (x/threads/kakao/copy), `item_id` | Is X Down (share buttons) | Social share button click |
 | `click_dashboard` | `location`, `source` | Is X Down (header/footer) | Dashboard link click |
 | `click_cta_alerts` | `location`, `source?` | Is X Down (CTA/footer) | Set Up Alerts click |

--- a/README.ko.md
+++ b/README.ko.md
@@ -284,6 +284,25 @@ README, 문서, 블로그에 실시간 상태 배지를 임베드할 수 있습�
 | `characterai` | Character.AI | `modal` | Modal |
 | `voyageai` | Voyage AI | `codex` | Codex |
 
+## Claude Code Statusline 통합
+
+Claude API, OpenAI, Gemini, GitHub Copilot 등 32개 AI 서비스의 장애 여부를 [Claude Code 스테이터스라인](https://docs.claude.com/en/docs/claude-code/statusline)에 직접 표시합니다. 모든 서비스가 정상일 때는 출력이 비어 있어 statusline 공간을 차지하지 않고, 장애가 발생하면 빨간색 표시와 함께 서비스명이 나타나 업스트림 문제와 로컬 문제를 즉시 구분할 수 있습니다.
+
+가장 빠른 설정 — `~/.claude/settings.json`에 추가:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+  }
+}
+```
+
+프리셋 모음 (컴팩트 배지, 전체 목록, 특정 프로바이더만, Powerline 친화 등): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
+
+특성: 렌더링당 단일 GET, Cloudflare edge에 5분 KV 캐시, 2초 타임아웃, 네트워크 에러 시 silent fail, Anthropic API 호출 없음, 클라이언트 식별자 미수집. shell 명령 출력을 지원하는 모든 statusline 도구와 호환 (`ccstatusline`의 Custom Command 위젯 포함).
+
 ## 프로젝트 구조
 
 ```

--- a/README.md
+++ b/README.md
@@ -285,6 +285,25 @@ Embed real-time status badges in your README, docs, or blog.
 | `characterai` | Character.AI | `modal` | Modal |
 | `voyageai` | Voyage AI | `codex` | Codex |
 
+## Claude Code Statusline Integration
+
+Surface AI service outages — Claude API, OpenAI, Gemini, GitHub Copilot, and 28 more — directly in your [Claude Code statusline](https://docs.claude.com/en/docs/claude-code/statusline). Output stays empty while every service is operational; degraded/down services appear with a red indicator so upstream issues are visually distinct from local ones.
+
+Quickest install — add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+  }
+}
+```
+
+Full guide with presets (compact badge, full list, scoped to specific providers, Powerline-friendly): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
+
+Properties: single GET per render, 5-min KV-cached on Cloudflare's edge, 2-second timeout, fail-silent on network error, no Anthropic API requests, no client identifier. Compatible with any statusline tool that supports shell-command output (including `ccstatusline`'s Custom Command widget).
+
 ## Project Structure
 
 ```

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,88 +11,88 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-06</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -100,19 +100,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ const ServiceDetails = lazyWithRetry(() => import('./pages/ServiceDetails'))
 const Settings = lazyWithRetry(() => import('./pages/Settings'))
 const AboutScore = lazyWithRetry(() => import('./pages/AboutScore'))
 const Ranking = lazyWithRetry(() => import('./pages/Ranking'))
+const Statusline = lazyWithRetry(() => import('./pages/Statusline'))
 
 class ChunkErrorBoundary extends Component {
   state = { hasError: false }
@@ -59,7 +60,7 @@ class ChunkErrorBoundary extends Component {
 import { ALL_SERVICE_IDS } from './utils/constants'
 import { initVitals } from './utils/vitals'
 
-const PAGE_NAMES = ['overview', 'latency', 'incidents', 'uptime', 'settings', 'about-score', 'ranking']
+const PAGE_NAMES = ['overview', 'latency', 'incidents', 'uptime', 'settings', 'about-score', 'ranking', 'statusline']
 
 function hashToPage(hash) {
   const id = hash.replace(/^#/, '').split(/[?&#]/)[0]
@@ -87,6 +88,7 @@ function resolvePage(page) {
     case 'settings':  return <Suspense fallback={<SkeletonUI />}><Settings /></Suspense>
     case 'about-score': return <Suspense fallback={<SkeletonUI />}><AboutScore /></Suspense>
     case 'ranking':     return <Suspense fallback={<SkeletonUI />}><Ranking /></Suspense>
+    case 'statusline':  return <Suspense fallback={<SkeletonUI />}><Statusline /></Suspense>
     default:          return <Overview />
   }
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -75,7 +75,16 @@ function IconSend() {
   )
 }
 
-const NAV_ICONS = { overview: IconGrid, latency: IconChart, incidents: IconClock, uptime: IconTarget, ranking: IconTrophy }
+function IconTerminal() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ opacity: 0.6 }}>
+      <rect x="1.5" y="2.5" width="11" height="9" rx="1" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M4 6l2 1.5L4 9M7 9h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+const NAV_ICONS = { overview: IconGrid, latency: IconChart, incidents: IconClock, uptime: IconTarget, ranking: IconTrophy, statusline: IconTerminal }
 
 const DASHBOARD_ITEMS = [
   { name: 'overview', labelKey: 'nav.overview' },
@@ -83,6 +92,7 @@ const DASHBOARD_ITEMS = [
   { name: 'incidents', labelKey: 'nav.incidents' },
   { name: 'uptime', labelKey: 'nav.uptime' },
   { name: 'ranking', labelKey: 'nav.ranking' },
+  { name: 'statusline', labelKey: 'nav.statusline' },
 ]
 
 const STATUS_DOT_CLASS = {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -84,7 +84,7 @@ function IconTerminal() {
   )
 }
 
-const NAV_ICONS = { overview: IconGrid, latency: IconChart, incidents: IconClock, uptime: IconTarget, ranking: IconTrophy, statusline: IconTerminal }
+const NAV_ICONS = { overview: IconGrid, latency: IconChart, incidents: IconClock, uptime: IconTarget, ranking: IconTrophy }
 
 const DASHBOARD_ITEMS = [
   { name: 'overview', labelKey: 'nav.overview' },
@@ -92,7 +92,6 @@ const DASHBOARD_ITEMS = [
   { name: 'incidents', labelKey: 'nav.incidents' },
   { name: 'uptime', labelKey: 'nav.uptime' },
   { name: 'ranking', labelKey: 'nav.ranking' },
-  { name: 'statusline', labelKey: 'nav.statusline' },
 ]
 
 const STATUS_DOT_CLASS = {
@@ -219,6 +218,25 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
           <span className="shrink-0"><IconReport /></span>
           {t('nav.reports')}
         </a>
+        {/* Divider — separates "data viewing" group above from "settings / integrations" group below.
+            aria-hidden because this sits inside the nav landmark and is purely visual. */}
+        <div aria-hidden="true" style={{ height: '1px', background: 'var(--border)', margin: '6px 0' }} />
+        {(() => {
+          const isStatuslineActive = page.name === 'statusline'
+          return (
+            <button
+              onClick={() => { trackEvent('navigate_page', { page: 'statusline' }); setPage({ name: 'statusline' }); onNavigate?.() }}
+              aria-current={isStatuslineActive ? 'page' : undefined}
+              className={`w-full text-left flex items-center transition-all cursor-pointer
+                ${isStatuslineActive ? 'bg-[var(--bg3)] text-[var(--text0)]' : 'text-[var(--text1)] hover:bg-[var(--bg3)] hover:text-[var(--text0)]'}`}
+              style={navItemStyle}
+            >
+              {isStatuslineActive && <span style={activeBarStyle} />}
+              <span className="shrink-0"><IconTerminal /></span>
+              {t('nav.statusline')}
+            </button>
+          )
+        })()}
         <a
           href="https://github.com/bentleypark/aiwatch/issues/new?template=service_request.md"
           target="_blank"

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -8,6 +8,7 @@ const en = {
   'nav.incidents': 'Incidents',
   'nav.uptime': 'Uptime Status',
   'nav.ranking': 'Reliability Ranking',
+  'nav.statusline': 'Statusline',
   'nav.settings': 'Settings',
   'nav.dashboard': 'Dashboard',
   'nav.reports': 'Reports',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -8,6 +8,7 @@ const ko = {
   'nav.incidents': '인시던트',
   'nav.uptime': '업타임 현황',
   'nav.ranking': '신뢰도 랭킹',
+  'nav.statusline': '스테이터스라인',
   'nav.settings': '설정',
   'nav.dashboard': '대시보드',
   'nav.reports': '월간 리포트',

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -117,6 +117,20 @@ const PRESET_SCOPED = `{
   }
 }`
 
+// PRESET_CLICKABLE wraps each service name in an OSC 8 hyperlink so cmd+click
+// (macOS) / ctrl+click (Linux) opens the AIWatch service detail page in the
+// browser. The escape sequence is "ESC]8;;URL ESC\ TEXT ESC]8;; ESC\". Manual
+// JS-string-with-backslash escaping for this is a nightmare to read, so we
+// build the object and let JSON.stringify handle the JSON-level encoding for
+// us. The inner template literal still has to escape jq-level backslashes
+// (\\u001b for ESC, \\\\ for a literal "\" that jq's raw-output then emits).
+const PRESET_CLICKABLE = JSON.stringify({
+  statusLine: {
+    type: 'command',
+    command: `( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != "operational") | "\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\"] | .[0:3] | join(" ")' ) 2>/dev/null || true`,
+  },
+}, null, 2)
+
 export default function Statusline() {
   const { lang } = useLang()
   return (
@@ -188,6 +202,14 @@ export default function Statusline() {
               </a>{' '}on GitHub.
             </p>
             <Snippet code={PRESET_SCOPED} eventLabel="scoped" />
+          </div>
+
+          <div>
+            <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Clickable (OSC 8 hyperlink)</h3>
+            <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
+              Each service name becomes a clickable hyperlink that opens the AIWatch service detail page (<code className="mono text-[var(--text0)]">cmd+click</code> on macOS, <code className="mono text-[var(--text0)]">ctrl+click</code> on Linux). Useful for jumping straight to incident details when the statusline shows something is wrong. Requires an OSC 8-compatible terminal — most modern emulators (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+) support it; tmux and some older shells may render the escape sequence as raw text instead.
+            </p>
+            <Snippet code={PRESET_CLICKABLE} eventLabel="clickable" />
           </div>
         </div>
       </Section>

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -4,7 +4,6 @@
 
 import { useState } from 'react'
 import { useLang } from '../hooks/useLang'
-import { usePage } from '../utils/pageContext'
 import { trackEvent } from '../utils/analytics'
 
 const API_URL = 'https://ai-watch.dev/api/status/cached'
@@ -25,17 +24,32 @@ function CopyButton({ text, eventLabel }) {
   return (
     <button
       onClick={onClick}
-      className="mono text-[10px] cursor-pointer transition-colors"
+      className="mono text-[11px] font-medium cursor-pointer transition-colors flex items-center gap-1.5"
       style={{
-        padding: '4px 10px',
+        padding: '5px 12px',
         borderRadius: '4px',
-        border: '1px solid var(--border)',
-        background: copied ? 'var(--status-bg-green)' : 'var(--bg2)',
-        color: copied ? 'var(--green)' : 'var(--text1)',
+        border: `1px solid ${copied ? 'var(--green)' : 'var(--border-hi)'}`,
+        background: copied ? 'var(--status-bg-green)' : 'var(--bg3)',
+        color: copied ? 'var(--green)' : 'var(--text0)',
       }}
-      aria-label={copied ? 'Copied to clipboard' : 'Copy snippet'}
+      aria-label={copied ? 'Copied to clipboard' : 'Copy snippet to clipboard'}
     >
-      {copied ? 'Copied' : 'Copy'}
+      {copied ? (
+        <>
+          <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden="true">
+            <path d="M2 5.5L4.5 8L9.5 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Copied
+        </>
+      ) : (
+        <>
+          <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M3 3V2a1 1 0 011-1h5a1 1 0 011 1v5a1 1 0 01-1 1h-1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+          Copy
+        </>
+      )}
     </button>
   )
 }
@@ -100,7 +114,6 @@ const PRESET_SCOPED = `{
 
 export default function Statusline() {
   const { lang } = useLang()
-  const { setPage } = usePage()
   return (
     <div className="space-y-4">
       {lang === 'ko' && (
@@ -159,14 +172,15 @@ export default function Statusline() {
             <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Scope to specific services</h3>
             <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
               Filter to the providers you actually use. Edit the <code className="mono text-[var(--text0)]">.id == "claude"</code> list to match the services that matter for your workflow — see the{' '}
-              <button
-                type="button"
-                onClick={() => setPage({ name: 'ranking' })}
-                className="underline cursor-pointer"
-                style={{ color: 'var(--blue)', background: 'none', border: 'none', padding: 0, font: 'inherit' }}
+              <a
+                href="https://github.com/bentleypark/aiwatch#available-service-ids"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+                style={{ color: 'var(--blue)' }}
               >
-                full service list
-              </button>{' '}for valid IDs.
+                full service ID table
+              </a>{' '}on GitHub.
             </p>
             <Snippet code={PRESET_SCOPED} eventLabel="scoped" />
           </div>
@@ -182,6 +196,30 @@ export default function Statusline() {
         </ul>
       </Section>
 
+      <Section title="Compatible with">
+        <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.7', marginBottom: '8px' }}>
+          The snippets above use Claude Code's native <code className="mono text-[var(--text0)]">statusLine</code> setting and run through any tool that supports shell-command output. Drop them into:
+        </p>
+        <ul className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.7', listStyle: 'disc', paddingLeft: '20px' }}>
+          <li><strong className="text-[var(--text0)]">Native Claude Code</strong> — paste directly into <code className="mono text-[var(--text0)]">~/.claude/settings.json</code> as shown.</li>
+          <li>
+            <strong className="text-[var(--text0)]">
+              <a
+                href="https://github.com/sirmalloc/ccstatusline"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+                style={{ color: 'var(--blue)' }}
+              >
+                ccstatusline
+              </a>
+            </strong>
+            {' '}— add as a Custom Command widget in the TUI; the command is the part inside the <code className="mono text-[var(--text0)]">"command":</code> field.
+          </li>
+          <li><strong className="text-[var(--text0)]">Any other statusline tool</strong> that exposes a shell-command output widget (the Custom Command pattern in most popular tools).</li>
+        </ul>
+      </Section>
+
       <Section title="Honest caveats">
         <ul className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.7', listStyle: 'disc', paddingLeft: '20px' }}>
           <li><strong className="text-[var(--text0)]">5-minute cache lag</strong> — incidents can take up to 5 minutes to appear in the statusline after AIWatch detects them.</li>
@@ -193,8 +231,7 @@ export default function Statusline() {
 
       <div className="text-[var(--text2)] text-[11px]" style={{ lineHeight: '1.6' }}>
         AIWatch is open-source under AGPL-3.0. Source on{' '}
-        <a href="https://github.com/bentleypark/aiwatch" target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--blue)' }}>GitHub</a>
-        . Compatible with any Claude Code statusline tool that supports shell-command output, including <code className="mono text-[var(--text0)]">ccstatusline</code>'s Custom Command widget.
+        <a href="https://github.com/bentleypark/aiwatch" target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--blue)' }}>GitHub</a>.
       </div>
     </div>
   )

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -55,11 +55,16 @@ function CopyButton({ text, eventLabel }) {
 }
 
 function Snippet({ code, eventLabel }) {
+  // Copy button placed FIRST in the header (left side) so it's the first thing
+  // a user's left-to-right scan hits. Putting it on the right made it easy to
+  // miss when the page chrome shrank the content column or when reviewers
+  // assumed it was tied to the code block's horizontal scroll. The
+  // settings.json label is now secondary metadata on the right.
   return (
     <div className="bg-[var(--bg0)] border border-[var(--border)] rounded-md overflow-hidden">
-      <div className="flex items-center justify-between border-b border-[var(--border)]" style={{ padding: '6px 12px' }}>
-        <span className="mono text-[10px] text-[var(--text2)] uppercase tracking-wider">settings.json</span>
+      <div className="flex items-center gap-3 border-b border-[var(--border)]" style={{ padding: '8px 12px' }}>
         <CopyButton text={code} eventLabel={eventLabel} />
+        <span className="mono text-[10px] text-[var(--text2)] uppercase tracking-wider" style={{ marginLeft: 'auto' }}>settings.json</span>
       </div>
       <pre className="mono text-[11px] text-[var(--text0)]" style={{ padding: '12px', margin: 0, overflowX: 'auto', lineHeight: '1.5' }}>
         <code>{code}</code>

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -1,0 +1,201 @@
+// AIWatch Claude Code statusline integration guide (#400 Phase 0).
+// Self-hosted surface so Phase 1 acceptance ("snippet documented somewhere
+// reachable from ai-watch.dev") doesn't depend on third-party merge timelines.
+
+import { useState } from 'react'
+import { useLang } from '../hooks/useLang'
+import { usePage } from '../utils/pageContext'
+import { trackEvent } from '../utils/analytics'
+
+const API_URL = 'https://ai-watch.dev/api/status/cached'
+
+function CopyButton({ text, eventLabel }) {
+  const [copied, setCopied] = useState(false)
+  const onClick = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      trackEvent('copy_statusline_snippet', { preset: eventLabel })
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Older browsers / restricted contexts — fall back to selection.
+      // No prompt() so we don't break flow; user can still select+copy manually.
+    }
+  }
+  return (
+    <button
+      onClick={onClick}
+      className="mono text-[10px] cursor-pointer transition-colors"
+      style={{
+        padding: '4px 10px',
+        borderRadius: '4px',
+        border: '1px solid var(--border)',
+        background: copied ? 'var(--status-bg-green)' : 'var(--bg2)',
+        color: copied ? 'var(--green)' : 'var(--text1)',
+      }}
+      aria-label={copied ? 'Copied to clipboard' : 'Copy snippet'}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  )
+}
+
+function Snippet({ code, eventLabel }) {
+  return (
+    <div className="bg-[var(--bg0)] border border-[var(--border)] rounded-md overflow-hidden">
+      <div className="flex items-center justify-between border-b border-[var(--border)]" style={{ padding: '6px 12px' }}>
+        <span className="mono text-[10px] text-[var(--text2)] uppercase tracking-wider">settings.json</span>
+        <CopyButton text={code} eventLabel={eventLabel} />
+      </div>
+      <pre className="mono text-[11px] text-[var(--text0)]" style={{ padding: '12px', margin: 0, overflowX: 'auto', lineHeight: '1.5' }}>
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
+      <div className="border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
+        <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
+          <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: 'var(--teal)' }} />
+          {title}
+        </div>
+      </div>
+      <div style={{ padding: '16px' }}>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+const PRESET_DEGRADED_ONLY = `{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | .[0:3] | join(\\" \\")' ) 2>/dev/null || true"
+  }
+}`
+
+const PRESET_COMPACT_BADGE = `{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '([.services[] | select(.status != \\"operational\\")] | length) as $n | if $n == 0 then empty else \\"🔴 \\" + ($n|tostring) + \\" AI services\\" end' ) 2>/dev/null || true"
+  }
+}`
+
+const PRESET_FULL_LIST = `{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"\\(if .status == \\"down\\" then \\"X\\" else \\"!\\" end)\\\\u00b7\\(.name)\\"] | join(\\" | \\")' ) 2>/dev/null || true"
+  }
+}`
+
+const PRESET_SCOPED = `{
+  "statusLine": {
+    "type": "command",
+    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.id == \\"claude\\" or .id == \\"openai\\" or .id == \\"gemini\\") | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | join(\\" \\")' ) 2>/dev/null || true"
+  }
+}`
+
+export default function Statusline() {
+  const { lang } = useLang()
+  const { setPage } = usePage()
+  return (
+    <div className="space-y-4">
+      {lang === 'ko' && (
+        <div
+          className="border border-[var(--border)] rounded-md text-[var(--text2)]"
+          style={{ padding: '10px 14px', fontSize: '11px', lineHeight: '1.6', background: 'var(--bg2)' }}
+        >
+          이 페이지는 영문으로만 제공됩니다 — 본문이 jq · curl 명령 위주라 영어로 유지했습니다. 명령어 자체는 한국어 환경에서도 동일하게 동작합니다.
+        </div>
+      )}
+      <div>
+        <h1 className="text-[var(--text0)] font-semibold" style={{ fontSize: '20px', marginBottom: '8px' }}>
+          AIWatch in your Claude Code statusline
+        </h1>
+        <p className="text-[var(--text2)] text-[13px]" style={{ lineHeight: '1.6' }}>
+          Surface AI service outages — Claude API, OpenAI, Gemini, GitHub Copilot, and 28 more — directly in your{' '}
+          <a
+            href="https://docs.claude.com/en/docs/claude-code/statusline"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+            style={{ color: 'var(--blue)' }}
+          >
+            Claude Code statusline
+          </a>
+          . When everything is healthy nothing is shown — your statusline real estate is preserved. When a service degrades or goes down, it appears with a red indicator so you can tell upstream issues from local ones at a glance.
+        </p>
+      </div>
+
+      <Section title="Quick start (recommended preset)">
+        <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '12px' }}>
+          Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Output stays empty while every monitored service is operational; up to 3 degraded/down services appear with a red dot when something breaks.
+        </p>
+        <Snippet code={PRESET_DEGRADED_ONLY} eventLabel="degraded_only" />
+      </Section>
+
+      <Section title="Other presets">
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Compact badge</h3>
+            <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
+              Shows a single count (e.g. <code className="mono text-[var(--text0)]">🔴 2 AI services</code>) instead of names. Best when statusline space is tight.
+            </p>
+            <Snippet code={PRESET_COMPACT_BADGE} eventLabel="compact_badge" />
+          </div>
+
+          <div>
+            <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Full list with severity</h3>
+            <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
+              Shows every degraded/down service with a one-character severity prefix — <code className="mono text-[var(--text0)]">X</code> for down, <code className="mono text-[var(--text0)]">!</code> for degraded. No emoji, plain text — friendly for Powerline themes that already provide their own iconography.
+            </p>
+            <Snippet code={PRESET_FULL_LIST} eventLabel="full_list" />
+          </div>
+
+          <div>
+            <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Scope to specific services</h3>
+            <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
+              Filter to the providers you actually use. Edit the <code className="mono text-[var(--text0)]">.id == "claude"</code> list to match the services that matter for your workflow — see the{' '}
+              <button
+                type="button"
+                onClick={() => setPage({ name: 'ranking' })}
+                className="underline cursor-pointer"
+                style={{ color: 'var(--blue)', background: 'none', border: 'none', padding: 0, font: 'inherit' }}
+              >
+                full service list
+              </button>{' '}for valid IDs.
+            </p>
+            <Snippet code={PRESET_SCOPED} eventLabel="scoped" />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="How it works">
+        <ul className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.7', listStyle: 'disc', paddingLeft: '20px' }}>
+          <li>Single GET to <code className="mono text-[var(--text0)]">{API_URL}</code> per statusline render. CORS-enabled, no authentication, no client identifier collected.</li>
+          <li>The endpoint serves a 5-minute KV-cached payload from Cloudflare's edge network — typical response time is under 100 ms from most regions.</li>
+          <li>The shell command sets a 2-second timeout (<code className="mono text-[var(--text0)]">--max-time 2</code>) and fails silent (<code className="mono text-[var(--text0)]">2{'>'}/dev/null || true</code>) so a network hiccup never breaks your statusline.</li>
+          <li>No requests to the Anthropic API. AIWatch operates its own status feed independently.</li>
+        </ul>
+      </Section>
+
+      <Section title="Honest caveats">
+        <ul className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.7', listStyle: 'disc', paddingLeft: '20px' }}>
+          <li><strong className="text-[var(--text0)]">5-minute cache lag</strong> — incidents can take up to 5 minutes to appear in the statusline after AIWatch detects them.</li>
+          <li><strong className="text-[var(--text0)]">jq + curl required</strong> — pre-installed on macOS &amp; most Linux distros. Windows users: install via WSL or use <code className="mono text-[var(--text0)]">winget install jqlang.jq</code> with curl from Windows 10+.</li>
+          <li><strong className="text-[var(--text0)]">Claude Code is Claude-only</strong> — this surface is informational, not a fallback router. When Claude API is down you'll know immediately, but you can't switch providers mid-session.</li>
+          <li><strong className="text-[var(--text0)]">Self-hosters</strong> — replace <code className="mono text-[var(--text0)]">{API_URL}</code> with your own AIWatch deployment.</li>
+        </ul>
+      </Section>
+
+      <div className="text-[var(--text2)] text-[11px]" style={{ lineHeight: '1.6' }}>
+        AIWatch is open-source under AGPL-3.0. Source on{' '}
+        <a href="https://github.com/bentleypark/aiwatch" target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--blue)' }}>GitHub</a>
+        . Compatible with any Claude Code statusline tool that supports shell-command output, including <code className="mono text-[var(--text0)]">ccstatusline</code>'s Custom Command widget.
+      </div>
+    </div>
+  )
+}

--- a/tests/statusline.spec.js
+++ b/tests/statusline.spec.js
@@ -71,4 +71,55 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     await expect(page.locator('body')).toContainText(/5-minute cache lag/i)
     await expect(page.locator('body')).toContainText(/CORS-enabled/i)
   })
+
+  test('Copy button is the first interactive element in the snippet header (left-aligned)', async ({ page }) => {
+    // Reviewer feedback (#400 follow-up 0b78e60): right-aligned Copy was easy to
+    // miss when the content column shrank. Pin the contract that Copy comes
+    // BEFORE the "settings.json" label in DOM order so a future flex/justify
+    // tweak doesn't silently regress.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    // xpath couples to the Snippet component shape (header div is the immediate
+    // previous sibling of <pre>). If a future refactor wraps <pre> in another
+    // div, update the xpath — see src/pages/Statusline.jsx Snippet().
+    const firstSnippetHeaderText = await page
+      .locator('pre').first().locator('xpath=preceding-sibling::div[1]')
+      .textContent()
+    expect(firstSnippetHeaderText).not.toBeNull()
+    const copyIdx = (firstSnippetHeaderText || '').indexOf('Copy')
+    const labelIdx = (firstSnippetHeaderText || '').indexOf('settings.json')
+    expect(copyIdx).toBeGreaterThanOrEqual(0)
+    expect(labelIdx).toBeGreaterThan(copyIdx)
+  })
+
+  test('"full service list" link points to the GitHub README anchor (not intra-SPA)', async ({ page }) => {
+    // Reviewer feedback (#400 follow-up f426ccd): the link was an intra-SPA
+    // setPage to /#ranking, but the Ranking page renders display names not
+    // service IDs — the snippet's jq filter needs the IDs. Pin the external
+    // GitHub README target so a future "let's keep navigation in-app" refactor
+    // doesn't silently break the documentation contract.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    const link = page.locator('a').filter({ hasText: /service ID table/i }).first()
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', /github\.com\/bentleypark\/aiwatch.*available-service-ids/)
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', /noopener/)
+  })
+
+  test('"Compatible with" section lists ccstatusline with a link', async ({ page }) => {
+    // Reviewer feedback (#400 follow-up f426ccd): ccstatusline mention moved
+    // out of the footer and into a dedicated section so users of that tool
+    // can spot integration support quickly. Pin the section + link presence
+    // so a future doc cleanup doesn't bury the cross-promotion that the
+    // Phase 1 distribution PR strategy depends on.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    await expect(page.locator('body')).toContainText(/Compatible with/i)
+    // `href*=` instead of `href=` so a future UTM/ref query-string addition
+    // doesn't break the test while still catching repo-owner moves.
+    const ccLink = page.locator('a[href*="github.com/sirmalloc/ccstatusline"]').first()
+    await expect(ccLink).toBeVisible()
+    await expect(ccLink).toHaveText(/ccstatusline/)
+  })
 })

--- a/tests/statusline.spec.js
+++ b/tests/statusline.spec.js
@@ -1,0 +1,74 @@
+// #400 Phase 0 — /statusline guide page (Claude Code statusline integration).
+// Pins: hash route works, all 4 presets render with copy buttons, sidebar nav
+// entry exists. A regression in any of these would re-block Phase 1's
+// "snippet documented somewhere reachable from ai-watch.dev" criterion.
+
+import { test, expect } from '@playwright/test'
+import { waitForDataLoad } from './helpers.js'
+
+test.describe('Statusline guide page (#400 Phase 0)', () => {
+  test('accessible via #statusline hash', async ({ page }) => {
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    await expect(page.locator('h1').filter({ hasText: /statusline/i })).toBeVisible()
+  })
+
+  test('renders the recommended preset snippet', async ({ page }) => {
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    // Pin the canonical curl + jq one-liner pieces: ai-watch.dev host, jq's
+    // status filter, fail-silent fallback, 2s timeout. Substrings chosen to
+    // avoid quoting/escaping ambiguity (the JSON-in-JSON produces \" in DOM).
+    const code = page.locator('pre').first()
+    await expect(code).toBeVisible()
+    const text = (await code.textContent()) || ''
+    expect(text).toContain('ai-watch.dev/api/status/cached')
+    expect(text).toContain('--max-time 2')
+    expect(text).toContain('select(.status')
+    expect(text).toContain('|| true')
+  })
+
+  test('renders all four documented presets with copy buttons', async ({ page }) => {
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    // 4 presets = 4 <pre> code blocks + 4 Copy buttons.
+    await expect(page.locator('pre')).toHaveCount(4)
+    const copyButtons = page.locator('button').filter({ hasText: /^Copy$/ })
+    await expect(copyButtons).toHaveCount(4)
+  })
+
+  test('copy button click does not throw and remains a button', async ({ page }) => {
+    // The clipboard `writeText` happy path is browser-permission-gated and
+    // unreliable to mock cleanly across Playwright projects. We pin the weaker
+    // contract instead: clicking the Copy button doesn't crash the page, and
+    // the button remains interactive afterward (i.e., the handler ran without
+    // throwing the React tree). Functional clipboard behavior is exercised
+    // manually during local verification.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    const firstCopy = page.locator('button').filter({ hasText: /^Copy|Copied$/ }).first()
+    await expect(firstCopy).toBeVisible()
+    await firstCopy.click()
+    // Page must still be intact — the snippet block above the button is a
+    // reliable post-click sanity check.
+    await expect(page.locator('pre').first()).toBeVisible()
+  })
+
+  test('sidebar navigation includes Statusline entry', async ({ page }) => {
+    await page.goto('/')
+    await waitForDataLoad(page)
+    const navButton = page.locator('button').filter({ hasText: /statusline|스테이터스라인/i }).first()
+    await expect(navButton).toBeVisible()
+    await navButton.click()
+    await expect(page.locator('h1').filter({ hasText: /statusline/i })).toBeVisible()
+  })
+
+  test('How-it-works and caveats sections are present', async ({ page }) => {
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    // Caveats explicitly call out the 5-minute cache lag — that's a hard contract
+    // we documented to users and shouldn't drop silently.
+    await expect(page.locator('body')).toContainText(/5-minute cache lag/i)
+    await expect(page.locator('body')).toContainText(/CORS-enabled/i)
+  })
+})

--- a/tests/statusline.spec.js
+++ b/tests/statusline.spec.js
@@ -28,13 +28,14 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     expect(text).toContain('|| true')
   })
 
-  test('renders all four documented presets with copy buttons', async ({ page }) => {
+  test('renders all five documented presets with copy buttons', async ({ page }) => {
     await page.goto('/#statusline')
     await waitForDataLoad(page)
-    // 4 presets = 4 <pre> code blocks + 4 Copy buttons.
-    await expect(page.locator('pre')).toHaveCount(4)
+    // 5 presets = 5 <pre> code blocks + 5 Copy buttons.
+    // (degraded_only, compact_badge, full_list, scoped, clickable)
+    await expect(page.locator('pre')).toHaveCount(5)
     const copyButtons = page.locator('button').filter({ hasText: /^Copy$/ })
-    await expect(copyButtons).toHaveCount(4)
+    await expect(copyButtons).toHaveCount(5)
   })
 
   test('copy button click does not throw and remains a button', async ({ page }) => {
@@ -105,6 +106,45 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     await expect(link).toHaveAttribute('href', /github\.com\/bentleypark\/aiwatch.*available-service-ids/)
     await expect(link).toHaveAttribute('target', '_blank')
     await expect(link).toHaveAttribute('rel', /noopener/)
+  })
+
+  test('Clickable preset contains OSC 8 hyperlink escape sequence', async ({ page }) => {
+    // The clickable preset wraps each service name in OSC 8 (ESC]8;;URL ESC\)
+    // so terminal emulators render it as a hyperlink. The literal escape
+    // sequence in the user-visible JSON string must contain `]8;;` and
+    // the `]8;;` closing pair — if a future cleanup "simplifies" by dropping
+    // the OSC 8 wrapper, this preset silently degrades to plain text and the
+    // hyperlink claim in the prose becomes false.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    const heading = page.locator('h3').filter({ hasText: /Clickable.*OSC 8/i })
+    await expect(heading).toBeVisible()
+    // Scope to the heading's parent subtree instead of nth(4) — survives a
+    // future reorder of preset blocks without spuriously passing on the wrong
+    // snippet.
+    const clickableSnippet = heading.locator('xpath=ancestor::div[1]').locator('pre')
+    const code = (await clickableSnippet.textContent()) || ''
+    // JSON.stringify double-encodes the embedded escape so the on-screen text
+    // is literal `\\u001b` (7 chars: \, \, u, 0, 0, 1, b) — that's what users
+    // copy. Substring checks below are escape-safe (no quoting ambiguity).
+    expect(code).toContain(']8;;')                       // OSC 8 opener
+    expect(code).toContain('https://ai-watch.dev/#')     // hyperlinked URL pointing to dashboard hash route
+    // The OSC 8 closer (ESC]8;;) appears at least twice — once after URL, once at the very end.
+    const matches = code.match(/\]8;;/g) || []
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('Clickable preset documents terminal compatibility caveat', async ({ page }) => {
+    // The OSC 8 escape isn't universal — tmux and some older shells render it
+    // as raw text. Documenting this in the page prose is what keeps users from
+    // copying the snippet into an unsupported terminal and concluding AIWatch
+    // is broken. Pin the caveat presence so a future docs trim doesn't drop it.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    await expect(page.locator('body')).toContainText(/OSC 8/i)
+    // At least one of the supported terminal names should be mentioned to
+    // give the user a quick "do I have one?" check.
+    await expect(page.locator('body')).toContainText(/iTerm2|Warp|kitty|WezTerm/i)
   })
 
   test('"Compatible with" section lists ccstatusline with a link', async ({ page }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,7 @@
     { "source": "/reports/", "destination": "/api/reports" },
     { "source": "/reports/:rest*", "destination": "/api/reports" },
     { "source": "/reports/:rest*/", "destination": "/api/reports" },
+    { "source": "/api/status/cached", "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 0 of the statusline initiative ([refs #400](https://github.com/bentleypark/aiwatch/issues/400)) — a self-hosted surface at \`ai-watch.dev/#statusline\` so users can drop AIWatch's status feed into their \`~/.claude/settings.json\` with a copy-pasteable one-liner. Unblocks Phase 1 acceptance ("snippet documented somewhere reachable from ai-watch.dev") without depending on third-party PR merge timelines.

## What lands

- **\`src/pages/Statusline.jsx\`** (new) — page with header, KO notice, 4 presets (degraded-only, compact badge, full list with severity prefix, scoped), "How it works" + "Honest caveats" sections, GitHub link footer
- **Routing** — new \`#statusline\` hash route in \`App.jsx\` (lazy-loaded), sidebar nav entry under DASHBOARD_ITEMS with new \`IconTerminal\`, \`nav.statusline\` locale key in en/ko
- **\`vercel.json\`** — adds \`/api/status/cached\` → Worker rewrite. Without this the snippets would hit the SPA catch-all and return HTML, jq would parse-error, and \`|| true\` would silently mask the bug as a permanently empty statusline. Caught by review round 1.
- **README + README.ko.md** — new "Claude Code Statusline Integration" section links to \`ai-watch.dev/#statusline\` with the quickest-install snippet
- **\`CLAUDE.md\`** — new \`copy_statusline_snippet\` row in GA4 Analytics Events table (\`preset\` parameter: degraded_only / compact_badge / full_list / scoped)

## Test coverage

- \`tests/statusline.spec.js\` (new, 6 Playwright tests):
  - hash-route reachable
  - recommended preset snippet contains canonical curl pieces (\`ai-watch.dev/api/status/cached\`, \`--max-time 2\`, \`select(.status\`, \`|| true\`)
  - all 4 presets render with Copy buttons
  - copy click does not throw
  - sidebar nav entry exists
  - How-it-works + caveats sections present

## Test results

- Vitest: 124/124 (no src/utils logic changes)
- Playwright desktop+mobile: **93/93** (6 statusline + 87 existing)
- \`npm run build\`: clean (~359 kB main bundle)

## Review

Converged at round 3 — Critical 0 / Important 0. Issues fixed along the way:

- **Critical** (round 1): \`vercel.json\` was missing \`/api/status/cached\` rewrite — snippets returned HTML in production
- **Important** (round 1): full-list preset collapsed both \`down\` and \`degraded\` to "D" — fixed to use distinct \`X\` (down) and \`!\` (degraded)
- **Important** (round 1): \`copy_statusline_snippet\` GA4 event undocumented in CLAUDE.md
- **Important** (round 1): KO sidebar label routed to fully-English page with no notice — added inline KO meta-copy
- **Important** (round 2): \`var(--green-dim)\` token undefined — Copy button confirm color silently fell back to \`unset\` — replaced with \`var(--status-bg-green)\`
- **Important** (round 2): \`<a href="#ranking">\` would not navigate inside the SPA because App.jsx listens only for \`popstate\` not \`hashchange\` — replaced with \`<button onClick={() => setPage({ name: 'ranking' })}>\`

## Phase 0 acceptance criteria (#400)

- [x] \`/statusline\` page reachable from \`ai-watch.dev\` with copy-pasteable settings.json snippet
- [x] At least 3 presets covering degraded-only, icons-only, full-name list (4 shipped — degraded-only, compact badge, full list, scoped)
- [x] Page documents the failure modes: empty output on success, 2s timeout, 5min cache lag, AIWatch host configurable for self-hosters
- [ ] **AIWatch \`/api/status/cached\` confirmed safe under expected statusline traffic** — verifiable only after deploy. Worker is on free tier with KV cache, single-GET-per-render to KV-cached path; expect read-mostly traffic well within budget. Will spot-check in production after merge.

## Test plan (post-merge)

- [ ] Visit \`https://ai-watch.dev/#statusline\` → page renders, all 4 snippets visible
- [ ] \`curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq '.services | length'\` returns 32 (proxy works post-deploy)
- [ ] Copy each preset, paste into \`~/.claude/settings.json\`, restart Claude Code session — degraded-only preset shows empty statusline (or appropriate output if a service is currently degraded), full-list shows \`X·name\` / \`!·name\` syntax
- [ ] KO language toggle on \`/#statusline\` shows the inline notice at top

## Phase 0 bridges to Phase 1

Once merged + deployed:
- awesome-claude-code submission ([hesreallyhim/awesome-claude-code#1762](https://github.com/hesreallyhim/awesome-claude-code/issues/1762)) link target works
- ccstatusline issue (next, optional) can reference \`ai-watch.dev/#statusline\` as canonical guide
- Reddit launch post (gated on Phase 0 + awesome-list approval) anchors to this page

🤖 Generated with [Claude Code](https://claude.com/claude-code)