### PR TITLE
fix: tier-based fallback for coding agents (#402)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ When adding a new monitored service, update ALL of the following:
 2. `worker/src/probe.ts` — add `ProbeTarget` if API endpoint exists for RTT measurement
 3. `worker/src/fallback.ts` — update ALL of:
    - `EXCLUDE_FALLBACK` — remove if fallback-eligible
-   - `API_TIER` — add tier number (1=Major LLM, 2=LLM, 3=Infra, 4=Voice)
+   - `API_TIER` — add tier number (API: 1=Major LLM, 2=LLM, 3=Infra, 4=Voice; agents: 11=CLI, 12=IDE, 13=Plugin)
    - `TIER_LABEL` — add label if new tier introduced
    - `buildGroupedFallbackText` uses tier-based grouping — verify Discord alerts show correct labels
 4. `worker/src/__tests__/` — update probe target count test, fallback tests, add service-specific tests
@@ -481,11 +481,15 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
   - **Recently Resolved**: on recovery, cron writes independent `recovered:{svcId}:{incId}` KV (2h TTL) regardless of AI analysis. Also marks per-incident analysis keys with `resolvedAt` field if they exist. `/api/status` returns `recentlyRecovered: Record<svcId, incId[]>` for operational services with recovery markers. Dashboard shows info banner (service names link to detail page) + "Recently Resolved" badge on specific incidents in ServiceDetails + Analyze modal link only when AI analysis exists. "See details in Analyze" hidden when no AI analysis data
   - **Contextual fallback** (`needsFallback`): AI analysis includes boolean flag assessing if incident warrants switching to alternative. When true, AnalysisModal + Is X Down AI Insight card show Score-based fallback list. Shared `getFallbacks()` utility in `src/utils/constants.js` (used by AnalysisModal + Overview)
   - Grouped fallback: when incident affects multiple categories, Discord alerts + dashboard show per-category alternatives via `buildGroupedFallbackText`
-  - **Fallback tier priority** (API services only): same-tier services are recommended first, then adjacent tiers. Within each tier, sorted by AIWatch Score descending. Defined in `worker/src/fallback.ts`, mirrored in `src/utils/constants.js` and `api/is-down.ts`:
+  - **Fallback tier priority**: same-tier services are recommended first, then adjacent tiers by distance. Within each tier, sorted by AIWatch Score descending. Defined in `worker/src/fallback.ts`, mirrored in `src/utils/constants.js`, `api/is-down.ts`, and `TIER_LABEL` in `src/pages/Overview.jsx`. API tiers (1-4) and coding-agent tiers (11-13) use distinct number ranges so a single `TIER_LABEL` map stays unambiguous, and `getFallbacks` already filters by category so the two ranges never compare against each other:
     - **Tier 1** (Major LLM): `claude`, `openai`, `gemini`
     - **Tier 2** (LLM): `mistral`, `cohere`, `groq`, `together`, `fireworks`, `deepseek`, `xai`, `perplexity`
     - **Tier 3** (Infrastructure): `bedrock`, `azureopenai`, `openrouter`
     - **Tier 4** (Voice): `elevenlabs`, `assemblyai`, `deepgram`
+    - **Tier 11** (Coding agent — CLI): `claudecode`, `codex`
+    - **Tier 12** (Coding agent — Standalone IDE): `cursor`, `windsurf`
+    - **Tier 13** (Coding agent — IDE Plugin): `copilot`, `junie`
+    - Pre-#402 the agent tiers were unset and every agent fell through to `?? 99`, so the recommendation collapsed to a Score-only sort and Junie (new service, shallow incident history → inflated Score) showed up as #1 for unrelated outages.
   - `EXCLUDE_FALLBACK` services are excluded from both source and candidate lists (keep in sync across `worker/src/fallback.ts`, `src/utils/constants.js`, `api/is-down.ts`): `replicate`, `huggingface`, `pinecone`, `stability`, `voyageai`, `modal`, `characterai`, `bedrock`, `azureopenai`
   - **Estimate-only services** (`uptimeSource === 'estimate'` + 0 incidents): `bedrock`, `azureopenai` — hidden from Ranking, Uptime rankings, fallback recommendations, category averages. Dashboard shows "— Not provided" instead of misleading 100% uptime
 - Status polling proxy: `worker/` directory (monorepo), Cloudflare Workers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,9 +486,10 @@ No React Router. Hash-based routing in `App.jsx` — `#claude` for service detai
     - **Tier 2** (LLM): `mistral`, `cohere`, `groq`, `together`, `fireworks`, `deepseek`, `xai`, `perplexity`
     - **Tier 3** (Infrastructure): `bedrock`, `azureopenai`, `openrouter`
     - **Tier 4** (Voice): `elevenlabs`, `assemblyai`, `deepgram`
-    - **Tier 11** (Coding agent — CLI): `claudecode`, `codex`
-    - **Tier 12** (Coding agent — Standalone IDE): `cursor`, `windsurf`
-    - **Tier 13** (Coding agent — IDE Plugin): `copilot`, `junie`
+    - **Tier 11** (`CLI Agent`): `claudecode`, `codex`
+    - **Tier 12** (`IDE Agent` — standalone): `cursor`, `windsurf`
+    - **Tier 13** (`Plugin Agent` — IDE plugin): `copilot`, `junie`
+    - The `Agent` suffix on each agent-tier label keeps the noun visible in grouped fallback output ("CLI Agent → Claude Code" vs the original ambiguous "CLI → Claude Code") — LLM/Voice/Infra stay bare because those abbreviations already read as service categories.
     - Pre-#402 the agent tiers were unset and every agent fell through to `?? 99`, so the recommendation collapsed to a Score-only sort and Junie (new service, shallow incident history → inflated Score) showed up as #1 for unrelated outages.
   - `EXCLUDE_FALLBACK` services are excluded from both source and candidate lists (keep in sync across `worker/src/fallback.ts`, `src/utils/constants.js`, `api/is-down.ts`): `replicate`, `huggingface`, `pinecone`, `stability`, `voyageai`, `modal`, `characterai`, `bedrock`, `azureopenai`
   - **Estimate-only services** (`uptimeSource === 'estimate'` + 0 incidents): `bedrock`, `azureopenai` — hidden from Ranking, Uptime rankings, fallback recommendations, category averages. Dashboard shows "— Not provided" instead of misleading 100% uptime

--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -151,13 +151,16 @@ export default async function handler(req: Request) {
           console.error(`[is-down/${slug}] target.aiwatchScore is not finite:`, target.aiwatchScore)
         }
 
-        // Build fallbacks from same data (tier-based priority for API services)
-        // Keep in sync with worker/src/fallback.ts API_TIER
+        // Build fallbacks from same data (tier-based priority for API services + coding agents)
+        // Keep in sync with worker/src/fallback.ts API_TIER and src/utils/constants.js API_TIER.
         const API_TIER: Record<string, number> = {
           claude: 1, openai: 1, gemini: 1,
           mistral: 2, cohere: 2, groq: 2, together: 2, fireworks: 2, deepseek: 2, xai: 2, perplexity: 2,
           bedrock: 3, azureopenai: 3, openrouter: 3,
           elevenlabs: 4, assemblyai: 4, deepgram: 4,
+          claudecode: 11, codex: 11,
+          cursor: 12, windsurf: 12,
+          copilot: 13, junie: 13,
         }
         if (!EXCLUDE_FALLBACK.includes(entry.id)) {
           const sourceTier = API_TIER[entry.id] ?? 99

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -323,7 +323,10 @@ function ActionBanner({ services, setPage, t }) {
   ))
 
   // Collect fallbacks per tier group — exclude non-operational + same provider
-  const TIER_LABEL = { 1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice' }
+  // Keep in sync with worker/src/fallback.ts TIER_LABEL — every tier number used in
+  // src/utils/constants.js API_TIER must have a label here, otherwise grouped fallback display
+  // silently degrades to the bare category label.
+  const TIER_LABEL = { 1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice', 11: 'CLI', 12: 'IDE', 13: 'Plugin' }
   const CATEGORY_LABEL = { api: 'API', app: 'AI Apps', agent: 'Coding' }
   const nonOperationalIds = new Set(services.filter(s => s.status !== 'operational').map(s => s.id))
   const affectedProviders = new Set(affected.map(s => s.provider))

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -326,7 +326,7 @@ function ActionBanner({ services, setPage, t }) {
   // Keep in sync with worker/src/fallback.ts TIER_LABEL — every tier number used in
   // src/utils/constants.js API_TIER must have a label here, otherwise grouped fallback display
   // silently degrades to the bare category label.
-  const TIER_LABEL = { 1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice', 11: 'CLI', 12: 'IDE', 13: 'Plugin' }
+  const TIER_LABEL = { 1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice', 11: 'CLI Agent', 12: 'IDE Agent', 13: 'Plugin Agent' }
   const CATEGORY_LABEL = { api: 'API', app: 'AI Apps', agent: 'Coding' }
   const nonOperationalIds = new Set(services.filter(s => s.status !== 'operational').map(s => s.id))
   const affectedProviders = new Set(affected.map(s => s.provider))

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -53,13 +53,18 @@ export const SERVICE_CATEGORIES = {
 // Keep in sync with worker/src/fallback.ts EXCLUDE_FALLBACK
 export const EXCLUDE_FALLBACK = ['replicate', 'huggingface', 'pinecone', 'stability', 'voyageai', 'modal', 'characterai', 'bedrock', 'azureopenai']
 
-// Fallback tier priority for API services
-// Keep in sync with worker/src/fallback.ts API_TIER
+// Fallback tier priority — API services (1-4) and coding agents (11-13) use distinct number ranges
+// so TIER_LABEL (in src/pages/Overview.jsx and worker/src/fallback.ts) maps each tier number to one
+// unambiguous label. Within a category, getFallbacks orders by tier-distance then by Score.
+// Keep in sync with worker/src/fallback.ts API_TIER and api/is-down.ts inline API_TIER.
 export const API_TIER = {
   claude: 1, openai: 1, gemini: 1,
   mistral: 2, cohere: 2, groq: 2, together: 2, fireworks: 2, deepseek: 2, xai: 2, perplexity: 2,
   bedrock: 3, azureopenai: 3, openrouter: 3,
   elevenlabs: 4, assemblyai: 4, deepgram: 4,
+  claudecode: 11, codex: 11,
+  cursor: 12, windsurf: 12,
+  copilot: 13, junie: 13,
 }
 
 /**

--- a/worker/src/__tests__/fallback.test.ts
+++ b/worker/src/__tests__/fallback.test.ts
@@ -190,6 +190,88 @@ describe('buildGroupedFallbackText', () => {
   })
 })
 
+// #402 — coding-agent tier (T11 CLI / T12 IDE / T13 Plugin) regression coverage.
+// Pre-#402 every agent fell through to `?? 99`, so getFallbacks ordered purely by Score, which let
+// Junie (new service, shallow incident history → inflated Score) appear as #1 for unrelated agents.
+// These tests pin the post-fix contract — same-tier peer ranks above cross-tier peers regardless of
+// Score, so the recommendation matches the affected agent's usage pattern (CLI/IDE/Plugin).
+describe('getFallbacks — coding agent tiers (#402)', () => {
+  // Adversarial Score layout: each tier's "wrong" candidates are given Scores that beat the
+  // correct same-tier peer, so a Score-only sort surfaces them first. Tier-distance sort must
+  // override that bias for the assertions below to pass.
+  //
+  // The two highest-Score services (cursor 99 / junie 95) sit in different tiers (T12 / T13)
+  // intentionally. That way, every "affected → expected #1" assertion below names a service that
+  // is NOT the highest Score in the fixture, so a regression that drops the tier-distance term and
+  // collapses to Score-only ordering provably fails — pinned by the simulator at the bottom of
+  // each test comment.
+  const agentServices = [
+    { id: 'claudecode', category: 'agent', name: 'Claude Code', status: 'operational', aiwatchScore: 70 },
+    { id: 'codex',      category: 'agent', name: 'Codex',       status: 'operational', aiwatchScore: 75 },
+    { id: 'cursor',     category: 'agent', name: 'Cursor',      status: 'operational', aiwatchScore: 99 },
+    { id: 'windsurf',   category: 'agent', name: 'Windsurf',    status: 'operational', aiwatchScore: 65 },
+    { id: 'copilot',    category: 'agent', name: 'GitHub Copilot', status: 'operational', aiwatchScore: 78 },
+    { id: 'junie',      category: 'agent', name: 'Junie',       status: 'operational', aiwatchScore: 95 },
+  ]
+
+  it('Claude Code (T11 CLI) → Codex first, despite Cursor + Junie having higher Scores', () => {
+    // Score-only regression would yield [Cursor 99, Junie 95]; tier-distance must produce Codex first.
+    const result = getFallbacks('claudecode', 'agent', agentServices)
+    expect(result[0].name).toBe('Codex')                // T11 same-tier peer (dist 0)
+    expect(result[1].name).toBe('Cursor')               // T12 dist 1, Cursor 99 > Windsurf 65
+  })
+
+  it('Cursor (T12 IDE) → Windsurf first as same-tier peer, despite Junie having a higher Score', () => {
+    // Score-only regression would yield [Junie 95, Copilot 78]; tier-distance must produce Windsurf first.
+    const result = getFallbacks('cursor', 'agent', agentServices)
+    expect(result[0].name).toBe('Windsurf')             // T12 same-tier peer (dist 0)
+    // Second slot: T11 and T13 are equidistant (1) — Score breaks the tie. Junie 95 wins.
+    expect(result[1].name).toBe('Junie')
+  })
+
+  it('GitHub Copilot (T13 Plugin) → Junie first, despite Cursor having a higher Score', () => {
+    // The "Junie #1 is correct" case — but only when Junie is the same-tier peer of the affected
+    // agent. Pre-bump fixture had cursor 80 < junie 95, so Score-only happened to agree with the
+    // tier verdict; the new cursor 99 makes this assertion load-bearing.
+    const result = getFallbacks('copilot', 'agent', agentServices)
+    expect(result[0].name).toBe('Junie')                // T13 same-tier peer (dist 0)
+    expect(result[1].name).toBe('Cursor')               // T12 dist 1 beats CLI dist 2
+  })
+
+  it('Codex (T11 CLI) → Claude Code first, mirroring the claudecode case', () => {
+    // Symmetry pin for the CLI tier — the live #402 trigger was a Codex outage, so this is the
+    // exact scenario users hit. Score-only regression gives [Cursor 99, Junie 95]; tier yields
+    // Claude Code despite its Score 70.
+    const result = getFallbacks('codex', 'agent', agentServices)
+    expect(result[0].name).toBe('Claude Code')
+    expect(result[1].name).toBe('Cursor')               // T12 dist 1, Cursor 99 > Windsurf 65
+  })
+
+  it('Junie (T13 Plugin) → GitHub Copilot first, mirroring the copilot case', () => {
+    // The "new service has its first outage" scenario that motivated #402. With Junie itself
+    // affected, the only same-tier candidate is Copilot — and that must win even though Cursor's
+    // Score (99) is higher.
+    const result = getFallbacks('junie', 'agent', agentServices)
+    expect(result[0].name).toBe('GitHub Copilot')       // T13 same-tier peer
+    expect(result[1].name).toBe('Cursor')               // T12 dist 1 beats CLI dist 2
+  })
+
+  it('Plugin tier wiped out (copilot affected, junie down) → walks to IDE tier (Cursor + Windsurf)', () => {
+    // Sibling-outage realism: when the only same-tier peer is unhealthy, the recommendation must
+    // walk to the nearest healthy tier rather than skip into a far tier just because Score is high.
+    // Score-only regression here produces [Cursor 99, Codex 75]; tier-walk produces [Cursor 99, Windsurf 65]
+    // because both IDE peers are dist 1 vs CLI peers at dist 2 — Windsurf 65 still beats Codex 75
+    // on tier-distance. Second-slot assertion is what makes this load-bearing.
+    const services = agentServices.map(s =>
+      s.id === 'junie' ? { ...s, status: 'down' } : s,
+    )
+    const result = getFallbacks('copilot', 'agent', services)
+    expect(result.find(f => f.name === 'Junie')).toBeUndefined()
+    expect(result[0].name).toBe('Cursor')               // T12 dist 1, Score 99
+    expect(result[1].name).toBe('Windsurf')             // T12 dist 1, Score 65 — still beats Codex 75 (T11 dist 2)
+  })
+})
+
 describe('EXCLUDE_FALLBACK', () => {
   it('contains inference/embedding/infra services but not voice services', () => {
     expect(EXCLUDE_FALLBACK).toContain('replicate')

--- a/worker/src/fallback.ts
+++ b/worker/src/fallback.ts
@@ -61,9 +61,14 @@ export function buildFallbackText(fallbacks: Array<{ name: string; score: number
 const CATEGORY_LABEL: Record<string, string> = {
   api: 'API', app: 'AI Apps', agent: 'Coding Agent',
 }
+// Agent tier labels carry an "Agent" suffix to keep the noun visible — without it the bare
+// `CLI` / `IDE` / `Plugin` reads as untyped jargon next to category-named peers in the same
+// fallback line ("AI Apps → claude.ai" + "CLI → Claude Code" was the asymmetry that triggered
+// the rename). LLM / Voice / Infra stay bare because those abbreviations are already
+// self-identifying as service categories in the API space.
 const TIER_LABEL: Record<number, string> = {
   1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice',
-  11: 'CLI', 12: 'IDE', 13: 'Plugin',
+  11: 'CLI Agent', 12: 'IDE Agent', 13: 'Plugin Agent',
 }
 
 /**

--- a/worker/src/fallback.ts
+++ b/worker/src/fallback.ts
@@ -3,13 +3,19 @@
 // Keep in sync with src/utils/constants.js EXCLUDE_FALLBACK
 export const EXCLUDE_FALLBACK = ['replicate', 'huggingface', 'pinecone', 'stability', 'voyageai', 'modal', 'characterai', 'bedrock', 'azureopenai']
 
-// Tier-based priority for API services — major LLMs first, then secondary, then infrastructure, then voice
-// Same-tier services are sorted by Score. Higher tier = lower number = higher priority.
+// Tier-based priority — same-tier services sorted by Score, then adjacent tiers by distance.
+// API tiers (1-4) and agent tiers (11-13) use distinct number ranges so TIER_LABEL stays unambiguous
+// and the cross-category category filter in getFallbacks already prevents API ↔ agent leakage.
+// Without agent tiers (#402), all 6 agents fell through to `?? 99` and got Score-only ordering, which
+// pushed Junie (new service, shallow incident history → inflated Score) to #1 for unrelated outages.
 const API_TIER: Record<string, number> = {
   claude: 1, openai: 1, gemini: 1,
   mistral: 2, cohere: 2, groq: 2, together: 2, fireworks: 2, deepseek: 2, xai: 2, perplexity: 2,
   bedrock: 3, azureopenai: 3, openrouter: 3,
   elevenlabs: 4, assemblyai: 4, deepgram: 4,
+  claudecode: 11, codex: 11,
+  cursor: 12, windsurf: 12,
+  copilot: 13, junie: 13,
 }
 
 interface FallbackCandidate {
@@ -55,7 +61,10 @@ export function buildFallbackText(fallbacks: Array<{ name: string; score: number
 const CATEGORY_LABEL: Record<string, string> = {
   api: 'API', app: 'AI Apps', agent: 'Coding Agent',
 }
-const TIER_LABEL: Record<number, string> = { 1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice' }
+const TIER_LABEL: Record<number, string> = {
+  1: 'LLM', 2: 'LLM', 3: 'Infra', 4: 'Voice',
+  11: 'CLI', 12: 'IDE', 13: 'Plugin',
+}
 
 /**
  * Build fallback text for a group of affected services (possibly spanning multiple categories).


### PR DESCRIPTION
closes #402

## Summary
- Extends `API_TIER` with coding-agent ranges (T11 CLI, T12 IDE, T13 Plugin) so same-tier peers rank first by Score, then adjacent tiers by distance.
- Distinct number ranges (1-4 vs 11-13) keep the shared `TIER_LABEL` map unambiguous; the per-category filter inside `getFallbacks` is what keeps API and agent tier numbers from ever being compared as distances.
- Mirrored across all four sync sites: `worker/src/fallback.ts`, `src/utils/constants.js`, `api/is-down.ts`, and `TIER_LABEL` in `src/pages/Overview.jsx`.

## Why
Pre-fix every agent fell through to `API_TIER[id] ?? 99`, so `getFallbacks` ordered purely by Score. Junie (recently added → shallow incident history → inflated Score) consistently surfaced as #1 even when the affected agent was Claude Code (CLI) or Cursor (IDE) — usage patterns it doesn't substitute for.

## Test plan
- [x] `npm run test:worker` — 1170/1170 passing (29 in `fallback.test.ts`, 6 of which are new agent-tier scenarios)
- [x] `npm run test:src` — 147/147 passing
- [x] `npm run build` — clean
- [x] `wrangler deploy --dry-run` — clean
- [x] PR review (round 1: 2 Critical → fixed; round 2: 0 Critical / 0 Important — converged)
- [ ] Vercel Preview verification — check Action banner fallback recommendation for an agent in degraded state (Codex was degraded at PR-creation time; expected: Claude Code first as same-tier CLI peer, regardless of Junie's higher Score)

## Out of scope (deferred to #403)
- `?? 99` silent-fallback warn-once helper
- Cross-mirror sync test for the 3 `API_TIER` copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)