### PR TITLE
feat: merge monthly archive into Incidents 90d filter (#375)

### DIFF
--- a/src/hooks/__tests__/useMonthlyArchives.test.js
+++ b/src/hooks/__tests__/useMonthlyArchives.test.js
@@ -1,0 +1,79 @@
+// #375 — pin the fetch contract so a future API_BASE refactor can't silently
+// break the 90d archive merge. Tests target the exported `fetchArchive` helper
+// rather than the React hook itself: useEffect/state behavior is exercised
+// end-to-end by the Playwright suite (network-request assertion on 90d filter).
+//
+// Tests intentionally keep `fetch` mocked at the module level since `fetchArchive`
+// is a pure function around `fetch` + a process-wide cache. Cache is reset between
+// tests via the `_resetArchiveCacheForTests` helper to avoid order-dependent flakes.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchArchive, _resetArchiveCacheForTests } from '../useMonthlyArchives'
+
+describe('fetchArchive (#375)', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    _resetArchiveCacheForTests()
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('returns parsed JSON on 200 OK', async () => {
+    const payload = { period: '2026-04', services: { mistral: { incidentList: [] } } }
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => payload })
+    const result = await fetchArchive('2026-04-success')
+    expect(result).toEqual(payload)
+  })
+
+  it('treats 404 as "archive does not exist" — returns null without throwing', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+    const result = await fetchArchive('2025-01-not-archived')
+    expect(result).toBeNull()
+  })
+
+  it('logs and resolves to null on transient HTTP error (5xx)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 })
+    const result = await fetchArchive('2026-04-502')
+    expect(result).toBeNull()
+    // Operator-visible signal so a silent failure ("90d merge stopped working")
+    // still leaves a console breadcrumb. UI itself degrades to live-only.
+    expect(warn).toHaveBeenCalled()
+    expect(warn.mock.calls[0][0]).toContain('2026-04-502')
+  })
+
+  it('logs and resolves to null on network error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('connection refused'))
+    const result = await fetchArchive('2026-04-err')
+    expect(result).toBeNull()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('returns the same promise on repeat calls within the same session (cache hit)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ period: '2026-04-cache' }) })
+    globalThis.fetch = fetchSpy
+    const a = fetchArchive('2026-04-cache-key')
+    const b = fetchArchive('2026-04-cache-key')
+    expect(a).toBe(b)
+    await a
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('purges the cache on rejection so the next call retries (does not pin the failure)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchSpy = vi.fn()
+      .mockRejectedValueOnce(new Error('first call fails'))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ period: '2026-04-retry' }) })
+    globalThis.fetch = fetchSpy
+    const first = await fetchArchive('2026-04-retry-key')
+    expect(first).toBeNull()
+    const second = await fetchArchive('2026-04-retry-key')
+    expect(second).toEqual({ period: '2026-04-retry' })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/hooks/useMonthlyArchives.js
+++ b/src/hooks/useMonthlyArchives.js
@@ -1,0 +1,80 @@
+// Fetches /api/report?month=YYYY-MM for the months covered by an extended period filter (#375).
+// Process-wide cache: archive responses are *almost* immutable — the operator can rebuild a
+// month via POST /api/admin/rebuild-archive (CLAUDE.md), but that's a rare path and a full
+// page reload clears this cache. Caching the promise across re-renders avoids re-fetching
+// when the user toggles between 7d/30d/90d. Cache key is the YYYY-MM string.
+
+import { useEffect, useState } from 'react'
+
+// Derive the API origin from VITE_API_URL (which points at /api/status). Strip the
+// trailing path so we can build sibling endpoints like /api/report. Mirrors usePolling.
+const API_BASE = (() => {
+  const raw = import.meta.env.VITE_API_URL || 'https://aiwatch-worker.p2c2kbf.workers.dev/api/status'
+  return raw.replace(/\/api\/status\/?(?:cached\/?)?$/, '')
+})()
+
+const promiseCache = new Map() // 'YYYY-MM' → Promise<archive | null>
+
+// Visible for tests in src/hooks/__tests__/useMonthlyArchives.test.js — React-renderHook
+// would require @testing-library/react which isn't in dev deps; exporting the fetcher
+// keeps the load-bearing fetch contract under test without that dep.
+export function _resetArchiveCacheForTests() { promiseCache.clear() }
+export function fetchArchive(month) {
+  const cached = promiseCache.get(month)
+  if (cached) return cached
+  const promise = fetch(`${API_BASE}/api/report?month=${month}`)
+    .then(r => {
+      // 404 is a real signal — that month was never archived (deploy started later).
+      // Treat it as "no data" rather than throwing, so other months still resolve.
+      if (r.status === 404) return null
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    })
+    .catch(err => {
+      // Surface in operator console without breaking the UI — 90d view degrades to
+      // live-only data, which matches pre-#375 behavior. Don't cache the rejection
+      // so a retry on the next selection actually re-attempts.
+      console.warn(`[useMonthlyArchives] ${month}: ${err.message}`)
+      promiseCache.delete(month)
+      return null
+    })
+  promiseCache.set(month, promise)
+  return promise
+}
+
+/**
+ * @param {string[]} months  e.g. ['2026-02', '2026-03', '2026-04']
+ * @returns {{archives: Record<string, object>, loading: boolean}}
+ */
+export function useMonthlyArchives(months) {
+  const [archives, setArchives] = useState({})
+  const [loading, setLoading] = useState(false)
+  // Identity-stable key for the dependency — months array is recomputed on every render
+  // by the consumer's useMemo, so a length+content fingerprint avoids spurious effect runs.
+  const key = months.join(',')
+
+  useEffect(() => {
+    if (!months.length) {
+      setArchives({})
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    Promise.all(months.map(m => fetchArchive(m).then(a => [m, a])))
+      .then(pairs => {
+        if (cancelled) return
+        const obj = {}
+        for (const [m, a] of pairs) {
+          if (a) obj[m] = a
+        }
+        setArchives(obj)
+        setLoading(false)
+      })
+    return () => { cancelled = true }
+  // months.join already encodes the array; React doesn't need to inspect months itself.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  return { archives, loading }
+}

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -6,9 +6,11 @@
 import { useState, useMemo } from 'react'
 import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
+import { useMonthlyArchives } from '../hooks/useMonthlyArchives'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
 import { getResolvedTime, getContextualTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
+import { archiveMonthsForPeriod, mergeArchiveIntoMap, archiveSupplementForService } from '../utils/archiveMerge'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -329,16 +331,24 @@ export default function Incidents() {
   const [selectedId,    setSelectedId]    = useState(null)
   const [expandedGroups, setExpandedGroups] = useState(() => new Set())
 
-  // Flatten all incidents from all services (stable ref while services unchanged)
-  // Normalize Worker statuses (investigating/identified) → 'ongoing' for display
+  // Archive merge — see src/utils/archiveMerge.js + src/hooks/useMonthlyArchives.js.
+  // Live /api/status only carries the upstream's last-N incidents (~5d for high-frequency
+  // services like Mistral/Together), so the 90d filter without archive supplement
+  // overpromises by 4-18×. Months: prev 1-3, current month excluded (covered by live).
+  const archiveMonths = useMemo(() => archiveMonthsForPeriod(period), [period])
+  const { archives } = useMonthlyArchives(archiveMonths)
+
+  // Flatten all incidents from all services. Normalize Worker statuses (investigating /
+  // identified) → 'ongoing' for display. Live wins on ID collision with archive — the live
+  // entry has the up-to-date timeline; archive is a frozen snapshot.
   // Deduplicate only when no service filter — services sharing a status page (e.g., Claude API +
   // claude.ai + Claude Code) return same incident IDs. With a service filter active, show all
   // incidents belonging to that service so none get hidden by earlier-processed services.
   const allIncidents = useMemo(
     () => {
       if (serviceFilter !== 'all') {
-        // With service filter: show all incidents for that service
-        return services.flatMap((svc) =>
+        // With service filter: show all incidents for that service.
+        const live = services.flatMap((svc) =>
           (svc.incidents ?? []).flatMap((inc) => [{
             ...inc,
             id: `${svc.id}:${inc.id}`,
@@ -349,9 +359,13 @@ export default function Incidents() {
             serviceId: svc.id,
           }])
         )
+        if (archiveMonths.length === 0) return live
+        const liveCompositeIds = new Set(live.map((i) => i.id))
+        const supplement = archiveSupplementForService(liveCompositeIds, serviceFilter, archives, services)
+        return live.concat(supplement)
       }
-      // Without filter: dedup by incidentId, collect all affected service names
-      const incMap = new Map() // incidentId → merged incident
+      // Without filter: dedup by raw incidentId, collect all affected service names.
+      const incMap = new Map() // raw incidentId → merged incident (composite id assigned at render time below)
       for (const svc of services) {
         for (const inc of svc.incidents ?? []) {
           const existing = incMap.get(inc.id)
@@ -360,6 +374,7 @@ export default function Incidents() {
           } else {
             incMap.set(inc.id, {
               ...inc,
+              // Keep raw id as the map key, but assign the composite id used downstream.
               id: `${svc.id}:${inc.id}`,
               status: inc.status === 'resolved' ? 'resolved'
                 : inc.status === 'monitoring' ? 'monitoring'
@@ -371,9 +386,23 @@ export default function Incidents() {
           }
         }
       }
+      // Archive supplement uses the same raw-id keying so a single incident that touched
+      // multiple services in the archive accumulates into one row, not duplicates.
+      // We rebuild the map keyed by raw id so mergeArchiveIntoMap can find collisions —
+      // the live phase above wrote composite ids into entry.id but kept the raw id as the
+      // Map key. mergeArchiveIntoMap reads/writes via the raw key only.
+      if (archiveMonths.length > 0) {
+        mergeArchiveIntoMap(incMap, archives, services)
+        // Re-assign composite id for archive-only entries — they're added with the raw id
+        // by mergeArchiveIntoMap so the live convention (`${serviceId}:${rawId}`) is the
+        // job of the consumer that mixes raw + composite worlds, i.e. here.
+        for (const [rawId, entry] of incMap) {
+          if (entry.fromArchive) entry.id = `${entry.serviceId}:${rawId}`
+        }
+      }
       return [...incMap.values()]
     },
-    [services, serviceFilter]
+    [services, serviceFilter, archives, archiveMonths]
   )
 
   // Apply service, status, and period filters; sort newest first

--- a/src/utils/__tests__/archiveMerge.test.js
+++ b/src/utils/__tests__/archiveMerge.test.js
@@ -1,0 +1,248 @@
+// #375 — archive supplement for the 90d Incidents filter.
+// These tests pin the live-wins-on-collision contract and the period-gating —
+// 7d/30d must not trigger archive fetches (their windows are smaller than the
+// upstream cap of every service we care about).
+
+import { describe, it, expect } from 'vitest'
+import {
+  archiveMonthsForPeriod,
+  archiveIncidentToLive,
+  mergeArchiveIntoMap,
+  archiveSupplementForService,
+  MAX_ARCHIVE_MONTHS,
+} from '../archiveMerge'
+
+describe('archiveMonthsForPeriod', () => {
+  it('returns empty for short windows that live data already covers', () => {
+    const now = new Date('2026-05-09T12:00:00Z')
+    expect(archiveMonthsForPeriod(7, now)).toEqual([])
+    expect(archiveMonthsForPeriod(30, now)).toEqual([])
+  })
+
+  it('returns prev 3 months for 90d on 2026-05-09', () => {
+    const now = new Date('2026-05-09T12:00:00Z')
+    expect(archiveMonthsForPeriod(90, now)).toEqual(['2026-02', '2026-03', '2026-04'])
+  })
+
+  it('crosses year boundary correctly (90d on 2026-02-15 → Nov/Dec/Jan)', () => {
+    const now = new Date('2026-02-15T12:00:00Z')
+    expect(archiveMonthsForPeriod(90, now)).toEqual(['2025-11', '2025-12', '2026-01'])
+  })
+
+  it('excludes the current month from the fetch list (live covers it)', () => {
+    const now = new Date('2026-05-09T12:00:00Z')
+    const months = archiveMonthsForPeriod(90, now)
+    expect(months).not.toContain('2026-05')
+  })
+
+  it(`caps at MAX_ARCHIVE_MONTHS (${MAX_ARCHIVE_MONTHS}) for ultra-long windows`, () => {
+    const now = new Date('2026-12-15T12:00:00Z')
+    // 365d would otherwise span 12 months — cap protects us from accidental config drift
+    const months = archiveMonthsForPeriod(365, now)
+    expect(months.length).toBeLessThanOrEqual(MAX_ARCHIVE_MONTHS)
+  })
+})
+
+describe('archiveIncidentToLive', () => {
+  const archIncident = {
+    id: '01ABC',
+    title: 'Mistral La Plateforme degraded',
+    startedAt: '2026-04-12T10:00:00Z',
+    resolvedAt: '2026-04-12T11:30:00Z',
+    durationMin: 90,
+    finalStatus: 'resolved',
+  }
+  const service = { id: 'mistral', name: 'Mistral API' }
+
+  it('preserves identity fields and uses the archive\'s finalStatus', () => {
+    const live = archiveIncidentToLive(archIncident, service)
+    expect(live.id).toBe('01ABC')
+    expect(live.title).toBe('Mistral La Plateforme degraded')
+    expect(live.status).toBe('resolved')
+    expect(live.startedAt).toBe('2026-04-12T10:00:00Z')
+    expect(live.resolvedAt).toBe('2026-04-12T11:30:00Z')
+    expect(live.serviceId).toBe('mistral')
+    expect(live.serviceName).toBe('Mistral API')
+  })
+
+  it('attaches fromArchive: true so the consumer can disable timeline-dependent UI', () => {
+    const live = archiveIncidentToLive(archIncident, service)
+    expect(live.fromArchive).toBe(true)
+    expect(live.timeline).toEqual([])
+  })
+
+  it('handles archive entries that never resolved (resolvedAt === null)', () => {
+    const live = archiveIncidentToLive({ ...archIncident, resolvedAt: null, finalStatus: 'monitoring' }, service)
+    expect(live.resolvedAt).toBeNull()
+    expect(live.status).toBe('monitoring')
+  })
+})
+
+describe('mergeArchiveIntoMap (no service filter — raw-id dedup mode)', () => {
+  const services = [
+    { id: 'claude', name: 'Claude API' },
+    { id: 'claudeai', name: 'claude.ai' },
+    { id: 'mistral', name: 'Mistral API' },
+  ]
+
+  function liveMapWith(...entries) {
+    return new Map(entries.map((e) => [e.id, { ...e, affectedNames: [...(e.affectedNames || [e.serviceName])] }]))
+  }
+
+  it('appends archive-only incidents to the map keyed by raw id', () => {
+    const liveMap = liveMapWith()
+    const archives = {
+      '2026-04': {
+        services: {
+          mistral: {
+            incidentList: [{ id: 'arch-1', title: 'old outage', startedAt: '2026-04-01T00:00:00Z', resolvedAt: '2026-04-01T01:00:00Z', durationMin: 60, finalStatus: 'resolved' }],
+          },
+        },
+      },
+    }
+    mergeArchiveIntoMap(liveMap, archives, services)
+    const entry = liveMap.get('arch-1')
+    expect(entry).toBeDefined()
+    expect(entry.title).toBe('old outage')
+    expect(entry.fromArchive).toBe(true)
+    expect(entry.serviceId).toBe('mistral')
+    expect(entry.affectedNames).toEqual(['Mistral API'])
+  })
+
+  it('does not overwrite live entries — affectedNames accumulates instead', () => {
+    // The live entry is a placeholder for "what Incidents.jsx already produced".
+    const liveMap = new Map([
+      ['shared-1', {
+        id: 'claude:shared-1', // composite id as Incidents.jsx writes it
+        title: 'live title',
+        status: 'ongoing',
+        startedAt: '2026-04-30T00:00:00Z',
+        timeline: [{ stage: 'investigating', at: '2026-04-30T00:00:00Z' }],
+        serviceId: 'claude',
+        serviceName: 'Claude API',
+        affectedNames: ['Claude API'],
+        fromArchive: undefined, // live
+      }],
+    ])
+    const archives = {
+      '2026-04': {
+        services: {
+          claudeai: {
+            incidentList: [{ id: 'shared-1', title: 'archive title (stale)', startedAt: '2026-04-30T00:00:00Z', resolvedAt: null, durationMin: 0, finalStatus: 'monitoring' }],
+          },
+        },
+      },
+    }
+    mergeArchiveIntoMap(liveMap, archives, services)
+    const entry = liveMap.get('shared-1')
+    // Live wins on title + status + timeline
+    expect(entry.title).toBe('live title')
+    expect(entry.status).toBe('ongoing')
+    expect(entry.timeline).toHaveLength(1)
+    // But the archive's service is added to affectedNames
+    expect(entry.affectedNames).toEqual(['Claude API', 'claude.ai'])
+  })
+
+  it('skips services that have been renamed/removed (archive serviceId not in live list)', () => {
+    const liveMap = new Map()
+    const archives = {
+      '2026-04': {
+        services: {
+          'unknown-service': {
+            incidentList: [{ id: 'orphan-1', title: 'orphan', startedAt: '2026-04-01T00:00:00Z', resolvedAt: null, durationMin: 0, finalStatus: 'resolved' }],
+          },
+        },
+      },
+    }
+    mergeArchiveIntoMap(liveMap, archives, services)
+    expect(liveMap.size).toBe(0)
+  })
+
+  it('skips estimate-only services that have no incidentList field', () => {
+    // bedrock / azureopenai / pinecone — archive entry exists but incidentList is absent.
+    const liveMap = new Map()
+    const archives = {
+      '2026-04': {
+        services: {
+          mistral: { /* no incidentList */ uptime: 99.5, score: 88 },
+          bedrock: { uptime: null, score: 92 }, // estimate-only — explicitly no incidents
+        },
+      },
+    }
+    mergeArchiveIntoMap(liveMap, archives, services)
+    expect(liveMap.size).toBe(0)
+  })
+
+  it('handles empty incidentList arrays without erroring', () => {
+    const liveMap = new Map()
+    const archives = { '2026-04': { services: { mistral: { incidentList: [] } } } }
+    mergeArchiveIntoMap(liveMap, archives, services)
+    expect(liveMap.size).toBe(0)
+  })
+
+  it('handles missing archives gracefully (e.g. one of three months 404\'d)', () => {
+    const liveMap = new Map()
+    const archives = {
+      '2026-02': null, // 404 from useMonthlyArchives surfaces as null
+      '2026-03': { services: { mistral: { incidentList: [{ id: 'arch-3', title: 'march', startedAt: '2026-03-15T00:00:00Z', resolvedAt: null, durationMin: 0, finalStatus: 'resolved' }] } } },
+      '2026-04': undefined,
+    }
+    expect(() => mergeArchiveIntoMap(liveMap, archives, services)).not.toThrow()
+    expect(liveMap.size).toBe(1)
+    expect(liveMap.get('arch-3')).toBeDefined()
+  })
+})
+
+describe('archiveSupplementForService (service filter mode)', () => {
+  const services = [
+    { id: 'mistral', name: 'Mistral API' },
+    { id: 'together', name: 'Together AI' },
+  ]
+
+  it('returns only the filtered service, with composite ids assigned', () => {
+    const liveCompositeIds = new Set(['mistral:live-only-1'])
+    const archives = {
+      '2026-04': {
+        services: {
+          mistral: {
+            incidentList: [
+              { id: 'arch-m-1', title: 'mistral old', startedAt: '2026-04-01T00:00:00Z', resolvedAt: '2026-04-01T01:00:00Z', durationMin: 60, finalStatus: 'resolved' },
+            ],
+          },
+          together: {
+            incidentList: [
+              { id: 'arch-t-1', title: 'together old', startedAt: '2026-04-02T00:00:00Z', resolvedAt: '2026-04-02T01:00:00Z', durationMin: 60, finalStatus: 'resolved' },
+            ],
+          },
+        },
+      },
+    }
+    const result = archiveSupplementForService(liveCompositeIds, 'mistral', archives, services)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('mistral:arch-m-1')
+    expect(result[0].title).toBe('mistral old')
+    // The Set must have been updated so a subsequent month doesn't double-add the same id
+    expect(liveCompositeIds.has('mistral:arch-m-1')).toBe(true)
+  })
+
+  it('skips archive entries whose composite id matches a live one', () => {
+    const liveCompositeIds = new Set(['mistral:dup-1'])
+    const archives = {
+      '2026-04': { services: { mistral: { incidentList: [{ id: 'dup-1', title: 'dup', startedAt: '2026-04-01T00:00:00Z', resolvedAt: null, durationMin: 0, finalStatus: 'resolved' }] } } },
+    }
+    const result = archiveSupplementForService(liveCompositeIds, 'mistral', archives, services)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns empty when filtered service has no archive entry', () => {
+    const liveCompositeIds = new Set()
+    const archives = { '2026-04': { services: { together: { incidentList: [{ id: 't', title: 't', startedAt: '2026-04-01T00:00:00Z', resolvedAt: null, durationMin: 0, finalStatus: 'resolved' }] } } } }
+    expect(archiveSupplementForService(liveCompositeIds, 'mistral', archives, services)).toEqual([])
+  })
+
+  it('does not throw when an archive month is null (404 path)', () => {
+    const liveCompositeIds = new Set()
+    const archives = { '2026-04': null }
+    expect(() => archiveSupplementForService(liveCompositeIds, 'mistral', archives, services)).not.toThrow()
+  })
+})

--- a/src/utils/archiveMerge.js
+++ b/src/utils/archiveMerge.js
@@ -1,0 +1,135 @@
+// Merge live /api/status incidents with monthly archive incidentList for the 90d filter.
+// Pre-#375 the 90d filter only saw live data, which the upstream status pages cap at
+// last-N entries — high-frequency services (Mistral, Together) showed only 3-5 days
+// instead of the promised 90. The archive (#375) preserves per-incident detail past
+// that window; this module is the client-side consumer.
+
+const DAY_MS = 86_400_000
+
+/**
+ * Months to fetch for a given period filter, current month excluded.
+ *
+ * UTC math is load-bearing here: archive:monthly:{YYYY-MM} keys are written by the
+ * Worker cron at UTC 00:00 on the 1st of each month, and the Playwright test asserts
+ * via `new Date().toISOString().slice(0,7)` which is also UTC. Using local-TZ accessors
+ * caused a 9-hour mismatch on UTC+9 runners around month-edge: the page would request
+ * an archive that the backend hadn't yet written (404, silently degrades to live).
+ *
+ * "Current month excluded" caveat: live data covers the current month for low-frequency
+ * services in full, but for high-frequency services (Mistral/Together) upstream still
+ * only returns ~5d of live entries. This merge shrinks the pre-#375 gap from ~85d to
+ * a few days at most — not a full fill. Acceptable trade-off since the alternative
+ * (early-rebuild current-month archive) collides with the daily-summary accumulator.
+ *
+ * MAX_ARCHIVE_MONTHS cap is defense-in-depth: a future 180d/365d preset shouldn't
+ * spawn 12 parallel /api/report fetches without a deliberate review.
+ *
+ * @param {number} days  period in days (7 / 30 / 90 today)
+ * @param {Date}   [now] inject for tests
+ * @returns {string[]}   ['2026-02', '2026-03', '2026-04']
+ */
+export const MAX_ARCHIVE_MONTHS = 6
+
+export function archiveMonthsForPeriod(days, now = new Date()) {
+  if (!days || days < 90) return []
+  const cutoff = new Date(now.getTime() - days * DAY_MS)
+  const months = []
+  const cursor = new Date(Date.UTC(cutoff.getUTCFullYear(), cutoff.getUTCMonth(), 1))
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)) // exclusive
+  while (cursor < end && months.length < MAX_ARCHIVE_MONTHS) {
+    months.push(`${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, '0')}`)
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1)
+  }
+  return months
+}
+
+/**
+ * Shape an archive incidentList entry into the live-incident shape Incidents.jsx
+ * already iterates. timeline:[] is intentional — archive only carries summary
+ * fields; the DetailPanel must handle empty timelines gracefully (already does).
+ */
+export function archiveIncidentToLive(archIncident, service) {
+  return {
+    id: archIncident.id, // raw upstream id; caller composes the `${serviceId}:${id}` view-id
+    title: archIncident.title,
+    // Archive only persists final state ('resolved' | 'monitoring'). The Incidents page
+    // status-normalize step already handles both — no extra mapping needed here.
+    status: archIncident.finalStatus,
+    startedAt: archIncident.startedAt,
+    resolvedAt: archIncident.resolvedAt ?? null,
+    timeline: [],
+    serviceName: service.name,
+    serviceId: service.id,
+    fromArchive: true,
+  }
+}
+
+/**
+ * Add archive incidents into the live-derived incident map. Live wins on ID collision —
+ * the live entry has the up-to-date timeline and status; the archive snapshot is older.
+ * Returns the same map (mutated for caller-side reuse).
+ *
+ * Both `liveMap` and the resulting affectedNames accumulation use the **raw** incident ID
+ * (not the composite serviceId:id) — that's how Incidents.jsx already deduplicates a
+ * single incident that affects multiple services (e.g. Claude API + claude.ai sharing
+ * one Anthropic status entry). Without that key shape, an archive entry that appeared
+ * across two services would render as two cards.
+ */
+export function mergeArchiveIntoMap(liveMap, archives, services) {
+  for (const month of Object.keys(archives)) {
+    const archive = archives[month]
+    const archServices = archive?.services
+    if (!archServices) continue
+    for (const [serviceId, sdata] of Object.entries(archServices)) {
+      const incidentList = sdata?.incidentList
+      if (!Array.isArray(incidentList) || incidentList.length === 0) continue
+      const service = services.find(s => s.id === serviceId)
+      if (!service) continue // service renamed/removed since archive was written
+      for (const arch of incidentList) {
+        const existing = liveMap.get(arch.id)
+        if (existing) {
+          if (!existing.affectedNames.includes(service.name)) existing.affectedNames.push(service.name)
+          continue
+        }
+        const live = archiveIncidentToLive(arch, service)
+        liveMap.set(arch.id, { ...live, affectedNames: [service.name] })
+      }
+    }
+  }
+  return liveMap
+}
+
+/**
+ * Service-filtered variant: returns a flat array of archive supplements for a single
+ * service that aren't already in the live set. Caller appends these to its live array.
+ * Skips the multi-service affectedNames accumulation since the filter view shows only
+ * one service at a time.
+ *
+ * @param {Set<string>} liveCompositeIds  set of `${serviceId}:${incidentId}` already shown
+ * @param {string} serviceFilter          service id user selected
+ * @param {Record<string, object>} archives
+ * @param {Array<{id, name}>} services
+ * @returns {Array<object>}  archive incidents in live shape, with composite id assigned
+ */
+export function archiveSupplementForService(liveCompositeIds, serviceFilter, archives, services) {
+  const out = []
+  for (const month of Object.keys(archives)) {
+    const archive = archives[month]
+    const archServices = archive?.services
+    if (!archServices) continue
+    const sdata = archServices[serviceFilter]
+    if (!sdata) continue
+    const incidentList = sdata.incidentList
+    if (!Array.isArray(incidentList) || incidentList.length === 0) continue
+    const service = services.find(s => s.id === serviceFilter)
+    if (!service) continue
+    for (const arch of incidentList) {
+      const cid = `${serviceFilter}:${arch.id}`
+      if (liveCompositeIds.has(cid)) continue
+      liveCompositeIds.add(cid)
+      const live = archiveIncidentToLive(arch, service)
+      out.push({ ...live, id: cid, affectedNames: [service.name] })
+    }
+  }
+  return out
+}

--- a/tests/incidents-archive-merge.spec.js
+++ b/tests/incidents-archive-merge.spec.js
@@ -1,0 +1,74 @@
+// #375 — pin the network contract for the 90d archive merge.
+// The unit suite covers merge/dedup logic; this E2E verifies the live wiring:
+// the Incidents page actually issues the /api/report fetch when 90d is selected,
+// and does NOT issue it for 7d/30d (those windows are already covered by live data).
+
+import { test, expect } from '@playwright/test'
+import { waitForDataLoad, navigateVia } from './helpers.js'
+
+const REPORT_PATH_RE = /\/api\/report\?month=\d{4}-\d{2}/
+
+test.describe('Incidents — 90d archive merge (#375)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await waitForDataLoad(page)
+    await navigateVia(page, 'Incidents')
+    await page.locator('main select').first().waitFor({ state: 'visible', timeout: 5000 })
+  })
+
+  test('selecting 90d period triggers /api/report fetch for archive months', async ({ page }) => {
+    // Track ALL /api/report URLs the page hits during the test. We capture both 'request'
+    // (asserts the fetch fires) and don't care about the response body — the unit suite
+    // already covers merge logic. Network-contract pin only.
+    const reportUrls = []
+    page.on('request', (req) => {
+      const url = req.url()
+      if (REPORT_PATH_RE.test(url)) reportUrls.push(url)
+    })
+
+    const periodSelect = page.locator('main select').nth(2)
+    await periodSelect.selectOption('90')
+
+    // useMonthlyArchives fires the fetch via useEffect — give it a beat to settle.
+    // 1500ms is conservative: archives are cached process-wide, but cold start needs
+    // Promise.all over 3 fetches. CI on slower runners has been the timing concern.
+    await page.waitForTimeout(1500)
+
+    expect(reportUrls.length).toBeGreaterThan(0)
+    // Each URL should specify a YYYY-MM that's NOT the current month (live covers it)
+    const currentMonth = new Date().toISOString().slice(0, 7)
+    for (const url of reportUrls) {
+      const match = url.match(/month=(\d{4}-\d{2})/)
+      expect(match).not.toBeNull()
+      expect(match[1]).not.toBe(currentMonth)
+    }
+  })
+
+  test('7d period does NOT trigger /api/report fetch', async ({ page }) => {
+    const reportUrls = []
+    page.on('request', (req) => {
+      if (REPORT_PATH_RE.test(req.url())) reportUrls.push(req.url())
+    })
+
+    const periodSelect = page.locator('main select').nth(2)
+    // 7d is already the default per Incidents.jsx initial state, but selecting explicitly
+    // exercises the filter-change path the way a user would.
+    await periodSelect.selectOption('7')
+    await page.waitForTimeout(800)
+
+    expect(reportUrls).toHaveLength(0)
+  })
+
+  test('30d period does NOT trigger /api/report fetch (live data covers 30d)', async ({ page }) => {
+    const reportUrls = []
+    page.on('request', (req) => {
+      if (REPORT_PATH_RE.test(req.url())) reportUrls.push(req.url())
+    })
+
+    const periodSelect = page.locator('main select').nth(2)
+    await periodSelect.selectOption('30')
+    await page.waitForTimeout(800)
+
+    expect(reportUrls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
closes #375

## Summary
- Folds the permanent monthly archive (`/api/report?month=YYYY-MM`) into the Incidents page 90d filter, so high-frequency services like Mistral / Together — whose upstream status pages cap at ~5 days of live data — finally show the full advertised window.
- Two filter modes preserved: no-filter dedups by raw incident id with affectedNames accumulation; service-filter dedups by composite id. Live wins on collision (timeline / status from live).
- 7d / 30d filters do **not** trigger archive fetches — pinned by Playwright network-contract test.

## Why
Survey on 2026-05-04 found 5 services under 30d of live data, 4 under 60d, 5 borderline (60-90d). The 90d filter was overpromising by 4-18× for the worst offenders. Backend archive (`incidentList` field on `archive:monthly:{YYYY-MM}`) already shipped via #375 backend work — this PR is the client consumer.

## Architecture
- \`src/utils/archiveMerge.js\` — pure helpers (period-gated month list, live-wins merge, service-filter supplement). UTC math is load-bearing: backend writes archive at UTC 00:00 of the 1st, Playwright asserts via \`toISOString().slice(0,7)\`. Round-1 review caught a local-TZ accessor that would have 9-hour drift on UTC+9 runners around month-edge.
- \`src/hooks/useMonthlyArchives.js\` — useEffect fetcher, process-wide promise cache (acknowledges \`/api/admin/rebuild-archive\` as a rare staleness path).
- \`src/pages/Incidents.jsx\` — wires the new hook into the existing \`allIncidents\` pipeline with both filter modes preserved.

## Test plan
- [x] 24 new unit tests (\`archiveMerge\` 18 + \`useMonthlyArchives\` 6) + 3 Playwright tests
- [x] \`npm run test:src\` — 171/171 passing
- [x] \`npm run test:worker\` — 1170/1170 passing
- [x] \`npm test --project=desktop\` — 101/101 passing (full regression)
- [x] \`npm run build\` — clean
- [x] PR review (round 1: 1 Important UTC mismatch → fixed; round 2: 0 findings, converged)
- [ ] Vercel Preview verification — select 90d filter, observe \`/api/report\` network calls in DevTools (Mistral/Together rows still won't materially grow until the May 2026 archive lands on 6/1; April's archive accumulator was 0 entries at backend-feature deploy time, so April data is permanently unrecoverable per discussion)

## Out of scope
- Backend was already shipped (worker/src/monthly-archive.ts; #375 backend portion)
- April 2026 archive recovery — confirmed unrecoverable (incidents:monthly:2026-04 had 0 detail entries at the time of inspection)
- "After 1-2 month deploy, Mistral/Together 90d filter shows >5d worth of data" — time-dependent acceptance criterion; verified naturally as 5월 archive lands 6/1

## Deferred to other issues
- \`?? 99\` silent-fallback hardening across API_TIER lookup sites — #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)