### PR TITLE
fix: align Overview Recent Incidents date with sort axis (#406)

### DIFF
--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -8,7 +8,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
-import { getResolvedTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
+import { getContextualTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -38,29 +38,8 @@ const TABLE_COLS = ['col.time', 'col.title', 'col.service', 'col.duration', 'col
 
 // ── Helpers ──────────────────────────────────────────────────
 // Sort/grouping helpers live in src/utils/incidentSort.js — shared with
-// Overview "Recent Incidents" and ServiceDetails.
-
-/** Last element of array (ES5-safe) */
-function last(arr) { return arr && arr.length > 0 ? arr[arr.length - 1] : undefined }
-
-/** Get contextual timestamp label and date based on status */
-function getContextualTime(inc, t) {
-  if (inc.status === 'resolved') {
-    const resolved = getResolvedTime(inc)
-    if (resolved) return { label: t('incidents.time.resolved'), date: resolved }
-  }
-  if (inc.status === 'monitoring') {
-    const lt = last(inc.timeline)
-    if (lt?.at) return { label: t('incidents.time.updated'), date: lt.at }
-  }
-  if (inc.status === 'ongoing') {
-    const lt = last(inc.timeline)
-    if (lt?.at && lt.at !== inc.startedAt) {
-      return { label: t('incidents.time.updated'), date: lt.at }
-    }
-  }
-  return { label: t('incidents.time.started'), date: inc.startedAt }
-}
+// Overview "Recent Incidents" and ServiceDetails. getContextualTime moved
+// there in #406 so the Overview list can match its sort axis on display.
 
 // ── Sub-components ───────────────────────────────────────────
 

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -10,7 +10,7 @@ import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, EXCLUDE_FALLBACK, API_TIER, getFallbacks } from '../utils/constants'
 import { buildCalendarFromIncidents } from '../utils/calendar'
-import { compareIncidents } from '../utils/incidentSort'
+import { compareIncidents, getContextualTime } from '../utils/incidentSort'
 import { formatTime, formatDate } from '../utils/time'
 import SkeletonUI from '../components/SkeletonUI'
 import StatusPill from '../components/StatusPill'
@@ -222,6 +222,12 @@ function IncidentItem({ incident, lang, t }) {
   const [expanded, setExpanded] = useState(false)
   const barCls = INC_BAR_CLASS[incident.status] ?? INC_BAR_CLASS.resolved
   const hasTimeline = (incident.timeline ?? []).length > 0
+  // Match the date column to the sort axis (#406): compareIncidents → getLatestActivity
+  // sorts by resolvedAt for resolved incidents, last timeline update for active ones.
+  // Showing startedAt instead produced visible inversions when two incidents straddled
+  // a calendar day boundary. Tooltip exposes the full label so users can tell whether
+  // the date is start / update / resolution without expanding the row.
+  const ctx = getContextualTime(incident, t)
   return (
     <div style={{ marginBottom: '8px' }}>
       <div
@@ -229,8 +235,12 @@ function IncidentItem({ incident, lang, t }) {
         style={{ padding: '2px 4px', margin: '-2px -4px' }}
         onClick={hasTimeline ? () => setExpanded((v) => !v) : undefined}
       >
-        <div className="mono text-[10px] text-[var(--text2)] whitespace-nowrap shrink-0" style={{ width: '52px', paddingTop: '1px' }}>
-          {formatDate(incident.startedAt, lang).split(' ').slice(0, 2).join(' ')}
+        <div
+          className="mono text-[10px] text-[var(--text2)] whitespace-nowrap shrink-0"
+          style={{ width: '52px', paddingTop: '1px' }}
+          title={`${ctx.label} ${formatDate(ctx.date, lang)}`}
+        >
+          {formatDate(ctx.date, lang).split(' ').slice(0, 2).join(' ')}
         </div>
         <div className={`w-[2px] rounded self-stretch ${barCls}`} style={{ minHeight: '32px' }} />
         <div className="flex-1 min-w-0">

--- a/src/utils/__tests__/incidentSort.test.js
+++ b/src/utils/__tests__/incidentSort.test.js
@@ -3,6 +3,7 @@ import {
   STATUS_PRIORITY,
   STATUS_ORDER,
   getResolvedTime,
+  getContextualTime,
   getLatestActivity,
   compareIncidents,
   compareGroupedRows,
@@ -487,5 +488,97 @@ describe('sumGroupDuration', () => {
     expect(result.totalMs).toBe(5 * 60_000)
     expect(result.hasOngoing).toBe(true)
     expect(result.resolvedCount).toBe(1)
+  })
+})
+
+// #406 — pin the contract that the timestamp this returns is the same axis
+// compareIncidents sorts by, so Overview's date column visually agrees with
+// list order. Identity-string `t` keeps fixtures terse.
+describe('getContextualTime', () => {
+  const t = (key) => key
+
+  it('resolved → uses resolvedAt with "resolved" label', () => {
+    const inc = { status: 'resolved', startedAt: '2026-04-28T00:00:00Z', resolvedAt: '2026-04-28T03:00:00Z' }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.resolved', date: '2026-04-28T03:00:00Z' })
+  })
+
+  it('resolved without resolvedAt → falls back to last `resolved` timeline entry', () => {
+    const inc = { status: 'resolved', startedAt: '2026-04-28T00:00:00Z', timeline: [
+      { stage: 'investigating', at: '2026-04-28T00:00:00Z' },
+      { stage: 'resolved', at: '2026-04-28T02:30:00Z' },
+    ] }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.resolved', date: '2026-04-28T02:30:00Z' })
+  })
+
+  it('resolved with neither resolvedAt nor a resolved timeline entry → falls through to startedAt', () => {
+    // Defensive — malformed payload. Better to label as start than to crash or
+    // render "Resolved (no time)".
+    const inc = { status: 'resolved', startedAt: '2026-04-28T00:00:00Z' }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.started', date: '2026-04-28T00:00:00Z' })
+  })
+
+  it('monitoring → last timeline update with "updated" label', () => {
+    const inc = { status: 'monitoring', startedAt: '2026-04-28T00:00:00Z', timeline: [
+      { stage: 'investigating', at: '2026-04-28T00:00:00Z' },
+      { stage: 'monitoring',    at: '2026-04-28T01:30:00Z' },
+    ] }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.updated', date: '2026-04-28T01:30:00Z' })
+  })
+
+  it('monitoring without timeline → falls through to startedAt', () => {
+    const inc = { status: 'monitoring', startedAt: '2026-04-28T00:00:00Z' }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.started', date: '2026-04-28T00:00:00Z' })
+  })
+
+  it('ongoing with newer timeline entry → "updated" label', () => {
+    const inc = { status: 'ongoing', startedAt: '2026-04-28T00:00:00Z', timeline: [
+      { stage: 'investigating', at: '2026-04-28T00:00:00Z' },
+      { stage: 'identified',    at: '2026-04-28T00:30:00Z' },
+    ] }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.updated', date: '2026-04-28T00:30:00Z' })
+  })
+
+  it('ongoing whose only timeline entry equals startedAt → uses startedAt with "started" label', () => {
+    // Without this guard the row would say "Updated 14:12" alongside "Started
+    // 14:12", which reads as a stale-ping lie even though nothing has happened.
+    const inc = { status: 'ongoing', startedAt: '2026-04-28T14:12:00Z', timeline: [
+      { stage: 'investigating', at: '2026-04-28T14:12:00Z' },
+    ] }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.started', date: '2026-04-28T14:12:00Z' })
+  })
+
+  it('investigating / identified statuses behave like ongoing (worker-native names)', () => {
+    // Pre-#406 the helper only matched 'ongoing' (post-normalize), missing the
+    // raw worker statuses that ServiceDetails passes through unmodified.
+    const investigating = { status: 'investigating', startedAt: '2026-04-28T00:00:00Z', timeline: [
+      { stage: 'investigating', at: '2026-04-28T00:30:00Z' },
+    ] }
+    expect(getContextualTime(investigating, t).label).toBe('incidents.time.updated')
+
+    const identified = { status: 'identified', startedAt: '2026-04-28T00:00:00Z', timeline: [
+      { stage: 'identified', at: '2026-04-28T00:45:00Z' },
+    ] }
+    expect(getContextualTime(identified, t).label).toBe('incidents.time.updated')
+  })
+
+  it('unknown status → falls through to startedAt with "started" label', () => {
+    // Defensive: a future status enum extension that ships ahead of this helper
+    // shouldn't crash the date column. Falling through to the most-conservative
+    // label lets the row render even if it's slightly less informative.
+    const inc = { status: 'investigating-something-new', startedAt: '2026-04-28T00:00:00Z' }
+    expect(getContextualTime(inc, t)).toEqual({ label: 'incidents.time.started', date: '2026-04-28T00:00:00Z' })
+  })
+
+  it('output date axis matches compareIncidents sort axis (#406 anti-regression)', () => {
+    // The whole point: the date this helper returns is what users see, and
+    // compareIncidents orders by getLatestActivity. Pin that they agree on
+    // resolved entries — if a future refactor diverges them, the Overview
+    // visible-inversion bug returns.
+    const earlier = { status: 'resolved', startedAt: '2026-04-28T14:12:00Z', resolvedAt: '2026-04-28T15:11:00Z' }
+    const later   = { status: 'resolved', startedAt: '2026-04-28T15:03:00Z', resolvedAt: '2026-04-28T15:17:00Z' }
+    expect(getContextualTime(earlier, t).date).toBe(earlier.resolvedAt)
+    expect(getContextualTime(later, t).date).toBe(later.resolvedAt)
+    expect(compareIncidents(earlier, later)).toBeGreaterThan(0)
+    // ↑ later sorts above earlier; later's contextual date is later than earlier's. Aligned.
   })
 })

--- a/src/utils/incidentSort.js
+++ b/src/utils/incidentSort.js
@@ -120,6 +120,44 @@ export function sumGroupDuration(group) {
   return { totalMs, hasOngoing, resolvedCount }
 }
 
+/** Last element of array (ES5-safe). */
+function last(arr) { return arr && arr.length > 0 ? arr[arr.length - 1] : undefined }
+
+/**
+ * Pick the timestamp + label that matches the incident's current state. The
+ * date this returns is the same axis used by `compareIncidents` for sort
+ * order — keeping list display and sort axis aligned avoids the visible
+ * inversion (#406) where a later-resolved incident outranks an earlier one
+ * but the displayed `startedAt` date suggests the opposite.
+ *
+ * Status order mirrors the worker's 4-state Incident.status plus the
+ * legacy 'ongoing' alias used by Incidents.jsx after pre-normalization.
+ * The 'updated' label fires for ongoing entries only when the timeline
+ * has actually moved past startedAt — otherwise the displayed time would
+ * just repeat startedAt and the label would read as a stale-update lie.
+ *
+ * @param {{ status: string, resolvedAt?: string, startedAt: string, timeline?: { stage: string, at: string }[] }} inc
+ * @param {(key: string) => string} t  i18n function (string-passing kept so this stays framework-agnostic — same convention used elsewhere in this module)
+ * @returns {{ label: string, date: string }}
+ */
+export function getContextualTime(inc, t) {
+  if (inc.status === 'resolved') {
+    const resolved = getResolvedTime(inc)
+    if (resolved) return { label: t('incidents.time.resolved'), date: resolved }
+  }
+  if (inc.status === 'monitoring') {
+    const lt = last(inc.timeline)
+    if (lt?.at) return { label: t('incidents.time.updated'), date: lt.at }
+  }
+  if (inc.status === 'ongoing' || inc.status === 'investigating' || inc.status === 'identified') {
+    const lt = last(inc.timeline)
+    if (lt?.at && lt.at !== inc.startedAt) {
+      return { label: t('incidents.time.updated'), date: lt.at }
+    }
+  }
+  return { label: t('incidents.time.started'), date: inc.startedAt }
+}
+
 /**
  * Resolved timestamp — `resolvedAt` field, or the last `resolved` timeline
  * entry, or null when the incident hasn't resolved yet.


### PR DESCRIPTION
closes #406

## Summary
- Overview's Recent Incidents list sorted resolved entries by \`resolvedAt\` but displayed \`startedAt\` — two incidents straddling a calendar-day boundary appeared visually inverted (later-resolved row labelled \"May 8\" above earlier-resolved row labelled \"May 9\").
- Promotes \`getContextualTime\` from \`src/pages/Incidents.jsx\` to \`src/utils/incidentSort.js\` and uses it on Overview. Display axis now matches sort axis on both pages.
- Tooltip on the date div exposes the full label (\`Started\` / \`Updated\` / \`Resolved\`) so users can tell what kind of timestamp they're seeing without expanding the row.

## Why
Two real Anthropic incidents from 5/8-5/9:
- File Operations: started 5/8 23:12 KST, **resolved 5/9 00:17** → Overview labelled \"May 8\"
- Sonnet 4.6: started **5/9 00:03**, resolved 5/9 00:11 → Overview labelled \"May 9\"

File Ops sorted above Sonnet (resolved 6m later) — correct by the sort logic. But the date column showed startedAt, so users saw \"May 8 above May 9\" and read it as broken sorting.

## Test plan
- [x] 9 new unit tests in \`incidentSort.test.js\` covering all status branches + sort-axis ↔ display-axis anti-regression pin
- [x] \`npm run test:src\` — 164/164 passing
- [x] \`npm test --project=desktop --grep \"incidents|Incidents\"\` — 16/16 passing
- [x] \`npm run build\` — clean
- [x] PR review converged on round 1 (0 Critical / 0 Important)
- [ ] Vercel Preview verification — Overview Recent Incidents date column shows resolved date for resolved entries; tooltip on hover shows the label

## Out of scope
- PR #405 (archive merge for 90d filter) is a separate open PR — no overlap.
- Mobile users get the corrected ordering + corrected date but no tooltip (52px column has no room for inline label). Acceptable since the date itself disambiguates the inversion that motivated this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)