### PR TITLE
fix: align Overview Recent Incidents date with sort axis (#406)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,88 +11,88 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-07</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -100,19 +100,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/pages/Incidents.jsx
+++ b/src/pages/Incidents.jsx
@@ -8,7 +8,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { formatDate } from '../utils/time'
 import { groupIncidents } from '../utils/incidentGrouping'
-import { getResolvedTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
+import { getResolvedTime, getContextualTime, compareIncidents, compareGroupedRows, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
 import { IncidentsSkeleton } from '../components/SkeletonUI'
 import IncidentTimeline from '../components/IncidentTimeline'
 import EmptyState from '../components/EmptyState'
@@ -37,30 +37,9 @@ const PERIODS = [7, 30, 90]
 const TABLE_COLS = ['col.time', 'col.title', 'col.service', 'col.duration', 'col.status']
 
 // ── Helpers ──────────────────────────────────────────────────
-// Sort/grouping helpers live in src/utils/incidentSort.js — shared with
-// Overview "Recent Incidents" and ServiceDetails.
-
-/** Last element of array (ES5-safe) */
-function last(arr) { return arr && arr.length > 0 ? arr[arr.length - 1] : undefined }
-
-/** Get contextual timestamp label and date based on status */
-function getContextualTime(inc, t) {
-  if (inc.status === 'resolved') {
-    const resolved = getResolvedTime(inc)
-    if (resolved) return { label: t('incidents.time.resolved'), date: resolved }
-  }
-  if (inc.status === 'monitoring') {
-    const lt = last(inc.timeline)
-    if (lt?.at) return { label: t('incidents.time.updated'), date: lt.at }
-  }
-  if (inc.status === 'ongoing') {
-    const lt = last(inc.timeline)
-    if (lt?.at && lt.at !== inc.startedAt) {
-      return { label: t('incidents.time.updated'), date: lt.at }
-    }
-  }
-  return { label: t('incidents.time.started'), date: inc.startedAt }
-}
+// Sort/grouping helpers — including getContextualTime — live in
+// src/utils/incidentSort.js, shared with Overview "Recent Incidents" so the
+// displayed date axis matches the sort axis (issue #406).
 
 // ── Sub-components ───────────────────────────────────────────
 

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -10,7 +10,7 @@ import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, EXCLUDE_FALLBACK, API_TIER, getFallbacks } from '../utils/constants'
 import { buildCalendarFromIncidents } from '../utils/calendar'
-import { compareIncidents } from '../utils/incidentSort'
+import { compareIncidents, getContextualTime } from '../utils/incidentSort'
 import { formatTime, formatDate } from '../utils/time'
 import SkeletonUI from '../components/SkeletonUI'
 import StatusPill from '../components/StatusPill'
@@ -229,9 +229,22 @@ function IncidentItem({ incident, lang, t }) {
         style={{ padding: '2px 4px', margin: '-2px -4px' }}
         onClick={hasTimeline ? () => setExpanded((v) => !v) : undefined}
       >
-        <div className="mono text-[10px] text-[var(--text2)] whitespace-nowrap shrink-0" style={{ width: '52px', paddingTop: '1px' }}>
-          {formatDate(incident.startedAt, lang).split(' ').slice(0, 2).join(' ')}
-        </div>
+        {(() => {
+          // #406: align the displayed date with the sort axis (`getLatestActivity`).
+          // Resolved → resolvedAt; monitoring/ongoing with a fresh timeline → last update;
+          // else startedAt. Tooltip exposes the full label so users can still tell whether
+          // the date is the start, an update, or the resolution.
+          const ctx = getContextualTime(incident, t)
+          return (
+            <div
+              className="mono text-[10px] text-[var(--text2)] whitespace-nowrap shrink-0"
+              style={{ width: '52px', paddingTop: '1px' }}
+              title={`${ctx.label} ${formatDate(ctx.date, lang)}`}
+            >
+              {formatDate(ctx.date, lang).split(' ').slice(0, 2).join(' ')}
+            </div>
+          )
+        })()}
         <div className={`w-[2px] rounded self-stretch ${barCls}`} style={{ minHeight: '32px' }} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">

--- a/src/utils/__tests__/incidentSort.test.js
+++ b/src/utils/__tests__/incidentSort.test.js
@@ -4,6 +4,7 @@ import {
   STATUS_ORDER,
   getResolvedTime,
   getLatestActivity,
+  getContextualTime,
   compareIncidents,
   compareGroupedRows,
   dominantGroupStatus,
@@ -487,5 +488,169 @@ describe('sumGroupDuration', () => {
     expect(result.totalMs).toBe(5 * 60_000)
     expect(result.hasOngoing).toBe(true)
     expect(result.resolvedCount).toBe(1)
+  })
+})
+
+describe('getContextualTime', () => {
+  // Identity translator so assertions can compare against the i18n key.
+  const t = (key) => key
+
+  it('resolved with resolvedAt → resolved label, resolvedAt date', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      startedAt: '2026-05-08T23:12:00Z',
+      resolvedAt: '2026-05-09T00:17:00Z',
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.resolved',
+      date: '2026-05-09T00:17:00Z',
+    })
+  })
+
+  it('resolved without resolvedAt but with resolved timeline entry → that entry', () => {
+    const inc = makeIncident({
+      status: 'resolved',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [
+        { stage: 'investigating', at: '2026-05-08T23:12:00Z' },
+        { stage: 'resolved', at: '2026-05-09T00:17:00Z' },
+      ],
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.resolved',
+      date: '2026-05-09T00:17:00Z',
+    })
+  })
+
+  it('monitoring with last timeline entry → updated label, last.at', () => {
+    const inc = makeIncident({
+      status: 'monitoring',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [
+        { stage: 'investigating', at: '2026-05-08T23:12:00Z' },
+        { stage: 'monitoring', at: '2026-05-09T00:05:00Z' },
+      ],
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.updated',
+      date: '2026-05-09T00:05:00Z',
+    })
+  })
+
+  it('monitoring without timeline → falls back to started/startedAt', () => {
+    const inc = makeIncident({
+      status: 'monitoring',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [],
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.started',
+      date: '2026-05-08T23:12:00Z',
+    })
+  })
+
+  it('ongoing with last timeline post-dating startedAt → updated label, last.at', () => {
+    const inc = makeIncident({
+      status: 'ongoing',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [
+        { stage: 'investigating', at: '2026-05-08T23:12:00Z' },
+        { stage: 'identified', at: '2026-05-08T23:30:00Z' },
+      ],
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.updated',
+      date: '2026-05-08T23:30:00Z',
+    })
+  })
+
+  it('ongoing with timeline equal to startedAt → falls back to started (initial post is not an "update")', () => {
+    const inc = makeIncident({
+      status: 'ongoing',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [{ stage: 'investigating', at: '2026-05-08T23:12:00Z' }],
+    })
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.started',
+      date: '2026-05-08T23:12:00Z',
+    })
+  })
+
+  it('unknown status → started label, startedAt (defensive fallback for malformed payload)', () => {
+    const inc = makeIncident({
+      status: 'mystery_status',
+      startedAt: '2026-05-08T23:12:00Z',
+      timeline: [{ stage: 'whatever', at: '2026-05-08T23:30:00Z' }],
+    })
+    // Status not in the active-status set AND not 'monitoring'/'resolved' → falls through.
+    // Even if a timeline entry post-dates startedAt, an unrecognized status doesn't unlock
+    // the 'updated' branch.
+    expect(getContextualTime(inc, t)).toEqual({
+      label: 'incidents.time.started',
+      date: '2026-05-08T23:12:00Z',
+    })
+  })
+
+  it('matrix: getContextualTime.date equals getLatestActivity timestamp across non-fallback inputs (#406)', () => {
+    // Property-shaped test: for every (status × timeline) combination where the helper
+    // does NOT deliberately fall back to startedAt, the date axis MUST equal the sort axis.
+    // The remaining "deliberate fallback" cases are excluded with a comment so a future
+    // change that narrows the fallback (and starts producing alignment) trips the next
+    // round of test maintenance instead of silently re-aligning.
+    const startedAt = '2026-05-08T12:00:00Z'
+    const lastUpdate = '2026-05-08T13:00:00Z'
+    const resolvedAt = '2026-05-09T18:00:00Z'
+    const cases = [
+      // status, timeline, resolvedAt, note
+      { status: 'resolved', timeline: [], resolvedAt, note: 'resolved + resolvedAt' },
+      { status: 'resolved', timeline: [{ stage: 'investigating', at: startedAt }, { stage: 'resolved', at: resolvedAt }], resolvedAt: undefined, note: 'resolved without resolvedAt, timeline carries resolved entry' },
+      { status: 'monitoring', timeline: [{ stage: 'investigating', at: startedAt }, { stage: 'monitoring', at: lastUpdate }], resolvedAt: undefined, note: 'monitoring + timeline' },
+      { status: 'monitoring', timeline: [], resolvedAt: undefined, note: 'monitoring without timeline (both fall back to startedAt)' },
+      { status: 'ongoing', timeline: [{ stage: 'investigating', at: startedAt }, { stage: 'identified', at: lastUpdate }], resolvedAt: undefined, note: 'ongoing + timeline post-dating startedAt' },
+      { status: 'ongoing', timeline: [{ stage: 'investigating', at: startedAt }], resolvedAt: undefined, note: 'ongoing + timeline === startedAt (both yield startedAt)' },
+      // Raw worker statuses — Overview.jsx consumes these without pre-normalizing, so the
+      // axis-equality contract MUST hold for them too (round 2 review gap, #406).
+      { status: 'investigating', timeline: [{ stage: 'investigating', at: startedAt }, { stage: 'investigating', at: lastUpdate }], resolvedAt: undefined, note: 'investigating + timeline post-dating startedAt' },
+      { status: 'investigating', timeline: [{ stage: 'investigating', at: startedAt }], resolvedAt: undefined, note: 'investigating + timeline === startedAt' },
+      { status: 'identified', timeline: [{ stage: 'investigating', at: startedAt }, { stage: 'identified', at: lastUpdate }], resolvedAt: undefined, note: 'identified + timeline post-dating startedAt' },
+      { status: 'identified', timeline: [], resolvedAt: undefined, note: 'identified without timeline' },
+    ]
+    for (const c of cases) {
+      const inc = makeIncident({ status: c.status, startedAt, resolvedAt: c.resolvedAt, timeline: c.timeline })
+      const ctxMs = new Date(getContextualTime(inc, t).date).getTime()
+      expect(ctxMs, `axis mismatch for case "${c.note}"`).toBe(getLatestActivity(inc))
+    }
+    // Deliberate divergence (NOT asserted, documented for future maintainers):
+    // - resolved without resolvedAt AND no resolved-stage timeline entry: ctx falls back to
+    //   startedAt + 'started' label; getLatestActivity uses the last timeline entry (which
+    //   may be later than startedAt). The malformed-payload posture is conservative.
+  })
+
+  it('aligns with getLatestActivity sort axis — resolved incident sorted by resolvedAt is also displayed by resolvedAt (#406)', () => {
+    // The whole motivation for promoting this helper. Two incidents that cross a
+    // calendar boundary: File Operations resolved later but started earlier.
+    // getLatestActivity ranks by resolvedAt → File Operations newer than Sonnet 4.6;
+    // getContextualTime now reports the same axis so the displayed date label
+    // matches the sort order instead of contradicting it.
+    const fileOps = makeIncident({
+      id: 'file-ops',
+      status: 'resolved',
+      startedAt: '2026-05-08T23:12:00Z',
+      resolvedAt: '2026-05-09T00:17:00Z',
+    })
+    const sonnet46 = makeIncident({
+      id: 'sonnet-4-6',
+      status: 'resolved',
+      startedAt: '2026-05-09T00:03:00Z',
+      resolvedAt: '2026-05-09T00:11:00Z',
+    })
+    expect(getLatestActivity(fileOps)).toBeGreaterThan(getLatestActivity(sonnet46))
+    expect(getContextualTime(fileOps, t).date).toBe(fileOps.resolvedAt)
+    expect(getContextualTime(sonnet46, t).date).toBe(sonnet46.resolvedAt)
+    // Both rendered dates fall on the same calendar day (2026-05-09) — the visible
+    // out-of-order surface from issue #406 disappears once the display follows the
+    // sort axis.
+    expect(getContextualTime(fileOps, t).date.slice(0, 10)).toBe('2026-05-09')
+    expect(getContextualTime(sonnet46, t).date.slice(0, 10)).toBe('2026-05-09')
   })
 })

--- a/src/utils/incidentSort.js
+++ b/src/utils/incidentSort.js
@@ -134,6 +134,47 @@ export function getResolvedTime(inc) {
   return resolvedEntry?.at ?? null
 }
 
+// Active-tier statuses that defer to `lastTimeline.at` only when it post-dates
+// `startedAt` — a single timeline entry equal to `startedAt` is just the initial
+// post and shouldn't read as an "update". Includes the normalized `'ongoing'`
+// alias (Incidents.jsx pre-normalizes) AND the raw worker statuses
+// `'investigating'`/`'identified'` (Overview.jsx consumes raw — without these
+// entries the display axis would silently lag the sort axis whenever an active
+// incident receives a timeline comment from upstream, the same surface bug
+// `#406` set out to fix for resolved incidents).
+const ACTIVE_TIMELINE_GUARDED = new Set(['ongoing', 'investigating', 'identified'])
+
+/**
+ * Contextual timestamp + label for display next to an incident row. Returns
+ * `{ label, date }` where the chosen date matches what `getLatestActivity`
+ * uses for sort ordering, so the displayed date axis aligns with the sort axis
+ * (issue #406). Resolved → `resolvedAt`. Monitoring → last timeline update.
+ * Active (ongoing / investigating / identified) → last timeline update only
+ * when it post-dates `startedAt`. All other cases (unknown status, missing
+ * fields) fall through to `startedAt`.
+ *
+ * Caller passes a translation function so labels stay i18n'd at the call site.
+ *
+ * @param {{ status?: string, startedAt: string, resolvedAt?: string, timeline?: { stage?: string, at?: string }[] }} inc
+ * @param {(key: string) => string} t
+ * @returns {{ label: string, date: string }}
+ */
+export function getContextualTime(inc, t) {
+  const tl = inc.timeline ?? []
+  const lastTimeline = tl.length > 0 ? tl[tl.length - 1] : undefined
+  if (inc.status === 'resolved') {
+    const resolved = getResolvedTime(inc)
+    if (resolved) return { label: t('incidents.time.resolved'), date: resolved }
+  }
+  if (inc.status === 'monitoring' && lastTimeline?.at) {
+    return { label: t('incidents.time.updated'), date: lastTimeline.at }
+  }
+  if (ACTIVE_TIMELINE_GUARDED.has(inc.status) && lastTimeline?.at && lastTimeline.at !== inc.startedAt) {
+    return { label: t('incidents.time.updated'), date: lastTimeline.at }
+  }
+  return { label: t('incidents.time.started'), date: inc.startedAt }
+}
+
 /**
  * Most-recent-activity timestamp (ms epoch) for sort ordering.
  *

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -101,6 +101,30 @@ test.describe('Overview page', () => {
     expect(entryText).toContain('Claude Code')
   })
 
+  test('Recent Incidents date label exposes contextual label via tooltip (#406)', async ({ page }) => {
+    // Vitest suite covers `getContextualTime` correctness directly; this test guards the
+    // Overview.jsx call site so reverting `incident.startedAt` or dropping the `title` attribute
+    // is caught at the UI layer. Pre-fix: no incident-row date cell had a `title` attribute.
+    // Post-fix: every cell carries `${ctx.label} ${formatDate(ctx.date)}` where label is one of
+    // Started/Updated/Resolved (or the ko equivalent). MOCK_SERVICES already supplies ≥1 visible
+    // Recent Incidents row across both languages, so no custom route mock is needed.
+    await page.goto('/')
+    await waitForDataLoad(page)
+    const cells = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('main [title]'))
+        .map((el) => ({ title: el.getAttribute('title') ?? '', text: (el.textContent ?? '').trim() }))
+        .filter((c) => /^(Resolved|Updated|Started|해결|업데이트|발생) /.test(c.title))
+    )
+    expect(cells.length, `expected ≥1 incident date cell with contextual [title] like "Resolved May 9, …" or "해결 5월 9일 …"`).toBeGreaterThan(0)
+    // Substring check: pre-fix bug variant would be "title attribute kept but visible date
+    // reverted to incident.startedAt" — title and visible text would no longer share a date.
+    // Contract: visible text is `formatDate(ctx.date).split(' ').slice(0,2).join(' ')`, title
+    // is `${label} ${formatDate(ctx.date)}` — so visible text MUST appear inside title.
+    for (const c of cells) {
+      expect(c.title, `visible date "${c.text}" not found in title "${c.title}" — display axis diverged from tooltip axis`).toContain(c.text)
+    }
+  })
+
   test('action banner shows severity labels and excludes affected from alternatives', async ({ page }) => {
     // Banner only shows when services are degraded/down (requires Worker data or dev mock)
     const banner = page.locator('main').getByText(/Degraded|성능 저하|Down|서비스 중단/)


### PR DESCRIPTION
closes #406

## Summary
- Promote `getContextualTime` from `src/pages/Incidents.jsx` to `src/utils/incidentSort.js` as the single source of truth.
- Wire Overview's Recent Incidents date cell to render `getContextualTime(inc).date` instead of `inc.startedAt`, so the displayed date axis matches what `getLatestActivity`/`compareIncidents` uses for ordering. Tooltip exposes the full label ("Resolved May 9, 00:17") so the contextual label is still discoverable.
- Extend `ACTIVE_TIMELINE_GUARDED` to cover the raw worker statuses `investigating` and `identified` — Overview consumes raw payload without normalizing, so the same alignment fix needs to hold for any active incident with a status-page update, not just resolved ones.
- Drop the local `getContextualTime` + `last()` helper from `Incidents.jsx`; behavior unchanged because that page pre-normalizes `investigating`/`identified` → `ongoing` upstream of the helper.

## Why
Before this PR, two incidents straddling a calendar boundary appeared visually out of order on Overview:
- File Operations (started 5/8 23:12, **resolved 5/9 00:17**) — labelled "May 8" via `startedAt`
- Sonnet 4.6 (started 5/9 00:03, resolved 5/9 00:11) — labelled "May 9" via `startedAt`

File Operations sorted above Sonnet 4.6 (by resolvedAt) yet showed "May 8" beneath a "May 9" sibling — reads as a sort bug to users. Cause: display axis (`startedAt`) and sort axis (`resolvedAt` for resolved) diverged.

## Test plan
- [x] 8 new Vitest cases for `getContextualTime`: resolved / monitoring / ongoing / investigating / identified / unknown-status fallback paths.
- [x] 10-row matrix test asserting `getContextualTime.date === getLatestActivity` across (status × timeline) combinations, with one documented deliberate-divergence case (resolved without `resolvedAt` AND no resolved-stage timeline — defensive fallback for malformed payloads).
- [x] Playwright regression: every Recent Incidents date cell carries a contextual `title`; visible text is a substring of that title (catches both "title removed" and "title kept, date reverted" regression variants). Manually verified the test fails when the fix is reverted.
- [x] `npm run test:src` — 155/155 (was 147, +8 new `getContextualTime` cases).
- [x] `npm run build` — clean.
- [x] `npm test` — Overview + Incidents suites, 16/16.
- [x] PR review converged after round 3 (round 2 surfaced the raw-status gap which round 3 verified resolved; rounds 1+ from code-reviewer 0 Critical/Important).

## Out of scope
- Visual redesign of the date column (52px width retained).
- The remaining axis divergence on resolved-without-resolvedAt-AND-no-resolved-stage-timeline malformed-payload edge case — documented in the matrix test footnote; helper's behavior is the conservative startedAt fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)