### PR TITLE
chore: gitignore Claude Code scheduled-tasks lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ blob-report/
 entities.json
 mempalace.yaml
 .claude/mcp.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore`.

## Why
The lock file is written by Claude Code's scheduled-tasks runtime once per session and carries the session ID + PID + acquire timestamp. It kept surfacing as an untracked file in `git status` and as an "uncommitted changes" warning on `gh pr create` (visible on the PR #408 / #409 push flow). Ignoring it stops the noise without affecting any operation.

## Test plan
- [x] After commit, `git status` no longer reports `.claude/scheduled_tasks.lock`.
- [x] Running a fresh Claude Code session that re-creates the file does not surface it in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)