### PR TITLE
fix: align groupIncidents sort axis with getLatestActivity (#411)

### DIFF
--- a/api/is-down/__tests__/incident-grouping.test.ts
+++ b/api/is-down/__tests__/incident-grouping.test.ts
@@ -143,7 +143,7 @@ describe('groupIncidents — day boundary', () => {
 })
 
 describe('groupIncidents — sort order', () => {
-  it('emits newest-first by representative time (rangeEnd for groups, startedAt for singles)', () => {
+  it('emits newest-first by latest activity (#411 — falls back to startedAt when resolvedAt unset)', () => {
     const rows = groupIncidents([
       mkInc({ id: 'old-single', title: 'Alpha', startedAt: '2026-04-10T10:00:00Z' }),
       mkInc({ id: 'g1', title: 'Group', startedAt: '2026-04-20T10:00:00Z' }),
@@ -285,5 +285,27 @@ describe('groupIncidents — generic-title flap clustering despite impact != nul
     const result = groupIncidents(incs)
     expect(result).toHaveLength(1)
     expect(result[0].kind).toBe('group')
+  })
+})
+
+describe('groupIncidents — sort axis alignment with latest activity (#411)', () => {
+  // SSR mirror of the SPA regression: resolved incidents sort by resolvedAt,
+  // not startedAt, so /is-X-down's grouped list matches Overview's order.
+  it('two resolved singles: sorts by resolvedAt desc, not startedAt desc', () => {
+    const modal = mkInc({ id: 'modal-1', title: 'Storage refactor following AWS us-east-1c issues', startedAt: '2026-05-11T08:59:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: 'minor', duration: '1m' })
+    const together = mkInc({ id: 'together-1', title: 'Kimi K2.6 — recovered', startedAt: '2026-05-11T08:57:00Z', resolvedAt: '2026-05-11T09:10:00Z', status: 'resolved', impact: null, duration: '13m' })
+    const result = groupIncidents([modal, together])
+    expect(result).toHaveLength(2)
+    const ids = result.map((r) => (r.kind === 'single' ? (r as SingleRow).incident.id : null))
+    expect(ids[0]).toBe('together-1') // resolvedAt 09:10
+    expect(ids[1]).toBe('modal-1')    // resolvedAt 09:00
+  })
+
+  it('tiebreak on identical resolvedAt preserves original input index', () => {
+    const a = mkInc({ id: 'a', title: 'Service A — recovered', startedAt: '2026-05-11T08:00:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: null })
+    const b = mkInc({ id: 'b', title: 'Service B — recovered', startedAt: '2026-05-11T08:30:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: null })
+    const result = groupIncidents([a, b])
+    const ids = result.map((r) => (r.kind === 'single' ? (r as SingleRow).incident.id : null))
+    expect(ids).toEqual(['a', 'b'])
   })
 })

--- a/api/is-down/incident-grouping.ts
+++ b/api/is-down/incident-grouping.ts
@@ -38,6 +38,23 @@ export function isGenericTitle(title: string | null | undefined): boolean {
   return GENERIC_TITLE_PATTERNS.some((p) => p.test(t))
 }
 
+// Latest-activity timestamp in ms for sort ordering — resolved incidents prefer
+// `resolvedAt` so a recently-resolved entry outranks an older resolved one,
+// matching `getLatestActivity` in `src/utils/incidentSort.js`. SSR's
+// `GroupingIncident` shape intentionally omits the `timeline` field, so the
+// active branch falls straight to `startedAt`. The SPA's timeline-based
+// promotion ("last timeline entry post-dates startedAt → use that") therefore
+// has no SSR analogue by design — do NOT add it here without also extending
+// the SSR payload contract. Used as the cross-row sort key in `groupIncidents`
+// so the visible Incidents / ServiceDetails / Is X Down order matches Overview
+// (#411 follow-up to #406).
+function getLatestActivityMs(inc: { status: string; startedAt: string; resolvedAt?: string | null }): number {
+  if (inc.status === 'resolved' && inc.resolvedAt) {
+    return new Date(inc.resolvedAt).getTime()
+  }
+  return new Date(inc.startedAt).getTime()
+}
+
 export interface GroupingIncident {
   id: string
   title: string
@@ -109,15 +126,20 @@ export function groupIncidents(
     bucket.entries.push(inc)
   })
 
-  const rows: Array<{ row: GroupedRow; sortKey: string; idx: number }> = []
+  const rows: Array<{ row: GroupedRow; sortKey: number; idx: number }> = []
 
   for (const { dayKey, normalizedTitle: nt, entries, firstIdx } of buckets.values()) {
     if (entries.length >= GROUP_THRESHOLD) {
       const startedAtTimes = entries.map((e) => e.startedAt)
       const rangeStart = startedAtTimes.reduce((a, b) => (a < b ? a : b))
+      // rangeEnd stays as the displayed time *range* (max startedAt across the
+      // bucket). Cross-row sort uses latest activity computed separately so a
+      // group's most-recently-resolved entry ranks the group correctly even when
+      // startedAt-rangeEnd would have placed it elsewhere (#411).
       const rangeEnd = startedAtTimes.reduce((a, b) => (a > b ? a : b))
       const statusCounts: Record<string, number> = {}
       for (const e of entries) statusCounts[e.status] = (statusCounts[e.status] ?? 0) + 1
+      const latestActivityMs = entries.reduce((m, e) => Math.max(m, getLatestActivityMs(e)), 0)
       rows.push({
         row: {
           kind: 'group',
@@ -130,23 +152,23 @@ export function groupIncidents(
           uniformStatus: Object.keys(statusCounts).length === 1,
           entries,
         },
-        sortKey: rangeEnd,
+        sortKey: latestActivityMs,
         idx: firstIdx,
       })
     } else {
       entries.forEach((inc) => {
         const idx = incidents.indexOf(inc)
-        rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+        rows.push({ row: { kind: 'single', incident: inc }, sortKey: getLatestActivityMs(inc), idx })
       })
     }
   }
 
   for (const { idx, inc } of ungroupable) {
-    rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+    rows.push({ row: { kind: 'single', incident: inc }, sortKey: getLatestActivityMs(inc), idx })
   }
 
   rows.sort((a, b) => {
-    if (a.sortKey !== b.sortKey) return a.sortKey < b.sortKey ? 1 : -1
+    if (a.sortKey !== b.sortKey) return b.sortKey - a.sortKey
     return a.idx - b.idx
   })
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,88 +11,88 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional 19 services (#263) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-09</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -100,19 +100,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/utils/__tests__/incidentGrouping.test.js
+++ b/src/utils/__tests__/incidentGrouping.test.js
@@ -247,7 +247,10 @@ describe('groupIncidents — ordering of mixed output', () => {
       makeIncident({ id: 's2', title: 'Real Outage', startedAt: '2026-04-15T08:00:00Z', impact: 'major' }),
     ]
     const result = groupIncidents(incs, UTC)
-    // Newest first by representative time (rangeEnd for groups, startedAt for singles)
+    // Newest first by `getLatestActivity` (#411). For these fixtures resolvedAt is unset, so
+    // getLatestActivity falls through to startedAt for singles and max(startedAt) for groups —
+    // i.e. the comparison happens to match rangeEnd here, but the sort axis is no longer
+    // rangeEnd-specific. See the dedicated #411 describe block below for the discriminating tests.
     const reps = result.map(r => r.kind === 'group' ? r.rangeEnd : r.incident.startedAt)
     const sorted = [...reps].sort().reverse()
     expect(reps).toEqual(sorted)
@@ -418,5 +421,78 @@ describe('groupIncidents — generic-title flap clustering despite impact != nul
     expect(result).toHaveLength(1)
     expect(result[0].kind).toBe('group')
     expect(result[0].count).toBe(2)
+  })
+})
+
+describe('groupIncidents — sort axis alignment with getLatestActivity (#411)', () => {
+  // Regression: pre-#411 `groupIncidents` sorted singles by `inc.startedAt` and
+  // groups by `max(startedAt)` while Overview's `compareIncidents`/`getLatestActivity`
+  // sorted resolved incidents by `resolvedAt`. The Modal/Together pair on
+  // 2026-05-11 was the canary — both pages showed the pair in opposite order.
+  // Post-#411 the axes match: the page that gets `groupIncidents` output sorts
+  // the same way Overview does.
+  const UTC = { timeZone: 'UTC' }
+
+  it('two resolved singles: sorts by resolvedAt desc, not startedAt desc', () => {
+    // Modal:        startedAt 08:59, resolvedAt 09:00 (later startedAt, earlier resolvedAt)
+    // Together AI:  startedAt 08:57, resolvedAt 09:10 (earlier startedAt, later resolvedAt)
+    // Pre-fix: Modal first (startedAt-desc). Post-fix: Together first (resolvedAt-desc).
+    const modal = { id: 'modal-1', title: 'Storage refactor following AWS us-east-1c issues', startedAt: '2026-05-11T08:59:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: 'minor', duration: '1m', timeline: [] }
+    const together = { id: 'together-1', title: 'Kimi K2.6 — recovered', startedAt: '2026-05-11T08:57:00Z', resolvedAt: '2026-05-11T09:10:00Z', status: 'resolved', impact: null, duration: '13m', timeline: [] }
+    const result = groupIncidents([modal, together], UTC)
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe('single')
+    expect(result[1].kind).toBe('single')
+    expect(result[0].incident.id).toBe('together-1') // resolved 09:10 > 09:00
+    expect(result[1].incident.id).toBe('modal-1')
+  })
+
+  it('active incident with later startedAt does not get pushed below a resolved one with earlier startedAt but later resolvedAt', () => {
+    // Active uses startedAt as latest activity (no timeline). Resolved uses resolvedAt.
+    // Active started 09:05 → sortKey 09:05. Resolved 08:57 → 09:10 → sortKey 09:10 → resolved first.
+    // This is correct: resolved's resolution is the more recent activity than the active's start.
+    // Pre-fix would have ranked by startedAt only: active(09:05) > resolved(08:57) → active first.
+    const active = { id: 'active-1', title: 'Service A outage', startedAt: '2026-05-11T09:05:00Z', status: 'investigating', impact: 'major', timeline: [] }
+    const resolved = { id: 'resolved-1', title: 'Service B blip — recovered', startedAt: '2026-05-11T08:57:00Z', resolvedAt: '2026-05-11T09:10:00Z', status: 'resolved', impact: null, duration: '13m', timeline: [] }
+    const result = groupIncidents([active, resolved], UTC)
+    expect(result[0].incident.id).toBe('resolved-1') // 09:10 resolved
+    expect(result[1].incident.id).toBe('active-1')   // 09:05 active
+    // Tier-aware reorder happens *after* groupIncidents via compareGroupedRows
+    // in callers — `groupIncidents` alone now reports newest-activity-first
+    // regardless of status. Callers that need the active-on-top behavior
+    // already pipe through compareGroupedRows (verified at the existing call
+    // sites in Incidents.jsx and ServiceDetails.jsx).
+  })
+
+  it('two groups: ranks by max(getLatestActivity) across entries, not max(startedAt)', () => {
+    // Asymmetric fixture so the test discriminates max-getLatestActivity from max-startedAt
+    // (would-be pre-fix axis) AND from tiebreak ordering. All entries have resolvedAt ≥ startedAt
+    // to stay in the valid-payload space:
+    // - Group A entries: max(startedAt) = 09:00, max(resolvedAt) = 09:30  → latestActivity 09:30
+    // - Group B entries: max(startedAt) = 09:10, max(resolvedAt) = 09:15  → latestActivity 09:15
+    // Pre-fix sort by max(startedAt) would rank B first (09:10 > 09:00). Post-fix sort by
+    // max(getLatestActivity) ranks A first (09:30 > 09:15). Different answers ⇒ the test
+    // actually exercises the new axis instead of passing via tiebreak.
+    const incs = [
+      { id: 'a1', title: 'Model X — recovered', startedAt: '2026-05-11T08:00:00Z', resolvedAt: '2026-05-11T09:30:00Z', status: 'resolved', impact: null, duration: '90m', timeline: [] },
+      { id: 'a2', title: 'Model X — recovered', startedAt: '2026-05-11T09:00:00Z', resolvedAt: '2026-05-11T09:20:00Z', status: 'resolved', impact: null, duration: '20m', timeline: [] },
+      { id: 'b1', title: 'Model Y — recovered', startedAt: '2026-05-11T09:10:00Z', resolvedAt: '2026-05-11T09:15:00Z', status: 'resolved', impact: null, duration: '5m', timeline: [] },
+      { id: 'b2', title: 'Model Y — recovered', startedAt: '2026-05-11T09:08:00Z', resolvedAt: '2026-05-11T09:14:00Z', status: 'resolved', impact: null, duration: '6m', timeline: [] },
+    ]
+    const result = groupIncidents(incs, UTC)
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe('group')
+    expect(result[1].kind).toBe('group')
+    expect(result[0].normalizedTitle).toBe('Model X') // Group A peaks at 09:30 → ranks first
+    expect(result[1].normalizedTitle).toBe('Model Y') // Group B peaks at 09:15
+  })
+
+  it('tiebreak on identical sortKey preserves original input index for determinism', () => {
+    const a = { id: 'a', title: 'Service A — recovered', startedAt: '2026-05-11T08:00:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: null, duration: '60m', timeline: [] }
+    const b = { id: 'b', title: 'Service B — recovered', startedAt: '2026-05-11T08:30:00Z', resolvedAt: '2026-05-11T09:00:00Z', status: 'resolved', impact: null, duration: '30m', timeline: [] }
+    // Both resolved at exactly 09:00. Tiebreak by input index → a first.
+    const result = groupIncidents([a, b], UTC)
+    expect(result[0].incident.id).toBe('a')
+    expect(result[1].incident.id).toBe('b')
   })
 })

--- a/src/utils/incidentGrouping.js
+++ b/src/utils/incidentGrouping.js
@@ -30,6 +30,8 @@
  * See issue #282.
  */
 
+import { getLatestActivity } from './incidentSort.js'
+
 export const GROUP_THRESHOLD = 2
 
 /**
@@ -113,9 +115,15 @@ function localDayKey(iso, timeZone) {
 }
 
 /**
- * Group qualifying incidents; pass others through individually.
- * Output sorted newest-first by representative time
- * (rangeEnd for groups, startedAt for singles).
+ * Group qualifying incidents; pass others through individually. Output is
+ * sorted newest-first by `getLatestActivity` (resolved → resolvedAt, active
+ * → last timeline entry / startedAt) — same axis `compareIncidents` uses on
+ * Overview so the visible order on Incidents / ServiceDetails / Is X Down
+ * matches the order Overview shows (#411 follow-up to #406). For groups, the
+ * representative time is the max `getLatestActivity` across entries (replaces
+ * the prior `rangeEnd = max(startedAt)` which silently diverged from the sort
+ * axis whenever a flap group's most-recently-resolved entry had a different
+ * startedAt-vs-resolvedAt rank).
  *
  * @param {Incident[]} incidents
  * @param {{ timeZone?: string }} [options] - timeZone override (tests). Omit in production.
@@ -146,16 +154,21 @@ export function groupIncidents(incidents, options = {}) {
     bucket.entries.push(inc)
   })
 
-  /** @type {Array<{ row: GroupRow|SingleRow, sortKey: string, idx: number }>} */
+  /** @type {Array<{ row: GroupRow|SingleRow, sortKey: number, idx: number }>} */
   const rows = []
 
   for (const { dayKey, normalizedTitle: nt, entries, firstIdx } of buckets.values()) {
     if (entries.length >= GROUP_THRESHOLD) {
       const startedAtTimes = entries.map(e => e.startedAt)
       const rangeStart = startedAtTimes.reduce((a, b) => a < b ? a : b)
+      // rangeEnd is the bucket's visible time *range*, used for display (#373).
+      // Sorting is by latest activity across entries, computed separately so a
+      // group whose most-recently-resolved entry resolved later than another
+      // group's still ranks newer even if their startedAt ranges coincide.
       const rangeEnd = startedAtTimes.reduce((a, b) => a > b ? a : b)
       const statusCounts = {}
       for (const e of entries) statusCounts[e.status] = (statusCounts[e.status] ?? 0) + 1
+      const latestActivityMs = entries.reduce((m, e) => Math.max(m, getLatestActivity(e)), 0)
       rows.push({
         row: {
           kind: 'group',
@@ -168,25 +181,25 @@ export function groupIncidents(incidents, options = {}) {
           uniformStatus: Object.keys(statusCounts).length === 1,
           entries,
         },
-        sortKey: rangeEnd,
+        sortKey: latestActivityMs,
         idx: firstIdx,
       })
     } else {
       // Below threshold — render each as a single row.
       entries.forEach((inc) => {
         const idx = incidents.indexOf(inc)
-        rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+        rows.push({ row: { kind: 'single', incident: inc }, sortKey: getLatestActivity(inc), idx })
       })
     }
   }
 
   for (const { idx, inc } of ungroupable) {
-    rows.push({ row: { kind: 'single', incident: inc }, sortKey: inc.startedAt, idx })
+    rows.push({ row: { kind: 'single', incident: inc }, sortKey: getLatestActivity(inc), idx })
   }
 
-  // Newest first by sortKey; tiebreak by original input index for stable ordering.
+  // Newest first by sortKey (ms epoch); tiebreak by original input index for stable ordering.
   rows.sort((a, b) => {
-    if (a.sortKey !== b.sortKey) return a.sortKey < b.sortKey ? 1 : -1
+    if (a.sortKey !== b.sortKey) return b.sortKey - a.sortKey
     return a.idx - b.idx
   })
 


### PR DESCRIPTION
closes #411

## Summary
- Align `groupIncidents` sort axis with `getLatestActivity` (resolved → `resolvedAt`, active → last timeline / `startedAt`) so Incidents page / ServiceDetails / Is X Down SSR sort the same way Overview does (post-#406).
- SPA helper now imports `getLatestActivity` from `incidentSort.js`; SSR adds a local `getLatestActivityMs` whose JSDoc spells out the "no SSR timeline branch by design" contract.
- `rangeEnd` retained as the displayed time-range bound on group rows — sort is decoupled from display so groups whose most-recently-resolved entry has a different startedAt-rank rank correctly.

## Why
Two resolved incidents on 2026-05-11 made the divergence visible:
- Modal — *Storage refactor following AWS us-east-1c issues* — startedAt 08:59, resolvedAt 09:00 (1m)
- Together AI — *Kimi K2.6* — startedAt 08:57, resolvedAt 09:10 (13m)

Pre-fix: Modal **above** Together on Incidents page (sort by startedAt — 08:59 > 08:57). Post-#406: Together **above** Modal on Overview (sort by resolvedAt — 09:10 > 09:00). Same data, opposite order — clear sort-bug surface for the user.

This is the sibling of #406: same axis-mismatch class of bug, different code path (`groupIncidents` → `compareGroupedRows` chain used by Incidents/ServiceDetails/Is X Down).

## Test plan
- [x] 4 new SPA Vitest cases (Modal/Together pair, active+resolved interleave, two-group asymmetric fixture that discriminates max-getLatestActivity from max-startedAt, tiebreak determinism).
- [x] 2 new SSR mirror Vitest cases (resolved pair + tiebreak; SSR lacks timeline so the active-interleave + two-group cases would degenerate).
- [x] Pre-existing sort-order test comments updated to reflect new axis.
- [x] `npm run test:src` — 162/162 (was 155 — +6 new + 1 unaccounted-but-green).
- [x] `npm run test:worker` — 1174/1174.
- [x] `npm run build` — clean.
- [x] PR review converged after round 2 (round 1 surfaced one Important: two-group fixture passed via tiebreak; fix re-paired times to discriminate new axis from old).
- [ ] Vercel Preview — Modal/Together on real data render in resolvedAt-desc order on Incidents page + ServiceDetails + `/is-modal-down` + `/is-together-down`; identical order on Overview Recent Incidents.

## Out of scope
- Existing `incidentSort.test.js` `compareGroupedRows` composition tests already cover tier-lift (active rows lifted above resolved) end-to-end. No new composed test was added — confirmed adequate by both reviewers.
- Active incidents with stale `startedAt` and no timeline → sortKey identical to pre-fix; no behavior change for that subset, which is the intended fix scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)