### PR TITLE
chore: move edge-fallback alert constants out of index.ts (fixes wrangler dev)

### DIFF
--- a/worker/src/__tests__/edge-fallback-alert.test.ts
+++ b/worker/src/__tests__/edge-fallback-alert.test.ts
@@ -3,7 +3,8 @@
 // auth, dedup, dispatch toggle on missing webhook, and input sanitization.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { handleEdgeFallbackAlert, EDGE_FALLBACK_ALERT_KEY_PREFIX, EDGE_FALLBACK_ALERT_TTL_S } from '../index'
+import { handleEdgeFallbackAlert } from '../index'
+import { EDGE_FALLBACK_ALERT_KEY_PREFIX, EDGE_FALLBACK_ALERT_TTL_S } from '../edge-fallback-alert-keys'
 
 function makeKV(initial: Record<string, string> = {}) {
   const store = { ...initial }

--- a/worker/src/edge-fallback-alert-keys.ts
+++ b/worker/src/edge-fallback-alert-keys.ts
@@ -1,0 +1,14 @@
+// KV key prefix + TTL for the Edge SSR fallback alert (#378).
+//
+// Extracted out of index.ts because `wrangler dev`'s local Workers runtime
+// rejects non-handler *value* exports from the entry module ("Incorrect type
+// for map entry '<name>': the provided value is not of type 'function or
+// ExportedHandler'"). `wrangler deploy` tolerates them, but `dev` does not — so
+// the documented local-test command (`npx wrangler dev --config worker/wrangler.toml`)
+// was failing to start. Function exports from index.ts are fine; only `export
+// const <literal>` breaks it. Keep these two here; index.ts imports them, and
+// the test (`worker/src/__tests__/edge-fallback-alert.test.ts`) imports them
+// from here too. If you add another shared constant for index.ts, put it in a
+// module like this rather than exporting it from index.ts.
+export const EDGE_FALLBACK_ALERT_TTL_S = 5 * 60 // 5min cooldown matches the worst-case Vercel Edge cache TTL
+export const EDGE_FALLBACK_ALERT_KEY_PREFIX = 'alerted:edge-fallback:'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -10,6 +10,7 @@ import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration }
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
 import { corsHeaders } from './cors'
+import { EDGE_FALLBACK_ALERT_TTL_S, EDGE_FALLBACK_ALERT_KEY_PREFIX } from './edge-fallback-alert-keys'
 
 interface Env {
   ALLOWED_ORIGIN: string
@@ -943,8 +944,8 @@ async function handleAdminAnalyze(request: Request, env: Env, cors: Record<strin
 // Auth: Bearer token in Authorization header, validated against EDGE_ALERT_TOKEN
 // secret. Same token must be set in Vercel env so both ends agree. Missing secret
 // returns 401 (no info leak about config state).
-export const EDGE_FALLBACK_ALERT_TTL_S = 5 * 60 // 5min cooldown matches the worst-case Vercel Edge cache TTL
-export const EDGE_FALLBACK_ALERT_KEY_PREFIX = 'alerted:edge-fallback:'
+// EDGE_FALLBACK_ALERT_TTL_S / _KEY_PREFIX live in ./edge-fallback-alert-keys —
+// `wrangler dev` rejects const exports from the entry module (see that file).
 
 interface EdgeFallbackRequest {
   surface?: string  // 'is-down' | 'reports'


### PR DESCRIPTION
## Problem
`npx wrangler dev --config worker/wrangler.toml --port 8788` — the documented local-test command in CLAUDE.md — fails to start:

```
✘ [ERROR] service core:user:aiwatch-worker: Uncaught TypeError: Incorrect type for map entry
  'EDGE_FALLBACK_ALERT_KEY_PREFIX': the provided value is not of type 'function or ExportedHandler'.
✘ [ERROR] The Workers runtime failed to start.
```

`wrangler dev`'s local Workers runtime rejects **non-handler value exports** from the entry module. `index.ts` `export const EDGE_FALLBACK_ALERT_TTL_S` / `EDGE_FALLBACK_ALERT_KEY_PREFIX` (added in #378 so `edge-fallback-alert.test.ts` could import them) trip it. `wrangler deploy` tolerates them — so this only broke `dev`, not deploys, which is why it went unnoticed. Function exports from `index.ts` (`readProbeSummaries`, `constantTimeEqual`, `handleEdgeFallbackAlert`, …) are fine; only `export const <literal>` breaks it.

## Fix
- New `worker/src/edge-fallback-alert-keys.ts` holds `EDGE_FALLBACK_ALERT_TTL_S` + `EDGE_FALLBACK_ALERT_KEY_PREFIX`, with a header comment explaining the constraint.
- `index.ts` imports them from there; no longer re-exports them. `handleEdgeFallbackAlert` and the rest of `index.ts` unchanged.
- `worker/src/__tests__/edge-fallback-alert.test.ts` imports the constants from the new module; `handleEdgeFallbackAlert` still from `../index`.

## Verification
- [x] `npx wrangler dev --config worker/wrangler.toml --port 8788` → `[wrangler:info] Ready on http://localhost:8788` ✅ (was: runtime failed to start)
- [x] `npx wrangler deploy --config worker/wrangler.toml --dry-run` → clean
- [x] `npm run test:worker` → 1186/1186 pass (edge-fallback-alert tests still green with the new import path)

## Notes
Mechanical extraction, zero behavior change — same constants, same values, same `handleEdgeFallbackAlert`. No frontend impact. Unblocks `wrangler dev` for local worker testing (e.g. verifying #413's `/api/openrouter-uptime/xai` route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)