### PR TITLE
fix: make workflow-gate hook commands cwd-independent (refs #415)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/git-mutation-gate.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/git-mutation-gate.sh\"",
             "timeout": 10,
             "statusMessage": "Checking git-mutation gate (#415)..."
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/stop-nag-gate.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-nag-gate.sh\"",
             "timeout": 10,
             "statusMessage": "Checking for auto-proceed nag (#415)..."
           }


### PR DESCRIPTION
## Summary

The `#415` workflow-gate hooks (`PreToolUse/Bash` → `git-mutation-gate.sh`, `Stop` → `stop-nag-gate.sh`) were registered in `.claude/settings.json` with a **relative** path: `bash .claude/hooks/<name>.sh`. Claude Code runs hook commands with the session's current working directory — so when the shell `cd`s into a sibling repo (e.g. `../aiwatch-reports`), the path no longer resolves:

```
bash: .claude/hooks/stop-nag-gate.sh: No such file or directory
```

…and the gate silently no-ops (the nag suppressor stops working, the git-mutation check stops warning).

Fix: reference `$CLAUDE_PROJECT_DIR` (the project root, which Claude Code sets for hook commands), double-quoted to tolerate spaces in the path. The hook **scripts** are unchanged — they already derive their own location from `${BASH_SOURCE[0]}`, so an absolute invocation path is sufficient and the internal `_audit.sh` log path stays correct.

(Same relative-path hazard exists in the gitignored `.claude/settings.local.json` for `lint-after-edit.sh`; that's a machine-local file outside this PR's scope — fixed locally.)

refs #415

## Test plan

- [x] `jq . .claude/settings.json` — valid JSON
- [x] Invoke both hook scripts from a foreign cwd (`/tmp`) with only `CLAUDE_PROJECT_DIR` set → both run, exit 0, `_audit.sh` writes to `$CLAUDE_PROJECT_DIR/.claude/hook-audit.jsonl`
- [x] `code-reviewer` agent review — 0 Critical, 0 Important
- [ ] After merge: open `/hooks` once (or restart Claude Code) so the updated `settings.json` takes effect — the settings watcher only re-reads on that event

🤖 Generated with [Claude Code](https://claude.com/claude-code)