### PR TITLE
feat: instrument statusline snippets with ?src= traffic tag (refs #400)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -296,14 +296,14 @@ Claude API, OpenAI, Gemini, GitHub Copilot 등 33개 AI 서비스의 장애 여�
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached?src=statusline-degraded_only | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
   }
 }
 ```
 
 프리셋 모음 (컴팩트 배지, 전체 목록, 특정 프로바이더만, Powerline 친화 등): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
 
-특성: 렌더링당 단일 GET, Cloudflare edge에 5분 KV 캐시, 2초 타임아웃, 네트워크 에러 시 silent fail, Anthropic API 호출 없음, 클라이언트 식별자 미수집. shell 명령 출력을 지원하는 모든 statusline 도구와 호환 (`ccstatusline`의 Custom Command 위젯 포함).
+특성: 렌더링당 단일 GET, Cloudflare edge에 5분 KV 캐시, 2초 타임아웃, 네트워크 에러 시 silent fail, Anthropic API 호출 없음, 클라이언트 식별자 미수집. `?src=statusline-<preset>` 쿼리 태그는 요청 로그에서 statusline 트래픽을 일반 cached-endpoint 호출과 구분하기 위한 용도일 뿐이며, Worker는 경로만 매칭하므로 캐시/응답 속도에 영향이 없고 사용자 식별자도 포함하지 않습니다. shell 명령 출력을 지원하는 모든 statusline 도구와 호환 (`ccstatusline`의 Custom Command 위젯 포함).
 
 ## 프로젝트 구조
 

--- a/README.md
+++ b/README.md
@@ -297,14 +297,14 @@ Quickest install — add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached?src=statusline-degraded_only | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
   }
 }
 ```
 
 Full guide with presets (compact badge, full list, scoped to specific providers, Powerline-friendly): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
 
-Properties: single GET per render, 5-min KV-cached on Cloudflare's edge, 2-second timeout, fail-silent on network error, no Anthropic API requests, no client identifier. Compatible with any statusline tool that supports shell-command output (including `ccstatusline`'s Custom Command widget).
+Properties: single GET per render, 5-min KV-cached on Cloudflare's edge, 2-second timeout, fail-silent on network error, no Anthropic API requests, no client identifier. The `?src=statusline-<preset>` query tag just lets us split statusline traffic from regular cached-endpoint hits in request logs — Worker matches on path only, so it doesn't affect caching or freshness, and carries no user identifier. Compatible with any statusline tool that supports shell-command output (including `ccstatusline`'s Custom Command widget).
 
 ## Project Structure
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,89 +11,89 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional Is-X-Down services (#263, expanded since) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-13</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -101,19 +101,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -276,7 +276,6 @@ export default function Statusline() {
           <li><strong className="text-[var(--text0)]">5-minute cache lag</strong> — incidents can take up to 5 minutes to appear in the statusline after AIWatch detects them.</li>
           <li><strong className="text-[var(--text0)]">jq + curl required</strong> — pre-installed on macOS &amp; most Linux distros. Windows users: install via WSL or use <code className="mono text-[var(--text0)]">winget install jqlang.jq</code> with curl from Windows 10+.</li>
           <li><strong className="text-[var(--text0)]">Claude Code is Claude-only</strong> — this surface is informational, not a fallback router. When Claude API is down you'll know immediately, but you can't switch providers mid-session.</li>
-          <li><strong className="text-[var(--text0)]">Self-hosters</strong> — replace <code className="mono text-[var(--text0)]">{API_URL}</code> with your own AIWatch deployment.</li>
         </ul>
       </Section>
 

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -8,6 +8,29 @@ import { trackEvent } from '../utils/analytics'
 
 const API_URL = 'https://ai-watch.dev/api/status/cached'
 
+// Tag each preset's URL so Cloudflare request analytics can separate
+// statusline-driven traffic from regular `/api/status/cached` hits and tell us
+// which preset users actually run. The Worker matches only on `url.pathname`
+// and reads from fixed KV keys (`services:latest`, etc.) — see the
+// `url.pathname === '/api/status/cached'` route handler in worker/src/index.ts
+// — so the query string is invisible to cache + KV behavior. It exists purely
+// for the request-log split. Carries no user identifier; the preset slug is
+// the only payload. Measurement framework + baseline-derived distribution
+// gating thresholds (Reddit launch, Anthropic Claude Code docs PR) live on
+// issue #400.
+const taggedUrl = (src) => `${API_URL}?src=statusline-${src}`
+
+// Slug constants are the join key between (a) the URL `?src=statusline-<slug>`
+// query tag in Cloudflare request logs and (b) the GA4 `copy_statusline_snippet`
+// event's `preset` parameter. Extracted to single source so a rename can't
+// silently desynchronize one side from the other — that drift would invalidate
+// the cross-system analytics correlation the gating measurement depends on.
+const SLUG_DEGRADED_ONLY = 'degraded_only'
+const SLUG_COMPACT_BADGE = 'compact_badge'
+const SLUG_FULL_LIST = 'full_list'
+const SLUG_SCOPED = 'scoped'
+const SLUG_CLICKABLE = 'clickable'
+
 function CopyButton({ text, eventLabel }) {
   const [copied, setCopied] = useState(false)
   const onClick = async () => {
@@ -92,28 +115,28 @@ function Section({ title, children }) {
 const PRESET_DEGRADED_ONLY = `{
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | .[0:3] | join(\\" \\")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 ${taggedUrl(SLUG_DEGRADED_ONLY)} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | .[0:3] | join(\\" \\")' ) 2>/dev/null || true"
   }
 }`
 
 const PRESET_COMPACT_BADGE = `{
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '([.services[] | select(.status != \\"operational\\")] | length) as $n | if $n == 0 then empty else \\"🔴 \\" + ($n|tostring) + \\" AI services\\" end' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 ${taggedUrl(SLUG_COMPACT_BADGE)} | jq -r '([.services[] | select(.status != \\"operational\\")] | length) as $n | if $n == 0 then empty else \\"🔴 \\" + ($n|tostring) + \\" AI services\\" end' ) 2>/dev/null || true"
   }
 }`
 
 const PRESET_FULL_LIST = `{
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"\\(if .status == \\"down\\" then \\"X\\" else \\"!\\" end)\\\\u00b7\\(.name)\\"] | join(\\" | \\")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 ${taggedUrl(SLUG_FULL_LIST)} | jq -r '[.services[] | select(.status != \\"operational\\") | \\"\\(if .status == \\"down\\" then \\"X\\" else \\"!\\" end)\\\\u00b7\\(.name)\\"] | join(\\" | \\")' ) 2>/dev/null || true"
   }
 }`
 
 const PRESET_SCOPED = `{
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.id == \\"claude\\" or .id == \\"openai\\" or .id == \\"gemini\\") | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | join(\\" \\")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 ${taggedUrl(SLUG_SCOPED)} | jq -r '[.services[] | select(.id == \\"claude\\" or .id == \\"openai\\" or .id == \\"gemini\\") | select(.status != \\"operational\\") | \\"🔴 \\" + .name] | join(\\" \\")' ) 2>/dev/null || true"
   }
 }`
 
@@ -127,7 +150,7 @@ const PRESET_SCOPED = `{
 const PRESET_CLICKABLE = JSON.stringify({
   statusLine: {
     type: 'command',
-    command: `( curl -sf --max-time 2 ${API_URL} | jq -r '[.services[] | select(.status != "operational") | "\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\"] | .[0:3] | join(" ")' ) 2>/dev/null || true`,
+    command: `( curl -sf --max-time 2 ${taggedUrl(SLUG_CLICKABLE)} | jq -r '[.services[] | select(.status != "operational") | "\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\"] | .[0:3] | join(" ")' ) 2>/dev/null || true`,
   },
 }, null, 2)
 
@@ -166,7 +189,7 @@ export default function Statusline() {
         <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '12px' }}>
           Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Output stays empty while every monitored service is operational; up to 3 degraded/down services appear with a red dot when something breaks.
         </p>
-        <Snippet code={PRESET_DEGRADED_ONLY} eventLabel="degraded_only" />
+        <Snippet code={PRESET_DEGRADED_ONLY} eventLabel={SLUG_DEGRADED_ONLY} />
       </Section>
 
       <Section title="Other presets">
@@ -176,7 +199,7 @@ export default function Statusline() {
             <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
               Shows a single count (e.g. <code className="mono text-[var(--text0)]">🔴 2 AI services</code>) instead of names. Best when statusline space is tight.
             </p>
-            <Snippet code={PRESET_COMPACT_BADGE} eventLabel="compact_badge" />
+            <Snippet code={PRESET_COMPACT_BADGE} eventLabel={SLUG_COMPACT_BADGE} />
           </div>
 
           <div>
@@ -184,7 +207,7 @@ export default function Statusline() {
             <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
               Shows every degraded/down service with a one-character severity prefix — <code className="mono text-[var(--text0)]">X</code> for down, <code className="mono text-[var(--text0)]">!</code> for degraded. No emoji, plain text — friendly for Powerline themes that already provide their own iconography.
             </p>
-            <Snippet code={PRESET_FULL_LIST} eventLabel="full_list" />
+            <Snippet code={PRESET_FULL_LIST} eventLabel={SLUG_FULL_LIST} />
           </div>
 
           <div>
@@ -201,7 +224,7 @@ export default function Statusline() {
                 full service ID table
               </a>{' '}on GitHub.
             </p>
-            <Snippet code={PRESET_SCOPED} eventLabel="scoped" />
+            <Snippet code={PRESET_SCOPED} eventLabel={SLUG_SCOPED} />
           </div>
 
           <div>
@@ -209,7 +232,7 @@ export default function Statusline() {
             <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
               Each service name becomes a clickable hyperlink that opens the AIWatch service detail page (<code className="mono text-[var(--text0)]">cmd+click</code> on macOS, <code className="mono text-[var(--text0)]">ctrl+click</code> on Linux). Useful for jumping straight to incident details when the statusline shows something is wrong. Requires an OSC 8-compatible terminal — most modern emulators (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+) support it; tmux and some older shells may render the escape sequence as raw text instead.
             </p>
-            <Snippet code={PRESET_CLICKABLE} eventLabel="clickable" />
+            <Snippet code={PRESET_CLICKABLE} eventLabel={SLUG_CLICKABLE} />
           </div>
         </div>
       </Section>
@@ -219,6 +242,7 @@ export default function Statusline() {
           <li>Single GET to <code className="mono text-[var(--text0)]">{API_URL}</code> per statusline render. CORS-enabled, no authentication, no client identifier collected.</li>
           <li>The endpoint serves a 5-minute KV-cached payload from Cloudflare's edge network — typical response time is under 100 ms from most regions.</li>
           <li>The shell command sets a 2-second timeout (<code className="mono text-[var(--text0)]">--max-time 2</code>) and fails silent (<code className="mono text-[var(--text0)]">2{'>'}/dev/null || true</code>) so a network hiccup never breaks your statusline.</li>
+          <li>Each snippet appends a <code className="mono text-[var(--text0)]">?src=statusline-&lt;preset&gt;</code> query tag so we can split statusline-driven requests from the rest of the cached-endpoint traffic when deciding which presets to keep maintaining. The Worker matches on path only, so the tag has no effect on caching, freshness, or your response — and the only payload is the preset slug, never a user identifier.</li>
           <li>No requests to the Anthropic API. AIWatch operates its own status feed independently.</li>
         </ul>
       </Section>

--- a/tests/statusline.spec.js
+++ b/tests/statusline.spec.js
@@ -1,7 +1,11 @@
 // #400 Phase 0 — /statusline guide page (Claude Code statusline integration).
-// Pins: hash route works, all 4 presets render with copy buttons, sidebar nav
-// entry exists. A regression in any of these would re-block Phase 1's
-// "snippet documented somewhere reachable from ai-watch.dev" criterion.
+// Pins: hash route works, all 5 presets render with copy buttons, sidebar nav
+// entry exists, and each preset URL carries its own ?src=statusline-<preset>
+// traffic-split tag (so statusline traffic is distinguishable from regular
+// `/api/status/cached` curl hits in Cloudflare request logs — the baseline the
+// issue #400 distribution gates compare against). A regression in any of these
+// would re-block Phase 1's "snippet documented somewhere reachable from
+// ai-watch.dev" criterion or silently invalidate the traction baseline.
 
 import { test, expect } from '@playwright/test'
 import { waitForDataLoad } from './helpers.js'
@@ -145,6 +149,60 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     // At least one of the supported terminal names should be mentioned to
     // give the user a quick "do I have one?" check.
     await expect(page.locator('body')).toContainText(/iTerm2|Warp|kitty|WezTerm/i)
+  })
+
+  test('each preset URL is tagged with ?src=statusline-<preset> for traffic split', async ({ page }) => {
+    // The traffic-split tag is what makes the Phase-1 → Reddit/Anthropic gating
+    // measurable (issue #400). Without it, statusline-driven requests are
+    // indistinguishable from regular `/api/status/cached` curl traffic and the
+    // baseline measurement collapses. A future copy-paste refactor that drops
+    // the tag would silently re-block that gate, so pin each preset's slug to
+    // its snippet's <pre> contents. Preset order matches Statusline.jsx render
+    // order: Quick start (degraded_only) then Other presets (compact_badge,
+    // full_list, scoped, clickable).
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    const presetOrder = ['degraded_only', 'compact_badge', 'full_list', 'scoped', 'clickable']
+    const preBlocks = page.locator('pre')
+    await expect(preBlocks).toHaveCount(presetOrder.length)
+    for (let i = 0; i < presetOrder.length; i++) {
+      const text = (await preBlocks.nth(i).textContent()) || ''
+      // `?src=statusline-<preset>` must be present in this preset's snippet AND
+      // must not be replaced by the slug of a different preset (catches "all
+      // snippets share one tag" regressions where the helper was inlined wrong).
+      expect(text, `preset #${i} (${presetOrder[i]}) snippet`).toContain(`?src=statusline-${presetOrder[i]}`)
+      for (const other of presetOrder) {
+        if (other === presetOrder[i]) continue
+        expect(text, `preset #${i} (${presetOrder[i]}) must not carry tag for ${other}`).not.toContain(`?src=statusline-${other}`)
+      }
+    }
+  })
+
+  test('"How it works" section documents the ?src= traffic tag', async ({ page }) => {
+    // User-facing transparency contract: the snippet sends a query parameter,
+    // and the page's "How it works" section explains what it is. The snippet
+    // half is already pinned by 'each preset URL is tagged...' above; this
+    // test pins the prose half. Both assertions are scoped to the "How it
+    // works" <section> subtree so that the literal `?src=statusline-*` inside
+    // the snippet <pre> blocks elsewhere on the page does not satisfy the
+    // first match and silently mask a deleted prose bullet — that drop without
+    // a matching telemetry removal would be the exact "silent telemetry add"
+    // surprise pattern the page's "no client identifier collected" line
+    // promises not to do.
+    await page.goto('/#statusline')
+    await waitForDataLoad(page)
+    // `section` element containing "How it works" — emitted by the Section
+    // helper in src/pages/Statusline.jsx. Two scoped assertions: the tag
+    // pattern is documented AND the no-identifier guarantee is restated.
+    // Either half disappearing should fail this test independently.
+    const howItWorks = page.locator('section').filter({ hasText: /How it works/i })
+    await expect(howItWorks).toHaveCount(1)
+    await expect(howItWorks).toContainText(/\?src=statusline/)
+    // Negation context is what makes this a transparency contract — the bullet
+    // must explicitly state the URL carries no identifier. Anchor the regex on
+    // a negation token (no | never) so "the page accidentally describes the
+    // user identifier we now collect" can't satisfy this assertion.
+    await expect(howItWorks).toContainText(/(?:no|never).{0,40}user identifier/i)
   })
 
   test('"Compatible with" section lists ccstatusline with a link', async ({ page }) => {


### PR DESCRIPTION
## What

Adds `?src=statusline-<preset>` query tag to each of the 5 Claude Code statusline snippets on `/#statusline` so Cloudflare request analytics can split statusline-driven traffic from regular `/api/status/cached` curl hits.

## Why — refs #400 Phase 0 → Phase 1 gating

Today statusline-driven requests are indistinguishable from generic cached-endpoint curl traffic in Cloudflare logs. That means the Phase 1 distribution gates (Reddit r/ClaudeAI launch, Anthropic Claude Code docs PR) have no defensible numeric trigger — they sit "gated on traction signal" indefinitely. The tag is the minimum instrumentation that makes those gates measurable.

## Measurement framework

After this lands, a 14-day baseline window collects:
- **Copy intent** — GA4 `copy_statusline_snippet { preset: <slug> }` events (already wired)
- **Install evidence** — Cloudflare request count by URL with `?src=statusline-*` query

Thresholds derive from the baseline rather than guessed numbers:

| Gate | Trigger (sustained ≥2 weeks) |
|---|---|
| Reddit r/ClaudeAI launch | 3× baseline (floor: 10 copy/wk or 50 tagged req/day) |
| Anthropic Claude Code docs PR | 10× baseline + Reddit gate met + ≥1 external mention |
| Phase 2 (ccstatusline native widget) | Reddit gate met or 100 tagged req/day sustained 7d |
| Phase 3 (npm package) | 30× baseline or 500 tagged req/day sustained 30d |

Sunset clause: if no gate triggers within 90 days of ccstatusline#365 merge (≈ 2026-08-11), close #400 with "shipped Phase 0 + 2/4 external channels, no demand signal".

## Worker safety

`/api/status/cached` route (`worker/src/index.ts`) matches on `url.pathname` only and reads from fixed KV keys (`services:latest`, `latency:24h`, `probe:24h`). Verified before the change. Query tag is invisible to cache + KV; no KV write budget impact.

## Drift protection

5 `SLUG_*` constants are the single source of truth for both `taggedUrl(SLUG_X)` inside preset templates and `eventLabel={SLUG_X}` JSX props on `<Snippet>` call sites. A rename propagates atomically — drift between the URL tag and the GA4 event's `preset` parameter is structurally impossible without detaching the constant.

## Tests

- Existing statusline.spec.js continues passing on all 11 prior tests
- New: `'each preset URL is tagged with ?src=statusline-<preset> for traffic split'` — per-preset slug presence + mutual exclusion (no preset's snippet carries another preset's tag, catching "all snippets share one tag" regressions)
- New: `'"How it works" section documents the ?src= traffic tag'` — scoped to `<section>` subtree so a silent prose drop fails the test independently; regex anchored on negation token (`no|never ... user identifier`) to catch the "we now log a user identifier" rewrite class

PR review (multi-agent) converged after round 2 — Critical 0 / Important 0.

## User-facing change

- `/#statusline` page snippets now embed `?src=statusline-<preset>` in the curl URL
- "How it works" gains a transparency bullet explaining the tag
- README KO/EN Quick install snippet bumped to match
- Existing installs (users who copied before this PR) keep working; the analytics split only measures new installs from merge forward

## Privacy posture preserved

The query tag carries only the preset slug literal (no UA mutation, cookie, timestamp, or random ID added by AIWatch). The page's "no client identifier collected" promise still holds; the new bullet restates this explicitly with "the only payload is the preset slug, never a user identifier".

## Scope

`refs #400` (not `closes`): Phase 0's last acceptance criterion ("AIWatch `/api/status/cached` confirmed safe under expected statusline traffic") still requires the 14-day baseline measurement before it closes. This PR is the instrumentation half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)