### PR TITLE
docs: add social share badges to README header (refs #347)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -20,6 +20,12 @@
 |---------|--------|
 | ![AIWatch 대시보드](docs/screenshot.png?v=3) | ![AIWatch 모바일](docs/screenshot-mobile.png?v=1) |
 
+**공유**
+[![X에 공유](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%2033%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81%20%28Claude%2C%20ChatGPT%2C%20Gemini%20%EC%99%B8%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+[![Reddit에 공유](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%2033%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81)
+[![Hacker News에 공유](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2033%20AI%20services)
+[![LinkedIn에 공유](https://img.shields.io/badge/Share-LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+
 ## 🛰️ 라이브 데모
 
 **[ai-watch.dev](https://ai-watch.dev)** — 회원가입 불필요. Cloudflare Workers로 5분마다 갱신.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Real-time monitoring dashboard for **33 AI services** — track status, latency,
 |---------|--------|
 | ![AIWatch Dashboard](docs/screenshot.png?v=3) | ![AIWatch Mobile](docs/screenshot-mobile.png?v=1) |
 
+**Share**
+[![Share on X](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2033%20AI%20services%20%28Claude%2C%20ChatGPT%2C%20Gemini%2C%20and%20more%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+[![Share on Reddit](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2033%20AI%20services)
+[![Share on Hacker News](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2033%20AI%20services)
+[![Share on LinkedIn](https://img.shields.io/badge/Share-LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+
 ## 🛰️ Live Demo
 
 Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated every 5 minutes via Cloudflare Workers.


### PR DESCRIPTION
## What

Adds a LobeChat-pattern social share row right after the hero image in both `README.md` and `README.ko.md` — 4 shield-style buttons (X, Reddit, Hacker News, LinkedIn) that pre-fill a share with the repo URL.

## Why — refs #347

Low-cost viral mechanic specifically suited to AIWatch's developer-tools audience. The buttons add zero ongoing maintenance cost while putting an inbound share path one click away for every README viewer.

## Channels

| Channel | EN README | KO README |
|---|---|---|
| X (Twitter) | EN text | KO text |
| Reddit | EN title | KO title |
| Hacker News | EN title | **EN title** (pragmatic — HN audience is overwhelmingly English-first; Korean title would reduce engagement) |
| LinkedIn | URL only (LinkedIn pulls OG metadata) | URL only |

**Skipped (intentional):** Telegram — issue marks it optional, EN dev share penetration is low. Easy to add as follow-up if traction warrants.

## Encoding

- Em dash `—` → `%E2%80%94`
- Korean characters → UTF-8 percent encoding (verified via `node -e 'encodeURIComponent(...)'`)
- Parens `(` `)` → `%28` `%29` in both EN and KO for robustness against future markdown-parser regressions on unbalanced link destinations

## Verification

- All 4 shields.io badge URLs return HTTP 200 (X / Reddit / HN / LinkedIn logo slugs all valid SimpleIcons)
- All 4 share-target endpoints accept the generated query strings (HN returned 429 from automated curl rate limiting, not a structural issue)
- Code review converged (Critical 0 / Important 0)

## Out of scope — deferred to other issues

| Badge | Gating issue | Why deferred |
|---|---|---|
| Discord | #346 | Discord server not yet created |
| Discussions | #344 | GitHub Discussions not yet enabled |
| Sponsor shield | #344 | `.github/FUNDING.yml` part of #344 |
| Vercel OSS Program | (external) | Application required |

`refs #347` (not `closes`): badge-audit half remains open until the gating issues land.

## How to verify rendering

GitHub README is the actual render surface — view the branch README at:
- EN: https://github.com/bentleypark/aiwatch/blob/docs/347-readme-share-badges/README.md
- KO: https://github.com/bentleypark/aiwatch/blob/docs/347-readme-share-badges/README.ko.md

The 4 badges should appear inline on a single row (matching the existing header badge pattern on lines 3-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)