### PR TITLE
feat: surface region recommendation in Overview banner + Edge SSR (refs #422 Phase 1 + 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,11 @@ When adding a new monitored service, update ALL of the following:
 8. `src/pages/ServiceDetails.jsx` — add `STATUS_URL` entry for official status page link
 9. `src/pages/Overview.jsx` — verify `TIER_LABEL` (keep in sync with `worker/src/fallback.ts`; `API_TIER` + `getFallbacks` imported from `src/utils/constants.js`)
 10. `api/is-down.ts` — add to `API_TIER` + `EXCLUDE_FALLBACK` (keep in sync with `worker/src/fallback.ts`)
+10b. (region-aware services only) Region data lives in TWO cross-mirrored copies — both must update together. The sync is pinned by `worker/src/__tests__/region-status-sync.test.ts`:
+   - `src/utils/regionStatus.js` — frontend (ServiceDetails RegionalAvailability card, Overview ActionBanner region line). Canonical source for the sync test.
+   - `api/is-down/region-status.ts` — Edge SSR (Is X Down? region recommendation line). Duplicated because Vercel Edge bundling cannot import from `src/`. Same shape, TS port.
+   
+   For both: add `SERVICE_REGIONS` entries (one per region with `key` substring-matched against incident title / componentNames + display `label`) and a `REGION_DOCS_URL` pointer to the provider's region docs. Add `ALWAYS_SHOW_REGIONS` membership only if the service should render the per-region card even with zero ongoing incidents (Bedrock / Azure OpenAI pattern). Surfaces on ServiceDetails + Overview ActionBanner via `regionStatusOf` (#422 Phase 1) + on `/is-*-down` SSR via the Edge mirror (#422 Phase 2).
 
 #### Documentation — service count ("N AI services")
 11. `CLAUDE.md` — architecture section: service count, service list, category breakdown, KV schema comment, probe count, fallback tier list
@@ -397,7 +402,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `save_settings` | — | Settings | Settings saved |
 | `webhook_register` | `type` (discord/slack) | Settings | Webhook URL added |
 | `webhook_remove` | `type` (discord/slack) | Settings | Webhook URL removed |
-| `region_switch_intent` | `service_id`, `recommended_region` | ServiceDetails (Regional) | Region guide link click |
+| `region_switch_intent` | `service_id`, `recommended_region`, `location` (`service_details` / `action_banner` / `is_down_page`) | ServiceDetails (Regional) · Overview (ActionBanner) · Is X Down SSR | Region guide link click — `location` distinguishes the surface that drove the click (#422 Phase 1 + Phase 2) |
 | `click_reports` | — | Sidebar | Monthly reports link click |
 | `click_request_service` | — | Sidebar (request link) | Service request link click |
 | `copy_statusline_snippet` | `preset` (degraded_only/compact_badge/full_list/scoped/clickable) | Statusline page (Copy buttons) | Statusline integration adoption signal (#400 Phase 0) |

--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -3,6 +3,7 @@
 import { SLUG_TO_SERVICE } from './is-down/slug-map'
 import { getSEOContent } from './is-down/seo-content'
 import { renderPage } from './is-down/html-template'
+import { regionStatusOf, type RegionStatusResult } from './is-down/region-status'
 
 export const config = { runtime: 'edge' }
 
@@ -213,7 +214,23 @@ export default async function handler(req: Request) {
       console.error(`[is-down/${slug}] API fetch ${err?.name === 'AbortError' ? 'timeout' : 'failed'}:`, err?.message)
     }
 
-    const html = renderPage(slug, serviceData as Parameters<typeof renderPage>[1], seo, fallbacks, aiInsight)
+    // Region recommendation (refs #422 Phase 2). regionStatusOf returns null
+    // when the service has no region map, no relevant incident, or every
+    // region is hit — the template's renderRegionRecommendation treats null
+    // as "skip the line entirely" so passing it directly is safe.
+    let regionRec: RegionStatusResult | null = null
+    if (serviceData) {
+      try {
+        regionRec = regionStatusOf(serviceData)
+      } catch (regionErr) {
+        // Region computation is best-effort — never block the page render.
+        // Edge logs the error so a future drift between the Worker's incident
+        // shape and our `IncidentLike` type is visible.
+        console.warn(`[is-down/${slug}] regionStatusOf threw:`, regionErr instanceof Error ? regionErr.message : regionErr)
+      }
+    }
+
+    const html = renderPage(slug, serviceData as Parameters<typeof renderPage>[1], seo, fallbacks, aiInsight, regionRec)
 
     // #378: when the upstream Worker fetch failed and we're rendering the
     // "Status data is temporarily unavailable" fallback, the response must NOT

--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { buildMetaDescription, renderIncidents, renderFooter, type ServiceData } from '../html-template'
+import { buildMetaDescription, renderIncidents, renderFooter, renderRegionRecommendation, renderShareButtons, type ServiceData } from '../html-template'
 import type { ServiceSEO } from '../seo-content'
 import { SLUG_TO_SERVICE, RELATED_SLUGS } from '../slug-map'
+import type { RegionStatusResult } from '../region-status'
 
 function mkSeo(overrides: Partial<ServiceSEO> = {}): ServiceSEO {
   return {
@@ -331,5 +332,233 @@ describe('renderFooter — Also check category grouping', () => {
     for (const s of linkSlugs) {
       expect(SLUG_TO_SERVICE[s]?.category, `${s} in API group must be api-category`).toBe('api')
     }
+  })
+})
+
+// ── renderRegionRecommendation (refs #422 Phase 2) ───────────────────
+//
+// Contract: returns '' on all skip conditions; otherwise emits a self-contained
+// callout block matching the AI Insight visual language. The function is the
+// SSR equivalent of the Overview ActionBanner region line + ServiceDetails
+// regional card recommendation — same three skip gates apply.
+
+function mkRegionRec(overrides: Partial<RegionStatusResult> = {}): RegionStatusResult {
+  const usEast = { key: 'AWS us-east-1', label: 'AWS US East', status: 'incident' as const, type: 'incident' as const }
+  const usWest = { key: 'AWS us-west-2', label: 'AWS US West', status: 'ok' as const, type: 'incident' as const }
+  const euWest = { key: 'AWS eu-west-1', label: 'AWS EU West', status: 'ok' as const, type: 'incident' as const }
+  const regions = [usEast, usWest, euWest]
+  return {
+    regions,
+    okRegions: [usWest, euWest],
+    incidentRegions: [usEast],
+    hasRegionSpecific: true,
+    allDown: false,
+    recommendedRegion: usWest,
+    docsUrl: 'https://docs.pinecone.io/troubleshooting/available-cloud-regions',
+    ongoingCount: 1,
+    ...overrides,
+  }
+}
+
+describe('renderRegionRecommendation', () => {
+  it('returns empty string when rec is null (service has no region map)', () => {
+    expect(renderRegionRecommendation(null, 'mistral')).toBe('')
+  })
+
+  it('returns empty string when hasRegionSpecific is false (global incident path)', () => {
+    // Global-incident fallback marks every region as affected but with hasRegionSpecific=false.
+    // Recommending a region in that state would be misleading — the renderer must skip.
+    const rec = mkRegionRec({ hasRegionSpecific: false })
+    expect(renderRegionRecommendation(rec, 'pinecone')).toBe('')
+  })
+
+  it('returns empty string when allDown (no OK region to recommend)', () => {
+    const allDown = mkRegionRec({
+      allDown: true,
+      okRegions: [],
+      recommendedRegion: null,
+    })
+    expect(renderRegionRecommendation(allDown, 'pinecone')).toBe('')
+  })
+
+  it('returns empty string when recommendedRegion is null even if other gates pass', () => {
+    // Defensive: if a future refactor sets allDown=false but recommendedRegion=null
+    // (would indicate a logic bug upstream), the renderer should still bail out.
+    const odd = mkRegionRec({ recommendedRegion: null })
+    expect(renderRegionRecommendation(odd, 'pinecone')).toBe('')
+  })
+
+  it('renders happy-path callout with affected + recommended labels', () => {
+    const html = renderRegionRecommendation(mkRegionRec(), 'pinecone')
+    expect(html).toContain('Try region:')
+    expect(html).toContain('AWS US West')
+    expect(html).toContain('AWS US East')
+    // Single affected region — joined with ", " (only one entry here so we just see the label)
+  })
+
+  it('joins multiple incident regions with ", "', () => {
+    const usEast = { key: 'AWS us-east-1', label: 'AWS US East', status: 'incident' as const, type: 'incident' as const }
+    const usWest = { key: 'AWS us-west-2', label: 'AWS US West', status: 'incident' as const, type: 'incident' as const }
+    const euWest = { key: 'AWS eu-west-1', label: 'AWS EU West', status: 'ok' as const, type: 'incident' as const }
+    const rec = mkRegionRec({
+      regions: [usEast, usWest, euWest],
+      okRegions: [euWest],
+      incidentRegions: [usEast, usWest],
+      recommendedRegion: euWest,
+    })
+    const html = renderRegionRecommendation(rec, 'pinecone')
+    expect(html).toContain('AWS US East, AWS US West')
+    expect(html).toContain('AWS EU West')
+  })
+
+  it('renders docs link with target=_blank rel=noopener noreferrer when docsUrl present', () => {
+    // Security contract — same as the ActionBanner pin (#422 Phase 1).
+    // External link MUST carry rel=noopener noreferrer to prevent reverse-tabnabbing.
+    const html = renderRegionRecommendation(mkRegionRec(), 'pinecone')
+    expect(html).toMatch(/target="_blank"/)
+    expect(html).toMatch(/rel="noopener noreferrer"/)
+    expect(html).toContain('docs.pinecone.io')
+  })
+
+  it('omits docs anchor when docsUrl is undefined', () => {
+    const rec = mkRegionRec({ docsUrl: undefined })
+    const html = renderRegionRecommendation(rec, 'pinecone')
+    expect(html).toContain('Try region:')
+    expect(html).not.toMatch(/<a /)
+  })
+
+  it('fires region_switch_intent GA4 event with location=is_down_page', () => {
+    // Pinned to keep the SSR-driven click attribution distinct from
+    // ServiceDetails (service_details) and ActionBanner (action_banner).
+    // Without this, GA funnel data can't tell which surface drove the click.
+    const html = renderRegionRecommendation(mkRegionRec(), 'pinecone')
+    expect(html).toContain("gtag('event','region_switch_intent'")
+    expect(html).toContain("location:'is_down_page'")
+    expect(html).toContain("service_id:'pinecone'")
+    // The recommended region key is JSON-encoded so a key with spaces (e.g.
+    // "AWS us-west-2") stays valid JS literal — assert that encoding holds.
+    // Quote-escape contract: inner `"` from JSON.stringify must be HTML-encoded
+    // as `&quot;` so the outer `onclick="..."` attribute doesn't truncate.
+    // See the regression test below ("onclick attribute parses as a single
+    // intact JS expression") for the DOM-level integrity check.
+    expect(html).toContain('recommended_region:&quot;AWS us-west-2&quot;')
+  })
+
+  it('onclick attribute parses as a single intact JS expression (regression: quote-escape contract)', () => {
+    // Regression pin for the Phase-2 review-round-3 Critical finding: the GA4
+    // onclick body contains `recommended_region:"AWS us-west-2"` which, if
+    // left as raw `"`, would prematurely close the outer `onclick="..."`
+    // attribute. HTML parser truncates at the first inner `"`, the rest of
+    // the JS body is interpreted as bogus HTML attributes, and the GA4
+    // event silently never fires. We escape inner `"` to `&quot;`.
+    //
+    // Reparse the rendered HTML through the test environment's DOM and pull
+    // the onclick attribute back out to verify it's whole. If a future
+    // contributor swaps the escape strategy (single-quoting, delegated
+    // listeners, etc.) we want this test to catch any regression that
+    // re-breaks the attribute boundary.
+    const html = renderRegionRecommendation(mkRegionRec(), 'pinecone')
+    const container = document.createElement('div')
+    container.innerHTML = html
+    const anchor = container.querySelector('a[onclick]')
+    expect(anchor, 'expected an anchor with onclick to be present').not.toBeNull()
+    const onclick = anchor!.getAttribute('onclick') ?? ''
+    // The full JS body must end with `})` — the closing of gtag(...) call.
+    // If the attribute was truncated, the value would end at `recommended_region:`
+    // and the trailing characters would have become separate attributes.
+    expect(onclick).toMatch(/\}\)$/)
+    // The recommended_region value is present, contains a space (Pinecone-shaped
+    // key), and the JSON.stringify quotes are entity-decoded back to literal `"`
+    // by the HTML parser when we read getAttribute (verified below).
+    expect(onclick).toContain('recommended_region:"AWS us-west-2"')
+    expect(onclick).toContain("location:'is_down_page'")
+    expect(onclick).toContain("service_id:'pinecone'")
+    // No stray HTML attributes leaked from a truncated onclick — the fix
+    // ensures the value is whole, so anchor has exactly the expected attrs.
+    const attrNames = anchor!.getAttributeNames().sort()
+    expect(attrNames).toEqual(['href', 'onclick', 'rel', 'style', 'target'])
+  })
+
+  it('escapes label content (defensive vs upstream-injected labels)', () => {
+    // Note: regression test for the share-button onclick attributes is in the
+    // `renderShareButtons` describe block below, not here — same bug class, same
+    // file, but two separate render call sites worth pinning independently so a
+    // future refactor that splits or merges them doesn't quietly orphan the fix.
+    // SERVICE_REGIONS labels are static + author-controlled today, but the
+    // renderer pipes them through `esc()` anyway as a defense-in-depth
+    // against a future "regions come from an upstream feed" change. Pin by
+    // passing a label with HTML-special chars.
+    const xssLabel = '<img src=x onerror="alert(1)">'
+    const usWest = { key: 'safe', label: xssLabel, status: 'ok' as const, type: 'incident' as const }
+    const usEast = { key: 'aff', label: 'Affected', status: 'incident' as const, type: 'incident' as const }
+    const rec = mkRegionRec({
+      regions: [usEast, usWest],
+      okRegions: [usWest],
+      incidentRegions: [usEast],
+      recommendedRegion: usWest,
+    })
+    const html = renderRegionRecommendation(rec, 'pinecone')
+    expect(html).not.toContain('<img src=x')
+    expect(html).toContain('&lt;img src=x')
+  })
+})
+
+// ── renderShareButtons (quote-escape contract — same class as #422 region rec) ──
+//
+// Phase 2 review round 4 audit caught a pre-existing instance of the same
+// quote-truncation bug in the share buttons: `item_id:${jsDisplayName}` from
+// JSON.stringify embeds a raw `"` into the double-quoted `onclick="..."`
+// attribute. HTML parser truncates → `gtag('event','share',...)` never fires
+// → bogus stray attributes leak. The fix (escJsForAttr helper) applies the same
+// shape across both call sites; this regression test mirrors the region-rec
+// pin so a future split/merge of the helper can't silently revert one side.
+
+describe('renderShareButtons onclick attributes (quote-escape contract)', () => {
+  // Minimal SEO fixture — only the display name + faqs are read by the
+  // share-button code path. The display name carries an embedded space so the
+  // JSON.stringify output has the inner `"` that the bug truncates on.
+  const seo = mkSeo({ displayName: 'Claude API' })
+  const service = mkService({ status: 'down' })
+  const canonical = 'https://ai-watch.dev/is-claude-down'
+  const ogImage = 'https://aiwatch-worker.p2c2kbf.workers.dev/api/og?v=1'
+
+  it('share-x onclick attribute parses as a single intact JS expression', () => {
+    const html = renderShareButtons(seo, service, canonical, ogImage)
+    const container = document.createElement('div')
+    container.innerHTML = html
+    const anchor = container.querySelector('a.share-x')
+    expect(anchor, 'share-x anchor missing').not.toBeNull()
+    const onclick = anchor!.getAttribute('onclick') ?? ''
+    // Whole gtag call survives.
+    expect(onclick).toMatch(/\}\)$/)
+    // Entity-decoded inner double quotes around the displayName.
+    expect(onclick).toContain('item_id:"Claude API"')
+    // No truncation residue — anchor has exactly the documented attrs.
+    expect(anchor!.getAttributeNames().sort()).toEqual(['class', 'href', 'onclick', 'rel', 'target'])
+  })
+
+  it('share-threads onclick attribute parses as a single intact JS expression', () => {
+    const html = renderShareButtons(seo, service, canonical, ogImage)
+    const container = document.createElement('div')
+    container.innerHTML = html
+    const anchor = container.querySelector('a.share-threads')
+    expect(anchor, 'share-threads anchor missing').not.toBeNull()
+    const onclick = anchor!.getAttribute('onclick') ?? ''
+    expect(onclick).toMatch(/\}\)$/)
+    expect(onclick).toContain('item_id:"Claude API"')
+    expect(anchor!.getAttributeNames().sort()).toEqual(['class', 'href', 'onclick', 'rel', 'target'])
+  })
+
+  it('share-x and share-threads onclick wire-format uses the entity-escaped form', () => {
+    // Raw HTML inspection — a future refactor that drops escJsForAttr but uses
+    // a different fix (delegated listeners, single-quoted attrs) must update
+    // this assertion deliberately. Pins the wire format alongside the DOM
+    // parse to give both layers their own regression signal.
+    const html = renderShareButtons(seo, service, canonical, ogImage)
+    // Single quotes inside an HTML attribute value don't need entity-encoding
+    // (the attribute is double-quoted, so `'` is just a literal). Only the
+    // double quotes from JSON.stringify need the `&quot;` treatment.
+    expect(html).toContain(`method:'x',content_type:'is_x_down',item_id:&quot;Claude API&quot;`)
+    expect(html).toContain(`method:'threads',content_type:'is_x_down',item_id:&quot;Claude API&quot;`)
   })
 })

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -6,6 +6,7 @@ import { groupIncidents, type GroupingIncident, type GroupRow, type SingleRow } 
 import { compareGroupedRows } from './incident-sort'
 import { CONSENT_INIT_COMMENT, CONSENT_INIT_SCRIPT } from '../_shared/consent-init'
 import { COOKIE_BANNER_HTML } from '../_shared/cookie-banner'
+import type { RegionStatusResult } from './region-status'
 
 /** Format recovery display — shared with worker/src/ai-analysis.ts */
 function formatRecoveryDisplay(recovery: string): string {
@@ -54,6 +55,22 @@ function esc(s: string | null | undefined): string {
 
 function safeJsonLd(data: unknown): string {
   return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+// Encode a JSON.stringify output (or any JS-string-literal-wrapped value) so the
+// inner `"` survives being embedded inside a double-quoted HTML attribute like
+// `onclick="..."`. Without this, the HTML tokenizer treats the first inner `"`
+// as the attribute terminator → truncates the JS body → the rest leaks as
+// stray attributes → the inline handler silently never runs. The browser
+// entity-decodes `&quot;` back to `"` before invoking the JS compiler, so the
+// embedded handler executes as intended.
+//
+// Discovered in #422 Phase 2 review round 3 (region recommendation onclick) and
+// audited across the file in round 4 — also fixes the pre-existing share-button
+// GA4 fire that has been silently dead. Centralized here so future
+// inline-onclick + JSON.stringify combinations don't re-discover the bug.
+function escJsForAttr(jsLiteral: string): string {
+  return jsLiteral.replace(/"/g, '&quot;')
 }
 
 function statusEmoji(status: string): string {
@@ -111,6 +128,12 @@ export function renderPage(
   seo: ServiceSEO,
   fallbacks: Fallback[],
   aiInsight?: { summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string } | null,
+  // Region recommendation (refs #422 Phase 2). When the affected service has
+  // region-specific incidents AND at least one healthy region, surface an
+  // actionable "Try region: X" line right under the AI Insight block. Null
+  // when the service has no region map, no relevant incident, or every region
+  // is hit (allDown — no useful recommendation).
+  regionRec?: RegionStatusResult | null,
 ): string {
   const title = `Is ${seo.displayName} Down? Live Status | AIWatch`
   const desc = buildMetaDescription(seo, service, aiInsight ?? null)
@@ -222,6 +245,7 @@ h2{font-size:18px;font-weight:600;margin:32px 0 16px;color:#e6edf3}
 ${renderStatusHeader(service, seo)}
 ${renderCTA(seo, service?.status ?? 'operational')}
 ${renderAIInsight(aiInsight, service?.status, fallbacks)}
+${renderRegionRecommendation(regionRec ?? null, slug)}
 ${renderIncidents(service)}
 ${renderDescription(seo, service)}
 ${renderFAQ(seo, fallbacks)}
@@ -305,6 +329,57 @@ ${insight.resolvedAt ? `<span>✅ Recovered: ${(() => { const m = Math.floor((Da
 </div>
 ${fallbackHtml}
 <p class="mono" style="font-size:9px;color:#484f58;margin-top:8px;opacity:0.7">⚠️ AI-generated estimation based on historical data. Actual time may vary.</p>
+</div>`
+}
+
+// ── Region recommendation (refs #422 Phase 2) ─────────────────────────
+//
+// When the SSR page is rendered during a partial regional outage (e.g.
+// Pinecone AWS us-east-1 down but other 5 regions healthy), surface a single
+// "Try region: <label>" line BEFORE the cross-service fallback recommendation.
+// Region-switch is structurally cheaper than service-switch (same SDK / IAM /
+// billing — only the endpoint URL changes), so it deserves first-line
+// visibility. Returns '' when there's nothing actionable to show.
+//
+// Exported (alongside other render helpers) so api/is-down/__tests__/html-template.test.ts
+// can pin both the happy-path HTML structure and the three skip conditions.
+export function renderRegionRecommendation(rec: RegionStatusResult | null, slug: string): string {
+  if (!rec) return ''
+  // Three skip conditions, same as ActionBanner (#422 Phase 1):
+  //   - hasRegionSpecific=false → global incident hit every region; recommending
+  //     a region would be misleading
+  //   - allDown → no healthy region to switch to
+  //   - !recommendedRegion → defensive, same as allDown in practice
+  if (!rec.hasRegionSpecific || rec.allDown || !rec.recommendedRegion) return ''
+
+  const affected = rec.incidentRegions.map((r) => esc(r.label)).join(', ')
+  const recLabel = esc(rec.recommendedRegion.label)
+  const docsHref = rec.docsUrl ? esc(rec.docsUrl) : ''
+
+  // Inline styles match the AI Insight callout's visual language: bg #161b22,
+  // 3px left border in the accent color (blue here, matching the region-card
+  // theme on /#service detail pages). The GA4 hook fires `region_switch_intent`
+  // with location=is_down_page so we can tell SSR-driven clicks from
+  // dashboard-driven clicks in the funnel data.
+  //
+  // Region key (e.g. Pinecone's "AWS us-west-2" — has a space) is serialized
+  // via JSON.stringify for a safe JS string literal, then HTML-attribute-
+  // encoded via escJsForAttr() so it survives being interpolated into the
+  // double-quoted `onclick="..."` attribute below. See escJsForAttr's docstring
+  // for the full contract.
+  const recKeyJs = escJsForAttr(JSON.stringify(rec.recommendedRegion.key))
+  const ga4OnClick = `typeof gtag==='function'&&gtag('event','region_switch_intent',{service_id:'${esc(slug)}',recommended_region:${recKeyJs},location:'is_down_page'})`
+
+  return `
+<div style="font-size:14px;margin:16px 0;padding:14px 16px;background:#161b22;border-left:3px solid #58a6ff;border-radius:0 6px 6px 0">
+<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+<span style="font-size:16px">📍</span>
+<strong style="color:#c9d1d9">Try region: ${recLabel}</strong>
+</div>
+<div style="font-size:12px;color:#8b949e;line-height:1.5">
+<span>Currently affected: ${affected}.</span>
+${docsHref ? `<br><a href="${docsHref}" target="_blank" rel="noopener noreferrer" onclick="${ga4OnClick}" style="color:#58a6ff">Region docs →</a>` : ''}
+</div>
 </div>`
 }
 
@@ -526,7 +601,7 @@ ${items}
 </div>`
 }
 
-function renderShareButtons(seo: ServiceSEO, service: ServiceData | null, canonical: string, ogImageUrl: string, aiInsight?: { summary: string; estimatedRecovery: string; affectedScope: string[] } | null): string {
+export function renderShareButtons(seo: ServiceSEO, service: ServiceData | null, canonical: string, ogImageUrl: string, aiInsight?: { summary: string; estimatedRecovery: string; affectedScope: string[] } | null): string {
   const status = service ? statusLabel(service.status) : 'Operational'
   const rawStatus = service?.status ?? 'operational'
 
@@ -596,18 +671,22 @@ function renderShareButtons(seo: ServiceSEO, service: ServiceData | null, canoni
   const encodedUrl = rawStatus !== 'operational' ? encodeURIComponent(canonical) : ''
   const xUrlParam = encodedUrl ? `&amp;url=${encodedUrl}` : ''
 
-  // Use JSON.stringify for safe JS string interpolation (prevents XSS via backslash/newline)
+  // Use JSON.stringify for safe JS string interpolation (prevents XSS via backslash/newline).
+  // jsDisplayNameAttr is the attribute-safe form for embedding inside `onclick="..."` —
+  // see escJsForAttr docstring. The raw `jsDisplayName` etc. are kept for `<script>` bodies
+  // where the inner `"` is correct (script content is CDATA-like, not HTML-attribute parsed).
   const jsDisplayName = JSON.stringify(seo.displayName)
+  const jsDisplayNameAttr = escJsForAttr(jsDisplayName)
   const jsCanonical = JSON.stringify(canonical)
   const jsOgImageUrl = JSON.stringify(ogImageUrl)
   const jsStatus = JSON.stringify(status)
 
   return `<div class="share-bar">
-<a href="https://x.com/intent/tweet?text=${encodedText}${xUrlParam}" target="_blank" rel="noopener" class="share-btn share-x" onclick="gtag('event','share',{method:'x',content_type:'is_x_down',item_id:${jsDisplayName}})">
+<a href="https://x.com/intent/tweet?text=${encodedText}${xUrlParam}" target="_blank" rel="noopener" class="share-btn share-x" onclick="gtag('event','share',{method:'x',content_type:'is_x_down',item_id:${jsDisplayNameAttr}})">
 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
 Post
 </a>
-<a href="https://www.threads.net/intent/post?text=${encodedText}${encodedUrl ? '%20' + encodedUrl : ''}" target="_blank" rel="noopener" class="share-btn share-threads" onclick="gtag('event','share',{method:'threads',content_type:'is_x_down',item_id:${jsDisplayName}})">
+<a href="https://www.threads.net/intent/post?text=${encodedText}${encodedUrl ? '%20' + encodedUrl : ''}" target="_blank" rel="noopener" class="share-btn share-threads" onclick="gtag('event','share',{method:'threads',content_type:'is_x_down',item_id:${jsDisplayNameAttr}})">
 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12.186 24h-.007c-3.581-.024-6.334-1.205-8.184-3.509C2.35 18.44 1.5 15.586 1.472 12.01v-.017c.03-3.579.879-6.43 2.525-8.482C5.845 1.205 8.6.024 12.18 0h.014c2.746.02 5.043.725 6.826 2.098 1.677 1.29 2.858 3.13 3.509 5.467l-2.04.569c-1.104-3.96-3.898-5.984-8.304-6.015-2.91.022-5.11.936-6.54 2.717C4.307 6.504 3.616 8.914 3.59 12c.025 3.083.718 5.496 2.057 7.164 1.432 1.783 3.631 2.698 6.54 2.717 2.623-.02 4.358-.631 5.8-2.045 1.647-1.613 1.618-3.593 1.09-4.798-.346-.789-.96-1.42-1.757-1.846-.184 2.985-1.086 5.27-2.844 6.39-1.34.853-3.065 1.062-4.62.559-1.72-.557-3.09-1.843-3.37-3.583-.203-1.264.066-2.418.757-3.248.86-1.032 2.278-1.578 3.952-1.578 2.37 0 3.877 1.128 4.453 2.325.153-.915.177-1.937.073-3.065l2.023-.235c.203 2.153.015 4.027-.735 5.483a5.997 5.997 0 0 0 1.013.607c1.27.605 2.567.665 3.557-.12 1.258-1 1.554-2.79 1.168-4.34-.478-1.922-1.806-3.598-3.853-4.85C17.257 5.282 14.907 4.725 12.2 4.708h-.015c-3.34.024-5.886 1.348-7.357 3.832C3.622 10.52 3.088 12.947 3.088 12c0-.96.533-3.504 1.74-5.488 1.41-2.319 3.756-3.568 6.857-3.655h.02c2.467.02 4.57.527 6.25 1.508 1.735 1.012 3.032 2.488 3.558 4.282.65 2.214.23 4.685-1.496 6.055-1.497 1.187-3.366 1.065-4.868.348a7.89 7.89 0 0 1-.778-.42c-.66 1.345-1.68 2.276-3.063 2.788-.986.365-2.103.432-3.243.19-1.882-.401-3.466-1.576-4.156-3.216-.475-1.13-.53-2.394-.155-3.586.468-1.484 1.634-2.632 3.288-3.063 1.918-.5 3.728-.074 5.02 1.182.574.558 1.005 1.26 1.283 2.094.228-.76.382-1.581.455-2.46l-.005-.038z"/></svg>
 Share
 </a>

--- a/api/is-down/region-status.ts
+++ b/api/is-down/region-status.ts
@@ -1,0 +1,181 @@
+// Server-side region status helper for /is-X-down SSR pages.
+//
+// Mirrors `regionStatusOf` from `src/utils/regionStatus.js` — duplicated rather
+// than shared because Vercel Edge bundling cannot import from `src/`. The cross-
+// mirror sync is pinned by `worker/src/__tests__/region-status-sync.test.ts`
+// (added in the same PR — refs #422 Phase 2): SERVICE_REGIONS deep-equal + the
+// inline keys must match. If you change the matching algorithm here, change the
+// SPA copy in the same commit.
+//
+// Why a TS port instead of JS import: keeps the Edge Function's compilation
+// surface fully typed and stops `node_modules`-vs-`src/` resolution from
+// surprising the Vercel bundler. The data shapes (SERVICE_REGIONS entries,
+// SERVICE_REGIONS keys, REGION_DOCS_URL slugs) are pure data — no runtime
+// side effects, no environment-variable reads, no module-load fetches.
+
+export type RegionDef = { key: string; label: string }
+
+export type IncidentLike = {
+  id?: unknown
+  title?: unknown
+  status?: unknown
+  componentNames?: unknown
+}
+
+export type ServiceLike = {
+  id?: string
+  incidents?: unknown[]
+}
+
+export type RegionRow = RegionDef & { status: 'ok' | 'incident'; type: IncidentType }
+
+export type IncidentType = 'down' | 'degraded_perf' | 'inference' | 'incident'
+
+export type RegionStatusResult = {
+  regions: RegionRow[]
+  okRegions: RegionRow[]
+  incidentRegions: RegionRow[]
+  hasRegionSpecific: boolean
+  allDown: boolean
+  recommendedRegion: RegionRow | null
+  docsUrl: string | undefined
+  ongoingCount: number
+}
+
+// Keep in lockstep with src/utils/regionStatus.js SERVICE_REGIONS. Order
+// matters: the FIRST healthy region in this array is what `recommendedRegion`
+// resolves to. Convention: cluster regions by cloud provider (AWS first, then
+// Azure, then GCP) so a same-cloud fallback is the natural default.
+export const SERVICE_REGIONS: Record<string, RegionDef[]> = {
+  xai: [
+    { key: 'us-east-1', label: 'US (us-east-1)' },
+    { key: 'eu-west-1', label: 'EU (eu-west-1)' },
+  ],
+  gemini: [
+    { key: 'us-central1', label: 'US Central (us-central1)' },
+    { key: 'europe-west1', label: 'Europe West (europe-west1)' },
+    { key: 'asia-northeast1', label: 'Asia Northeast (asia-northeast1)' },
+  ],
+  openai: [
+    { key: 'us-east-1', label: 'US East (us-east-1)' },
+    { key: 'us-west-2', label: 'US West (us-west-2)' },
+    { key: 'eu-central-1', label: 'Europe Central (eu-central-1)' },
+  ],
+  azureopenai: [
+    { key: 'East US 2', label: 'East US 2' },
+    { key: 'Central US', label: 'Central US' },
+    { key: 'Sweden Central', label: 'Sweden Central' },
+    { key: 'UK South', label: 'UK South' },
+    { key: 'Australia East', label: 'Australia East' },
+    { key: 'Korea Central', label: 'Korea Central' },
+    { key: 'Norway East', label: 'Norway East' },
+  ],
+  bedrock: [
+    { key: 'us-east-1', label: 'US East (N. Virginia)' },
+    { key: 'us-west-2', label: 'US West (Oregon)' },
+    { key: 'eu-west-1', label: 'Europe (Ireland)' },
+    { key: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+  ],
+  pinecone: [
+    { key: 'AWS us-east-1', label: 'AWS US East' },
+    { key: 'AWS us-west-2', label: 'AWS US West' },
+    { key: 'AWS eu-west-1', label: 'AWS EU West' },
+    { key: 'Azure eastus2', label: 'Azure East US' },
+    { key: 'GCP us-central1', label: 'GCP US Central' },
+    { key: 'GCP europe-west4', label: 'GCP EU West' },
+  ],
+}
+
+export const REGION_DOCS_URL: Record<string, string> = {
+  xai: 'https://docs.x.ai/docs/regions',
+  gemini: 'https://cloud.google.com/vertex-ai/docs/general/locations',
+  openai: 'https://platform.openai.com/docs/guides/production-best-practices',
+  chatgpt: 'https://status.openai.com',
+  azureopenai: 'https://learn.microsoft.com/azure/ai-services/openai/concepts/models',
+  bedrock: 'https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html',
+  pinecone: 'https://docs.pinecone.io/troubleshooting/available-cloud-regions',
+}
+
+const ALWAYS_SHOW_REGIONS = new Set(['bedrock', 'azureopenai'])
+
+export function classifyIncident(title: unknown): IncidentType {
+  if (!title || typeof title !== 'string') return 'incident'
+  const lower = title.toLowerCase()
+  if (/\b(down|outage|unavailable)\b/.test(lower)) return 'down'
+  if (/\b(latency|slow|timeout|delay)\b/.test(lower)) return 'degraded_perf'
+  if (/\b(inference|grok|model|gemini|vertex|bedrock)\b/.test(lower)) return 'inference'
+  return 'incident'
+}
+
+export function regionStatusOf(service: ServiceLike | null | undefined): RegionStatusResult | null {
+  if (!service || typeof service !== 'object') return null
+  const regionDefs = service.id ? SERVICE_REGIONS[service.id] : undefined
+  if (!Array.isArray(regionDefs) || regionDefs.length === 0) return null
+
+  const allIncidents = Array.isArray(service.incidents) ? service.incidents : []
+  // aistudio:-prefixed incidents come from the global direct Gemini API surface,
+  // which has no per-region breakdown — including them would trigger the
+  // "no region match → mark all regions affected" fallback and overstate the
+  // impact. See worker/src/services.ts #310.
+  const ongoing = allIncidents.filter((i): i is IncidentLike => {
+    if (!i || typeof i !== 'object') return false
+    const inc = i as IncidentLike
+    return (
+      typeof inc.title === 'string' &&
+      inc.status !== 'resolved' &&
+      typeof inc.id === 'string' &&
+      !(inc.id as string).startsWith('aistudio:')
+    )
+  })
+
+  const alwaysShow = service.id ? ALWAYS_SHOW_REGIONS.has(service.id) : false
+  if (ongoing.length === 0 && !alwaysShow) return null
+
+  const status: Record<string, { status: 'ok' | 'incident'; type: IncidentType }> = {}
+  for (const r of regionDefs) {
+    status[r.key] = { status: 'ok', type: 'incident' }
+  }
+
+  let hasRegionSpecific = false
+  for (const inc of ongoing) {
+    const titleLower = (inc.title as string).toLowerCase()
+    const compNames = Array.isArray(inc.componentNames)
+      ? (inc.componentNames as unknown[]).map((n) => String(n).toLowerCase())
+      : []
+    for (const r of regionDefs) {
+      const keyLower = r.key.toLowerCase()
+      if (titleLower.includes(keyLower) || compNames.some((n) => n.includes(keyLower))) {
+        // First-match-wins for incident type — see SPA copy
+        // src/utils/regionStatus.js for rationale. Deterministic across
+        // re-renders / re-orders, vs the pre-extraction last-wins behavior.
+        if (status[r.key].status === 'ok') {
+          status[r.key] = { status: 'incident', type: classifyIncident(inc.title) }
+        }
+        hasRegionSpecific = true
+      }
+    }
+  }
+
+  if (!hasRegionSpecific && ongoing.length > 0) {
+    const globalType = classifyIncident((ongoing[0] as IncidentLike).title)
+    for (const r of regionDefs) {
+      status[r.key] = { status: 'incident', type: globalType }
+    }
+  }
+
+  const regions: RegionRow[] = regionDefs.map((r) => ({ ...r, ...status[r.key] }))
+  const okRegions = regions.filter((r) => r.status === 'ok')
+  const incidentRegions = regions.filter((r) => r.status === 'incident')
+  const allDown = okRegions.length === 0
+
+  return {
+    regions,
+    okRegions,
+    incidentRegions,
+    hasRegionSpecific,
+    allDown,
+    recommendedRegion: okRegions[0] ?? null,
+    docsUrl: service.id ? REGION_DOCS_URL[service.id] : undefined,
+    ongoingCount: ongoing.length,
+  }
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -61,6 +61,7 @@ const en = {
   'overview.banner.down': 'Down',
   'overview.banner.affected': '{n} services affected',
   'overview.banner.fallback': 'Suggested fallback:',
+  'overview.banner.regionSwitch': 'Switch region:',
   'overview.banner.noFallback': 'No direct fallback available · Retry or caching recommended',
   'overview.banner.viewIssues': 'View Issues tab for details',
   'overview.banner.viewIncidents': 'View incident details',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -61,6 +61,7 @@ const ko = {
   'overview.banner.down': '서비스 중단',
   'overview.banner.affected': '{n}개 서비스 장애',
   'overview.banner.fallback': '대체 추천:',
+  'overview.banner.regionSwitch': '리전 전환:',
   'overview.banner.noFallback': '대체 서비스 없음 · 재시도 또는 캐싱 권장',
   'overview.banner.viewIssues': 'Issues 탭에서 확인',
   'overview.banner.viewIncidents': '인시던트 상세 확인',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -9,6 +9,7 @@ import { usePolling } from '../hooks/usePolling'
 import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, EXCLUDE_FALLBACK, getFallbacks, tierFor, tierLabelFor } from '../utils/constants'
+import { regionStatusOf } from '../utils/regionStatus'
 import { buildCalendarFromIncidents } from '../utils/calendar'
 import { compareIncidents, getContextualTime } from '../utils/incidentSort'
 import { formatTime, formatDate } from '../utils/time'
@@ -369,6 +370,29 @@ function ActionBanner({ services, setPage, t }) {
     categoryGroups.push({ category: svc.category, label, items: candidates.slice(0, perGroup) })
   }
 
+  // Region-switch recommendations (refs #422 Phase 1). For each affected service
+  // whose status page reports per-region incidents AND has at least one healthy
+  // region, surface "Pinecone → AWS US West" alongside the cross-service fallback.
+  // Region switch is structurally cheaper than service switch (same SDK / IAM /
+  // billing) so it deserves first-line visibility — today this guidance is
+  // siloed in ServiceDetails and requires a click to discover.
+  //
+  // Skip when:
+  //   • regionStatusOf returns null (no region map / no relevant incidents)
+  //   • hasRegionSpecific === false (global-incident fallback path — every
+  //     region marked affected; suggesting "switch region" would be misleading)
+  //   • allDown — no OK region to recommend
+  const regionRecs = []
+  for (const svc of affected) {
+    const rs = regionStatusOf(svc)
+    if (!rs || !rs.hasRegionSpecific || rs.allDown || !rs.recommendedRegion) continue
+    regionRecs.push({
+      svc,
+      recommendedRegion: rs.recommendedRegion,
+      docsUrl: rs.docsUrl,
+    })
+  }
+
   return (
     <div className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg" style={{ padding: '10px 14px', lineHeight: 1.5, borderLeft: `3px solid ${borderColor}` }}>
       {downList.length > 0 && (
@@ -400,6 +424,42 @@ function ActionBanner({ services, setPage, t }) {
           >
             👉 {t('overview.banner.viewIncidents')}
           </button>
+        </div>
+      )}
+      {/* Region-switch recommendation line (refs #422 Phase 1). Renders before
+          cross-service fallback so the cheaper-to-execute action lands first.
+          Service name is clickable (drills into ServiceDetails for the full
+          region card); the recommended-region label links out to the provider's
+          region docs and fires region_switch_intent GA4 with location=action_banner. */}
+      {regionRecs.length > 0 && (
+        <div className="mono text-[11px] text-[var(--text2)]" style={{ marginTop: '4px' }}>
+          <span>{t('overview.banner.regionSwitch')}</span>
+          {regionRecs.map((rec, ri) => (
+            <span key={rec.svc.id}>
+              {ri > 0 && ' · '}
+              {' '}
+              <span
+                className="text-[var(--text0)] hover:underline cursor-pointer"
+                onClick={() => setPage({ name: 'service', serviceId: rec.svc.id })}
+              >
+                {rec.svc.name}
+              </span>
+              <span className="text-[var(--text2)]"> → </span>
+              {rec.docsUrl ? (
+                <a
+                  href={rec.docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--green)] hover:underline"
+                  onClick={() => trackEvent('region_switch_intent', { service_id: rec.svc.id, recommended_region: rec.recommendedRegion.key, location: 'action_banner' })}
+                >
+                  {rec.recommendedRegion.label}
+                </a>
+              ) : (
+                <span className="text-[var(--green)]">{rec.recommendedRegion.label}</span>
+              )}
+            </span>
+          ))}
         </div>
       )}
       {categoryGroups.length > 0 ? (

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -13,6 +13,7 @@ import { buildCalendarFromIncidents } from '../utils/calendar'
 import { groupIncidents } from '../utils/incidentGrouping'
 import { compareGroupedRows, dominantGroupStatus } from '../utils/incidentSort'
 import { SCORE_TEXT_CLASS } from '../utils/constants'
+import { regionStatusOf, SERVICE_REGIONS } from '../utils/regionStatus'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
 import StatusPill from '../components/StatusPill'
@@ -370,57 +371,10 @@ function IncidentGroupRow({ group, t, lang }) {
 }
 
 // ── Regional Availability ────────────────────────────────
-// Extracts region info from ongoing incident titles
-
-const SERVICE_REGIONS = {
-  xai: [
-    { key: 'us-east-1', label: 'US (us-east-1)' },
-    { key: 'eu-west-1', label: 'EU (eu-west-1)' },
-  ],
-  gemini: [
-    { key: 'us-central1', label: 'US Central (us-central1)' },
-    { key: 'europe-west1', label: 'Europe West (europe-west1)' },
-    { key: 'asia-northeast1', label: 'Asia Northeast (asia-northeast1)' },
-  ],
-  openai: [
-    { key: 'us-east-1', label: 'US East (us-east-1)' },
-    { key: 'us-west-2', label: 'US West (us-west-2)' },
-    { key: 'eu-central-1', label: 'Europe Central (eu-central-1)' },
-  ],
-  azureopenai: [
-    { key: 'East US 2', label: 'East US 2' },
-    { key: 'Central US', label: 'Central US' },
-    { key: 'Sweden Central', label: 'Sweden Central' },
-    { key: 'UK South', label: 'UK South' },
-    { key: 'Australia East', label: 'Australia East' },
-    { key: 'Korea Central', label: 'Korea Central' },
-    { key: 'Norway East', label: 'Norway East' },
-  ],
-  bedrock: [
-    { key: 'us-east-1', label: 'US East (N. Virginia)' },
-    { key: 'us-west-2', label: 'US West (Oregon)' },
-    { key: 'eu-west-1', label: 'Europe (Ireland)' },
-    { key: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
-  ],
-  pinecone: [
-    { key: 'AWS us-east-1', label: 'AWS US East' },
-    { key: 'AWS us-west-2', label: 'AWS US West' },
-    { key: 'AWS eu-west-1', label: 'AWS EU West' },
-    { key: 'Azure eastus2', label: 'Azure East US' },
-    { key: 'GCP us-central1', label: 'GCP US Central' },
-    { key: 'GCP europe-west4', label: 'GCP EU West' },
-  ],
-}
-
-// Classify incident type from title keywords
-function classifyIncident(title) {
-  if (!title || typeof title !== 'string') return 'incident'
-  const lower = title.toLowerCase()
-  if (/\b(down|outage|unavailable)\b/.test(lower)) return 'down'
-  if (/\b(latency|slow|timeout|delay)\b/.test(lower)) return 'degraded_perf'
-  if (/\b(inference|grok|model|gemini|vertex|bedrock)\b/.test(lower)) return 'inference'
-  return 'incident' // generic
-}
+// Renders the per-region status card on service detail pages. Region matching
+// + recommendation logic now lives in src/utils/regionStatus.js so the Overview
+// ActionBanner and future Worker / Edge surfaces share one source of truth
+// (refs #422 Phase 1). This component is presentation-only.
 
 // Label key for each incident type
 const INCIDENT_TYPE_LABEL = {
@@ -444,85 +398,30 @@ const INCIDENT_DOT_COLOR = {
   incident: 'bg-[var(--red)]',
 }
 
-const REGION_DOCS_URL = {
-  xai: 'https://docs.x.ai/docs/regions',
-  gemini: 'https://cloud.google.com/vertex-ai/docs/general/locations',
-  openai: 'https://platform.openai.com/docs/guides/production-best-practices',
-  chatgpt: 'https://status.openai.com',
-  azureopenai: 'https://learn.microsoft.com/azure/ai-services/openai/concepts/models',
-  bedrock: 'https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html',
-  pinecone: 'https://docs.pinecone.io/troubleshooting/available-cloud-regions',
-}
-
 function RegionalAvailability({ service, t }) {
   try {
-    const regions = SERVICE_REGIONS[service.id]
-    if (!regions) return null
+    const state = regionStatusOf(service)
+    if (!state) return null
 
-    const incidents = Array.isArray(service.incidents) ? service.incidents : []
-    // aistudio:-prefixed incidents come from the global direct Gemini API
-    // surface, which has no per-region breakdown — including them would trigger
-    // the "no region match → mark all regions affected" fallback and overstate
-    // the impact. Region breakdown only makes sense for Vertex (gcloud) feed
-    // entries, whose titles include region keywords. See #310.
-    const ongoing = incidents.filter(
-      (i) =>
-        i &&
-        typeof i.title === 'string' &&
-        i.status !== 'resolved' &&
-        typeof i.id === 'string' &&
-        !i.id.startsWith('aistudio:'),
-    )
-    // Services with componentNames-based region matching (e.g., Bedrock AWS RSS) always show regional status
-    const ALWAYS_SHOW_REGIONS = ['bedrock', 'azureopenai']
-    const alwaysShow = ALWAYS_SHOW_REGIONS.includes(service.id)
-    if (ongoing.length === 0 && !alwaysShow) return null
-
-    const regionStatus = {}
-    let hasRegionSpecific = false
-
-    for (const r of regions) {
-      regionStatus[r.key] = { status: 'ok', type: 'incident' }
-    }
-
-    for (const inc of ongoing) {
-      const titleLower = (inc.title || '').toLowerCase()
-      const compNames = (inc.componentNames ?? []).map(n => n.toLowerCase())
-      for (const r of regions) {
-        const keyLower = r.key.toLowerCase()
-        if (titleLower.includes(keyLower) || compNames.some(n => n.includes(keyLower))) {
-          regionStatus[r.key] = { status: 'incident', type: classifyIncident(inc.title) }
-          hasRegionSpecific = true
-        }
-      }
-    }
-
-    if (!hasRegionSpecific && ongoing.length > 0) {
-      const globalType = classifyIncident(ongoing[0].title)
-      for (const r of regions) {
-        regionStatus[r.key] = { status: 'incident', type: globalType }
-      }
-    }
-
-    const okRegions = regions.filter(r => regionStatus[r.key].status === 'ok')
-    const allDown = regions.length - okRegions.length === regions.length
-    const docsUrl = REGION_DOCS_URL[service.id]
-    const recommendText = (t('svc.region.recommend') || '').replace('{region}', okRegions[0]?.label ?? '')
+    const { regions, okRegions, allDown, recommendedRegion, docsUrl, ongoingCount } = state
+    // recommendText interpolates the FIRST OK region's label — the recommendation
+    // policy itself (array-order, same-cloud-first by SERVICE_REGIONS layout)
+    // lives in regionStatus.js.
+    const recommendText = (t('svc.region.recommend') || '').replace('{region}', recommendedRegion?.label ?? '')
 
     return (
       <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
         <div className="border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
           <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
-            <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: ongoing.length > 0 ? 'var(--amber)' : 'var(--green)' }} />
+            <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: ongoingCount > 0 ? 'var(--amber)' : 'var(--green)' }} />
             {t('svc.region.title')}
           </div>
         </div>
         <div style={{ padding: '16px' }}>
           <div className="flex flex-col" style={{ gap: '8px' }}>
             {regions.map((region) => {
-              const info = regionStatus[region.key]
-              const isIncident = info.status === 'incident'
-              const type = info.type || 'incident'
+              const isIncident = region.status === 'incident'
+              const type = region.type || 'incident'
               const dotCls = isIncident ? (INCIDENT_DOT_COLOR[type] ?? 'bg-[var(--red)]') : 'bg-[var(--green)]'
               const textCls = isIncident ? (INCIDENT_TYPE_COLOR[type] ?? 'text-[var(--red)]') : 'text-[var(--green)]'
               const labelKey = isIncident ? (INCIDENT_TYPE_LABEL[type] ?? 'svc.region.incident') : 'svc.region.noIncidents'
@@ -535,16 +434,34 @@ function RegionalAvailability({ service, t }) {
               )
             })}
           </div>
-          {!allDown && okRegions.length > 0 && ongoing.length > 0 && (
-            <div className="mono text-[10px] text-[var(--blue)] mt-3 flex items-center justify-between" style={{ padding: '6px 8px', background: 'var(--bg2)', borderRadius: '4px' }}>
+          {/* Recommendation callout — three visual adjustments from the
+              original `mt-3` / `padding: 6px 8px` / `items-center`:
+              1) `marginTop: 20px` (was mt-3=12px): the callout sits on a
+                 different background layer (var(--bg2)) than the region list
+                 above, but only 12px of separation made the layered surfaces
+                 read as a single block — the user perception was the box was
+                 "touching" the last region row. 20px gives the callout its
+                 own visual section.
+              2) `padding: 12px 14px` (was 6px/8px): tighter values cramped
+                 the vertical rhythm when the text wrapped to 3 lines on
+                 narrow viewports, and made the link look hung from the top
+                 edge.
+              3) `items-start` (was items-center): aligns the Check API Guide
+                 link to the first line of the wrapped text rather than its
+                 vertical midpoint — the centered layout placed the link
+                 awkwardly low on mobile.
+              `gap-2` replaces `ml-2` so the gap survives any future wrap /
+              RTL layout change. */}
+          {!allDown && okRegions.length > 0 && ongoingCount > 0 && (
+            <div className="mono text-[10px] text-[var(--blue)] flex items-start justify-between gap-2" style={{ marginTop: '20px', padding: '12px 14px', background: 'var(--bg2)', borderRadius: '4px' }}>
               <span>{recommendText}</span>
               {docsUrl && (
                 <a
                   href={docsUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="ml-2 font-bold underline hover:text-[var(--text1)] shrink-0"
-                  onClick={() => trackEvent('region_switch_intent', { service_id: service.id, recommended_region: okRegions[0].key })}
+                  className="font-bold underline hover:text-[var(--text1)] shrink-0"
+                  onClick={() => trackEvent('region_switch_intent', { service_id: service.id, recommended_region: recommendedRegion.key, location: 'service_details' })}
                 >
                   {t('svc.region.action.guide')} →
                 </a>
@@ -552,7 +469,7 @@ function RegionalAvailability({ service, t }) {
             </div>
           )}
           {allDown && (
-            <div className="mono text-[10px] text-[var(--red)] mt-3" style={{ padding: '6px 8px', background: 'var(--bg2)', borderRadius: '4px' }}>
+            <div className="mono text-[10px] text-[var(--red)]" style={{ marginTop: '20px', padding: '12px 14px', background: 'var(--bg2)', borderRadius: '4px' }}>
               {t('svc.region.allDown')}
             </div>
           )}

--- a/src/utils/__tests__/regionStatus.test.js
+++ b/src/utils/__tests__/regionStatus.test.js
@@ -1,0 +1,318 @@
+import { describe, test, expect } from 'vitest'
+import { regionStatusOf, classifyIncident, SERVICE_REGIONS } from '../regionStatus'
+
+describe('classifyIncident', () => {
+  test('returns "down" on outage/down/unavailable keywords', () => {
+    expect(classifyIncident('Pinecone is down')).toBe('down')
+    expect(classifyIncident('Service outage detected')).toBe('down')
+    expect(classifyIncident('API unavailable')).toBe('down')
+  })
+
+  test('returns "degraded_perf" on latency/slow/timeout/delay keywords', () => {
+    expect(classifyIncident('Increased latency on us-east-1')).toBe('degraded_perf')
+    expect(classifyIncident('Slow responses')).toBe('degraded_perf')
+    expect(classifyIncident('Request timeout')).toBe('degraded_perf')
+    expect(classifyIncident('Processing delay')).toBe('degraded_perf')
+  })
+
+  test('returns "inference" on inference/model/vertex/bedrock keywords', () => {
+    expect(classifyIncident('Inference layer issue')).toBe('inference')
+    expect(classifyIncident('Grok model misbehaving')).toBe('inference')
+    expect(classifyIncident('Vertex regional issue')).toBe('inference')
+  })
+
+  test('falls back to "incident" when no keyword matches', () => {
+    expect(classifyIncident('General investigation')).toBe('incident')
+    expect(classifyIncident('')).toBe('incident')
+    expect(classifyIncident(null)).toBe('incident')
+    expect(classifyIncident(undefined)).toBe('incident')
+  })
+
+  test('handles non-string input defensively', () => {
+    expect(classifyIncident(123)).toBe('incident')
+    expect(classifyIncident({})).toBe('incident')
+  })
+})
+
+describe('regionStatusOf — null guards', () => {
+  test('returns null for unknown service id (no region map)', () => {
+    expect(regionStatusOf({ id: 'unknown-service', incidents: [] })).toBeNull()
+  })
+
+  test('returns null for missing / non-object service', () => {
+    expect(regionStatusOf(null)).toBeNull()
+    expect(regionStatusOf(undefined)).toBeNull()
+    expect(regionStatusOf('pinecone')).toBeNull()
+  })
+
+  test('returns null when service has region map but no ongoing incidents AND not always-show', () => {
+    // pinecone has a region map, but no incident → skip (alwaysShow=false)
+    expect(regionStatusOf({ id: 'pinecone', incidents: [] })).toBeNull()
+  })
+
+  test('returns result for always-show services even without incidents (bedrock / azureopenai)', () => {
+    // Bedrock + Azure OpenAI render the card unconditionally so users can confirm
+    // "regions look healthy" at a glance — without this, an operational state is
+    // indistinguishable from "no region data".
+    const bedrock = regionStatusOf({ id: 'bedrock', incidents: [] })
+    expect(bedrock).not.toBeNull()
+    expect(bedrock.allDown).toBe(false)
+    expect(bedrock.okRegions.length).toBe(bedrock.regions.length)
+    expect(bedrock.ongoingCount).toBe(0)
+    expect(bedrock.hasRegionSpecific).toBe(false)
+
+    const azure = regionStatusOf({ id: 'azureopenai', incidents: [] })
+    expect(azure).not.toBeNull()
+    expect(azure.okRegions.length).toBe(azure.regions.length)
+  })
+})
+
+describe('regionStatusOf — region matching via incident title', () => {
+  test('marks regions matching incident title substring as incident', () => {
+    // Title contains the literal region key `AWS us-east-1` (space form). Real
+    // Pinecone incidents sometimes use bracket form `[AWS][us-east-1]` instead,
+    // which substring-match misses — those cases are matched via componentNames
+    // (next describe block) since Atlassian Statuspage always populates that
+    // field. Title-substring matching covers feeds that don't have structured
+    // components (e.g., RSS-only sources).
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [{ id: 'p1', status: 'investigating', title: 'AWS us-east-1 5xx errors on read' }],
+    })
+    expect(result).not.toBeNull()
+    expect(result.hasRegionSpecific).toBe(true)
+    expect(result.allDown).toBe(false)
+
+    const usEast = result.regions.find((r) => r.key === 'AWS us-east-1')
+    expect(usEast.status).toBe('incident')
+    // Title contains no down/latency/inference keywords → generic 'incident'
+    expect(usEast.type).toBe('incident')
+
+    const usWest = result.regions.find((r) => r.key === 'AWS us-west-2')
+    expect(usWest.status).toBe('ok')
+  })
+
+  test('recommendedRegion is first OK by SERVICE_REGIONS array order', () => {
+    // Pinecone array order: AWS us-east-1, AWS us-west-2, AWS eu-west-1,
+    // Azure eastus2, GCP us-central1, GCP europe-west4. Knock out us-east-1 via
+    // componentNames (mirrors the real Pinecone Atlassian Statuspage payload —
+    // titles use bracket form `[AWS][us-east-1]` which substring-match misses,
+    // but components always carry the structured `AWS us-east-1` string).
+    // First OK should be us-west-2 (same-cloud first by design).
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [{
+        id: 'p1',
+        status: 'investigating',
+        title: '[AWS][us-east-1] 5xx errors on read',
+        componentNames: ['AWS us-east-1'],
+      }],
+    })
+    expect(result.recommendedRegion?.key).toBe('AWS us-west-2')
+    expect(result.recommendedRegion?.label).toBe('AWS US West')
+  })
+
+  test('first-match-wins when two ongoing incidents claim the same region with different types', () => {
+    // Deliberate semantic — see comment in regionStatus.js where the guard
+    // `if (status[r.key].status === 'ok')` lives. Old ServiceDetails.jsx
+    // overwrote on every match (last-wins), causing badge color flips across
+    // re-renders when upstream re-sorted `service.incidents`. Today's behavior
+    // is deterministic: the FIRST matching incident in array order owns the
+    // type. Test both orderings to lock the contract.
+    const downFirst = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'a', status: 'investigating', title: 'AWS us-east-1 outage', componentNames: ['AWS us-east-1'] },
+        { id: 'b', status: 'investigating', title: 'AWS us-east-1 latency', componentNames: ['AWS us-east-1'] },
+      ],
+    })
+    expect(downFirst.regions.find((r) => r.key === 'AWS us-east-1').type).toBe('down')
+
+    const latencyFirst = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'b', status: 'investigating', title: 'AWS us-east-1 latency', componentNames: ['AWS us-east-1'] },
+        { id: 'a', status: 'investigating', title: 'AWS us-east-1 outage', componentNames: ['AWS us-east-1'] },
+      ],
+    })
+    expect(latencyFirst.regions.find((r) => r.key === 'AWS us-east-1').type).toBe('degraded_perf')
+  })
+
+  test('classifies multiple per-region incidents independently by their own title', () => {
+    const result = regionStatusOf({
+      id: 'gemini',
+      incidents: [
+        { id: 'g1', status: 'investigating', title: 'us-central1 vertex inference slowness' },
+        { id: 'g2', status: 'investigating', title: 'europe-west1 latency spike' },
+      ],
+    })
+    const us = result.regions.find((r) => r.key === 'us-central1')
+    const eu = result.regions.find((r) => r.key === 'europe-west1')
+    const asia = result.regions.find((r) => r.key === 'asia-northeast1')
+    expect(us.status).toBe('incident')
+    expect(eu.status).toBe('incident')
+    expect(asia.status).toBe('ok')
+    expect(result.hasRegionSpecific).toBe(true)
+  })
+})
+
+describe('regionStatusOf — region matching via componentNames (Bedrock / Azure pattern)', () => {
+  test('matches via componentNames when title omits the region key', () => {
+    // AWS RSS / Azure RSS sometimes encode the region in the component name
+    // ("us-east-1") rather than the title prose ("5xx errors on read"). The
+    // matcher walks both surfaces so either source counts.
+    const result = regionStatusOf({
+      id: 'bedrock',
+      incidents: [{
+        id: 'b1',
+        status: 'investigating',
+        title: 'Increased error rates',
+        componentNames: ['Amazon Bedrock (us-east-1)'],
+      }],
+    })
+    const usEast = result.regions.find((r) => r.key === 'us-east-1')
+    expect(usEast.status).toBe('incident')
+    expect(result.hasRegionSpecific).toBe(true)
+  })
+
+  test('componentNames matching is case-insensitive', () => {
+    const result = regionStatusOf({
+      id: 'bedrock',
+      incidents: [{ id: 'b1', status: 'investigating', title: 'foo', componentNames: ['US-EAST-1 issue'] }],
+    })
+    expect(result.regions.find((r) => r.key === 'us-east-1').status).toBe('incident')
+  })
+})
+
+describe('regionStatusOf — global-incident fallback', () => {
+  test('marks all regions as incident when title has no region match', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [{ id: 'p1', status: 'investigating', title: 'API authentication broken' }],
+    })
+    expect(result.hasRegionSpecific).toBe(false)
+    expect(result.allDown).toBe(true)
+    expect(result.recommendedRegion).toBeNull()
+    expect(result.regions.every((r) => r.status === 'incident')).toBe(true)
+  })
+
+  test('global-incident type is taken from the first ongoing incident', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'p1', status: 'investigating', title: 'Service outage in progress' },
+        { id: 'p2', status: 'investigating', title: 'Latency degradation' },
+      ],
+    })
+    expect(result.regions.every((r) => r.type === 'down')).toBe(true)
+  })
+})
+
+describe('regionStatusOf — incident filtering', () => {
+  test('skips resolved incidents (only ongoing affect region status)', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'p-old', status: 'resolved', title: 'AWS us-east-1 outage', componentNames: ['AWS us-east-1'] },
+        { id: 'p-new', status: 'investigating', title: 'AWS us-west-2 issue', componentNames: ['AWS us-west-2'] },
+      ],
+    })
+    expect(result.regions.find((r) => r.key === 'AWS us-east-1').status).toBe('ok')
+    expect(result.regions.find((r) => r.key === 'AWS us-west-2').status).toBe('incident')
+  })
+
+  test('resolved + ongoing on the same region key — region picks up the ongoing type, count excludes resolved', () => {
+    // Today the resolved filter at the top of regionStatusOf removes resolved
+    // entries before the matching loop runs, so this works by construction.
+    // If a future refactor moves the resolved skip into the inner loop (e.g.,
+    // `if (inc.status === 'resolved') continue`) without removing them from
+    // the `ongoing` array, `ongoingCount` would inflate and the resolved
+    // incident's classification could leak into the badge. Pin both.
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'p-old', status: 'resolved', title: 'AWS us-east-1 prior outage', componentNames: ['AWS us-east-1'] },
+        { id: 'p-new', status: 'investigating', title: 'AWS us-east-1 latency', componentNames: ['AWS us-east-1'] },
+      ],
+    })
+    // Region picks up the ONGOING incident's type, not the resolved 'down'.
+    expect(result.regions.find((r) => r.key === 'AWS us-east-1').type).toBe('degraded_perf')
+    expect(result.regions.find((r) => r.key === 'AWS us-east-1').status).toBe('incident')
+    // Only one ongoing — resolved must not inflate the count.
+    expect(result.ongoingCount).toBe(1)
+  })
+
+  test('skips aistudio:-prefixed incidents (Gemini direct API has no region breakdown)', () => {
+    // worker/src/services.ts merges Vertex (gcloud) + AI Studio feeds for Gemini;
+    // AI Studio entries get an aistudio: prefix and represent the global direct
+    // API surface. Including them in region status would over-warn — the gcloud
+    // entries are the only ones with region info.
+    const result = regionStatusOf({
+      id: 'gemini',
+      incidents: [
+        { id: 'aistudio:global-1', status: 'investigating', title: 'Gemini API issue' },
+      ],
+    })
+    // All aistudio incidents filtered → ongoingCount===0; no always-show for gemini
+    expect(result).toBeNull()
+  })
+
+  test('does not crash on incidents with missing / malformed fields', () => {
+    // Defensive against upstream feed glitches. Skips bad entries silently.
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        null,
+        {},
+        { title: 'no id' },
+        { id: 'no-title', status: 'investigating' },
+        { id: 'good', status: 'investigating', title: 'AWS us-east-1 issue' },
+      ],
+    })
+    expect(result).not.toBeNull()
+    expect(result.regions.find((r) => r.key === 'AWS us-east-1').status).toBe('incident')
+  })
+})
+
+describe('regionStatusOf — docsUrl pass-through', () => {
+  test('returns docsUrl when service has a mapping', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [{ id: 'p1', status: 'investigating', title: 'AWS us-east-1 issue' }],
+    })
+    expect(result.docsUrl).toMatch(/pinecone\.io/)
+  })
+
+  test('docsUrl is undefined for services without a mapping', () => {
+    // bedrock has a docsUrl in the map; if it didn't, this would be undefined.
+    // Sanity-check with a hypothetical service via regionDefs override.
+    const result = regionStatusOf(
+      { id: 'fake-service', incidents: [{ id: 'x', status: 'investigating', title: 'foo' }] },
+      { regions: [{ key: 'r1', label: 'R1' }] },
+    )
+    expect(result.docsUrl).toBeUndefined()
+  })
+})
+
+describe('SERVICE_REGIONS — invariants', () => {
+  test('every region entry has both `key` and `label` strings', () => {
+    for (const [svcId, regions] of Object.entries(SERVICE_REGIONS)) {
+      expect(Array.isArray(regions), `${svcId} regions must be an array`).toBe(true)
+      expect(regions.length, `${svcId} has at least 1 region`).toBeGreaterThan(0)
+      for (const r of regions) {
+        expect(typeof r.key, `${svcId}.${r.key} key must be a string`).toBe('string')
+        expect(typeof r.label, `${svcId}.${r.label} label must be a string`).toBe('string')
+        expect(r.key.length).toBeGreaterThan(0)
+        expect(r.label.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('region keys within a service are unique (no accidental duplicates)', () => {
+    for (const [svcId, regions] of Object.entries(SERVICE_REGIONS)) {
+      const keys = regions.map((r) => r.key)
+      const unique = new Set(keys)
+      expect(unique.size, `${svcId} has duplicate region keys: ${keys}`).toBe(keys.length)
+    }
+  })
+})

--- a/src/utils/regionStatus.js
+++ b/src/utils/regionStatus.js
@@ -1,0 +1,189 @@
+// Region status computation — extracted from src/pages/ServiceDetails.jsx
+// (RegionalAvailability component) so the Overview ActionBanner can surface
+// the same region recommendation that today only appears on detail pages.
+// Pure data + pure function — no React, no DOM, no fetch — so it's safely
+// callable from JSX, vitest, and (after a TS mirror in Phase 2) the Worker
+// and Edge SSR functions.
+//
+// Refs issue #422 Phase 1.
+
+// ── Region maps ──────────────────────────────────────────────
+//
+// `key` is the substring matched against incident.title.lower() AND against
+// each item of incident.componentNames.lower(). Order matters — the FIRST
+// healthy region in this list is what `recommendedRegion` resolves to.
+// Convention: cluster regions by cloud provider (AWS first, then Azure, then
+// GCP) so a same-cloud fallback is the natural default for partial regional
+// outages. Geographic affinity / RTT-aware ranking is out of scope for Phase 1.
+
+export const SERVICE_REGIONS = {
+  xai: [
+    { key: 'us-east-1', label: 'US (us-east-1)' },
+    { key: 'eu-west-1', label: 'EU (eu-west-1)' },
+  ],
+  gemini: [
+    { key: 'us-central1', label: 'US Central (us-central1)' },
+    { key: 'europe-west1', label: 'Europe West (europe-west1)' },
+    { key: 'asia-northeast1', label: 'Asia Northeast (asia-northeast1)' },
+  ],
+  openai: [
+    { key: 'us-east-1', label: 'US East (us-east-1)' },
+    { key: 'us-west-2', label: 'US West (us-west-2)' },
+    { key: 'eu-central-1', label: 'Europe Central (eu-central-1)' },
+  ],
+  azureopenai: [
+    { key: 'East US 2', label: 'East US 2' },
+    { key: 'Central US', label: 'Central US' },
+    { key: 'Sweden Central', label: 'Sweden Central' },
+    { key: 'UK South', label: 'UK South' },
+    { key: 'Australia East', label: 'Australia East' },
+    { key: 'Korea Central', label: 'Korea Central' },
+    { key: 'Norway East', label: 'Norway East' },
+  ],
+  bedrock: [
+    { key: 'us-east-1', label: 'US East (N. Virginia)' },
+    { key: 'us-west-2', label: 'US West (Oregon)' },
+    { key: 'eu-west-1', label: 'Europe (Ireland)' },
+    { key: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+  ],
+  pinecone: [
+    { key: 'AWS us-east-1', label: 'AWS US East' },
+    { key: 'AWS us-west-2', label: 'AWS US West' },
+    { key: 'AWS eu-west-1', label: 'AWS EU West' },
+    { key: 'Azure eastus2', label: 'Azure East US' },
+    { key: 'GCP us-central1', label: 'GCP US Central' },
+    { key: 'GCP europe-west4', label: 'GCP EU West' },
+  ],
+}
+
+export const REGION_DOCS_URL = {
+  xai: 'https://docs.x.ai/docs/regions',
+  gemini: 'https://cloud.google.com/vertex-ai/docs/general/locations',
+  openai: 'https://platform.openai.com/docs/guides/production-best-practices',
+  chatgpt: 'https://status.openai.com',
+  azureopenai: 'https://learn.microsoft.com/azure/ai-services/openai/concepts/models',
+  bedrock: 'https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html',
+  pinecone: 'https://docs.pinecone.io/troubleshooting/available-cloud-regions',
+}
+
+// Services whose region card is shown unconditionally — even when no ongoing
+// incident — because their component-tagged incidents already encode the
+// region (AWS RSS componentNames, Azure RSS componentNames). Without the
+// card the user has no way to confirm "AWS US East operational" at-a-glance.
+const ALWAYS_SHOW_REGIONS = new Set(['bedrock', 'azureopenai'])
+
+// ── Pure helpers ─────────────────────────────────────────────
+
+// Classify incident type from title keywords. Returns one of:
+//   'down' | 'degraded_perf' | 'inference' | 'incident'
+// Generic 'incident' is the fallback when no keyword matches — callers can
+// treat it as a less-severe-than-'down' indicator.
+export function classifyIncident(title) {
+  if (!title || typeof title !== 'string') return 'incident'
+  const lower = title.toLowerCase()
+  if (/\b(down|outage|unavailable)\b/.test(lower)) return 'down'
+  if (/\b(latency|slow|timeout|delay)\b/.test(lower)) return 'degraded_perf'
+  if (/\b(inference|grok|model|gemini|vertex|bedrock)\b/.test(lower)) return 'inference'
+  return 'incident'
+}
+
+// ── Main computation ─────────────────────────────────────────
+//
+// Returns `null` when there's nothing to render — either the service has no
+// region map, or it has no ongoing incidents AND isn't an always-show service.
+// Callers can treat null as "skip the region UI" without further checks.
+//
+// Returns a result object otherwise with:
+//   regions[]            — one entry per defined region, `{ key, label, status, type }`
+//   okRegions[]          — subset of regions with status 'ok'
+//   incidentRegions[]    — subset with status 'incident'
+//   hasRegionSpecific    — true if any region matched an incident title /
+//                          componentNames substring; false when we fell back
+//                          to the "global incident → mark all regions" path
+//   allDown              — every defined region is in incident state
+//   recommendedRegion    — first OK region by SERVICE_REGIONS array order,
+//                          or null when allDown
+//   docsUrl              — REGION_DOCS_URL[service.id] or undefined
+//   ongoingCount         — number of ongoing incidents considered
+
+export function regionStatusOf(service, opts = {}) {
+  if (!service || typeof service !== 'object') return null
+  const { regions: regionDefs = SERVICE_REGIONS[service.id] } = opts
+  if (!Array.isArray(regionDefs) || regionDefs.length === 0) return null
+
+  const allIncidents = Array.isArray(service.incidents) ? service.incidents : []
+  // aistudio:-prefixed incidents come from the global direct Gemini API surface,
+  // which has no per-region breakdown — including them would trigger the
+  // "no region match → mark all regions affected" fallback and overstate the
+  // impact. Region breakdown only makes sense for Vertex (gcloud) feed entries
+  // whose titles include region keywords. See worker/src/services.ts (#310).
+  const ongoing = allIncidents.filter(
+    (i) =>
+      i &&
+      typeof i.title === 'string' &&
+      i.status !== 'resolved' &&
+      typeof i.id === 'string' &&
+      !i.id.startsWith('aistudio:'),
+  )
+
+  const alwaysShow = ALWAYS_SHOW_REGIONS.has(service.id)
+  if (ongoing.length === 0 && !alwaysShow) return null
+
+  // Default every region to OK; downgrade as incidents claim regions.
+  const status = {}
+  for (const r of regionDefs) {
+    status[r.key] = { status: 'ok', type: 'incident' }
+  }
+
+  let hasRegionSpecific = false
+  for (const inc of ongoing) {
+    const titleLower = (inc.title || '').toLowerCase()
+    const compNames = (inc.componentNames ?? []).map((n) => String(n).toLowerCase())
+    for (const r of regionDefs) {
+      const keyLower = r.key.toLowerCase()
+      if (titleLower.includes(keyLower) || compNames.some((n) => n.includes(keyLower))) {
+        // First-match-wins for incident type. NOTE: this is a DELIBERATE
+        // semantic change from the pre-extraction code in ServiceDetails.jsx,
+        // which unconditionally overwrote with the last matching incident's
+        // classification. Under the old behavior, the badge color flipped each
+        // time `service.incidents` was re-sorted in upstream parsers — visually
+        // unstable when the same region had multiple ongoing incidents (e.g. a
+        // "Service outage" plus a follow-up "Latency spike"). First-match-wins
+        // is deterministic across re-renders. If two ongoing incidents claim
+        // the same region with different `classifyIncident` outputs, the one
+        // that appears earliest in `service.incidents` decides the badge.
+        if (status[r.key].status === 'ok') {
+          status[r.key] = { status: 'incident', type: classifyIncident(inc.title) }
+        }
+        hasRegionSpecific = true
+      }
+    }
+  }
+
+  // Global-incident fallback — no region substring matched but we know
+  // something IS ongoing. Mark every region with the first incident's type.
+  // This is intentionally pessimistic: better to over-warn than under-warn
+  // when the upstream feed gives us no region signal.
+  if (!hasRegionSpecific && ongoing.length > 0) {
+    const globalType = classifyIncident(ongoing[0].title)
+    for (const r of regionDefs) {
+      status[r.key] = { status: 'incident', type: globalType }
+    }
+  }
+
+  const regions = regionDefs.map((r) => ({ ...r, ...status[r.key] }))
+  const okRegions = regions.filter((r) => r.status === 'ok')
+  const incidentRegions = regions.filter((r) => r.status === 'incident')
+  const allDown = okRegions.length === 0
+
+  return {
+    regions,
+    okRegions,
+    incidentRegions,
+    hasRegionSpecific,
+    allDown,
+    recommendedRegion: okRegions[0] ?? null,
+    docsUrl: REGION_DOCS_URL[service.id],
+    ongoingCount: ongoing.length,
+  }
+}

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -179,3 +179,168 @@ test.describe('Overview page', () => {
   })
 
 })
+
+// ── ActionBanner region recommendation (refs #422 Phase 1) ───────────
+//
+// Surfaces the region-switch hint that today only appears on the per-service
+// detail page. The line renders only when:
+//   - the affected service has a SERVICE_REGIONS entry
+//   - at least one region is OK (not allDown)
+//   - the incident actually matched a region key (hasRegionSpecific) — global
+//     incidents that taint every region must NOT produce a misleading "switch
+//     to region X" suggestion
+// These three gates are tested below via mock API responses.
+
+test.describe('ActionBanner region recommendation', () => {
+  test('partial regional outage surfaces "Switch region: X → Y" above fallback', async ({ page }) => {
+    // Pinecone with AWS us-east-1 hit via componentNames (mirrors the real
+    // Atlassian feed shape — title uses [AWS][us-east-1] bracket form that
+    // substring-match can't parse, but components always carry the structured
+    // `AWS us-east-1` string).
+    const inc = {
+      id: 'pinecone-aws-east-422',
+      title: '[AWS][us-east-1] 5xx errors on read',
+      status: 'investigating',
+      impact: 'major',
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      componentNames: ['AWS us-east-1'],
+      timeline: [],
+    }
+    const mockData = { json: {
+      services: [{
+        id: 'pinecone', category: 'api', name: 'Pinecone', provider: 'Pinecone',
+        status: 'degraded', latency: 80, uptime30d: 99.91, calendarDays: 30, incidents: [inc],
+      }],
+      lastUpdated: new Date().toISOString(),
+    } }
+    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
+    await page.goto('/')
+    // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
+    // the mobile (hidden) <span> and the desktop <div>. When negative-test
+    // mocks override most services back to operational, the helper's
+    // `.first()` resolution can land on the hidden mobile span. Wait directly
+    // for any service card to render instead — same effect, resilient to the
+    // mocked-service ordering.
+    await page.locator('main button').first().waitFor({ state: 'visible', timeout: 20000 })
+
+    // Region recommendation line surfaces with the i18n label + recommended region.
+    // Label key `overview.banner.regionSwitch` → "Switch region:" (en) / "리전 전환:" (ko).
+    await expect(page.locator('main').getByText(/Switch region|리전 전환/)).toBeVisible({ timeout: 10000 })
+    // Recommended region is the next OK in SERVICE_REGIONS array order — AWS us-west-2.
+    await expect(page.locator('main').getByText(/AWS US West/)).toBeVisible()
+
+    // Security contract — `target="_blank"` external link MUST carry
+    // `rel="noopener noreferrer"` to prevent reverse-tabnabbing into the
+    // provider docs site. A future "clean up the anchor props" refactor that
+    // drops `rel` would be a real (low-impact but real) security regression
+    // with otherwise no test guarding it.
+    const docsLink = page.locator('main a').filter({ hasText: /AWS US West/ }).first()
+    await expect(docsLink).toHaveAttribute('target', '_blank')
+    await expect(docsLink).toHaveAttribute('rel', /noopener/)
+    await expect(docsLink).toHaveAttribute('rel', /noreferrer/)
+
+    // Order: region rec line appears before "Suggested fallback" since cheaper
+    // action (region switch) deserves first-line visibility.
+    const banner = page.locator('main').filter({ hasText: /Switch region|리전 전환/ }).first()
+    const bannerText = (await banner.textContent()) ?? ''
+    const regionIdx = bannerText.search(/Switch region|리전 전환/)
+    const fallbackIdx = bannerText.search(/Suggested fallback|대체 추천/)
+    if (fallbackIdx > -1) {
+      expect(regionIdx, `region line should precede fallback line (regionIdx=${regionIdx}, fallbackIdx=${fallbackIdx})`).toBeLessThan(fallbackIdx)
+    }
+  })
+
+  // MOCK_SERVICES (src/hooks/usePolling.js) ships with several default-degraded
+  // entries to keep the dashboard demo lively, INCLUDING an xAI mock incident
+  // titled `eu-west-1.api.x.ai went down` — that title matches xAI's region key
+  // `eu-west-1`, so a Pinecone-only test mock would still see "Switch region:
+  // xAI → US" surface from the mock fallthrough. Negative tests must explicitly
+  // operational-ize the four default-degraded mock services (openai, xai,
+  // huggingface, elevenlabs) so only the test's intended affected service
+  // contributes to ActionBanner.
+  const operationalize = (id, name) => ({
+    id, category: 'api', name, provider: name, status: 'operational',
+    latency: 100, uptime30d: 99.99, calendarDays: 30, incidents: [],
+  })
+  const MOCK_DEGRADED_OVERRIDE = [
+    operationalize('openai', 'OpenAI API'),
+    operationalize('xai', 'xAI (Grok)'),
+    operationalize('huggingface', 'Hugging Face'),
+    operationalize('elevenlabs', 'ElevenLabs'),
+  ]
+
+  test('global outage (no region keyword) does NOT show region line', async ({ page }) => {
+    // Title and componentNames carry no region substring → regionStatusOf falls
+    // into the "global incident → mark all regions affected" branch, which sets
+    // hasRegionSpecific=false. Recommending any region in this state would be
+    // misleading. Banner must show the cross-service fallback ONLY.
+    const inc = {
+      id: 'pinecone-global-422',
+      title: 'API authentication broken',
+      status: 'investigating',
+      impact: 'major',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      componentNames: [],
+      timeline: [],
+    }
+    const mockData = { json: {
+      services: [
+        { id: 'pinecone', category: 'api', name: 'Pinecone', provider: 'Pinecone',
+          status: 'down', latency: 80, uptime30d: 99.91, calendarDays: 30, incidents: [inc] },
+        ...MOCK_DEGRADED_OVERRIDE,
+      ],
+      lastUpdated: new Date().toISOString(),
+    } }
+    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
+    await page.goto('/')
+    // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
+    // the mobile (hidden) <span> and the desktop <div>. When negative-test
+    // mocks override most services back to operational, the helper's
+    // `.first()` resolution can land on the hidden mobile span. Wait directly
+    // for any service card to render instead — same effect, resilient to the
+    // mocked-service ordering.
+    await page.locator('main button').first().waitFor({ state: 'visible', timeout: 20000 })
+
+    // Down banner present (sanity)
+    await expect(page.locator('main').getByText(/Down|중단/).first()).toBeVisible({ timeout: 10000 })
+    // Region recommendation line is NOT shown — the algorithm marks every
+    // region affected, so there's no OK region to recommend.
+    await expect(page.locator('main').getByText(/Switch region|리전 전환/)).not.toBeVisible()
+  })
+
+  test('affected service without region data does not show region line', async ({ page }) => {
+    // Mistral has no SERVICE_REGIONS entry → regionStatusOf returns null →
+    // banner skips the region line entirely. The fallback line still renders.
+    const inc = {
+      id: 'mistral-422',
+      title: 'API errors',
+      status: 'investigating',
+      impact: 'major',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      timeline: [],
+    }
+    const mockData = { json: {
+      services: [
+        { id: 'mistral', category: 'api', name: 'Mistral API', provider: 'Mistral AI',
+          status: 'degraded', latency: 120, uptime30d: 99.5, calendarDays: 30, incidents: [inc] },
+        ...MOCK_DEGRADED_OVERRIDE,
+      ],
+      lastUpdated: new Date().toISOString(),
+    } }
+    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
+    await page.goto('/')
+    // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
+    // the mobile (hidden) <span> and the desktop <div>. When negative-test
+    // mocks override most services back to operational, the helper's
+    // `.first()` resolution can land on the hidden mobile span. Wait directly
+    // for any service card to render instead — same effect, resilient to the
+    // mocked-service ordering.
+    await page.locator('main button').first().waitFor({ state: 'visible', timeout: 20000 })
+
+    await expect(page.locator('main').getByText(/Degraded|성능 저하/).first()).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('main').getByText(/Switch region|리전 전환/)).not.toBeVisible()
+  })
+})

--- a/worker/src/__tests__/region-status-sync.test.ts
+++ b/worker/src/__tests__/region-status-sync.test.ts
@@ -1,0 +1,74 @@
+// #422 Phase 2 — pin the cross-mirror sync of SERVICE_REGIONS + REGION_DOCS_URL.
+//
+// Two independent copies live in this repo:
+//   1. src/utils/regionStatus.js   — frontend (ServiceDetails RegionalAvailability card,
+//                                              Overview ActionBanner region line)
+//   2. api/is-down/region-status.ts — Edge SSR (Is X Down? region recommendation line,
+//                                                 separate compilation surface from `src/`)
+//
+// A Worker-side copy is planned but not in this PR — when it lands, extend this test to
+// triangulate all three (same pattern as worker/src/__tests__/api-tier-sync.test.ts for
+// API_TIER). For now, keep the SPA ↔ Edge pair locked.
+//
+// File 2 (api/is-down/region-status.ts) can't be imported here — Edge Functions are a
+// different compilation surface (no @vercel/edge types in this Workers test runner).
+// Read it via fs and check structural parity. Catches forgotten additions; doesn't catch
+// label typos (acceptable — labels are user-visible, a typo would be caught on first render
+// of any region-aware service).
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+// Vitest resolves cross-package paths via the repo root; this works because frontend `src/`
+// and worker `src/` share a single repo with one node_modules. The import is data-only.
+import { SERVICE_REGIONS as frontendRegions, REGION_DOCS_URL as frontendDocs } from '../../../src/utils/regionStatus'
+
+const REPO_ROOT = join(__dirname, '..', '..', '..')
+const EDGE_FILE = readFileSync(join(REPO_ROOT, 'api/is-down/region-status.ts'), 'utf-8')
+
+describe('SERVICE_REGIONS cross-mirror sync (#422 Phase 2)', () => {
+  it('api/is-down/region-status.ts inline copy contains every canonical service id', () => {
+    for (const id of Object.keys(frontendRegions)) {
+      // Match `  id: [` line (TS object key, the Edge file uses `'id'` quoting for none of
+      // these because all are valid identifiers). Anchor to start-of-line + 2-space indent
+      // to avoid false matches in comments.
+      const re = new RegExp(`^  ${id}: \\[`, 'm')
+      expect(re.test(EDGE_FILE), `api/is-down/region-status.ts is missing SERVICE_REGIONS["${id}"]`).toBe(true)
+    }
+  })
+
+  it('api/is-down/region-status.ts inline copy contains every canonical region key', () => {
+    // For each (svcId, regions) pair, every region.key must appear as a quoted string
+    // literal somewhere inside the Edge file's SERVICE_REGIONS object. Single quotes
+    // because TS prettier default; double would also be valid — check both.
+    for (const [svcId, regions] of Object.entries(frontendRegions)) {
+      for (const region of regions) {
+        const needleSingle = `key: '${region.key}'`
+        const needleDouble = `key: "${region.key}"`
+        const found = EDGE_FILE.includes(needleSingle) || EDGE_FILE.includes(needleDouble)
+        expect(found, `Edge file missing region key "${region.key}" for ${svcId}`).toBe(true)
+      }
+    }
+  })
+
+  it('region count per service matches (SPA ≡ Edge inline)', () => {
+    // Count occurrences of `key: '...'` per service block. If counts diverge for any
+    // service, the Edge file has either an extra or missing region — caught here even
+    // if the per-key string-match above passes due to a stray duplicate.
+    for (const [svcId, regions] of Object.entries(frontendRegions)) {
+      const blockRe = new RegExp(`${svcId}: \\[([\\s\\S]*?)\\]`, 'm')
+      const match = EDGE_FILE.match(blockRe)
+      expect(match, `Edge file: could not locate ${svcId} region array`).toBeTruthy()
+      const block = match![1]
+      const keyMatches = block.match(/key:\s*['"]/g) ?? []
+      expect(keyMatches.length, `${svcId} region count mismatch — SPA=${regions.length}, Edge=${keyMatches.length}`).toBe(regions.length)
+    }
+  })
+
+  it('every service id in REGION_DOCS_URL also appears in the Edge file', () => {
+    for (const id of Object.keys(frontendDocs)) {
+      const re = new RegExp(`^  ${id}: ['"]`, 'm')
+      expect(re.test(EDGE_FILE), `Edge file missing REGION_DOCS_URL["${id}"]`).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## What

Closes the silo gap where AIWatch's region-switch guidance only appears on the per-service detail page. Now surfaces on **Overview ActionBanner** + **Edge SSR `/is-X-down`**, so a user landing during a partial regional outage (e.g. Pinecone AWS us-east-1 down with 5 other regions healthy) sees the cheaper action ("switch to AWS us-west-2 — same SDK + IAM") instead of just the cross-service fallback.

## Phase 1 — extract + Overview ActionBanner

- **NEW** `src/utils/regionStatus.js` — pure functions extracted from `RegionalAvailability` (no React / DOM / fetch). Exports `regionStatusOf()`, `classifyIncident()`, `SERVICE_REGIONS`, `REGION_DOCS_URL`. 25 vitest cases.
- **`ServiceDetails`** — uses the utility, no behavior change. Recommendation callout **padding bumped** (mt 12→20px, padding 6/8→12/14, items-center→items-start, ml-2→gap-2) per user feedback that the tight values made the box read as "touching" the region row and centered the docs link awkwardly on mobile.
- **`Overview` ActionBanner** — new "Switch region:" line above the cross-service fallback when an affected service has region-specific partial outage. Click → provider docs + `region_switch_intent` GA4 with `location='action_banner'`. 3 Playwright cases pin partial-outage / global-outage / no-region-map behavior.
- **Deliberate semantic** — type classification is now first-match-wins (was last-wins inline in ServiceDetails). Old behavior caused badge color flicker when upstream re-sorted incidents. Both orderings asserted by test.

## Phase 2 — Edge SSR `/is-X-down`

- **NEW** `api/is-down/region-status.ts` — TS port (Edge bundling can't reach `src/`, same constraint as `api/is-down/incident-sort.ts`).
- **NEW** `worker/src/__tests__/region-status-sync.test.ts` — pins SPA ↔ Edge mirror (4 cases: ids, region keys, count per service, REGION_DOCS_URL).
- **`/is-*-down`** now renders a "Try region:" callout between AI Insight and the incident list when the same three gates pass. 9 vitest cases pin the skip conditions, label rendering, security attrs, GA4 firing with `location='is_down_page'`, defensive XSS escape.

## Quote-escape contract fix (caught in PR review)

- **NEW** `escJsForAttr()` helper in `api/is-down/html-template.ts` — entity-encodes `JSON.stringify` output's inner `"` to `&quot;` so JS literals survive being embedded inside double-quoted `onclick="..."` attributes. Without this, the HTML parser truncates the attribute at the first inner `"`, the inline `gtag()` call silently never fires, and trailing JS body leaks as bogus attributes.
- **Two call sites fixed**: `renderRegionRecommendation` (this PR's new code, caught in review round 3) **and** `renderShareButtons` (pre-existing bug exposed by round 4 audit — `share-x` + `share-threads` GA4 events have been silently dead). 4 regression tests cover both layers (DOM-parse + wire-format) at both sites.

## Docs

- `CLAUDE.md` GA4 event row: `region_switch_intent` lists all 3 `location` values (`service_details` / `action_banner` / `is_down_page`).
- `CLAUDE.md` "Adding a new service" checklist 10b: region data lives in two cross-mirrored copies; both must update together; `region-status-sync.test.ts` is the gate.

## Tests

| Suite | Result |
|---|---|
| src vitest | **231 passed** (was 215, +16) |
| worker vitest | **1191 passed** (+4 mirror-sync) |
| Edge TS check | clean |
| Build | ServiceDetails 27.27kB (was 29.84kB pre-refactor — extraction win) |

## PR review

Converged after **round 5** (Critical 0 / Important 0):
- Round 1: Phase 1 — 2 Important fixed (CLAUDE.md GA4 docs, misleading comment + missing first-match-wins test, rel/target Playwright pin, resolved+ongoing test)
- Round 2: Phase 1 — converged
- Round 3: Phase 2 — 1 Critical fixed (region-rec onclick quote-escape)
- Round 4: Phase 2 audit — 1 Critical found (renderShareButtons same pattern, pre-existing)
- Round 5: convergence verified, share-button fix + regression tests confirmed catching the bug

## Scope

`refs #422` (not `closes`) — Phase 3 (cloud-tag ranking, geographic affinity) remains explicitly deferred per the issue body. Value/complexity ratio poor at our incident frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)