### PR TITLE
fix: category-group is-down footer cross-links + add Junie to README (closes #424)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -93,7 +93,7 @@
 | ChatGPT | OpenAI |
 | Character.AI | Character AI |
 
-### 코딩 에이전트 (5개)
+### 코딩 에이전트 (6개)
 
 | 서비스 | 제공업체 |
 |--------|----------|
@@ -102,6 +102,7 @@
 | Cursor | Anysphere |
 | GitHub Copilot | Microsoft |
 | Windsurf | Codeium |
+| Junie | JetBrains |
 
 ## 기술 스택
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | ChatGPT | OpenAI |
 | Character.AI | Character AI |
 
-### Coding Agents (5)
+### Coding Agents (6)
 
 | Service | Provider |
 |---------|----------|
@@ -103,6 +103,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | Cursor | Anysphere |
 | GitHub Copilot | Microsoft |
 | Windsurf | Codeium |
+| Junie | JetBrains |
 
 ## Tech Stack
 

--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { buildMetaDescription, renderIncidents, type ServiceData } from '../html-template'
+import { buildMetaDescription, renderIncidents, renderFooter, type ServiceData } from '../html-template'
 import type { ServiceSEO } from '../seo-content'
+import { SLUG_TO_SERVICE, RELATED_SLUGS } from '../slug-map'
 
 function mkSeo(overrides: Partial<ServiceSEO> = {}): ServiceSEO {
   return {
@@ -237,5 +238,98 @@ describe('renderIncidents — 30-day window + grouping', () => {
     expect(invIdx).toBeGreaterThan(-1)
     expect(newestResolvedIdx).toBeGreaterThan(-1)
     expect(invIdx).toBeLessThan(newestResolvedIdx)
+  })
+})
+
+// ── renderFooter — "Also check" category grouping (#424) ─────────────
+//
+// The footer cross-links were previously a flat blob in SLUG_TO_SERVICE
+// insertion order (SEO-rollout phase order — API / app / agent interleaved).
+// renderFooter now groups the non-current, non-related links by category
+// with API / AI Apps / Coding Agents sub-labels.
+
+describe('renderFooter — Also check category grouping', () => {
+  it('emits the three category sub-labels in API → AI Apps → Coding Agents order', () => {
+    // Use a slug whose RELATED_SLUGS doesn't drain a whole category, so all
+    // three groups are non-empty. `claude` (api) relates to claude-ai, claude-code,
+    // openai, chatgpt — leaves api/app/agent all populated.
+    const html = renderFooter('claude')
+    const apiIdx = html.indexOf('<strong style="color:#8b949e">API:</strong>')
+    const appIdx = html.indexOf('<strong style="color:#8b949e">AI Apps:</strong>')
+    const agentIdx = html.indexOf('<strong style="color:#8b949e">Coding Agents:</strong>')
+    expect(apiIdx, 'API sub-label present').toBeGreaterThan(-1)
+    expect(appIdx, 'AI Apps sub-label present').toBeGreaterThan(-1)
+    expect(agentIdx, 'Coding Agents sub-label present').toBeGreaterThan(-1)
+    // Order: API before AI Apps before Coding Agents.
+    expect(apiIdx).toBeLessThan(appIdx)
+    expect(appIdx).toBeLessThan(agentIdx)
+  })
+
+  it('every non-current, non-related service appears exactly once under exactly one category', () => {
+    // Completeness contract: the grouping must not drop any service. For a
+    // given page, the footer should account for every SLUG_TO_SERVICE entry =
+    // current + related + (sum of category groups).
+    const slug = 'claude'
+    const html = renderFooter(slug)
+    const related = (RELATED_SLUGS[slug] ?? []).filter(s => SLUG_TO_SERVICE[s])
+    const expectedInFooter = Object.keys(SLUG_TO_SERVICE).filter(
+      s => s !== slug && !related.includes(s),
+    )
+    // Each expected service's is-down link must be present exactly once.
+    for (const s of expectedInFooter) {
+      const href = `/is-${s}-down`
+      const occurrences = html.split(href).length - 1
+      expect(occurrences, `${s} should appear exactly once in the footer "Also check" block`).toBe(1)
+    }
+    // No related service leaks into the "Also check" groups — related links
+    // live on the separate "Related:" line. (They will still match `/is-X-down`
+    // via the Related line, so scope the count to the "Also check:" paragraph.)
+    const alsoCheckStart = html.indexOf('Also check:')
+    const alsoCheckBlock = html.slice(alsoCheckStart)
+    for (const r of related) {
+      expect(alsoCheckBlock.includes(`/is-${r}-down`), `related service ${r} must NOT appear in "Also check"`).toBe(false)
+    }
+  })
+
+  it('omits a category sub-label entirely when that category has no remaining services', () => {
+    // `claude-code` (agent) relates to claude, cursor, github-copilot, windsurf,
+    // codex, junie. Every other agent is either current or related → the
+    // Coding Agents group is empty and must not render a stray "Coding Agents:"
+    // label. API + AI Apps groups remain.
+    const html = renderFooter('claude-code')
+    expect(html).not.toContain('<strong style="color:#8b949e">Coding Agents:</strong>')
+    expect(html).toContain('<strong style="color:#8b949e">API:</strong>')
+    expect(html).toContain('<strong style="color:#8b949e">AI Apps:</strong>')
+  })
+
+  it('FOOTER_CATEGORY_ORDER covers every category present in SLUG_TO_SERVICE', () => {
+    // Completeness guard. renderFooter buckets `remaining` into the three
+    // categories API / AI Apps / Coding Agents. If a future service is added
+    // with a 4th category value (the `category` field is typed `string`, not
+    // a union, so this compiles silently), its is-down link would vanish from
+    // the footer with no other test failure — the exact silent SEO-link-loss
+    // this whole #424 change set out to prevent. Fail loudly here instead.
+    const present = new Set(Object.values(SLUG_TO_SERVICE).map(e => e.category))
+    expect([...present].sort()).toEqual(['agent', 'api', 'app'])
+  })
+
+  it('grouped links are category-pure — no cross-category leakage within a group', () => {
+    // Pull the API group's text span and assert it contains only api-category
+    // service links. A regression that mis-buckets (e.g. category typo) would
+    // surface as an agent/app link inside the API <span>.
+    // NOTE: the slice below assumes the group markup is a FLAT <span> with no
+    // nested <span>. If a future refactor nests spans, update the bounds.
+    const html = renderFooter('claude')
+    // The API group is a <span> ... up to the next <span> or </p>.
+    const apiSpanStart = html.indexOf('<strong style="color:#8b949e">API:</strong>')
+    const afterApi = html.slice(apiSpanStart)
+    const apiSpanEnd = afterApi.indexOf('</span>')
+    const apiSpan = afterApi.slice(0, apiSpanEnd)
+    // Every /is-X-down link inside the API span must map to an api-category slug.
+    const linkSlugs = [...apiSpan.matchAll(/\/is-([a-z-]+)-down/g)].map(m => m[1])
+    expect(linkSlugs.length).toBeGreaterThan(0)
+    for (const s of linkSlugs) {
+      expect(SLUG_TO_SERVICE[s]?.category, `${s} in API group must be api-category`).toBe('api')
+    }
   })
 })

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -670,8 +670,22 @@ function shareKakao(){
 }
 
 
-function renderFooter(slug: string): string {
-  // Related services first (SEO cross-linking), then remaining
+// "Also check" footer cross-links are grouped by category (#424). Without
+// grouping, the links render in `SLUG_TO_SERVICE` insertion order — which is
+// the historical SEO-page rollout order, mixing API / app / agent services
+// with no logic. Grouping gives the SEO internal-link block a coherent
+// structure and lets a reader scan to the category they care about.
+const FOOTER_CATEGORY_ORDER: ReadonlyArray<{ key: string; label: string }> = [
+  { key: 'api', label: 'API' },
+  { key: 'app', label: 'AI Apps' },
+  { key: 'agent', label: 'Coding Agents' },
+]
+
+// Exported for api/is-down/__tests__/html-template.test.ts — pins the
+// category-grouped "Also check" structure (#424).
+export function renderFooter(slug: string): string {
+  // Related services first (SEO cross-linking), then everything else grouped
+  // by category.
   const related = (RELATED_SLUGS[slug] ?? []).filter(s => SLUG_TO_SERVICE[s])
   const allSlugs = Object.keys(SLUG_TO_SERVICE).filter(s => s !== slug)
   const remaining = allSlugs.filter(s => !related.includes(s))
@@ -683,15 +697,28 @@ function renderFooter(slug: string): string {
       return `<a href="/is-${esc(s)}-down" style="font-weight:500">Is ${esc(name)} down?</a>`
     })
     .join(' &middot; ')
-  const otherLinks = remaining
-    .map(s => `<a href="/is-${esc(s)}-down">Is ${esc(SLUG_TO_SERVICE[s]?.name ?? s.replace(/-/g, ' '))} down?</a>`)
-    .join(' ')
+
+  // Group `remaining` by category. Within each category the existing
+  // deterministic SLUG_TO_SERVICE order is preserved. Empty categories emit
+  // nothing — no stray sub-label. Every service falls into exactly one of
+  // api / app / agent (all SLUG_TO_SERVICE entries carry one of those three),
+  // so no service is dropped by the grouping.
+  const otherGroups = FOOTER_CATEGORY_ORDER
+    .map(({ key, label }) => {
+      const links = remaining
+        .filter(s => SLUG_TO_SERVICE[s]?.category === key)
+        .map(s => `<a href="/is-${esc(s)}-down">Is ${esc(SLUG_TO_SERVICE[s]?.name ?? s.replace(/-/g, ' '))} down?</a>`)
+      if (links.length === 0) return ''
+      return `<span style="display:block;margin-top:4px"><strong style="color:#8b949e">${label}:</strong> ${links.join(' ')}</span>`
+    })
+    .filter(Boolean)
+    .join('')
 
   return `<div class="footer">
 <p style="margin-bottom:12px"><a href="https://ai-watch.dev" class="btn" onclick="typeof gtag==='function'&&gtag('event','click_dashboard',{location:'is_down_page',source:'footer'})">View Full Dashboard</a></p>
 <p><a href="https://ai-watch.dev/#${esc(seoEntry?.id ?? slug)}" onclick="typeof gtag==='function'&&gtag('event','click_service_detail',{location:'is_down_page',service_id:'${esc(seoEntry?.id ?? slug)}'})">Detailed service page</a> &middot; <a href="/reports/" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'footer'})">Monthly reports</a> &middot; <a href="https://ai-watch.dev/#settings" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'footer'})">Set up alerts</a></p>
 ${relatedLinks ? `<p style="margin-top:12px;font-size:13px">Related: ${relatedLinks}</p>` : ''}
-${otherLinks ? `<p style="margin-top:8px;font-size:12px">Also check: ${otherLinks}</p>` : ''}
+${otherGroups ? `<p style="margin-top:8px;font-size:12px">Also check:${otherGroups}</p>` : ''}
 <p style="margin-top:12px">&copy; 2026 AIWatch. Real-time AI service status monitoring.</p>
 </div>`
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,89 +11,89 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional Is-X-Down services (#263, expanded since) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-15</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-05-16</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -101,19 +101,19 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Two service-list consistency fixes from a footer audit. `closes #424`.

## 1. is-down footer "Also check" — category grouping

`renderFooter()` built the "Also check" cross-links as a flat string in `SLUG_TO_SERVICE` insertion order — the historical SEO-page rollout phase order, which interleaves API / app / agent services with no logic:

> Is Claude API down? · Is ChatGPT down? · Is Gemini API down? · Is GitHub Copilot down? · Is Cursor down? · Is Claude Code down? · Is OpenAI API down? · …

The link set was already **complete** (auto-generated from `SLUG_TO_SERVICE`, verified in sync with `worker/src/services.ts` — 31 is-down services; Cerebras, Junie all present), so nothing was structurally missing. This is a **presentation** fix.

**Change**: links now grouped into **API** / **AI Apps** / **Coding Agents** sub-labelled blocks via a new `FOOTER_CATEGORY_ORDER` const. Within each category the existing deterministic `SLUG_TO_SERVICE` order is preserved; empty categories emit nothing.

`renderFooter` is now exported for testing. **5 new vitest cases**:
- 3 sub-labels render in API → AI Apps → Coding Agents order
- every non-current, non-related service appears exactly once under exactly one category (completeness contract)
- related services don't leak into "Also check"
- an emptied category emits no stray sub-label
- links inside a group are category-pure
- **completeness guard** — fails loudly if a future service introduces a 4th `category` value (the field is typed `string`, so a new value would otherwise silently drop that service's footer link — the exact silent SEO-link-loss this change prevents)

## 2. README — Junie missing from Coding Agents table

`README.md` + `README.ko.md` "Coding Agents" service tables listed only 5 entries; **Junie** (JetBrains coding agent, #336) was missing and the header said `(5)` / `(5개)`. CLAUDE.md already documents 6 agents, and the README's lower "Available Service IDs" table already had `junie` — only the Coding Agents service table was out of sync.

Header → `(6)` / `(6개)`, `| Junie | JetBrains |` row added after Windsurf (matches CLAUDE.md's documented agent order).

## Tests

- 20 `html-template` vitest cases pass (+5)
- Build clean, Edge TS check clean
- Existing Playwright `footer has internal cross-links` test unaffected — the `<a href="/is-X-down">` elements are preserved, just wrapped in category `<span>`s

## Verification

PR review converged — Critical 0 / Important 0. The one Suggestion (unenforced 3-category invariant) was addressed with the completeness-guard test.

## Note on merge order

PR #423 (region recommendation, open) also touches `api/is-down/html-template.ts` — different function (`renderRegionRecommendation` vs `renderFooter`), so git should auto-merge; whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)