### PR TITLE
feat: RSS as a first-class channel on the landing page (#434)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `click_ranking` | `location`, `source` | Is X Down (header/alternatives) | Ranking link click |
 | `click_service_detail` | `location`, `service_id` | Is X Down (footer) | Service detail page click |
 | `click_reports` | `location`, `source` | Is X Down (alternatives/footer) | Monthly reports link click (Is X Down) |
-| `copy_rss` | `location`, `service_id` | ServiceDetails (header) · Settings (Alerts) · Overview (incident banner) · Sidebar (footer) | RSS feed URL copied to clipboard. `location` ∈ `service_details`/`settings`/`action_banner`/`sidebar`; `service_id`=`'all'` for the all-services `/feed.xml`, the page slug for per-service feeds (#432, #433) |
+| `copy_rss` | `location`, `service_id` | ServiceDetails (header) · Settings (Alerts) · Overview (incident banner) · Sidebar (footer) · Landing (alerts section) | RSS feed URL copied to clipboard. `location` ∈ `service_details`/`settings`/`action_banner`/`sidebar`/`landing`; `service_id`=`'all'` for the all-services `/feed.xml`, the page slug for per-service feeds (#432, #433, #434) |
 | `click_ph_upvote` | `location` | Landing page (PH banner) | Product Hunt upvote link click |
 | `font_load_failed` | `transport_type: 'beacon'` | index.html `<link>` onerror | Google Fonts CSS preload failed (CDN outage, ad blocker, network) — surfaces silent fallback to system fonts (refs #191) |
 

--- a/api/intro/html-template.ts
+++ b/api/intro/html-template.ts
@@ -308,6 +308,16 @@ ${CONSENT_INIT_SCRIPT}
   /* ALERT SECTION */
   .alert-section { border-top: 1px solid var(--border); padding: 64px 24px; }
   .alert-inner { max-width: 900px; margin: 0 auto; }
+  /* Channel badges (#434) — frames alerts as a 3-channel feature (Discord · Slack
+     · RSS), elevating RSS to a first-class channel. The RSS chip copies the feed. */
+  .alert-channels { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 10px; margin: 20px 0 20px; }
+  .ch-badge { display: inline-flex; align-items: center; gap: 6px; background: var(--bg2); border: 1px solid var(--border); border-radius: 999px; padding: 7px 14px; font-size: 13px; font-weight: 500; font-family: var(--font-mono); color: var(--text1); }
+  button.ch-badge { cursor: pointer; transition: border-color 0.2s; }
+  button.ch-rss:hover { border-color: #f26522; }
+  /* RSS subscribe link in the final CTA box (#434) */
+  .cta-rss { margin-top: 16px; }
+  .cta-rss button { display: inline-flex; align-items: center; gap: 6px; background: none; border: none; color: var(--text2); font-size: 13px; font-family: var(--font-mono); cursor: pointer; }
+  .cta-rss button:hover { color: var(--text0); text-decoration: underline; }
   .alert-grid { display: grid; grid-template-columns: 1fr; gap: 20px; margin-top: 36px; max-width: 560px; }
   .discord-wrap { background: #313338; border-radius: 10px; padding: 16px; }
   .slack-wrap { background: #1a1d21; border-radius: 10px; padding: 16px; }
@@ -885,21 +895,15 @@ ${CONSENT_INIT_SCRIPT}
 <section class="alert-section">
   <div class="alert-inner">
     <p class="section-label">// real-time alerts</p>
-    <h2 class="section-title" data-i18n="alert.title">Discord · Slack 실시간 알림</h2>
+    <h2 class="section-title" data-i18n="alert.title">장애 알림, 원하는 방식으로</h2>
     <p class="section-sub" data-i18n="alert.sub">장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.</p>
+    <div class="alert-channels">
+      <span class="ch-badge"><svg width="14" height="14" viewBox="0 0 24 24" fill="#5865F2" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028 14.09 14.09 0 001.226-1.994.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/></svg>Discord</span>
+      <span class="ch-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="#E01E5A" aria-hidden="true"><path d="M5.042 15.165a2.528 2.528 0 01-2.52 2.523A2.528 2.528 0 010 15.165a2.527 2.527 0 012.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 012.521-2.52 2.527 2.527 0 012.521 2.52v6.313A2.528 2.528 0 018.834 24a2.528 2.528 0 01-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 01-2.521-2.52A2.528 2.528 0 018.834 0a2.528 2.528 0 012.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 012.521 2.521 2.528 2.528 0 01-2.521 2.521H2.522A2.528 2.528 0 010 8.834a2.528 2.528 0 012.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 012.522-2.521A2.528 2.528 0 0124 8.834a2.528 2.528 0 01-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 01-2.523 2.521 2.527 2.527 0 01-2.52-2.521V2.522A2.527 2.527 0 0115.165 0a2.528 2.528 0 012.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 012.523 2.522A2.528 2.528 0 0115.165 24a2.527 2.527 0 01-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 01-2.52-2.523 2.526 2.526 0 012.52-2.52h6.313A2.527 2.527 0 0124 15.165a2.528 2.528 0 01-2.522 2.523h-6.313z"/></svg>Slack</span>
+      <button type="button" class="ch-badge ch-rss" onclick="copyRss(this)" title="Copy RSS feed URL" aria-label="Copy RSS feed URL"><svg width="13" height="13" viewBox="0 0 24 24" fill="#f26522" aria-hidden="true"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83C19.56 11.4 12.6 4.44 4 4.44zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg><span class="rss-label">RSS</span></button>
+    </div>
     <div class="alert-grid">
       <div>
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:10px;">
-          <div style="display:flex;align-items:center;gap:5px;">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="#5865F2"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028 14.09 14.09 0 001.226-1.994.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/></svg>
-            <span style="font-size:11px;font-weight:500;color:#5865F2;font-family:var(--font-mono);">Discord</span>
-          </div>
-          <span style="font-size:11px;color:#444;font-family:var(--font-mono);">·</span>
-          <div style="display:flex;align-items:center;gap:5px;">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="#E01E5A"><path d="M5.042 15.165a2.528 2.528 0 01-2.52 2.523A2.528 2.528 0 010 15.165a2.527 2.527 0 012.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 012.521-2.52 2.527 2.527 0 012.521 2.52v6.313A2.528 2.528 0 018.834 24a2.528 2.528 0 01-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 01-2.521-2.52A2.528 2.528 0 018.834 0a2.528 2.528 0 012.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 012.521 2.521 2.528 2.528 0 01-2.521 2.521H2.522A2.528 2.528 0 010 8.834a2.528 2.528 0 012.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 012.522-2.521A2.528 2.528 0 0124 8.834a2.528 2.528 0 01-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 01-2.523 2.521 2.527 2.527 0 01-2.52-2.521V2.522A2.527 2.527 0 0115.165 0a2.528 2.528 0 012.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 012.523 2.522A2.528 2.528 0 0115.165 24a2.527 2.527 0 01-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 01-2.52-2.523 2.526 2.526 0 012.52-2.52h6.313A2.527 2.527 0 0124 15.165a2.528 2.528 0 01-2.522 2.523h-6.313z"/></svg>
-            <span style="font-size:11px;font-weight:500;color:#E01E5A;font-family:var(--font-mono);">Slack</span>
-          </div>
-        </div>
         <div class="discord-wrap">
           <!-- incident + AI Analysis 통합 -->
           <div class="bot-msg">
@@ -1111,6 +1115,12 @@ ${CONSENT_INIT_SCRIPT}
       <a href="https://ai-watch.dev" class="btn-primary" style="font-size:16px;padding:14px 32px;" data-i18n="cta.btn1" onclick="gtag('event','click_dashboard',{location:'landing_cta',source:'intro'})">대시보드 열기 →</a>
       <a href="https://ai-watch.dev/#settings" class="btn-secondary" style="font-size:14px;padding:12px 24px;" data-i18n="cta.btn2" onclick="gtag('event','click_cta_alerts',{location:'landing_cta',source:'intro'})">알림 설정하기</a>
     </div>
+    <div class="cta-rss">
+      <button type="button" onclick="copyRss(this)" title="Copy RSS feed URL">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="#f26522" aria-hidden="true"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83C19.56 11.4 12.6 4.44 4 4.44zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg>
+        <span class="rss-label" data-i18n="cta.rss">RSS로 구독</span>
+      </button>
+    </div>
   </div>
 </section>
 
@@ -1150,8 +1160,9 @@ const i18n = {
     'how.2.title': '분석', 'how.2.desc': 'Claude Sonnet이 패턴 · 복구 시간 · 영향 범위 분석',
     'how.3.title': '알림', 'how.3.desc': 'Discord · Slack 즉시 발송 + Fallback 추천 포함',
     'how.4.title': '리포트', 'how.4.desc': '월간 업타임 추이 · 인시던트 통계 리포트 공개',
-    'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord/Slack 알림 무료', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기',
-    'alert.title': 'Discord · Slack 실시간 알림', 'alert.sub': '장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
+    'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord · Slack · RSS 알림', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기', 'cta.rss': 'RSS로 구독',
+    'alert.title': '장애 알림, 원하는 방식으로', 'alert.sub': '장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
+    'alert.rss.copied': '복사됨 ✓', 'alert.rss.prompt': 'RSS 피드 URL 복사:',
     'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.hook': '가장 안정적인 AI 서비스는? 답은 의외일 수 있습니다.', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 33개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'report.chart.note': '* 하위 점수는 리포팅 방식 차이일 수 있으며, 실제 불안정성을 의미하지 않습니다', 'ai.title': '장애가 나면 AI가 분석합니다', 'ai.sub': '단순 상태 표시에서 한 발 더 — 장애 패턴, 예상 복구 시간, 영향 범위를 Claude Sonnet이 즉시 분석합니다.',
     'footer.report': '월간 리포트', 'footer.alert': '알림 설정'
   },
@@ -1176,8 +1187,9 @@ const i18n = {
     'how.2.title': 'Analyze', 'how.2.desc': 'Claude Sonnet analyzes pattern, recovery time & scope',
     'how.3.title': 'Alert', 'how.3.desc': 'Discord · Slack instant alert + fallback recommendations',
     'how.4.title': 'Report', 'how.4.desc': 'Monthly uptime trends · incident statistics report',
-    'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord/Slack alerts included', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts',
-    'alert.title': 'Discord & Slack alerts', 'alert.sub': 'Instant incident alerts with AI analysis and fallback recommendations. Free.',
+    'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord · Slack · RSS alerts', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts', 'cta.rss': 'Subscribe via RSS',
+    'alert.title': 'Get notified, your way', 'alert.sub': 'Instant incident alerts with AI analysis and fallback recommendations. Free.',
+    'alert.rss.copied': 'Copied ✓', 'alert.rss.prompt': 'Copy this RSS feed URL:',
     'report.title': 'Monthly AI Reliability Report', 'report.hook': 'Which AI service is most reliable? The answer may surprise you.', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 33 services.', 'report.chart.note': '* Lower scores may reflect reporting granularity, not actual instability', 'ai.title': 'AI analyzes every incident', 'ai.sub': 'One step beyond status monitoring — Claude Sonnet instantly analyzes incident patterns, estimated recovery time, and impact scope.',
     'footer.report': 'Monthly Report', 'footer.alert': 'Alert Settings'
   }
@@ -1197,6 +1209,31 @@ function setLang(lang) {
     if (key in i18n[lang]) el.innerHTML = i18n[lang][key];
   });
   document.documentElement.lang = lang;
+}
+
+// RSS subscribe (#434) — copy the all-services feed rather than linking it (a
+// feed URL opened directly downloads raw XML). prompt() fallback for insecure
+// contexts; copy_rss fires only on a confirmed copy. Labels come from i18n so
+// the copied/restored text follows the current language.
+function copyRss(btn) {
+  var url = 'https://ai-watch.dev/feed.xml';
+  var el = btn.querySelector('.rss-label') || btn; // swap only the label, keep the icon
+  if (el.getAttribute('data-busy')) return;         // ignore re-clicks during the pending write + feedback window
+  var orig = el.textContent;
+  el.setAttribute('data-busy', '1');                // set synchronously so a rapid double-click can't double-fire
+  function done() {
+    // Arm the reset before the i18n lookup so data-busy is always cleared even if
+    // the label assignment throws — otherwise the chip could stick on "busy".
+    setTimeout(function () { el.textContent = orig; el.removeAttribute('data-busy'); }, 2000);
+    el.textContent = i18n[currentLang]['alert.rss.copied'];
+    if (typeof gtag === 'function') gtag('event', 'copy_rss', { location: 'landing', service_id: 'all' });
+  }
+  function fallback() { el.removeAttribute('data-busy'); window.prompt(i18n[currentLang]['alert.rss.prompt'], url); }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(url).then(done).catch(fallback);
+  } else {
+    fallback();
+  }
 }
 try {
   setLang(currentLang);

--- a/docs/aiwatch-landing.html
+++ b/docs/aiwatch-landing.html
@@ -281,6 +281,16 @@
   /* ALERT SECTION */
   .alert-section { border-top: 1px solid var(--border); padding: 64px 24px; }
   .alert-inner { max-width: 900px; margin: 0 auto; }
+  /* Channel badges (#434) — frames alerts as a 3-channel feature (Discord · Slack
+     · RSS), elevating RSS to a first-class channel. The RSS chip copies the feed. */
+  .alert-channels { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 10px; margin: 20px 0 20px; }
+  .ch-badge { display: inline-flex; align-items: center; gap: 6px; background: var(--bg2); border: 1px solid var(--border); border-radius: 999px; padding: 7px 14px; font-size: 13px; font-weight: 500; font-family: var(--font-mono); color: var(--text1); }
+  button.ch-badge { cursor: pointer; transition: border-color 0.2s; }
+  button.ch-rss:hover { border-color: #f26522; }
+  /* RSS subscribe link in the final CTA box (#434) */
+  .cta-rss { margin-top: 16px; }
+  .cta-rss button { display: inline-flex; align-items: center; gap: 6px; background: none; border: none; color: var(--text2); font-size: 13px; font-family: var(--font-mono); cursor: pointer; }
+  .cta-rss button:hover { color: var(--text0); text-decoration: underline; }
   .alert-grid { display: grid; grid-template-columns: 1fr; gap: 20px; margin-top: 36px; max-width: 560px; }
   .discord-wrap { background: #313338; border-radius: 10px; padding: 16px; }
   .slack-wrap { background: #1a1d21; border-radius: 10px; padding: 16px; }
@@ -865,21 +875,15 @@
 <section class="alert-section">
   <div class="alert-inner">
     <p class="section-label">// real-time alerts</p>
-    <h2 class="section-title" data-i18n="alert.title">Discord · Slack 실시간 알림</h2>
+    <h2 class="section-title" data-i18n="alert.title">장애 알림, 원하는 방식으로</h2>
     <p class="section-sub" data-i18n="alert.sub">장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.</p>
+    <div class="alert-channels">
+      <span class="ch-badge"><svg width="14" height="14" viewBox="0 0 24 24" fill="#5865F2" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028 14.09 14.09 0 001.226-1.994.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/></svg>Discord</span>
+      <span class="ch-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="#E01E5A" aria-hidden="true"><path d="M5.042 15.165a2.528 2.528 0 01-2.52 2.523A2.528 2.528 0 010 15.165a2.527 2.527 0 012.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 012.521-2.52 2.527 2.527 0 012.521 2.52v6.313A2.528 2.528 0 018.834 24a2.528 2.528 0 01-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 01-2.521-2.52A2.528 2.528 0 018.834 0a2.528 2.528 0 012.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 012.521 2.521 2.528 2.528 0 01-2.521 2.521H2.522A2.528 2.528 0 010 8.834a2.528 2.528 0 012.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 012.522-2.521A2.528 2.528 0 0124 8.834a2.528 2.528 0 01-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 01-2.523 2.521 2.527 2.527 0 01-2.52-2.521V2.522A2.527 2.527 0 0115.165 0a2.528 2.528 0 012.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 012.523 2.522A2.528 2.528 0 0115.165 24a2.527 2.527 0 01-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 01-2.52-2.523 2.526 2.526 0 012.52-2.52h6.313A2.527 2.527 0 0124 15.165a2.528 2.528 0 01-2.522 2.523h-6.313z"/></svg>Slack</span>
+      <button type="button" class="ch-badge ch-rss" onclick="copyRss(this)" title="Copy RSS feed URL" aria-label="Copy RSS feed URL"><svg width="13" height="13" viewBox="0 0 24 24" fill="#f26522" aria-hidden="true"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83C19.56 11.4 12.6 4.44 4 4.44zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg><span class="rss-label">RSS</span></button>
+    </div>
     <div class="alert-grid">
       <div>
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:10px;">
-          <div style="display:flex;align-items:center;gap:5px;">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="#5865F2"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028 14.09 14.09 0 001.226-1.994.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/></svg>
-            <span style="font-size:11px;font-weight:500;color:#5865F2;font-family:var(--font-mono);">Discord</span>
-          </div>
-          <span style="font-size:11px;color:#444;font-family:var(--font-mono);">·</span>
-          <div style="display:flex;align-items:center;gap:5px;">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="#E01E5A"><path d="M5.042 15.165a2.528 2.528 0 01-2.52 2.523A2.528 2.528 0 010 15.165a2.527 2.527 0 012.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 012.521-2.52 2.527 2.527 0 012.521 2.52v6.313A2.528 2.528 0 018.834 24a2.528 2.528 0 01-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 01-2.521-2.52A2.528 2.528 0 018.834 0a2.528 2.528 0 012.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 012.521 2.521 2.528 2.528 0 01-2.521 2.521H2.522A2.528 2.528 0 010 8.834a2.528 2.528 0 012.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 012.522-2.521A2.528 2.528 0 0124 8.834a2.528 2.528 0 01-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 01-2.523 2.521 2.527 2.527 0 01-2.52-2.521V2.522A2.527 2.527 0 0115.165 0a2.528 2.528 0 012.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 012.523 2.522A2.528 2.528 0 0115.165 24a2.527 2.527 0 01-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 01-2.52-2.523 2.526 2.526 0 012.52-2.52h6.313A2.527 2.527 0 0124 15.165a2.528 2.528 0 01-2.522 2.523h-6.313z"/></svg>
-            <span style="font-size:11px;font-weight:500;color:#E01E5A;font-family:var(--font-mono);">Slack</span>
-          </div>
-        </div>
         <div class="discord-wrap">
           <!-- incident + AI Analysis 통합 -->
           <div class="bot-msg">
@@ -1077,6 +1081,12 @@
       <a href="https://ai-watch.dev" class="btn-primary" style="font-size:16px;padding:14px 32px;" data-i18n="cta.btn1" onclick="gtag('event','click_dashboard',{location:'landing_cta',source:'intro'})">대시보드 열기 →</a>
       <a href="https://ai-watch.dev/#settings" class="btn-secondary" style="font-size:14px;padding:12px 24px;" data-i18n="cta.btn2" onclick="gtag('event','click_cta_alerts',{location:'landing_cta',source:'intro'})">알림 설정하기</a>
     </div>
+    <div class="cta-rss">
+      <button type="button" onclick="copyRss(this)" title="Copy RSS feed URL">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="#f26522" aria-hidden="true"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83C19.56 11.4 12.6 4.44 4 4.44zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg>
+        <span class="rss-label" data-i18n="cta.rss">RSS로 구독</span>
+      </button>
+    </div>
   </div>
 </section>
 
@@ -1115,8 +1125,9 @@ const i18n = {
     'how.2.title': '분석', 'how.2.desc': 'Claude Sonnet이 패턴 · 복구 시간 · 영향 범위 분석',
     'how.3.title': '알림', 'how.3.desc': 'Discord · Slack 즉시 발송 + Fallback 추천 포함',
     'how.4.title': '리포트', 'how.4.desc': '월간 업타임 추이 · 인시던트 통계 리포트 공개',
-    'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord/Slack 알림 무료', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기',
-    'alert.title': 'Discord · Slack 실시간 알림', 'alert.sub': '장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
+    'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord · Slack · RSS 알림', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기', 'cta.rss': 'RSS로 구독',
+    'alert.title': '장애 알림, 원하는 방식으로', 'alert.sub': '장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
+    'alert.rss.copied': '복사됨 ✓', 'alert.rss.prompt': 'RSS 피드 URL 복사:',
     'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 33개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'ai.title': '장애가 나면 AI가 분석합니다', 'ai.sub': '단순 상태 표시에서 한 발 더 — 장애 패턴, 예상 복구 시간, 영향 범위를 Claude Sonnet이 즉시 분석합니다.',
     'footer.report': '월간 리포트', 'footer.alert': '알림 설정'
   },
@@ -1141,8 +1152,9 @@ const i18n = {
     'how.2.title': 'Analyze', 'how.2.desc': 'Claude Sonnet analyzes pattern, recovery time & scope',
     'how.3.title': 'Alert', 'how.3.desc': 'Discord · Slack instant alert + fallback recommendations',
     'how.4.title': 'Report', 'how.4.desc': 'Monthly uptime trends · incident statistics report',
-    'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord/Slack alerts included', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts',
-    'alert.title': 'Discord & Slack alerts', 'alert.sub': 'Instant incident alerts with AI analysis and fallback recommendations. Free.',
+    'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord · Slack · RSS alerts', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts', 'cta.rss': 'Subscribe via RSS',
+    'alert.title': 'Get notified, your way', 'alert.sub': 'Instant incident alerts with AI analysis and fallback recommendations. Free.',
+    'alert.rss.copied': 'Copied ✓', 'alert.rss.prompt': 'Copy this RSS feed URL:',
     'report.title': 'Monthly AI Reliability Report', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 33 services.', 'ai.title': 'AI analyzes every incident', 'ai.sub': 'One step beyond status monitoring — Claude Sonnet instantly analyzes incident patterns, estimated recovery time, and impact scope.',
     'footer.report': 'Monthly Report', 'footer.alert': 'Alert Settings'
   }
@@ -1162,6 +1174,29 @@ function setLang(lang) {
     if (key in i18n[lang]) el.innerHTML = i18n[lang][key];
   });
   document.documentElement.lang = lang;
+}
+
+// RSS subscribe (#434) — copy the all-services feed (a feed URL opened directly
+// downloads raw XML). prompt() fallback; copy_rss fires only on confirmed copy.
+function copyRss(btn) {
+  var url = 'https://ai-watch.dev/feed.xml';
+  var el = btn.querySelector('.rss-label') || btn; // swap only the label, keep the icon
+  if (el.getAttribute('data-busy')) return;         // ignore re-clicks during the pending write + feedback window
+  var orig = el.textContent;
+  el.setAttribute('data-busy', '1');                // set synchronously so a rapid double-click can't double-fire
+  function done() {
+    // Arm the reset before the i18n lookup so data-busy is always cleared even if
+    // the label assignment throws — otherwise the chip could stick on "busy".
+    setTimeout(function () { el.textContent = orig; el.removeAttribute('data-busy'); }, 2000);
+    el.textContent = i18n[currentLang]['alert.rss.copied'];
+    if (typeof gtag === 'function') gtag('event', 'copy_rss', { location: 'landing', service_id: 'all' });
+  }
+  function fallback() { el.removeAttribute('data-busy'); window.prompt(i18n[currentLang]['alert.rss.prompt'], url); }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(url).then(done).catch(fallback);
+  } else {
+    fallback();
+  }
 }
 try {
   setLang(currentLang);

--- a/tests/intro.spec.js
+++ b/tests/intro.spec.js
@@ -117,4 +117,38 @@ test.describe('Landing page (/intro)', () => {
     const featureCard = page.locator('.feature-card.fade-up').first()
     await expect(featureCard).toHaveClass(/visible/, { timeout: 5000 })
   })
+
+  test('alerts section RSS channel badge copies the feed URL + restores its label (#434)', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto('/intro', { waitUntil: 'domcontentloaded' })
+    const rssBadge = page.locator('.alert-channels .ch-rss')
+    await rssBadge.scrollIntoViewIfNeeded()
+    await expect(rssBadge).toBeVisible()
+    const label = rssBadge.locator('.rss-label')
+    await rssBadge.click()
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('https://ai-watch.dev/feed.xml')
+    await expect(label).toHaveText(/Copied ✓|복사됨 ✓/)
+    // Restores to "RSS" after the 2s feedback window (guards the data-busy/reset path)
+    await expect(label).toHaveText('RSS', { timeout: 4000 })
+  })
+
+  test('final CTA box offers a localized RSS subscribe link that copies the feed URL (#434)', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto('/intro', { waitUntil: 'domcontentloaded' })
+    const ctaRss = page.locator('.cta-rss button')
+    const label = ctaRss.locator('.rss-label')
+    await ctaRss.scrollIntoViewIfNeeded()
+
+    // EN i18n wiring + copy + restore
+    await page.locator('.lang-toggle button').filter({ hasText: 'EN' }).click()
+    await expect(label).toHaveText('Subscribe via RSS')
+    await ctaRss.click()
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('https://ai-watch.dev/feed.xml')
+    await expect(label).toHaveText('Copied ✓')
+    await expect(label).toHaveText('Subscribe via RSS', { timeout: 4000 }) // restores after the timeout
+
+    // KO i18n wiring (pins the cta.rss key in both locales)
+    await page.locator('.lang-toggle button').filter({ hasText: 'KO' }).click()
+    await expect(label).toHaveText('RSS로 구독')
+  })
 })


### PR DESCRIPTION
Closes #434.

Surfaces RSS on the Product Hunt landing page (`api/intro/html-template.ts`) and reframes the alerts section so notifications read as a core 3-channel feature (#428) rather than a Discord/Slack add-on.

> ⚠️ **Stacked on #436** (`feat/433-settings-rss` → #435 → main). Base is that branch, not `main`. Merge order: #435 → #436 → this.

## Changes

**Alerts section (reframed — operator feedback in-session)**
- Title "Discord & Slack alerts" → **"Get notified, your way"** (KO: "장애 알림, 원하는 방식으로").
- Sub moved directly under the title.
- A **Discord · Slack · RSS** channel-badge row; the RSS chip copies `/feed.xml`.
- Removed the now-duplicate Discord/Slack icon header that sat inside the demo card (it was shown twice — once in the badge row, once in the mockup).

**Final CTA box**
- `cta.sub` now lists "Discord · Slack · RSS alerts"; a **"Subscribe via RSS"** link below the buttons.

**Inline `copyRss()`**
- Copies the all-services feed (a feed URL opened directly downloads raw XML); swaps only the `.rss-label` (keeps the icon); synchronous `data-busy` re-entrancy guard cleared on every path (success/reject/no-clipboard) with the reset armed before the i18n lookup so it can't stick; `window.prompt` fallback; `copy_rss` GA4 (`location:'landing'`) only on a confirmed copy.

**Sync + docs**
- `docs/aiwatch-landing.html` design draft hand-synced (CLAUDE.md #17 mirror contract).
- CLAUDE.md GA4 table lists the `landing` location.

## Testing
- `/intro` Edge function renders (curl + snapshot); lint 0 errors
- E2E (`tests/intro.spec.js`, `intro` project / vercel dev :3333): channel-badge copy + **label restore**, and the CTA link **pinned across EN/KO i18n** — both pass
- PR review (code-reviewer · pr-test-analyzer · silent-failure-hunter), 2 rounds, converged: round-1 Important (untested label-restore/busy-guard + locale coupling) → added tests + hardened guard; round-2 found the reset could stick if the i18n lookup threw → reset now armed first. Zero open Critical/Important.

## Follow-ups
- Reports template RSS remains deferred (different repo + retrospective content paradigm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)