### PR TITLE
feat: surface partial-outage count for BetterStack services (#447)

### DIFF
--- a/src/components/StatusPill.jsx
+++ b/src/components/StatusPill.jsx
@@ -10,17 +10,36 @@ const PILL_CLASS = {
   down:        'bg-[var(--status-bg-red)]   text-[var(--red)]',
 }
 
-export default function StatusPill({ status = 'operational' }) {
+export default function StatusPill({ status = 'operational', partialCount = 0 }) {
   const { t } = useLang()
   const cls = PILL_CLASS[status] ?? PILL_CLASS.operational
+  // Show the "N affected" chip only when the service reads operational but some
+  // underlying resources report issues (BetterStack <30% threshold case, #447).
+  // On degraded/down the pill itself already conveys the problem.
+  const showPartial = status === 'operational' && partialCount > 0
 
-  return (
+  const pill = (
     <span
       role="status"
       className={`inline-flex items-center mono font-medium uppercase text-[9px] tracking-[0.06em] whitespace-nowrap shrink-0 ${cls}`}
       style={{ padding: '3px 7px', borderRadius: '4px' }}
     >
       {t(`status.${status}`)}
+    </span>
+  )
+
+  if (!showPartial) return pill
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {pill}
+      <span
+        className="inline-flex items-center mono font-medium text-[9px] whitespace-nowrap shrink-0 bg-[var(--status-bg-amber)] text-[var(--amber)]"
+        style={{ padding: '3px 7px', borderRadius: '4px' }}
+        title={t('status.partial.tooltip')}
+      >
+        ⚠ {partialCount}{t('status.partial.suffix')}
+      </span>
     </span>
   )
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -33,6 +33,8 @@ const en = {
   'status.degraded_perf': 'Degraded',
   'status.degraded': 'Partial Outage',
   'status.down': 'Major Outage',
+  'status.partial.suffix': ' affected',
+  'status.partial.tooltip': 'Some components are reporting issues on the provider status page; overall service availability is still nominal.',
 
   // Overview
   'overview.last.updated': 'Last updated',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -33,6 +33,8 @@ const ko = {
   'status.degraded_perf': '성능 저하',
   'status.degraded': '부분 장애',
   'status.down': '주요 장애',
+  'status.partial.suffix': '개 영향',
+  'status.partial.tooltip': '제공사 상태 페이지에서 일부 구성요소에 이슈가 보고됐습니다. 서비스 전체 가용성은 정상 범위입니다.',
 
   // Overview
   'overview.last.updated': '마지막 업데이트',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -116,7 +116,7 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
           <span className="text-[13px] font-medium text-[var(--text0)] truncate min-w-0">{service.name}</span>
           <div className="flex items-center gap-1.5">
             {isRecovered && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
-            <StatusPill status={service.status} />
+            <StatusPill status={service.status} partialCount={service.partialCount} />
           </div>
         </div>
         <div className="flex items-center justify-between" style={{ marginBottom: '4px' }}>
@@ -138,7 +138,7 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
           </div>
           <div className="flex items-center gap-1.5">
             {isRecovered && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
-            <StatusPill status={service.status} />
+            <StatusPill status={service.status} partialCount={service.partialCount} />
           </div>
         </div>
 

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -710,7 +710,7 @@ export default function ServiceDetails({ serviceId }) {
         </div>
         <div className="flex items-center gap-1.5">
           {!!recentlyRecovered[service.id] && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}
-          <StatusPill status={service.status} />
+          <StatusPill status={service.status} partialCount={service.partialCount} />
         </div>
       </div>
 

--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { parseRssIncidents, parseXaiRssIncidents, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds } from '../betterstack'
+import { parseRssIncidents, parseXaiRssIncidents, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackPartialCount } from '../betterstack'
 
 describe('parseRssIncidents', () => {
   it('groups RSS items by guid into incidents', () => {
@@ -999,5 +999,54 @@ describe('parseBetterStackResolvedIds', () => {
   it('returns empty set when no status_reports', () => {
     expect(parseBetterStackResolvedIds({})).toEqual(new Set())
     expect(parseBetterStackResolvedIds({ included: [] })).toEqual(new Set())
+  })
+})
+
+describe('parseBetterStackPartialCount (#447)', () => {
+  const resource = (status: string) => ({ type: 'status_page_resource', attributes: { status } })
+
+  it('counts degraded + downtime resources', () => {
+    expect(parseBetterStackPartialCount({
+      included: [resource('downtime'), resource('degraded'), resource('downtime'), resource('operational')],
+    })).toBe(3)
+  })
+
+  it('returns 0 when all resources are operational', () => {
+    expect(parseBetterStackPartialCount({
+      included: [resource('operational'), resource('operational')],
+    })).toBe(0)
+  })
+
+  it('excludes maintenance resources (planned, not an outage)', () => {
+    expect(parseBetterStackPartialCount({
+      included: [resource('maintenance'), resource('maintenance'), resource('downtime')],
+    })).toBe(1)
+  })
+
+  it('ignores non status_page_resource entries', () => {
+    expect(parseBetterStackPartialCount({
+      included: [
+        { type: 'status_report', attributes: { status: 'downtime' } },
+        resource('downtime'),
+      ],
+    })).toBe(1)
+  })
+
+  it('returns 0 for missing / empty included', () => {
+    expect(parseBetterStackPartialCount({})).toBe(0)
+    expect(parseBetterStackPartialCount({ included: [] })).toBe(0)
+  })
+
+  it('reflects the partial-outage gap: status operational (<30%) yet partialCount > 0', () => {
+    // 2 downtime out of 10 → parseBetterStackStatus collapses to operational, but the
+    // 2 affected resources are still surfaced via partialCount (the #447 perception gap).
+    const included = [
+      ...Array.from({ length: 8 }, () => resource('operational')),
+      resource('downtime'),
+      resource('downtime'),
+    ]
+    const data = { data: { attributes: { aggregate_state: 'downtime' } }, included }
+    expect(parseBetterStackStatus(data)).toBe('operational')  // <30% threshold
+    expect(parseBetterStackPartialCount(data)).toBe(2)        // but 2 are affected
   })
 })

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -259,6 +259,22 @@ export function parseBetterStackStatus(data: BetterStackIndex): 'operational' | 
   return 'degraded'
 }
 
+/**
+ * Count resources reporting a real issue (degraded or downtime), excluding planned
+ * maintenance and operational ones. Surfaced as `partialCount` so the UI can show a
+ * "N affected" badge when `parseBetterStackStatus` collapses a partial outage to
+ * `operational` via the <30% threshold (#447) — closes the perception gap between
+ * BetterStack's "Some services are down" header and the AIWatch card without
+ * reintroducing the per-model flap noise the threshold deliberately suppresses.
+ */
+export function parseBetterStackPartialCount(data: BetterStackIndex): number {
+  return (data.included ?? []).filter(
+    (r) =>
+      r.type === 'status_page_resource' &&
+      (r.attributes?.status === 'degraded' || r.attributes?.status === 'downtime')
+  ).length
+}
+
 export function parseBetterStackUptime(data: BetterStackIndex): number | null {
   const resources = (data.included ?? []).filter(
     (r) => r.type === 'status_page_resource' && r.attributes?.availability != null

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -17,7 +17,7 @@ import {
   computeDailyImpactFromIncidents,
 } from './parsers/aistudio'
 import { parseInstatusIncidents } from './parsers/instatus'
-import { parseRssIncidents, parseXaiRssIncidents, type BetterStackIndex, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds } from './parsers/betterstack'
+import { parseRssIncidents, parseXaiRssIncidents, type BetterStackIndex, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackPartialCount } from './parsers/betterstack'
 import { parseOnlineOrNotIncidents, parseOnlineOrNotUptime } from './parsers/onlineornot'
 import { parseAwsRssIncidents, deriveAwsStatus } from './parsers/aws'
 
@@ -707,6 +707,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
       // Better Stack uptime + status: parse /index.json for aggregate_state and availability
       let betterStackUptime: number | null = null
       let betterStackStat: 'operational' | 'degraded' | 'down' | null = null
+      let betterStackPartial = 0
       let bsDailyImpact: Record<string, DailyImpactLevel> | null = null
       if (betterStackRes && !betterStackRes.ok) {
         console.warn(`[fetchService] ${config.id} BetterStack index.json returned HTTP ${betterStackRes.status}`)
@@ -717,6 +718,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
           const bsData: BetterStackIndex = await betterStackRes.json()
           betterStackUptime = parseBetterStackUptime(bsData)
           betterStackStat = parseBetterStackStatus(bsData)
+          betterStackPartial = parseBetterStackPartialCount(bsData)
           bsDailyImpact = parseBetterStackDailyImpact(bsData)
           // Reconcile RSS incidents with index.json resolved status (authoritative)
           const resolvedIds = parseBetterStackResolvedIds(bsData)
@@ -783,6 +785,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         calendarDays: has30dCalendar ? 30 : 14,
         ...(dailyImpact && Object.keys(dailyImpact).length > 0 ? { dailyImpact } : {}),
         ...(betterStackUptime != null ? { uptime30d: betterStackUptime, uptimeSource: 'platform_avg' as const } : {}),
+        ...(betterStackPartial > 0 ? { partialCount: betterStackPartial } : {}),
       }
     }
   } catch (err) {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -32,6 +32,10 @@ export interface ServiceStatus {
   calendarDays?: number
   uptimeSource?: 'official' | 'platform_avg' | 'estimate'
   detectedAt?: string
+  /** BetterStack only: count of resources reporting a real issue (degraded/downtime)
+   *  while the service stays operational under the <30% threshold (#447). UI shows a
+   *  "N affected" badge; absent when 0. */
+  partialCount?: number
 }
 
 export type DailyImpactLevel = 'minor' | 'major' | 'critical'


### PR DESCRIPTION
closes #447

## Problem

For BetterStack-backed services (Together AI, Fireworks, HuggingFace, Modal), the official status page lists many per-model/component resources. When a subset is down, BetterStack shows **"Some services are down"**, but `parseBetterStackStatus` deliberately collapses the service to **operational** when fewer than 30% of resources are non-operational (flap-noise suppression — #283/#349/#373).

Result: official shows a partial outage while the AIWatch card reads Operational — a perception gap for users depending on an affected model.

## Fix (no change to status determination)

Surface a separate `partialCount` field; the 30% threshold + flap suppression stay exactly as-is.

- **Worker** — `parseBetterStackPartialCount(data)` counts degraded+downtime resources (excludes maintenance + operational). Attached to `ServiceStatus` only when `> 0`. New `partialCount?: number` on the type.
- **Frontend** — `StatusPill` renders an amber **"⚠ N affected"** chip only when `status === 'operational' && partialCount > 0` (on degraded/down the pill itself conveys the issue). Passed from `ServiceCard` (mobile + desktop) and `ServiceDetails`; flows through `usePolling` via the live spread. Non-BetterStack services never set the field → no chip (backward compatible).
- **i18n** — `status.partial.suffix` / `status.partial.tooltip` (ko/en). Badge reads `⚠ 3 affected` / `⚠ 3개 영향`.

```
Together AI   [Operational] ⚠ 3 affected
```

## Intended emergent behavior
If a BetterStack service hits the existing cross-validation override (degraded + no incidents + healthy probe → operational), the chip then surfaces on the now-operational card. This is **desirable** — "probe healthy but provider flags N resources" — flagged by review for awareness.

## Tests
6 new Vitest cases in `betterstack.test.ts` (degraded+downtime counted, maintenance/operational excluded, non-resource entries ignored, empty/missing → 0, and the cross-function insight: status collapses to operational under <30% while `partialCount > 0`). `npm run test:worker` green (1274 total); dry-run build + frontend build + lint (0 errors) clean.

The StatusPill display gate has no committed unit test — the repo has no component-test infra (frontend Vitest is pure-util only) and both reviewers agreed extracting the trivial 2-term gate would test a tautology. Instead the badge render was **verified live via Playwright** (Together card showed `Operational ⚠ 3 affected`).

## Review
`/pr-review-toolkit:review-pr` (code-reviewer + pr-test-analyzer): 0 Critical, 0 Important.

## Out of scope (pre-existing)
3 failures in `api/is-down/__tests__/html-template.test.ts` exist on clean `main` (unrelated to this change) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)