### PR TITLE
test: add date-literal recurrence guard for is-down html-template (#443)

### DIFF
--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { buildMetaDescription, renderIncidents, renderFooter, renderRegionRecommendation, renderShareButtons, renderPage, type ServiceData } from '../html-template'
 import type { ServiceSEO } from '../seo-content'
 import { SLUG_TO_SERVICE, RELATED_SLUGS } from '../slug-map'
@@ -625,5 +627,35 @@ describe('RSS feed surfacing on /is-*-down (#430)', () => {
     expect(html).toContain(
       "gtag('event','copy_rss',{location:'is_down_page',service_id:b.dataset.svc})",
     )
+  })
+})
+
+// ── Recurrence guard (#443 / #449) ───────────────────────────────────
+//
+// buildMetaDescription + renderIncidents filter incidents on a
+// Date.now()-anchored rolling 30-day window. A hard-coded calendar-date
+// literal in any fixture here silently ages out of that window and the
+// test starts failing on a future date with no code change — exactly the
+// #443 breakage. Every fixture MUST derive its dates from daysAgo(n) /
+// dayAgo(n) instead. This meta-test reads its own source and fails if a
+// YYYY-MM-DD literal reappears, so the brittle pattern is caught the
+// moment it's reintroduced rather than weeks later when the calendar
+// happens to roll past the window edge.
+describe('date-literal guard (#443)', () => {
+  it('contains no hard-coded calendar-date literals — fixtures use relative daysAgo()/dayAgo() only', () => {
+    const source = readFileSync(fileURLToPath(import.meta.url), 'utf8')
+    // Matches an ISO-ish YYYY-MM-DD literal (year 19xx/20xx). No trailing
+    // boundary: fixture dates are usually followed by `T` (e.g. ...-20T10:00),
+    // and a `\b` there would never match. The pattern text itself is
+    // digit-class-based, so it never matches its own source line.
+    // Scope: this only catches the ISO-dashed form — the sole literal shape
+    // used by every fixture in this file (and the one #443 actually broke on).
+    // Exotic brittle forms (numeric `new Date(y, m, d)`, epoch-ms literals) are
+    // not detected, but they don't occur here and aren't the realistic regression.
+    const hits = source.match(/\b(?:19|20)\d\d-\d\d-\d\d/g) ?? []
+    expect(
+      hits,
+      'Hard-coded date literal(s) found — replace with daysAgo(n)/dayAgo(n) so fixtures stay inside the rolling 30-day window (see #443).',
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
closes #443

## Summary

#443 flagged that fixed-date fixtures in `api/is-down/__tests__/html-template.test.ts` silently age out of the rolling 30-day window (`Date.now() - 30 * 86_400_000` in `renderIncidents`/`buildMetaDescription`) and start failing on a future date with no code change.

- **Task 1 (convert fixtures to relative dates)** — already completed in #449/#450 via the `daysAgo(n)`/`dayAgo(n)` helpers.
- **Task 2 (audit the repo for other window-gated fixtures)** — done; **no other brittle path found**. `groupIncidents` doesn't window-filter (32-day-old `2026-04-20` fixtures still pass), `buildRssFeed` takes an injected `now` (sort + 50-item cap, no window), `archiveMerge`/`monthly-narrative`/`monthly-archive` inject `now`/`period`, `competitive.ts` `weekAgo` only builds a server-side GitHub query, and `changelog.test.ts` calls `parseRssEntries` directly (bypasses the `weekAgo` filter). `incidentSort`'s real-incident dates are intentional documentation and left untouched.
- **Task 3 (verify green on a clean checkout)** — `npm run test:src` is green (257 tests).

## What this PR adds

A **self-scan recurrence guard** in `html-template.test.ts` — the one file whose fixtures gate on the rolling window. It reads its own source and fails if a hard-coded `YYYY-MM-DD` literal reappears, so the brittle pattern is caught immediately on reintroduction rather than weeks later when the calendar rolls past the window edge.

## Verification

- Guard passes on the clean file; injecting a `2026-04-20` literal makes it fail and report the offending literal (verified end-to-end, then reverted).
- Regex omits a trailing `\b` because fixture dates are followed by `T` (`...-20T10:00`), where a word boundary would never match.
- `npm run test:src` → 257 passed.
- PR review (code-reviewer + pr-test-analyzer): no Critical/Important findings; the one scope note (guard only catches the ISO-dashed form) is documented in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)