### PR TITLE
fix: force statusline lite payload on proxied /api/status/cached (#452)

### DIFF
--- a/api/__tests__/vercel-rewrites.test.ts
+++ b/api/__tests__/vercel-rewrites.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Guards the #452 fix. The Vercel-proxied `/api/status/cached` rewrite MUST force
+// the statusline lite projection (`?src=statusline-*`). Without the tag the Worker
+// returns the full ~2.2 MB payload (services + probe:24h + latency:24h + AI
+// analysis), and legacy/untagged pollers — statusline snippets copied before #438,
+// which poll ~every prompt — re-download all of it through Vercel (uncached proxy,
+// billed as Fast Data Transfer). Vercel Observability measured this route at the
+// top of Fast Data Transfer (2.9K req × 2.26 MB ≈ 5.74 GB/cycle) when the quota
+// overran — forcing lite drops it ~1000× (≈2 KB/req).
+//
+// Nothing in our own code reads this proxied path: the SPA (usePolling.js),
+// Statusline.jsx, and the is-down Edge SSR (api/is-down.ts) all hit the Worker
+// domain directly. So it only ever serves external/legacy callers, who need
+// exactly {id,name,status} — which the lite projection provides.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..')
+const vercelConfig = JSON.parse(
+  readFileSync(join(repoRoot, 'vercel.json'), 'utf8'),
+) as { rewrites: Array<{ source: string; destination: string }> }
+
+describe('vercel.json /api/status/cached rewrite (#452)', () => {
+  it('forces the statusline lite projection so the proxied path never serves the full payload', () => {
+    const rule = vercelConfig.rewrites.find((r) => r.source === '/api/status/cached')
+    expect(rule, '/api/status/cached rewrite must exist').toBeDefined()
+    // Targets the Worker, still routes to the cached endpoint (a typo'd path like
+    // /api/status would pass the tag check but break callers), and carries a
+    // ?src=statusline-* tag (isStatuslineRequest matches any src starting with
+    // "statusline-" → buildStatuslinePayload).
+    expect(rule!.destination).toContain('aiwatch-worker.p2c2kbf.workers.dev')
+    expect(rule!.destination).toContain('/api/status/cached')
+    expect(rule!.destination).toMatch(/[?&]src=statusline-/)
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -38,7 +38,7 @@
     { "source": "/reports/", "destination": "/api/reports" },
     { "source": "/reports/:rest*", "destination": "/api/reports" },
     { "source": "/reports/:rest*/", "destination": "/api/reports" },
-    { "source": "/api/status/cached", "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached" },
+    { "source": "/api/status/cached", "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-proxy" },
     { "source": "/feed.xml", "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/feed.xml" },
     { "source": "/feed/:slug", "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/feed/:slug" },
     { "source": "/(.*)", "destination": "/index.html" }


### PR DESCRIPTION
closes #452

## Problem

Vercel **Fast Data Transfer hit 106.91 GB / 100 GB** (over the Pro quota). Observability path breakdown:

| Route | Requests | Avg size | Fast Data Transfer |
|---|---|---|---|
| **`/api/status/cached`** | **2.9K** | **2.26 MB** | **5.74 GB — top route** |
| `/assets/index-*.js` | 27 | 32 kB | 3 MB |
| `/api/is-down` | 94 | 107 kB | 1.06 MB |
| `/feed.xml`, `/feed/:slug` | — | — | not in top 10 |

`/api/status/cached` is the only heavy-per-request route (~100× the next). The 2.26 MB average proves these requests get the **full** payload — i.e. no `?src=statusline-*` lite tag.

## Root cause

#438 added the lite projection (`?src=statusline-*` → ~2 KB) and pointed the *snippet generator* at the Worker domain, but:
1. The lite projection only triggers when the caller adds the tag.
2. **Statusline snippets copied before #438** still poll `ai-watch.dev/api/status/cached` with **no tag** → full ~2.2 MB every prompt.
3. Vercel doesn't cache the proxied (rewrite-to-external) response (`x-vercel-cache: MISS`), so every poll bills as outbound.

Nothing in our own code uses the proxied path — the SPA (`usePolling.js`), `Statusline.jsx`, and the is-down Edge SSR (`api/is-down.ts:73`) all hit the Worker domain directly. So `ai-watch.dev/api/status/cached` only ever serves legacy/external callers, who need exactly `{id,name,status}`.

## Fix

```diff
- "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached"
+ "destination": "https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-proxy"
```

`isStatuslineRequest()` matches any `src` starting with `statusline-`, so the proxied path now always returns `buildStatuslinePayload` (`{id,name,status}` + `cachedAt`). Already-copied snippets keep working (their `jq` reads exactly those fields) but stop downloading 2 MB. SPA/SSR unaffected (Worker-direct). **~1000× reduction** on the top route.

## Verification

- Worker direct `?src=statusline-proxy` → **2055 B** vs **2.14 MB** untagged.
- `vercel dev` locally: `localhost:3333/api/status/cached` → **2055 B**, `{id,name,status}` × 33 (rewrite appends the tag correctly).
- New `api/__tests__/vercel-rewrites.test.ts` pins the rewrite (Worker host + `/api/status/cached` path + `?src=statusline-` tag); confirmed it fails if the tag is stripped.
- `npm run test:src` → 257 passed.
- PR review (code-reviewer + pr-test-analyzer): no Critical/Important; applied the suggested path-preservation assertion.

**Post-deploy check** (in #452): `curl -s -o /dev/null -w "%{size_download}" https://ai-watch.dev/api/status/cached` → expect ~2 KB.

## Follow-up (not this PR)
Feeds (`/feed.xml`, `/feed/:slug`) are also proxied + uncached but small (22 KB, not in top 10). Structural fix = #439 (bind Worker subdomain) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)