### PR TITLE
test: make E2E hermetic against live local-worker data (#455)

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,8 +1,12 @@
 // Shared test helpers — usePolling has an 800ms simulated loading delay.
 
 export async function waitForDataLoad(page) {
-  // Wait for the skeleton to clear — service name is a reliable signal
-  await page.locator('main').getByText('Claude API').first().waitFor({ state: 'visible', timeout: 20000 })
+  // Wait for the skeleton to clear — a service card name is a reliable signal.
+  // Filter to the visible match: under some live-data layouts (e.g. when an
+  // ActionBanner renders above the grid because a service is down/degraded) the
+  // first 'Claude API' node in <main> is a 0×0 element, so a bare `.first()`
+  // resolves to a never-visible node and times out (#455).
+  await page.locator('main').getByText('Claude API').filter({ visible: true }).first().waitFor({ state: 'visible', timeout: 20000 })
 }
 
 // Navigate to a page via sidebar click (desktop only)

--- a/tests/latency.spec.js
+++ b/tests/latency.spec.js
@@ -19,8 +19,10 @@ test.describe('Latency page', () => {
   test('renders latency rankings with service names', async ({ page }) => {
     // Rankings section should show numbered services with latency bars
     const main = page.locator('main')
-    await expect(main.getByText('Claude API').first()).toBeVisible()
-    await expect(main.getByText('OpenAI API').first()).toBeVisible()
+    // visible-filtered: a 0×0 'Claude API' node can sort first in <main> under
+    // some layouts (#455).
+    await expect(main.getByText('Claude API').filter({ visible: true }).first()).toBeVisible()
+    await expect(main.getByText('OpenAI API').filter({ visible: true }).first()).toBeVisible()
   })
 
   test('renders 24h trend section', async ({ page }) => {

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -1,9 +1,12 @@
 import { test, expect } from '@playwright/test'
+import { waitForDataLoad } from './helpers.js'
 
 test.describe('Mobile viewport', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.locator('main').getByText('Claude API').first().waitFor({ state: 'visible', timeout: 20000 })
+    // Use the shared helper (visible-filtered) instead of an inline copy so the
+    // 0×0 'Claude API' fix lives in one place (#455).
+    await waitForDataLoad(page)
   })
 
   test('sidebar hidden by default, hamburger opens overlay', async ({ page }) => {
@@ -34,7 +37,21 @@ test.describe('Mobile viewport', () => {
   })
 
   test('topbar icons stay within viewport when analyze button is visible', async ({ page }) => {
-    // Wait for analyze button (🤖) — mock data includes aiAnalysis for openai
+    // Provide deterministic analysis data so the 🤖 button is present — the DEV
+    // mock fallback's analysis only appears when no worker is reachable, so a
+    // running local worker would otherwise leave the button disabled (#455).
+    await page.route('**/api/status**', (route) => route.fulfill({ json: {
+      services: [
+        { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'degraded', latency: 200, uptime30d: 99.9, incidents: [
+          { id: 'oi-m', title: 'Elevated errors', status: 'investigating', impact: 'major', startedAt: new Date().toISOString(), duration: null, timeline: [] },
+        ] },
+      ],
+      aiAnalysis: { openai: [{ summary: 'Elevated error rate under investigation.', estimatedRecovery: '~1h', affectedScope: ['API'], needsFallback: true, analyzedAt: new Date().toISOString(), incidentId: 'oi-m' }] },
+      lastUpdated: new Date().toISOString(),
+    } }))
+    await page.reload()
+
+    // Wait for analyze button (🤖) — enabled because the mock has an active analysis
     const analyzeBtn = page.locator('header button[aria-label]').filter({ hasText: '🤖' })
     await expect(analyzeBtn).toBeVisible({ timeout: 10000 })
 

--- a/tests/multi-service-incident.spec.js
+++ b/tests/multi-service-incident.spec.js
@@ -37,7 +37,7 @@ const MOCK = {
 
 test.describe('Multi-service incident display', () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: MOCK })
     })
     await page.route('**/api/status/cached', async (route) => {

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -4,12 +4,12 @@ import { waitForDataLoad } from './helpers.js'
 test.describe('Offline / API failure (dev mode)', () => {
   test('falls back to mock data when API is unreachable', async ({ page }) => {
     // Block all API requests to simulate Worker not running
-    await page.route('**/api/status*', (route) => route.abort('connectionrefused'))
+    await page.route('**/api/status**', (route) => route.abort('connectionrefused'))
     await page.goto('/')
 
     // In dev mode, mock data should load as fallback (network error → MOCK_SERVICES)
-    await expect(page.locator('main').getByText('Claude API').first()).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('main').getByText('OpenAI API').first()).toBeVisible()
+    await expect(page.locator('main').getByText('Claude API').filter({ visible: true }).first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('main').getByText('OpenAI API').filter({ visible: true }).first()).toBeVisible()
 
     // Offline EmptyState should NOT appear in dev mode with network error
     await expect(page.getByText(/Unable to connect|연결할 수 없습니다/)).not.toBeVisible()
@@ -32,7 +32,7 @@ test.describe('Offline / API failure (dev mode)', () => {
 
   test('shows error state when API returns malformed response', async ({ page }) => {
     // Return invalid JSON to simulate a non-network error
-    await page.route('**/api/status*', (route) =>
+    await page.route('**/api/status**', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: 'not json' })
     )
     await page.goto('/')
@@ -42,11 +42,11 @@ test.describe('Offline / API failure (dev mode)', () => {
   })
 
   test('mock data includes expected service count', async ({ page }) => {
-    await page.route('**/api/status*', (route) => route.abort('connectionrefused'))
+    await page.route('**/api/status**', (route) => route.abort('connectionrefused'))
     await page.goto('/')
 
     // Wait for mock data to load
-    await expect(page.locator('main').getByText('Claude API').first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('main').getByText('Claude API').filter({ visible: true }).first()).toBeVisible({ timeout: 15000 })
 
     // Verify key services from mock data are present
     const services = ['Claude API', 'ChatGPT', 'Gemini API', 'Groq Cloud', 'Cursor']
@@ -59,7 +59,7 @@ test.describe('Offline / API failure (dev mode)', () => {
     // Intercept API — return degraded Azure OpenAI with NO incidents,
     // and override all MOCK_SERVICES that have degraded/investigating status to operational
     const allOperational = (id) => ({ id, category: 'api', name: id, provider: '', status: 'operational', latency: null, uptime30d: null, incidents: [] })
-    await page.route('**/api/status*', (route) =>
+    await page.route('**/api/status**', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -89,7 +89,7 @@ test.describe('Offline / API failure (dev mode)', () => {
 
   test('action banner shows incident link when investigating service has active incidents', async ({ page }) => {
     // Intercept API and return an operational service with an unresolved incident
-    await page.route('**/api/status*', (route) =>
+    await page.route('**/api/status**', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -118,7 +118,7 @@ test.describe('Offline / API failure (dev mode)', () => {
   })
 
   test('action banner shows Monitoring label when incident is in monitoring status', async ({ page }) => {
-    await page.route('**/api/status*', (route) =>
+    await page.route('**/api/status**', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -88,7 +88,7 @@ test.describe('Overview page', () => {
       services: [mkSvc('claude', 'api', 'Claude API'), mkSvc('claudeai', 'app', 'claude.ai'), mkSvc('claudecode', 'agent', 'Claude Code')],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(bulkLinkedMock) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(bulkLinkedMock) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(bulkLinkedMock) })
     await page.goto('/')
     await waitForDataLoad(page)
@@ -213,7 +213,7 @@ test.describe('ActionBanner region recommendation', () => {
       }],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(mockData) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
     await page.goto('/')
     // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
@@ -292,7 +292,7 @@ test.describe('ActionBanner region recommendation', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(mockData) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
     await page.goto('/')
     // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
@@ -329,7 +329,7 @@ test.describe('ActionBanner region recommendation', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(mockData) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(mockData) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(mockData) })
     await page.goto('/')
     // waitForDataLoad checks for `Claude API` text which is rendered in BOTH
@@ -348,7 +348,7 @@ test.describe('ActionBanner region recommendation', () => {
 test.describe('RSS subscribe affordances (#433)', () => {
   test('incident banner shows an RSS copy icon that copies the all-services feed', async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
-    await page.route('**/api/status*', (route) => route.fulfill({ json: {
+    await page.route('**/api/status**', (route) => route.fulfill({ json: {
       services: [
         { id: 'deepseek', category: 'api', name: 'DeepSeek API', provider: 'DeepSeek', status: 'degraded', latency: 200, uptime30d: 99.5, incidents: [] },
         { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, incidents: [] },

--- a/tests/security-banner.spec.js
+++ b/tests/security-banner.spec.js
@@ -37,7 +37,7 @@ const MOCK = {
 
 test.describe('Security Alerts Banner', () => {
   test('shows banner for recent security alerts (< 24h)', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: { ...MOCK, securityAlerts: [RECENT_ALERT] } })
     })
     await page.route('**/api/status/cached', async (route) => {
@@ -53,7 +53,7 @@ test.describe('Security Alerts Banner', () => {
   })
 
   test('hides banner for old alerts (> 24h)', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: { ...MOCK, securityAlerts: [OLD_ALERT] } })
     })
     await page.route('**/api/status/cached', async (route) => {
@@ -69,7 +69,7 @@ test.describe('Security Alerts Banner', () => {
   })
 
   test('hides banner when no security alerts', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: MOCK })
     })
     await page.route('**/api/status/cached', async (route) => {
@@ -85,7 +85,7 @@ test.describe('Security Alerts Banner', () => {
 
   test('overview banner shows service tag for all alerts', async ({ page }) => {
     const alerts = [RECENT_ALERT, OSV_ALERT]
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: { ...MOCK, securityAlerts: alerts } })
     })
     await page.route('**/api/status/cached', async (route) => {
@@ -106,7 +106,7 @@ test.describe('Security Alerts in ServiceDetails', () => {
   const ALERTS = [OSV_ALERT, RECENT_ALERT]
 
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: { ...MOCK, securityAlerts: ALERTS } })
     })
     await page.route('**/api/status/cached', async (route) => {

--- a/tests/service-details.spec.js
+++ b/tests/service-details.spec.js
@@ -14,7 +14,10 @@ test.describe('ServiceDetails page', () => {
   test('renders service header with name and provider', async ({ page }) => {
     const main = page.locator('main')
     await expect(main.getByRole('heading', { name: 'Claude API', exact: true })).toBeVisible()
-    await expect(main.getByText('Anthropic')).toBeVisible()
+    // .first() — 'Anthropic' (the provider) appears in several places on the
+    // detail page (header + sibling/fallback service rows); we only assert the
+    // provider is shown.
+    await expect(main.getByText('Anthropic').first()).toBeVisible()
   })
 
   test('renders metric cards with uptime', async ({ page }) => {
@@ -67,7 +70,7 @@ test.describe('AIWatch Score Breakdown denominators (#132)', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(probedMock) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(probedMock) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(probedMock) })
     await page.goto('/#claude')
     await expect(page.locator('main').getByText(/Status Calendar|상태 캘린더/)).toBeVisible({ timeout: 20000 })
@@ -96,7 +99,7 @@ test.describe('AIWatch Score Breakdown denominators (#132)', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(unsupportedMock) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(unsupportedMock) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(unsupportedMock) })
     await page.goto('/#chatgpt')
     await expect(page.locator('main').getByText(/Status Calendar|상태 캘린더/)).toBeVisible({ timeout: 20000 })
@@ -120,7 +123,7 @@ test.describe('AIWatch Score Breakdown denominators (#132)', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(unavailableMock) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(unavailableMock) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(unavailableMock) })
     await page.goto('/#claude')
     await expect(page.locator('main').getByText(/Status Calendar|상태 캘린더/)).toBeVisible({ timeout: 20000 })
@@ -143,7 +146,7 @@ test.describe('AIWatch Score Breakdown denominators (#132)', () => {
       ],
       lastUpdated: new Date().toISOString(),
     } }
-    await page.route('**/api/status', async (route) => { await route.fulfill(insufficientMock) })
+    await page.route('**/api/status**', async (route) => { await route.fulfill(insufficientMock) })
     await page.route('**/api/status/cached', async (route) => { await route.fulfill(insufficientMock) })
     await page.goto('/#claude')
     await expect(page.locator('main').getByText(/Status Calendar|상태 캘린더/)).toBeVisible({ timeout: 20000 })
@@ -165,7 +168,7 @@ test.describe('xAI Regional Availability', () => {
 
   test('shows regional status with incident type for xAI', async ({ page }) => {
     // Intercept API: serve mock response with xAI EU incident
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       const mockResponse = {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -191,7 +194,7 @@ test.describe('xAI Regional Availability', () => {
     const globalMock = { ...XAI_MOCK, incidents: [
       { id: 'xa-g', title: 'Elevated API Error Rates', startedAt: new Date(Date.now() - 3600000).toISOString(), duration: null, status: 'investigating', impact: null, timeline: [] },
     ] }
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -222,7 +225,7 @@ test.describe('xAI Regional Availability', () => {
 
 test.describe('Gemini Regional Availability', () => {
   test('shows regional status for Gemini with region-specific incident', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -249,7 +252,7 @@ test.describe('Gemini Regional Availability', () => {
 
 test.describe('OpenAI Regional Availability', () => {
   test('shows regional status for OpenAI with global incident', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -276,7 +279,7 @@ test.describe('OpenAI Regional Availability', () => {
 
 test.describe('Bedrock Regional Availability (always visible)', () => {
   test('shows all regions operational when no incidents', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -294,7 +297,7 @@ test.describe('Bedrock Regional Availability (always visible)', () => {
   })
 
   test('shows region-specific incident via componentNames', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -321,7 +324,7 @@ test.describe('Bedrock Regional Availability (always visible)', () => {
 
 test.describe('Azure OpenAI Regional Availability (always visible)', () => {
   test('shows all 7 regions operational when no incidents', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -339,7 +342,7 @@ test.describe('Azure OpenAI Regional Availability (always visible)', () => {
   })
 
   test('shows region-specific incident for Azure OpenAI', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, calendarDays: 30, incidents: [] },
@@ -365,12 +368,26 @@ test.describe('Azure OpenAI Regional Availability (always visible)', () => {
 
 test.describe('Detection Lead badge', () => {
   test('shows lead badge for OpenAI ongoing incident', async ({ page }) => {
+    // Deterministic mock: OpenAI with an ongoing incident whose detectedAt is
+    // 7min before startedAt (1–60m window → Detection Lead badge). Relying on
+    // the DEV mock fallback breaks against a running local worker (#455).
+    const startedAt = new Date(Date.now() - 2 * 3600_000).toISOString()
+    const detectedAt = new Date(Date.now() - 2 * 3600_000 - 7 * 60_000).toISOString()
+    await page.route('**/api/status**', (route) => route.fulfill({ json: {
+      services: [
+        { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'degraded', latency: 200, uptime30d: 99.21, detectedAt, incidents: [
+          { id: 'oi-ongoing', title: 'Elevated error rates', status: 'investigating', impact: 'major', startedAt, duration: null, timeline: [] },
+        ] },
+      ],
+      lastUpdated: new Date().toISOString(),
+    } }))
     await page.goto('/')
-    await waitForDataLoad(page)
-    // Navigate to OpenAI (mock: detectedAt 7min before ongoing incident)
+    // Wait for the card to render before clicking (deterministic load signal —
+    // the mock settles after usePolling's ~800ms simulated delay).
+    await expect(page.locator('main button').filter({ hasText: 'OpenAI API' }).first()).toBeVisible({ timeout: 20000 })
     await page.locator('main button').filter({ hasText: 'OpenAI API' }).first().click()
     await expect(page.locator('main').getByText('Incident History')).toBeVisible({ timeout: 5000 })
-    // Lead badge should be visible for ongoing incident
+    // Lead badge should be visible for the ongoing incident (Detection Lead)
     await expect(page.locator('main').getByText('lead').first()).toBeVisible()
   })
 })
@@ -396,7 +413,7 @@ test.describe('Incident accordion in ServiceDetails', () => {
 
 test.describe('Non-probe service latency card', () => {
   test('shows "Not provided" latency for non-probe API service', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.95, uptimeSource: 'official', calendarDays: 30, incidents: [], aiwatchScore: 92 },
@@ -417,7 +434,7 @@ test.describe('Non-probe service latency card', () => {
   })
 
   test('shows RTT latency for probe API service', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: {
         services: [
           { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 142, uptime30d: 99.95, uptimeSource: 'official', calendarDays: 30, incidents: [] },
@@ -448,7 +465,7 @@ test.describe('Estimate-only services (Bedrock, Azure OpenAI)', () => {
   }
 
   test('shows "Not provided" for estimate service with no incidents', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: ESTIMATE_MOCK })
     })
     await page.goto('/#bedrock')
@@ -464,7 +481,7 @@ test.describe('Estimate-only services (Bedrock, Azure OpenAI)', () => {
   })
 
   test('hides 24h Trend chart for non-probe services', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: ESTIMATE_MOCK })
     })
     await page.goto('/#bedrock')
@@ -474,7 +491,7 @@ test.describe('Estimate-only services (Bedrock, Azure OpenAI)', () => {
   })
 
   test('excludes estimate services from Ranking scored list', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
+    await page.route('**/api/status**', async (route) => {
       await route.fulfill({ json: ESTIMATE_MOCK })
     })
     await page.goto('/#ranking')

--- a/tests/uptime.spec.js
+++ b/tests/uptime.spec.js
@@ -16,8 +16,9 @@ test.describe('Uptime page', () => {
 
   test('renders uptime rankings with service names', async ({ page }) => {
     const main = page.locator('main')
-    // Rankings section should show services with uptime bars
-    await expect(main.getByText('Claude API').first()).toBeVisible()
+    // Rankings section should show services with uptime bars (visible-filtered —
+    // a 0×0 'Claude API' node can sort first in <main>, #455)
+    await expect(main.getByText('Claude API').filter({ visible: true }).first()).toBeVisible()
   })
 
   test('renders uptime matrix', async ({ page }) => {
@@ -40,9 +41,11 @@ test.describe('Uptime Rankings — estimate-only services', () => {
   }
 
   test('shows estimate-only services as "—" instead of percentage', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
-      await route.fulfill({ json: MOCK })
-    })
+    // Mock BOTH endpoints — the initial load hits /api/status/cached first, so
+    // routing only /api/status leaks real worker data (e.g. live 100% services)
+    // when a local worker is running and makes this assertion flaky (#455).
+    await page.route('**/api/status', (route) => route.fulfill({ json: MOCK }))
+    await page.route('**/api/status/cached', (route) => route.fulfill({ json: MOCK }))
     await page.goto('/#uptime')
     const rankings = page.locator('section').filter({ hasText: /Uptime Rankings/ })
     await expect(rankings).toBeVisible({ timeout: 20000 })
@@ -61,9 +64,8 @@ test.describe('Uptime Rankings — estimate-only services', () => {
   })
 
   test('excludes estimate-only services from summary cards', async ({ page }) => {
-    await page.route('**/api/status', async (route) => {
-      await route.fulfill({ json: MOCK })
-    })
+    await page.route('**/api/status', (route) => route.fulfill({ json: MOCK }))
+    await page.route('**/api/status/cached', (route) => route.fulfill({ json: MOCK }))
     await page.goto('/#uptime')
     const main = page.locator('main')
     await expect(main.getByText(/Uptime Rankings/).first()).toBeVisible({ timeout: 20000 })


### PR DESCRIPTION
closes #455

## Problem
The local E2E suite went red (~65 failures) whenever a dev worker was running, while CI stayed green (no worker there). Two distinct root causes:

1. **0×0 'Claude API' element** (the filed #455): `waitForDataLoad` (and inline copies) waited on `main.getByText('Claude API').first()`. Under live-data layouts where an `ActionBanner` renders above the grid (a service is down/degraded), the first `Claude API` node in `<main>` is a **0×0 element**, so `.first()` resolved to a never-visible node and timed out.

2. **Cached-endpoint leak**: many specs routed `**/api/status` or `**/api/status*` — neither matches `/api/status/cached` (Playwright glob `*` doesn't cross `/`). Since `usePolling` fetches the cached endpoint first, real worker data leaked into otherwise-mocked tests.

## Fix
- **Helper**: `waitForDataLoad` now uses `.filter({ visible: true }).first()`. `mobile.spec` reuses the shared helper instead of an inline copy; `latency`/`uptime`/`offline` assertions use the visible filter.
- **Route globs**: changed to `**/api/status**` (verified to intercept both `/api/status` and `/api/status/cached`) across service-details, overview, security-banner, multi-service-incident, offline; uptime's estimate tests route both endpoints explicitly.
- **Deterministic mocks**: the two tests that depended on the DEV mock-fallback's analysis data (mobile analyze button, service-details Detection Lead badge) now provide their own route mocks. service-details header asserts the provider with `.first()` (it legitimately appears in several rows on the detail page).

## Result
Desktop + mobile: **113 pass locally** with a live worker running (was ~65 failing). The only remaining local failures are the 2 `analysis-fallback.spec.js` tests, which are rewritten by #456 (intentionally untouched here to avoid a conflict) and already pass in CI.

## Review
Two-agent review (code + test-quality) → 0 Critical/Important. Verified the deterministic mocks faithfully exercise the same code paths (`Topbar.hasAnalysis`, `ServiceDetails` lead-badge window) the DEV fallback used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)