### PR TITLE
feat: region-switch hint in Discord incident alerts (refs #422)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ worker/
     rss.ts      # Incident RSS 2.0 feed generation (#54) — buildFeedResponse (400/404/503/200 decision), buildRssFeed, feedSlug↔is-down-slug map (pinned by feed-slug-sync.test.ts)
     og.ts       # OG image SVG generator (1200×630 for social share)
     og-render.ts # SVG → PNG conversion (resvg-wasm, Inter font from CDN)
-    alerts.ts   # Alert detection logic (buildIncidentAlerts, buildServiceAlerts, formatDetectionLead)
+    alerts.ts   # Alert detection logic (buildIncidentAlerts, buildServiceAlerts, formatDetectionLead, buildRegionHint). buildRegionHint (#422 Phase 2) reuses the Edge region-status port (api/is-down/region-status.ts) — imported, not re-copied — to append a "📍 Try region: <label>" line to new-incident Discord embeds for region-aware services with a region-specific partial outage
     fallback.ts # Fallback recommendation (getFallbacks, buildFallbackText, buildGroupedFallbackText for multi-category incidents)
     ai-analysis.ts # Hybrid AI incident analysis — Gemma 4 26B (Workers AI) primary + Claude Sonnet (AI Gateway) fallback (system/user prompt, needsFallback assessment, TTL refresh, re-analysis, incidentId dedup, timeline context, boilerplate filtering, formatRecoveryDisplay)
     changelog.ts # Changelog/news collection (OpenAI blog RSS, Google AI blog RSS, Anthropic /news HTML parsing) — 15s timeout + 1 retry on transient errors, per-source last-fetch KV markers for stale-source detection (#274)

--- a/api/is-down/region-status.ts
+++ b/api/is-down/region-status.ts
@@ -36,6 +36,11 @@ export type RegionStatusResult = {
   okRegions: RegionRow[]
   incidentRegions: RegionRow[]
   hasRegionSpecific: boolean
+  // True when at least one ongoing incident matched NO region — a whole-service
+  // outage. Distinct from !hasRegionSpecific: a region-specific AND a global
+  // incident can be ongoing simultaneously. Consumers that must not recommend a
+  // region during a global outage (Worker Discord hint, #422) gate on this.
+  hasGlobalIncident: boolean
   allDown: boolean
   recommendedRegion: RegionRow | null
   docsUrl: string | undefined
@@ -137,11 +142,14 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
   }
 
   let hasRegionSpecific = false
+  // Per-incident global detection — see SPA copy src/utils/regionStatus.js (#422).
+  let hasGlobalIncident = false
   for (const inc of ongoing) {
     const titleLower = (inc.title as string).toLowerCase()
     const compNames = Array.isArray(inc.componentNames)
       ? (inc.componentNames as unknown[]).map((n) => String(n).toLowerCase())
       : []
+    let incMatched = false
     for (const r of regionDefs) {
       const keyLower = r.key.toLowerCase()
       if (titleLower.includes(keyLower) || compNames.some((n) => n.includes(keyLower))) {
@@ -152,8 +160,10 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
           status[r.key] = { status: 'incident', type: classifyIncident(inc.title) }
         }
         hasRegionSpecific = true
+        incMatched = true
       }
     }
+    if (!incMatched) hasGlobalIncident = true
   }
 
   if (!hasRegionSpecific && ongoing.length > 0) {
@@ -173,6 +183,7 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
     okRegions,
     incidentRegions,
     hasRegionSpecific,
+    hasGlobalIncident,
     allDown,
     recommendedRegion: okRegions[0] ?? null,
     docsUrl: service.id ? REGION_DOCS_URL[service.id] : undefined,

--- a/src/utils/__tests__/regionStatus.test.js
+++ b/src/utils/__tests__/regionStatus.test.js
@@ -191,6 +191,7 @@ describe('regionStatusOf — global-incident fallback', () => {
       incidents: [{ id: 'p1', status: 'investigating', title: 'API authentication broken' }],
     })
     expect(result.hasRegionSpecific).toBe(false)
+    expect(result.hasGlobalIncident).toBe(true)
     expect(result.allDown).toBe(true)
     expect(result.recommendedRegion).toBeNull()
     expect(result.regions.every((r) => r.status === 'incident')).toBe(true)
@@ -205,6 +206,34 @@ describe('regionStatusOf — global-incident fallback', () => {
       ],
     })
     expect(result.regions.every((r) => r.type === 'down')).toBe(true)
+  })
+})
+
+describe('regionStatusOf — hasGlobalIncident flag (#422)', () => {
+  test('false when every ongoing incident matches a region', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [{ id: 'p1', status: 'investigating', title: 'AWS us-east-1 degraded' }],
+    })
+    expect(result.hasRegionSpecific).toBe(true)
+    expect(result.hasGlobalIncident).toBe(false)
+  })
+
+  test('true when a global incident coexists with a region-specific one (region marking unchanged)', () => {
+    const result = regionStatusOf({
+      id: 'pinecone',
+      incidents: [
+        { id: 'p1', status: 'investigating', title: 'AWS us-east-1 degraded' },
+        { id: 'p2', status: 'investigating', title: 'API authentication broken' }, // matches no region
+      ],
+    })
+    // Both flags true; region marking is intentionally unchanged — only us-east-1 down,
+    // so the SPA/Edge render exactly as before (allDown stays false). The flag is what
+    // lets the Worker hint suppress in this mixed case.
+    expect(result.hasRegionSpecific).toBe(true)
+    expect(result.hasGlobalIncident).toBe(true)
+    expect(result.allDown).toBe(false)
+    expect(result.okRegions.length).toBeGreaterThan(0)
   })
 })
 

--- a/src/utils/regionStatus.js
+++ b/src/utils/regionStatus.js
@@ -100,6 +100,10 @@ export function classifyIncident(title) {
 //   hasRegionSpecific    — true if any region matched an incident title /
 //                          componentNames substring; false when we fell back
 //                          to the "global incident → mark all regions" path
+//   hasGlobalIncident    — true if at least one ongoing incident matched NO
+//                          region (a whole-service outage). Distinct from
+//                          !hasRegionSpecific: both a region-specific AND a
+//                          global incident can be ongoing at once (#422)
 //   allDown              — every defined region is in incident state
 //   recommendedRegion    — first OK region by SERVICE_REGIONS array order,
 //                          or null when allDown
@@ -136,9 +140,18 @@ export function regionStatusOf(service, opts = {}) {
   }
 
   let hasRegionSpecific = false
+  // True when at least one ongoing incident matched NO region key — i.e. a
+  // "global" incident affecting the whole service, not a single region. Tracked
+  // per-incident (not just the aggregate `!hasRegionSpecific`) so the mixed case
+  // — one region-specific incident PLUS one global incident — is detectable.
+  // Region marking is intentionally left unchanged (SPA/Edge render identically);
+  // only consumers that must NOT recommend a region during a global outage
+  // (Worker Discord hint, #422 Phase 2) read this flag. See buildRegionHint.
+  let hasGlobalIncident = false
   for (const inc of ongoing) {
     const titleLower = (inc.title || '').toLowerCase()
     const compNames = (inc.componentNames ?? []).map((n) => String(n).toLowerCase())
+    let incMatched = false
     for (const r of regionDefs) {
       const keyLower = r.key.toLowerCase()
       if (titleLower.includes(keyLower) || compNames.some((n) => n.includes(keyLower))) {
@@ -156,8 +169,10 @@ export function regionStatusOf(service, opts = {}) {
           status[r.key] = { status: 'incident', type: classifyIncident(inc.title) }
         }
         hasRegionSpecific = true
+        incMatched = true
       }
     }
+    if (!incMatched) hasGlobalIncident = true
   }
 
   // Global-incident fallback — no region substring matched but we know
@@ -181,6 +196,7 @@ export function regionStatusOf(service, opts = {}) {
     okRegions,
     incidentRegions,
     hasRegionSpecific,
+    hasGlobalIncident,
     allDown,
     recommendedRegion: okRegions[0] ?? null,
     docsUrl: REGION_DOCS_URL[service.id],

--- a/worker/src/__tests__/alerts.test.ts
+++ b/worker/src/__tests__/alerts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, isFlapNotice, normalizeFlapTitle, flapSuppressionKey, isFlapSuppressible } from '../alerts'
+import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, isFlapNotice, normalizeFlapTitle, flapSuppressionKey, isFlapSuppressible, buildRegionHint } from '../alerts'
 import type { AlertCandidate, ScoredService } from '../alerts'
 import type { Incident } from '../types'
 
@@ -140,6 +140,91 @@ describe('buildIncidentAlerts', () => {
     expect(alerts).toHaveLength(2)
     expect(alerts[0].key).toBe('alerted:new:inc1')
     expect(alerts[1].key).toBe('alerted:res:inc2')
+  })
+})
+
+describe('region-switch hint (#422)', () => {
+  // Pinecone is region-aware (SERVICE_REGIONS) with AWS us-east-1 listed first and
+  // AWS us-west-2 second — so a us-east-1-only outage recommends "AWS US West".
+  const regionSpecific: Incident = {
+    id: 'pc1', title: 'Index unavailable', status: 'investigating',
+    startedAt: recentDate, impact: 'major', componentNames: ['AWS us-east-1'],
+  }
+
+  it('buildRegionHint recommends the first healthy region for a region-specific outage', () => {
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'degraded', incidents: [regionSpecific] })
+    expect(buildRegionHint(pinecone)).toBe('📍 Try region: AWS US West')
+  })
+
+  it('buildRegionHint returns undefined for a non-region-aware service', () => {
+    // mistral has no SERVICE_REGIONS entry → regionStatusOf returns null
+    const mistral = mockService({ id: 'mistral', name: 'Mistral API', status: 'degraded',
+      incidents: [{ id: 'm1', title: 'Errors', status: 'investigating', startedAt: recentDate, impact: 'major' }] })
+    expect(buildRegionHint(mistral)).toBeUndefined()
+  })
+
+  it('buildRegionHint returns undefined for a global (non-region-specific) incident', () => {
+    // No region in title/components → every region marked down via fallback → allDown → no recommendation
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'down',
+      incidents: [{ id: 'pc-global', title: 'Major outage', status: 'investigating', startedAt: recentDate, impact: 'critical' }] })
+    expect(buildRegionHint(pinecone)).toBeUndefined()
+  })
+
+  it('attaches regionText to the new-incident alert for region-specific outages', () => {
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'degraded', incidents: [regionSpecific] })
+    const alerts = buildIncidentAlerts([pinecone], new Set(), NOW)
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0].regionText).toBe('📍 Try region: AWS US West')
+  })
+
+  it('does not attach regionText to resolved alerts', () => {
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'operational',
+      incidents: [{ ...regionSpecific, id: 'pc-res', status: 'resolved', duration: '20m' }] })
+    const alerts = buildIncidentAlerts([pinecone], new Set(['pc-res']), NOW)
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0].key).toBe('alerted:res:pc-res')
+    expect(alerts[0].regionText).toBeUndefined()
+  })
+
+  it('suppresses the hint when a global incident coexists with a region-specific one', () => {
+    // A region-tagged outage flips hasRegionSpecific=true, but a coexisting global
+    // incident (matches no region) means the whole service is affected — recommending
+    // a "healthy" region would point operators at a region the global outage also
+    // takes down. Must suppress. (#422 — pr-test-analyzer Severity-9 finding)
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'down', incidents: [
+      regionSpecific,
+      { id: 'pc-global', title: 'Major outage', status: 'investigating', startedAt: recentDate, impact: 'critical' },
+    ] })
+    expect(buildRegionHint(pinecone)).toBeUndefined()
+    const alerts = buildIncidentAlerts([pinecone], new Set(), NOW)
+    // Both incidents alert; neither carries a region hint while the global outage is open.
+    expect(alerts.every(a => a.regionText === undefined)).toBe(true)
+  })
+
+  it('recommends the first healthy region when several regions are hit (partial multi-region)', () => {
+    // Two region-specific incidents knock out AWS us-east-1 + us-west-2 → first
+    // remaining healthy region in SERVICE_REGIONS order is AWS eu-west-1 ("AWS EU West").
+    const pinecone = mockService({ id: 'pinecone', name: 'Pinecone', status: 'degraded', incidents: [
+      { id: 'pc-e', title: 'Outage', status: 'investigating', startedAt: recentDate, impact: 'major', componentNames: ['AWS us-east-1'] },
+      { id: 'pc-w', title: 'Outage', status: 'investigating', startedAt: recentDate, impact: 'major', componentNames: ['AWS us-west-2'] },
+    ] })
+    expect(buildRegionHint(pinecone)).toBe('📍 Try region: AWS EU West')
+  })
+
+  it('mergeTogetherAlerts preserves regionText from the first merged alert', () => {
+    // Together has no region map so this is undefined in practice, but the merge path
+    // is generic — pin that a set regionText survives the merge. (#422 Severity-6)
+    const withRegion: AlertCandidate = {
+      key: 'alerted:new:t1', title: '🔴 Together AI — New Incident', description: 'A — down',
+      color: 0xED4245, url: 'https://ai-watch.dev/#together', regionText: '📍 Try region: AWS US West',
+    }
+    const second: AlertCandidate = {
+      key: 'alerted:new:t2', title: '🔴 Together AI — New Incident', description: 'B — down',
+      color: 0xED4245, url: 'https://ai-watch.dev/#together',
+    }
+    const merged = mergeTogetherAlerts([withRegion, second])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].regionText).toBe('📍 Try region: AWS US West')
   })
 })
 

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -4,6 +4,22 @@
 import { getFallbacks, buildFallbackText } from './fallback'
 import { sanitize, formatDuration } from './utils'
 import { computeLeadMs } from './detection-lead-log'
+// #422 Phase 2 — region-switch hint in Discord alerts. We reuse the existing
+// Edge TS port rather than adding a third copy of SERVICE_REGIONS: the Worker
+// bundler (esbuild via wrangler) can import across dirs (unlike Vercel Edge,
+// which is why that port exists), and the file is pure data + functions with no
+// runtime deps. This keeps the region map at two text-sync-pinned copies (SPA +
+// this shared Edge/Worker port) instead of three. The SPA↔Edge parity is pinned
+// by worker/src/__tests__/region-status-sync.test.ts.
+//
+// Trade-off (accepted, #422): this import reaches outside worker/tsconfig.json's
+// rootDir ("src"), so a standalone `tsc -p worker/tsconfig.json` would emit
+// TS6059. The worker is never built with tsc — wrangler/esbuild bundles it and CI
+// runs vitest + `wrangler deploy --dry-run`, none of which trip on rootDir — so
+// this is latent only. Preferred over a third SERVICE_REGIONS copy (drift > tsc
+// purity here). If a tsc typecheck is ever added for the worker, add this path to
+// the tsconfig `include` or relocate the shared port.
+import { regionStatusOf } from '../../api/is-down/region-status'
 import type { ServiceStatus } from './services'
 import type { Incident } from './types'
 
@@ -59,10 +75,35 @@ export interface AlertCandidate {
   title: string
   description: string
   fallbackText?: string
+  /** #422 — region-switch hint (e.g. "📍 Try region: AWS US West") for new incidents
+   *  on region-aware services with a region-specific partial outage. Rendered below the
+   *  cross-service fallback. Absent on resolved alerts and non-region-aware services. */
+  regionText?: string
   color: number
   url: string
   /** When alerts are merged (e.g., Together AI), contains all original dedup keys */
   _mergedKeys?: string[]
+}
+
+/**
+ * Build the Discord region-switch hint for a new incident, or undefined when no
+ * region recommendation applies. A region line is only useful when the outage is
+ * region-specific AND at least one region is still healthy:
+ *  - non-region-aware service (no SERVICE_REGIONS entry) → regionStatusOf returns null
+ *  - global (non-region-specific) incident → hasRegionSpecific=false: cross-service
+ *    fallback is the right guidance, not a region switch
+ *  - every region hit (allDown) → no healthy region to recommend
+ *  - a global incident coexisting with a region-specific one (hasGlobalIncident) →
+ *    the whole service is affected, so a "healthy" region is not actually safe to
+ *    recommend even though some regions look ok (#422 — would otherwise point
+ *    operators at a region the global outage is also taking down)
+ */
+export function buildRegionHint(svc: ScoredService): string | undefined {
+  const state = regionStatusOf(svc)
+  if (!state || !state.hasRegionSpecific || state.allDown || state.hasGlobalIncident || !state.recommendedRegion) {
+    return undefined
+  }
+  return `📍 Try region: ${state.recommendedRegion.label}`
 }
 
 export interface ScoredService extends ServiceStatus {
@@ -125,6 +166,7 @@ export function buildIncidentAlerts(
       title: `🔴 ${displayName} — New Incident`,
       description: sanitize(inc.title),
       fallbackText,
+      regionText: buildRegionHint(firstSvc),
       color: 0xED4245,
       url: `https://ai-watch.dev/#${ids[0]}`,
     })
@@ -178,6 +220,7 @@ export function mergeTogetherAlerts(alerts: AlertCandidate[]): AlertCandidate[] 
       title: `🔴 Together AI — ${newAlerts.length} New Incidents`,
       description: descriptions.join('\n'),
       fallbackText: newAlerts[0].fallbackText,
+      regionText: newAlerts[0].regionText, // Together has no region map → undefined; preserved for parity
       color: 0xED4245,
       url: 'https://ai-watch.dev/#together',
       _mergedKeys: newAlerts.map(a => a.key),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -662,6 +662,9 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
     } else if (alert.fallbackText) {
       parts.push(`${DIV}\n${alert.fallbackText}`)
     }
+    // #422 — region-switch hint below the cross-service fallback. Cheaper first-line
+    // action (same SDK/IAM) when the outage is region-specific with healthy regions left.
+    if (alert.regionText) parts.push(`${DIV}\n${alert.regionText}`)
     parts.push(`${DIV}\n[View on AIWatch](${alert.url})`)
     await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
       title: alert.title,


### PR DESCRIPTION
## What

Completes the **Discord half of #422 Phase 2**: new-incident Discord embeds now surface a `📍 Try region: <label>` line below the cross-service fallback, for region-aware services experiencing a **region-specific partial outage**. This is the cheaper first-line action (same SDK + IAM, near-zero code change) that the 2026-05-15 partial Pinecone outage (AWS us-east-1 down, 5 regions healthy) showed was invisible to operators watching Discord.

Example embed (Pinecone us-east-1 partial outage — note Pinecone is `EXCLUDE_FALLBACK`, so the region hint is the *only* actionable guidance):

```
🔴 Pinecone — New Incident
Index unavailable
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
📍 Try region: AWS US West
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
[View on AIWatch](https://ai-watch.dev/#pinecone)
```

## Approach

Per the chosen design, `worker/src/alerts.ts` **reuses the existing Edge region port** (`api/is-down/region-status.ts`) rather than adding a third copy of `SERVICE_REGIONS`. The Worker bundler (esbuild via wrangler) can import across dirs, so the region map stays at two text-sync-pinned copies (SPA + shared Edge/Worker port) instead of three.

- `buildRegionHint()` — pure function; emits a hint only when the outage is region-specific, not all-down, and a healthy region remains.
- `regionText` field on `AlertCandidate`, wired into the new-incident loop and preserved through `mergeTogetherAlerts`.
- `worker/src/index.ts` renders it as its own divided embed section, below fallback and above the View link.

## Correctness fix from review

PR review caught a real bug: when a **global incident coexists with a region-specific one**, `hasRegionSpecific` flips true and the global incident's "mark all regions down" fallback was skipped — so the hint would recommend a region the global outage is *also* taking down. Fixed by adding an **additive `hasGlobalIncident` flag** to `regionStatusOf` (mirrored in the SPA + Edge copies) and gating the hint on it. The flag is additive — existing SPA/Edge render paths don't read it, so their behavior is byte-identical.

## Tests
- `worker/src/__tests__/alerts.test.ts`: +8 cases (region-specific recommend, non-region-aware, global → suppressed, mixed global+regional → suppressed, partial multi-region, new-vs-resolved attachment, merge preservation).
- `src/utils/__tests__/regionStatus.test.js`: +2 cases pinning `hasGlobalIncident`.
- worker vitest 1282/1282 · SPA vitest 268/268 · `wrangler --dry-run` · `npm run build` · E2E overview+service-details 43/43.

## Scope
- `refs #422` (not `closes`): Phase 1 + Edge SSR shipped in #423; **Phase 3** (cloud-tag ranking) stays deferred per the issue. The Discord surface is also soft-gated on Phase 1 click signal — this lands the capability so it's ready when a region-specific incident next fires.

## Known trade-off (documented in code)
The cross-dir import trips `tsc TS6059` (outside worker `rootDir`), but the worker is built via esbuild/wrangler — not tsc — so CI and the build are unaffected. Recorded in the import comment as a conscious choice (drift-avoidance over tsc purity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)