### PR TITLE
docs: add Context Hub (chub) workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,45 @@ Each drawer save specifies **wing + room + hall**. Hall is the memory type (fixe
 - **Rooms** (topics): `architecture`, `debugging`, `feedback`, `decisions`, `deployments`
 - **Halls** (memory types, fixed): `facts`, `events`, `discoveries`, `preferences`, `advice`
 
+## API Docs via Context Hub (chub)
+
+This project uses [Context Hub](https://github.com/andrewyng/context-hub) (`chub` CLI) to fetch
+current, version-accurate API docs **before writing code against an external API/SDK/library** —
+instead of relying on training-cutoff knowledge (anti-hallucination). The global `get-api-docs`
+skill auto-triggers this flow.
+
+### Flow
+```bash
+chub update                          # refresh registry (occasionally)
+chub search "<keywords>" --json      # find the right doc id
+chub get <id> --lang js              # fetch (always pass --lang)
+chub annotate <id> "<gotcha>"        # save discovered gaps — persists across sessions
+```
+
+### AIWatch stack coverage (verified present, mostly maintainer-curated)
+`react/react` (React 19) · `vite/vite` · `tailwindcss/tailwindcss` (**v4**, CSS-first) ·
+`vitest/vitest` · `playwright/playwright` · `typescript/typescript` · `vercel/*` (Edge Functions) ·
+`esbuild/esbuild` (transitive via Vite — no direct config to tune)
+
+**Anthropic** is a special case: AIWatch calls the **Messages REST API via the Cloudflare AI Gateway
+with raw `fetch()`** (no `@anthropic-ai/sdk` dependency — see `worker/src/ai-analysis.ts`), so reach
+for the Anthropic Messages **REST API** doc shape, not an SDK-client doc.
+
+### Cloudflare doc selection (footgun)
+For `worker/src/*` runtime code (`env.AI` Gemma binding, KV `STATUS_CACHE` binding, `scheduled`
+cron handler, `wrangler.toml`) use **`cloudflare/workers-runtime`** (community). Do **NOT** use
+`cloudflare/workers` — that's the REST *management* API (Zones/DNS/script upload), the wrong layer.
+(An annotation already flags this on `cloudflare/workers`.)
+
+### Treat docs as orientation, not ground truth for our edge cases
+chub gives correct API *shape* but not project-specific battle scars. Example verified in the trial:
+the Workers AI doc shows only `res.response`, but `ai-analysis.ts` must also handle the
+OpenAI-compatible `res.choices[0].message.content` / `.reasoning` shape (model-dependent) plus
+`chat_template_kwargs:{enable_thinking:false}` for Gemma. Save such findings with `chub annotate`.
+
+**chub vs MemPalace**: chub = external API ground-truth (public, shared); MemPalace = this project's
+decisions/debugging/feedback (private, project-scoped). Complementary, different layers.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## What

Adds a `## API Docs via Context Hub (chub)` section to CLAUDE.md documenting the dev-tooling workflow for fetching current, version-accurate API docs via the `chub` CLI **before writing code against an external API/SDK/library** (anti-hallucination), so future Claude Code sessions use it consistently.

Added after a hands-on trial in this repo (chub installed, registry pulled, `get-api-docs` skill registered, 3 critical libs spot-checked against production code).

## Section contents

- **Flow**: `chub update` → `search --json` → `get <id> --lang js` → `annotate`; global `get-api-docs` skill auto-triggers it.
- **Stack coverage** (verified present): react (19), vite, tailwindcss (v4), vitest, playwright, typescript, vercel (Edge Functions), esbuild (transitive via Vite).
- **⚠️ Cloudflare footgun**: for `worker/src/*` runtime code (`env.AI` Gemma, KV `STATUS_CACHE`, `scheduled` cron, `wrangler.toml`) use `cloudflare/workers-runtime` (community) — **not** `cloudflare/workers` (that's the REST *management* API, wrong layer).
- **Anthropic special case**: Messages REST API via raw `fetch()` through the AI Gateway (no `@anthropic-ai/sdk`) — fetch the REST doc shape, not an SDK doc.
- **"Docs are orientation, not ground truth"**: the Workers AI dual-response-format example (`ai-analysis.ts` handles both legacy `res.response` and OpenAI-compat `res.choices[].message`) showing why codebase edge-case handling still matters; save gaps via `chub annotate`.
- **chub vs MemPalace** scope delineation (external API ground-truth vs project-scoped memory).

## Verification

- Docs-only change (no code/tests/build).
- PR review (comment-analyzer + code-reviewer) **converged: 0 Critical / 0 Important**. Every technical claim was verified against the actual repo (`wrangler.toml` bindings, `ai-analysis.ts:332,336-340`, `package.json` versions, `src/index.css` v4 entrypoint).

No issue number — standalone documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)