### PR TITLE
fix: broaden /api/alert Discord host allow-list (legacy + beta hosts, versioned paths) (#468)

### DIFF
--- a/worker/src/__tests__/utils.test.ts
+++ b/worker/src/__tests__/utils.test.ts
@@ -9,9 +9,36 @@ function mockKV(store: Record<string, string> = {}): KVLike {
   }
 }
 
-describe('isAllowedAlertWebhook (SSRF allow-list, #467)', () => {
+describe('isAllowedAlertWebhook (SSRF allow-list, #467 + #468)', () => {
   it('accepts an HTTPS discord.com webhook URL', () => {
     expect(isAllowedAlertWebhook('https://discord.com/api/webhooks/123456789/abcDEF-token')).toBe(true)
+  })
+
+  it('accepts the legacy + beta Discord hosts (#468)', () => {
+    expect(isAllowedAlertWebhook('https://discordapp.com/api/webhooks/123/abc')).toBe(true)
+    expect(isAllowedAlertWebhook('https://canary.discord.com/api/webhooks/123/abc')).toBe(true)
+    expect(isAllowedAlertWebhook('https://ptb.discord.com/api/webhooks/123/abc')).toBe(true)
+  })
+
+  it('accepts any real *.discord.com subdomain (the wildcard is intentional — Discord owns the zone)', () => {
+    expect(isAllowedAlertWebhook('https://foo.discord.com/api/webhooks/123/abc')).toBe(true)
+    expect(isAllowedAlertWebhook('https://a.b.discord.com/api/webhooks/123/abc')).toBe(true)
+  })
+
+  it('normalizes host via the URL parser (uppercase host still matches)', () => {
+    // URL.hostname lowercases — guards against a future hand-rolled case-sensitive host check.
+    expect(isAllowedAlertWebhook('https://DISCORD.COM/api/webhooks/123/abc')).toBe(true)
+  })
+
+  it('rejects authority-confusion / userinfo bypass (the canonical SSRF allow-list trick)', () => {
+    // URL.hostname resolves to evil.tld here; a string-match on the raw URL would wrongly allow it.
+    expect(isAllowedAlertWebhook('https://discord.com@evil.tld/api/webhooks/123/abc')).toBe(false)
+    expect(isAllowedAlertWebhook('https://evil.tld/#@discord.com/api/webhooks/123/abc')).toBe(false)
+  })
+
+  it('accepts version-prefixed webhook paths (#468)', () => {
+    expect(isAllowedAlertWebhook('https://discord.com/api/v10/webhooks/123/abc')).toBe(true)
+    expect(isAllowedAlertWebhook('https://discord.com/api/v9/webhooks/123/abc')).toBe(true)
   })
 
   it('rejects non-HTTPS schemes', () => {
@@ -19,18 +46,21 @@ describe('isAllowedAlertWebhook (SSRF allow-list, #467)', () => {
     expect(isAllowedAlertWebhook('ftp://discord.com/api/webhooks/123/abc')).toBe(false)
   })
 
-  it('rejects non-discord.com hosts (no suffix/subdomain bypass)', () => {
-    // Guards against a future endsWith('discord.com') regression letting these through.
-    expect(isAllowedAlertWebhook('https://evildiscord.com/api/webhooks/123/abc')).toBe(false)
-    expect(isAllowedAlertWebhook('https://discord.com.evil.tld/api/webhooks/123/abc')).toBe(false)
+  it('rejects look-alike hosts (the leading-dot guard blocks suffix/substring bypass)', () => {
+    expect(isAllowedAlertWebhook('https://evildiscord.com/api/webhooks/123/abc')).toBe(false)       // no leading dot
+    expect(isAllowedAlertWebhook('https://discord.com.evil.tld/api/webhooks/123/abc')).toBe(false)  // ends in .evil.tld
+    expect(isAllowedAlertWebhook('https://notdiscord.com/api/webhooks/123/abc')).toBe(false)
+    expect(isAllowedAlertWebhook('https://discordapp.com.evil.tld/api/webhooks/123/abc')).toBe(false)
     expect(isAllowedAlertWebhook('https://hooks.slack.com/services/T/B/x')).toBe(false)
-    // Legacy/beta Discord hosts are intentionally NOT accepted yet (broadening tracked in #468).
-    expect(isAllowedAlertWebhook('https://discordapp.com/api/webhooks/123/abc')).toBe(false)
-    expect(isAllowedAlertWebhook('https://canary.discord.com/api/webhooks/123/abc')).toBe(false)
+    // Label-less / trailing-dot host edges — the regex requires real labels + exact suffix.
+    expect(isAllowedAlertWebhook('https://.discord.com/api/webhooks/123/abc')).toBe(false)
+    expect(isAllowedAlertWebhook('https://discord.com./api/webhooks/123/abc')).toBe(false)
   })
 
-  it('rejects discord.com URLs that are not a webhook path', () => {
+  it('rejects Discord hosts whose path is not a webhook path', () => {
     expect(isAllowedAlertWebhook('https://discord.com/api/users/@me')).toBe(false)
+    expect(isAllowedAlertWebhook('https://discord.com/api/v10/users/@me')).toBe(false)
+    expect(isAllowedAlertWebhook('https://discord.com/webhooks/123/abc')).toBe(false) // missing /api/ prefix
     expect(isAllowedAlertWebhook('https://discord.com/')).toBe(false)
   })
 

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -18,11 +18,22 @@ export function sanitize(s: string, maxLen = 1000): string {
 }
 
 // SSRF allow-list for the /api/alert webhook proxy: HTTPS Discord webhook URLs only (#467 \u2014
-// Slack moved to native /feed RSS, so the proxy no longer forwards to hooks.slack.com). The
-// hostname must equal `discord.com` exactly (no subdomain/suffix matching, which would let
-// `evildiscord.com` or `discord.com.evil.tld` through) and the path must be a real webhook path.
-// Broadening to discordapp.com / canary.discord.com is tracked in #468. Extracted as a pure
-// predicate so the boundary is unit-testable (the rest of the proxy is inline in the fetch handler).
+// Slack moved to native /feed RSS, so the proxy no longer forwards to hooks.slack.com).
+//
+// Host (#468): `discordapp.com` (legacy host, still issued/saved) exact-match, plus `discord.com`
+// and any real `*.discord.com` subdomain (`canary.`/`ptb.` beta clients hand these out), matched by
+// DISCORD_HOST. Every name in Discord's zone is controlled by Discord's DNS, so the wildcard is
+// safe; the regex requires non-empty labels + an exact `discord.com` suffix, so look-alikes
+// (`evildiscord.com`, `discord.com.evil.tld`), the label-less `.discord.com`, and trailing-dot
+// FQDNs (`discord.com.`) are all rejected. `URL.hostname` is already lowercased and strips any
+// userinfo (`discord.com@evil.tld` \u2192 host `evil.tld`), so authority-confusion bypasses fail here.
+//
+// Path (#468): a webhook path, optionally version-prefixed \u2014 `/api/webhooks/...` or
+// `/api/v{N}/webhooks/...` (some SDKs/tools emit the versioned form).
+//
+// Extracted as a pure predicate so the boundary is unit-testable (the rest of the proxy is inline
+// in the fetch handler). HTTPS-only + the proxy's rate limit are unchanged.
+const DISCORD_HOST = /^([a-z0-9-]+\.)*discord\.com$/
 export function isAllowedAlertWebhook(webhookUrl: string): boolean {
   let parsed: URL
   try {
@@ -30,10 +41,12 @@ export function isAllowedAlertWebhook(webhookUrl: string): boolean {
   } catch {
     return false
   }
+  const host = parsed.hostname
+  const hostAllowed = host === 'discordapp.com' || DISCORD_HOST.test(host)
   return (
     parsed.protocol === 'https:' &&
-    parsed.hostname === 'discord.com' &&
-    parsed.pathname.startsWith('/api/webhooks/')
+    hostAllowed &&
+    /^\/api\/(v\d+\/)?webhooks\//.test(parsed.pathname)
   )
 }
 


### PR DESCRIPTION
## Summary
The `/api/alert` Discord webhook proxy's SSRF allow-list accepted **only** `https://discord.com/api/webhooks/...`, rejecting other legitimate Discord webhook URLs with **403** — so Settings **Send test** and browser-side per-user alerts (#467) failed for users on legacy/beta hosts or version-prefixed paths.

## Change (`worker/src/utils.ts` `isAllowedAlertWebhook`)
- **Host**: `discordapp.com` (legacy, still issued/saved) exact-match + `discord.com` and any real `*.discord.com` subdomain (`canary.`/`ptb.` beta clients) via `/^([a-z0-9-]+\.)*discord\.com$/`.
- **Path**: `/api/webhooks/` **or** `/api/v{N}/webhooks/` (`/^\/api\/(v\d+\/)?webhooks\//`).
- HTTPS-only + the proxy rate limit unchanged.

## SSRF safety
The regex requires non-empty labels and an exact `discord.com` suffix, so every accepted host is inside Discord's DNS zone. Rejected: look-alikes (`evildiscord.com`, `discord.com.evil.tld`, `discordapp.com.evil.tld`), label-less `.discord.com`, trailing-dot `discord.com.`. `URL.hostname` lowercases + strips userinfo, so the authority-confusion bypass `discord.com@evil.tld` resolves to `evil.tld` and is rejected. IDN/punycode look-alikes encode to `xn--…` and fail the ASCII label class.

## Tests (`worker/src/__tests__/utils.test.ts`)
Broadened accepts (legacy/beta/`foo.discord.com`/uppercase host/versioned path) + SSRF guards (userinfo bypass, leading/trailing-dot, suffix look-alikes, non-webhook paths, unparseable). worker **1325** pass; `wrangler deploy --dry-run` clean; live `/api/alert` matrix verified (legit hosts pass validation, bypass vectors 403).

## Review
`/pr-review-toolkit:review-pr` to convergence (round 2 = 0 Critical/0 Important; the round-1 test-gap findings — userinfo bypass + generic subdomain accept — are now pinned, and the predicate was tightened so `.discord.com` is rejected).

## Notes
Worker-only change → needs a manual `npm run deploy:worker` after merge to go live. Found during #467 verification; pre-existing gap.

closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)