### PR TITLE
fix: dedup status+incident user-webhook alerts + group multi-service incidents w/ per-category fallback + AI (#473, #474)

### DIFF
--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -661,7 +661,7 @@ function usePollingInternal() {
       // server-side path only posts to the operator webhook, never to a visitor's configured one,
       // so this restores per-user delivery. No-op unless a Discord webhook is set. Best-effort;
       // fires only while a tab is open. Diff against the previous poll's snapshot.
-      runWebhookAlerts(alertPrevRef.current, merged)
+      runWebhookAlerts(alertPrevRef.current, merged, data.aiAnalysis ?? {})
       alertPrevRef.current = merged
 
       // Overlay probe RTT onto service.latency (replaces status page timing with real API RTT)

--- a/src/utils/__tests__/webhookAlerts.test.js
+++ b/src/utils/__tests__/webhookAlerts.test.js
@@ -195,4 +195,166 @@ describe('runWebhookAlerts (dispatch — Discord only)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(JSON.parse(fetchMock.mock.calls[0][1].body).payload.embeds[0].title).toContain('Incident resolved')
   })
+
+  // ── status↔incident dedup (#473) ─────────────────────────────────────
+  it('suppresses the status embed when a NEW incident covers the same down event (no duplicate, #473)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    runWebhookAlerts([], [svc('claude', 'operational')]) // baseline (no incidents)
+    // claude goes down AND posts a new incident in the same poll → only the incident embed, not down.
+    runWebhookAlerts([svc('claude', 'operational')], [downWith([{ id: 'i1', status: 'investigating', title: 'API errors' }])])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).payload.embeds[0].title).toContain('New incident')
+  })
+
+  it('suppresses the recovery status embed when the incident resolves the same cycle (#473)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    runWebhookAlerts([], [downWith([{ id: 'i1', status: 'investigating', title: 'API errors' }])]) // baseline
+    runWebhookAlerts(
+      [downWith([{ id: 'i1', status: 'investigating', title: 'API errors' }])],
+      [svc('claude', 'operational', [{ id: 'i1', status: 'resolved', title: 'API errors', duration: '1h' }])],
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1) // only "Incident resolved", not "Recovered"
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).payload.embeds[0].title).toContain('Incident resolved')
+  })
+
+  it('suppresses a down status embed when an ongoing incident from a prior cycle covers it (operator parity, #473)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const inc = [{ id: 'i1', status: 'investigating', title: 'API errors' }]
+    // Baseline: incident already present while still operational (minor incident, not yet down).
+    runWebhookAlerts([], [svc('claude', 'operational', inc)])
+    // Status drops to down; i1 is ongoing but NOT new this cycle → no incident embed, and the
+    // down status embed is suppressed because the ongoing incident already covers it.
+    runWebhookAlerts([svc('claude', 'operational', inc)], [svc('claude', 'down', inc)])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('still fires a status embed for a status change with NO incident covering it (#473)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    runWebhookAlerts([], [svc('claude', 'operational')]) // baseline
+    // Down with no incident posted (early-detection case) → status embed still fires.
+    runWebhookAlerts([svc('claude', 'operational')], [svc('claude', 'down')])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).payload.embeds[0].title).toContain('CLAUDE — Down')
+  })
+
+  // ── grouping + fallback + AI parity with operator (#474) ─────────────
+  const incidentEmbedBody = (fetchMock) =>
+    JSON.parse(fetchMock.mock.calls.find((c) => JSON.parse(c[1].body).payload.embeds[0].title.includes('New incident'))[1].body).payload.embeds[0]
+
+  it('groups a multi-service incident into ONE embed with "{provider} ({names})" (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const op = (id, name) => ({ id, name, provider: 'Anthropic', status: 'operational', category: id === 'claudeai' ? 'app' : 'api', incidents: [] })
+    const down = (id, name) => ({ id, name, provider: 'Anthropic', status: 'down', category: id === 'claudeai' ? 'app' : 'api', incidents: [{ id: 'x', status: 'investigating', title: 'Elevated errors' }] })
+    runWebhookAlerts([], [op('claude', 'Claude API'), op('claudeai', 'claude.ai')]) // baseline
+    runWebhookAlerts([op('claude', 'Claude API'), op('claudeai', 'claude.ai')], [down('claude', 'Claude API'), down('claudeai', 'claude.ai')])
+    // Exactly one incident embed (not one per service), titled with the grouped provider + names.
+    const incidentTitles = fetchMock.mock.calls.map((c) => JSON.parse(c[1].body).payload.embeds[0].title).filter((t) => t.includes('New incident'))
+    expect(incidentTitles).toEqual(['🔴 Anthropic (Claude API, claude.ai) — New incident'])
+  })
+
+  it('adds a Suggested fallback line for an impaired service (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const claudeOp = { id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', category: 'api', aiwatchScore: 80, incidents: [] }
+    const claudeDown = { ...claudeOp, status: 'down', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] }
+    const openai = { id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', category: 'api', aiwatchScore: 79, incidents: [] }
+    runWebhookAlerts([], [claudeOp, openai]) // baseline
+    runWebhookAlerts([claudeOp, openai], [claudeDown, openai])
+    expect(incidentEmbedBody(fetchMock).description).toContain('Suggested fallback: OpenAI API (Score 79)')
+  })
+
+  it('includes the AI analysis section when available for the incident (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const claudeOp = { id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', category: 'api', incidents: [] }
+    const claudeDown = { ...claudeOp, status: 'down', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] }
+    const aiAnalysis = { claude: [{ incidentId: 'x', summary: 'Opus inference degraded.', estimatedRecovery: '1–3h', affectedScope: ['Claude API'] }] }
+    runWebhookAlerts([], [claudeOp]) // baseline
+    runWebhookAlerts([claudeOp], [claudeDown], aiAnalysis)
+    const desc = incidentEmbedBody(fetchMock).description
+    expect(desc).toContain('🤖 Opus inference degraded.')
+    expect(desc).toContain('⏱ Est. recovery: 1–3h')
+    expect(desc).toContain('📡 Scope: Claude API')
+  })
+
+  it('omits the AI section when no analysis matches the incident (#474 default path)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const op = { id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', category: 'api', incidents: [] }
+    const down = { ...op, status: 'down', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] }
+    runWebhookAlerts([], [op]) // baseline
+    runWebhookAlerts([op], [down], { claude: [{ incidentId: 'OTHER', summary: 'unrelated' }] }) // no match for 'x'
+    expect(incidentEmbedBody(fetchMock).description).not.toContain('🤖')
+  })
+
+  it('groups a multi-service RESOLVED incident into one embed (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const inv = (id, name) => ({ id, name, provider: 'Anthropic', status: 'down', category: id === 'claudeai' ? 'app' : 'api', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] })
+    const res = (id, name) => ({ id, name, provider: 'Anthropic', status: 'operational', category: id === 'claudeai' ? 'app' : 'api', incidents: [{ id: 'x', status: 'resolved', title: 'Errors', duration: '1h' }] })
+    runWebhookAlerts([], [inv('claude', 'Claude API'), inv('claudeai', 'claude.ai')]) // baseline
+    runWebhookAlerts([inv('claude', 'Claude API'), inv('claudeai', 'claude.ai')], [res('claude', 'Claude API'), res('claudeai', 'claude.ai')])
+    const resolvedTitles = fetchMock.mock.calls.map((c) => JSON.parse(c[1].body).payload.embeds[0].title).filter((t) => t.includes('Incident resolved'))
+    expect(resolvedTitles).toEqual(['🟢 Anthropic (Claude API, claude.ai) — Incident resolved (1h)'])
+  })
+
+  it('omits the fallback line for an EXCLUDE_FALLBACK service (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    // bedrock is in EXCLUDE_FALLBACK → getFallbacks returns [] even with operational candidates.
+    const op = { id: 'bedrock', name: 'Bedrock', provider: 'AWS', status: 'operational', category: 'api', aiwatchScore: 90, incidents: [] }
+    const down = { ...op, status: 'down', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] }
+    const openai = { id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', category: 'api', aiwatchScore: 79, incidents: [] }
+    runWebhookAlerts([], [op, openai]) // baseline
+    runWebhookAlerts([op, openai], [down, openai])
+    expect(incidentEmbedBody(fetchMock).description).not.toContain('Suggested fallback')
+  })
+
+  it('renders a single-service incident with a bare name (no provider grouping) even when provider is set (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const op = { id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', category: 'api', aiwatchScore: 80, incidents: [] }
+    const down = { ...op, status: 'down', incidents: [{ id: 'x', status: 'investigating', title: 'Errors' }] }
+    const openai = { id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', category: 'api', aiwatchScore: 79, incidents: [] }
+    runWebhookAlerts([], [op, openai]) // baseline
+    runWebhookAlerts([op, openai], [down, openai]) // incident only on claude → single service
+    expect(incidentEmbedBody(fetchMock).title).toBe('🔴 Claude API — New incident') // bare, no "Anthropic (...)"
+  })
+
+  it('neutralizes @everyone/@here in the incident title before posting (#474 sanitize parity)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const op = { id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'down', category: 'api', incidents: [] }
+    const down = { ...op, incidents: [{ id: 'x', status: 'investigating', title: 'Outage @everyone <@123>' }] }
+    runWebhookAlerts([], [{ ...op, status: 'operational', incidents: [] }]) // baseline
+    runWebhookAlerts([{ ...op, status: 'operational', incidents: [] }], [down])
+    const desc = incidentEmbedBody(fetchMock).description
+    expect(desc).not.toMatch(/@everyone/)
+    expect(desc).not.toContain('<@123>')
+    expect(desc).toContain('[mention]')
+  })
+
+  it('shows per-category fallback for a multi-category incident (#474)', () => {
+    withSettings()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true })
+    const aff = (id, name, cat) => ({ id, name, provider: 'Anthropic', category: cat, status: 'down', aiwatchScore: 80, incidents: [{ id: 'm', status: 'investigating', title: 'Errors' }] })
+    const affOp = (id, name, cat) => ({ ...aff(id, name, cat), status: 'operational', incidents: [] })
+    const cand = (id, name, cat, score) => ({ id, name, provider: 'OpenAI', category: cat, status: 'operational', aiwatchScore: score, incidents: [] })
+    const candidates = [cand('openai', 'OpenAI API', 'api', 79), cand('chatgpt', 'ChatGPT', 'app', 70), cand('codex', 'Codex', 'agent', 60)]
+    const baseline = [affOp('claude', 'Claude API', 'api'), affOp('claudeai', 'claude.ai', 'app'), affOp('claudecode', 'Claude Code', 'agent'), ...candidates]
+    const incident = [aff('claude', 'Claude API', 'api'), aff('claudeai', 'claude.ai', 'app'), aff('claudecode', 'Claude Code', 'agent'), ...candidates]
+    runWebhookAlerts([], baseline) // baseline
+    runWebhookAlerts(baseline, incident, {})
+    const desc = incidentEmbedBody(fetchMock).description
+    // One labeled line per affected category — not just the first service's category.
+    expect(desc).toContain('👉 Suggested fallback')
+    expect(desc).toMatch(/LLM: OpenAI API/)
+    expect(desc).toMatch(/AI Apps: ChatGPT/)
+    expect(desc).toMatch(/CLI Agent: Codex/)
+  })
 })

--- a/src/utils/webhookAlerts.js
+++ b/src/utils/webhookAlerts.js
@@ -11,7 +11,7 @@
 // open (no raw URL is stored server-side — privacy by design). Cross-tab/poll dedup via a localStorage
 // cooldown; the operator (Worker) posts to a *different* webhook, so there is no cross-source dupe.
 
-import { SETTINGS_STORAGE_KEY } from './constants'
+import { SETTINGS_STORAGE_KEY, getGroupedFallbacks } from './constants'
 
 const ALERT_COOLDOWN_MS = 5 * 60_000
 const COOLDOWN_STORAGE_KEY = 'aiwatch-alert-cooldowns'
@@ -129,13 +129,72 @@ function statusEmbed({ svcId, name, prevStatus, status }) {
   }
 }
 
-function incidentEmbed({ kind, svcId, name, title, duration }) {
+// Neutralize @everyone/@here pings, user/role mentions, and code fences in provider-sourced text
+// before POSTing to the user's Discord channel (#474). Mirrors the operator's worker sanitize()
+// (worker/src/utils.ts) — the operator applies it to incident titles, so the per-user path must too.
+function sanitizeForDiscord(s, maxLen = 1000) {
+  return String(s ?? '')
+    .replace(/@(everyone|here)/g, '@​$1')
+    .replace(/<@[!&]?\d+>/g, '[mention]')
+    .replace(/```/g, '\\`\\`\\`')
+    .slice(0, maxLen)
+}
+
+/** Find the AI analysis entry for a grouped incident across its affected services (#474). */
+function findAiAnalysis(aiAnalysis, svcIds, incId) {
+  for (const svcId of svcIds) {
+    const arr = aiAnalysis?.[svcId]
+    if (!Array.isArray(arr)) continue
+    const match = arr.find((a) => a && a.incidentId === incId)
+    if (match) return match
+  }
+  return null
+}
+
+/** Build a rich, grouped incident embed (#474) matching the operator alert: provider-grouped
+ *  display name for multi-service incidents, a Suggested fallback line for impaired services, and
+ *  an AI-analysis section when available. `group` = { kind, incId, title, duration, svcIds[], names[] }. */
+function incidentEmbed(group, services, aiAnalysis, byId) {
+  const { kind, incId, title, duration, svcIds, names } = group
   const resolved = kind === 'resolved'
+  const first = byId.get(svcIds[0])
+  // Operator parity: "Anthropic (Claude API, claude.ai, Claude Code)" when >1 service shares the incident.
+  const displayName = names.length > 1 && first?.provider ? `${first.provider} (${names.join(', ')})` : names[0]
   const durationText = duration ? ` (${duration})` : ''
+
+  const sections = [sanitizeForDiscord(title)]
+  if (!resolved) {
+    const ai = findAiAnalysis(aiAnalysis, svcIds, incId)
+    if (ai?.summary) {
+      const aiLines = [`🤖 ${sanitizeForDiscord(ai.summary)}`]
+      // Mirror formatRecoveryDisplay / AnalysisModal: 'N/A' means no estimate → show the friendly
+      // phrasing rather than a bare "N/A"; skip the line for the other non-estimate sentinel.
+      const recovery = ai.estimatedRecovery === 'N/A' ? 'Exceeded typical pattern' : ai.estimatedRecovery
+      if (recovery && recovery !== 'No historical data for estimation') aiLines.push(`⏱ Est. recovery: ${recovery}`)
+      if (ai.affectedScope?.length) aiLines.push(`📡 Scope: ${sanitizeForDiscord(ai.affectedScope.join(', '), 200)}`)
+      sections.push(aiLines.join('\n'))
+    }
+    // Per-category fallback for ALL impaired services in this (possibly multi-category) incident,
+    // mirroring the dashboard/operator grouped fallback (#474). A multi-surface Anthropic incident
+    // (Claude API = LLM, claude.ai = app, Claude Code = agent) shows one alternative line per
+    // category — not just the first service's. getGroupedFallbacks handles tier subdivision,
+    // EXCLUDE_FALLBACK, operational filtering, and same-provider exclusion.
+    const affected = svcIds.map((id) => byId.get(id)).filter((s) => s && s.status !== 'operational')
+    const fbGroups = getGroupedFallbacks(affected, services)
+    if (fbGroups.length > 0) {
+      const fmt = (items) => items.map((i) => (i.aiwatchScore != null ? `${i.name} (Score ${i.aiwatchScore})` : i.name)).join(' · ')
+      if (fbGroups.length === 1) {
+        sections.push(`👉 Suggested fallback: ${fmt(fbGroups[0].items)}`)
+      } else {
+        sections.push(`👉 Suggested fallback\n${fbGroups.map((g) => `• ${g.label}: ${fmt(g.items)}`).join('\n')}`)
+      }
+    }
+  }
+
   return {
-    title: resolved ? `🟢 ${name} — Incident resolved${durationText}` : `🔴 ${name} — New incident`,
-    url: `https://ai-watch.dev/#${svcId}`,
-    description: title,
+    title: resolved ? `🟢 ${displayName} — Incident resolved${durationText}` : `🔴 ${displayName} — New incident`,
+    url: `https://ai-watch.dev/#${svcIds[0]}`,
+    description: sections.join('\n\n'),
     color: resolved ? 0x57F287 : 0xED4245,
     timestamp: new Date().toISOString(),
     footer: { text: 'AIWatch Alert' },
@@ -160,35 +219,67 @@ function sendDiscord(discordUrl, embed) {
 // every already-open incident on page load). Module-scoped, reset on full reload.
 let incidentFirstRun = true
 
+/** Group per-(service, incident) alerts from computeIncidentAlerts into one entry per incident
+ *  (kind + incId), collecting all affected service ids/names — so a multi-service incident becomes
+ *  a single grouped embed (#474). svcIds[0] (the first service seen in currentServices order)
+ *  anchors the embed's provider, url, and fallback source; currentServices order is stable. */
+function groupIncidentAlerts(incidentAlerts) {
+  const groups = new Map()
+  for (const a of incidentAlerts) {
+    const k = `${a.kind}:${a.incId}`
+    const g = groups.get(k)
+    if (g) {
+      if (!g.svcIds.includes(a.svcId)) { g.svcIds.push(a.svcId); g.names.push(a.name) }
+    } else {
+      groups.set(k, { kind: a.kind, incId: a.incId, title: a.title, duration: a.duration, svcIds: [a.svcId], names: [a.name] })
+    }
+  }
+  return [...groups.values()]
+}
+
 /** Run browser-side Discord alerting for one poll. No-op unless a Discord webhook is configured. */
-export function runWebhookAlerts(prevServices, currentServices) {
+export function runWebhookAlerts(prevServices, currentServices, aiAnalysis = {}) {
   const settings = readAlertSettings()
   const discordUrl = settings?.discordUrl
   if (!discordUrl) return
 
+  const currSnap = buildIncidentSnapshot(currentServices)
+
+  // Incident alerts are computed first so status alerts can dedup against them (#473). On the first
+  // poll we only baseline the incident snapshot (never alert on already-open incidents), so
+  // incidentGroups stays empty — but status alerts still process (production's first poll has an
+  // empty prevServices ⇒ computeStatusAlerts returns [] anyway; a later poll is the real first diff).
+  let incidentGroups = []
+  if (incidentFirstRun) {
+    incidentFirstRun = false
+  } else {
+    let prevSnap = {}
+    try {
+      const raw = localStorage.getItem(PREV_INCIDENTS_KEY)
+      if (raw) { const parsed = JSON.parse(raw); prevSnap = parsed.data ?? parsed }
+    } catch { /* ignore */ }
+    incidentGroups = groupIncidentAlerts(computeIncidentAlerts(prevSnap, currSnap, currentServices, settings))
+  }
+  const incidentSvcIds = new Set(incidentGroups.flatMap((g) => g.svcIds))
+  const byId = new Map(currentServices.map((s) => [s.id, s]))
+
   for (const a of computeStatusAlerts(prevServices, currentServices, settings)) {
+    // Suppress the status embed when an incident embed covers the same service: a new/resolved
+    // incident alert this cycle (incidentSvcIds), or an ongoing incident from a prior cycle still
+    // covering a down/degraded (operator-parity hasOngoingIncident). Status changes with NO incident
+    // (e.g. down before the status page posts one) still fire — that signal isn't duplicated.
+    if (incidentSvcIds.has(a.svcId)) continue
+    if (a.status !== 'operational' && (byId.get(a.svcId)?.incidents ?? []).some((i) => i.status !== 'resolved')) continue
     const key = `${a.svcId}:${a.status}`
     if (isInCooldown(key)) continue
     setCooldown(key)
     sendDiscord(discordUrl, statusEmbed(a))
   }
-
-  const currSnap = buildIncidentSnapshot(currentServices)
-  if (incidentFirstRun) {
-    incidentFirstRun = false
-    try { localStorage.setItem(PREV_INCIDENTS_KEY, JSON.stringify(currSnap)) } catch { /* ignore */ }
-    return
-  }
-  let prevSnap = {}
-  try {
-    const raw = localStorage.getItem(PREV_INCIDENTS_KEY)
-    if (raw) { const parsed = JSON.parse(raw); prevSnap = parsed.data ?? parsed }
-  } catch { /* ignore */ }
-  for (const a of computeIncidentAlerts(prevSnap, currSnap, currentServices, settings)) {
-    const key = a.kind === 'new' ? `inc:${a.incId}` : `inc-resolve:${a.incId}`
+  for (const g of incidentGroups) {
+    const key = g.kind === 'new' ? `inc:${g.incId}` : `inc-resolve:${g.incId}`
     if (isInCooldown(key)) continue
     setCooldown(key)
-    sendDiscord(discordUrl, incidentEmbed(a))
+    sendDiscord(discordUrl, incidentEmbed(g, currentServices, aiAnalysis, byId))
   }
   try { localStorage.setItem(PREV_INCIDENTS_KEY, JSON.stringify(currSnap)) } catch { /* ignore */ }
 }


### PR DESCRIPTION
## Summary
The browser-side per-user Discord webhook (#467) diverged from the operator alert in two ways; this brings them to parity. **Browser-only — operator path unchanged.**

### #473 — status↔incident duplicate
`runWebhookAlerts` computed status alerts and incident alerts independently, so a service going **down with an incident** sent *both* a `🔴 … Down` status embed and a `🔴 … New incident` embed (the operator path long suppressed this). Now a status embed is suppressed when an incident embed already covers the service — same-cycle new/resolved incident, or an ongoing incident from a prior cycle (mirrors `buildServiceAlerts.hasOngoingIncident`). Status changes with **no** incident (down before a status-page post) still fire.

### #474 — alert parity (matches operator format)
- **Group** per-(service, incident) alerts by `incidentId` → one embed titled `{provider} ({names})` for multi-service incidents, e.g. `🔴 Anthropic (Claude API, claude.ai, Claude Code) — New incident`, instead of one bare per-service alert.
- **Per-category Suggested fallback** via `getGroupedFallbacks` (the helper Overview ActionBanner / AnalysisModal already use): a multi-category incident shows one line per category (LLM / AI Apps / CLI Agent), same-provider candidates excluded.
- **AI-analysis section** (`🤖` summary · `⏱` est recovery · `📡` scope) from `/api/status` `aiAnalysis` when present; gracefully omitted otherwise. `'N/A'` recovery → "Exceeded typical pattern" (operator parity).
- **`sanitizeForDiscord`** on the incident title + AI summary/scope (neutralizes `@everyone`/`@here`, `<@mentions>`, code fences — mirrors the worker `sanitize()`).

## Verification
Captured the **real `/api/alert` payload from the live browser module** (dynamic-import + fetch capture) for a 3-surface Anthropic incident:
```
🔴 Anthropic (Claude API, claude.ai, Claude Code) — New incident
Elevated errors on Opus 4.7
👉 Suggested fallback
• LLM: OpenAI API (Score 79)
• AI Apps: ChatGPT (Score 72)
• CLI Agent: Codex (Score 60)
```
(an earlier capture confirmed the AI section + `@everyone`→`@​everyone` sanitize). Exactly **one** send — the per-service down status embeds are suppressed (#473). **32** webhookAlerts unit tests; frontend **317** pass; build + lint (0 errors).

## Review
`/pr-review-toolkit:review-pr` run to convergence (final round = 0 Critical/0 Important), including a focused re-review of the per-category-fallback delta.

## Notes
Worker-formatted-payload refactor to eliminate this browser/operator divergence long-term is tracked in **#475** (deferred).

closes #473
closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)