### PR TITLE
fix: newline-separate incident feed paragraphs so Slack /feed doesn't glue them (#479)

### DIFF
--- a/worker/src/__tests__/rss.test.ts
+++ b/worker/src/__tests__/rss.test.ts
@@ -254,6 +254,13 @@ describe('buildRssFeed — item formatting (#467)', () => {
     expect(xml).toContain(']]></description>')
   })
 
+  it('separates description paragraphs with a newline so flatteners (Slack /feed) don\'t glue them (#479)', () => {
+    const inc = incident({ id: 'sep', title: 'Outage', status: 'resolved', resolvedAt: '2026-05-10T14:00:00.000Z', duration: '14m', timeline: [{ stage: 'resolved', text: 'Qwen3 recovered', at: '2026-05-10T14:00:00.000Z' }] })
+    const xml = buildRssFeed([service({ incidents: [inc] })], { scope: 'all' }, NOW)
+    expect(xml).toContain('lasted 14m</p>\n<p>Qwen3 recovered</p>')
+    expect(xml).not.toContain('14m</p><p>') // not glued
+  })
+
   it('escapes HTML-significant characters inside the CDATA description (no injection)', () => {
     const xml = buildRssFeed([service({ status: 'down', incidents: [incident({ id: 'x', impact: 'major', timeline: [{ stage: 'investigating', text: '<img src=x onerror=alert(1)>', at: '2026-05-10T12:00:00.000Z' }] })] })], { scope: 'all' }, NOW)
     expect(xml).toContain('&lt;img src=x onerror=alert(1)&gt;')

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -231,7 +231,11 @@ function descHtml(
   if (coAffected.length > 0) lines.push(`<p>Also affecting: ${escHtml(coAffected.join(', '))}</p>`)
   if (latest?.text) lines.push(`<p>${escHtml(latest.text)}</p>`)
   if (opts.fallbackText) lines.push(`<p>↪ ${escHtml(opts.fallbackText)}</p>`)
-  return lines.join('')
+  // Join with a newline, not '' (#479): block-level <p> render with a break in real RSS readers,
+  // but Slack's /feed app FLATTENS the tags and would otherwise concatenate adjacent paragraphs
+  // ("lasted 14m" + "Qwen3…" → "14mQwen3…"). The newline is insignificant whitespace between block
+  // elements for HTML readers, and a line break for flatteners.
+  return lines.join('\n')
 }
 
 function itemXml(


### PR DESCRIPTION
## Bug
In the incident RSS feed (Slack `/feed` app), a resolved incident rendered with the duration and the recovery text glued together:
> 🟢 Resolved · lasted 14m**Q**wen3 Coder 480B A35B Instruct FP8 recovered

## Root cause
`descHtml` (`worker/src/rss.ts`) builds the description as separate `<p>…</p>` blocks but joined them with `lines.join('')`. RSS readers render `<p>` as block-level (visual break), but Slack `/feed` **flattens** the tags and concatenated the inner text with no separator → `…14m` + `Qwen3…`. Affects every multi-paragraph item (meta line, "Also affecting", latest update, fallback) — not just resolved.

## Fix
`lines.join('\n')` — insignificant whitespace between block elements for HTML readers (no visual change), a line break for flatteners like Slack. One-line change; `descHtml` is the only paragraph-join site (verified in review).

## Verification
- Served local feed now emits `…lasted 14m</p>\n<p>Qwen3 Coder 480B A35B Instruct FP8 recovered</p>` (newline separator present).
- New regression test asserts `lasted 14m</p>\n<p>Qwen3 recovered</p>` and `not.toContain('14m</p><p>')`. Worker **1326** pass; dry-run clean.
- `/pr-review-toolkit` review converged (0 Critical/0 Important; confirmed CDATA/XML safety, no reader regression, only glue site).

## Notes
Worker-only → needs a manual `npm run deploy:worker` after merge to go live; Slack will then show the recovery text on its own line.

closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)