### PR TITLE
chore: fire chub + modern-web-guidance at the decision moment via PreToolUse hook (refs #415)

### DIFF
--- a/.claude/hooks/tooling-trigger.sh
+++ b/.claude/hooks/tooling-trigger.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PreToolUse(Edit|Write|MultiEdit) reference-tooling trigger — #415-style backstop.
+#
+# Both reference tools (the get-api-docs/chub skill and the modern-web-guidance plugin skill) carry
+# their own model-invoked trigger descriptions, but those are passive context = probabilistic
+# compliance (the exact #415 failure mode that left chub "documented but unused"). This hook fires
+# DETERMINISTICALLY before a file edit and, only when the target path is a high-signal surface,
+# emits a SOFT reminder (systemMessage, exit 0 — never blocks) pointing at the right tool:
+#   • External integration (worker parsers / services / ai-analysis / changelog / security &
+#     platform monitors / reddit / package.json) → use the `get-api-docs` (chub) skill for the
+#     CURRENT API/SDK shape before trusting training knowledge.
+#   • Frontend HTML/CSS/client-JS (src components/pages, *.jsx, *.css, Edge SSR html templates)
+#     → run the `modern-web-guidance` skill FIRST (a11y / Core Web Vitals / Baseline-safe APIs).
+#
+# Soft on purpose; every fire is logged via _audit.sh so `npm run hook-audit` can show whether it
+# changes behavior. Never blocks on a hook bug: missing jq / parse failure / no path → exit 0.
+
+set -u
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || exit 0
+audit() { bash "${HOOK_DIR}/_audit.sh" "tooling-trigger" "$1" "$2" 2>/dev/null || true; }
+
+command -v jq >/dev/null 2>&1 || exit 0
+INPUT="$(cat 2>/dev/null)" || exit 0
+FP="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)" || exit 0
+[ -z "$FP" ] && exit 0
+
+# Test/spec files need neither API-currency nor web-platform guidance — stay silent there.
+case "$FP" in
+  *__tests__*|*.test.*|*.spec.*) exit 0 ;;
+esac
+
+msg=""
+note=""
+case "$FP" in
+  */worker/src/parsers/*|*/worker/src/services.ts|*/worker/src/ai-analysis.ts|*/worker/src/changelog.ts|*/worker/src/security-monitor.ts|*/worker/src/platform-monitor.ts|*/worker/src/reddit.ts|*/package.json)
+    msg="📚 External integration touched — use the \`get-api-docs\` (chub) skill for the CURRENT API/SDK shape BEFORE coding; training knowledge may be stale (chub search → get --lang js; annotate gotchas)."
+    note="chub:${FP##*/}"
+    ;;
+  */src/components/*|*/src/pages/*|*.jsx|*.css|*html-template.ts|*/api/is-down.ts|*/api/intro.ts)
+    msg="🎨 Frontend HTML/CSS/client-JS touched — run the \`modern-web-guidance\` skill FIRST (accessibility / Core Web Vitals / Baseline-safe modern platform features) before hand-writing patterns."
+    note="modern-web:${FP##*/}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+audit "inject" "$note"
+# jq -Rs . turns the raw message into a properly-escaped JSON string literal.
+esc="$(printf '%s' "$msg" | jq -Rs . 2>/dev/null)"
+if [ -n "$esc" ] && [ "$esc" != "null" ]; then
+  printf '{"systemMessage":%s}\n' "$esc"
+else
+  safe="$(printf '%s' "$msg" | tr '\n"' '  ')"
+  printf '{"systemMessage":"%s"}\n' "$safe"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,17 @@
             "statusMessage": "Checking git-mutation gate (#415)..."
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/tooling-trigger.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking reference-tooling triggers..."
+          }
+        ]
       }
     ],
     "Stop": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,14 @@ OpenAI-compatible `res.choices[0].message.content` / `.reasoning` shape (model-d
 **chub vs MemPalace**: chub = external API ground-truth (public, shared); MemPalace = this project's
 decisions/debugging/feedback (private, project-scoped). Complementary, different layers.
 
+### modern-web-guidance + when-to-use-which
+The **`modern-web-guidance`** Claude Code plugin (Google Chrome marketplace) adds Baseline-current
+web-platform skills (a11y / Core Web Vitals / modern HTML/CSS/JS); run its skill **first** on any
+HTML/CSS/client-JS work. Install: `/plugin marketplace add GoogleChrome/modern-web-guidance` +
+`/plugin install modern-web-guidance@googlechrome`. The full trigger map (which of chub vs
+modern-web-guidance to run by file path) and the `tooling-trigger.sh` PreToolUse backstop are in
+**[docs/reference/reference-tooling.md](docs/reference/reference-tooling.md)**.
+
 ## Commands
 
 ```bash
@@ -197,10 +205,11 @@ gh pr merge --squash --delete-branch
 
 ### Workflow-gate hooks (#415)
 
-`.claude/settings.json` wires three enforcement hooks (scripts in `.claude/hooks/`) — because written rules alone (this file + auto-memory) only get probabilistic compliance:
+`.claude/settings.json` wires four enforcement hooks (scripts in `.claude/hooks/`) — because written rules alone (this file + auto-memory) only get probabilistic compliance:
 - **`workflow-gates-reminder.sh`** (UserPromptSubmit) — re-injects the 4 non-negotiable gates (text in `.claude/hooks/workflow-gates.txt`) as `additionalContext` on **every turn**. Targets the root cause (rules are passive context loaded once at session start; compaction drops methodology), and is the only hook surface that fires each turn + survives compaction. Soft (cannot block); logged as `inject`. Mirrors memory note `feedback_workflow_gates`.
 - **`git-mutation-gate.sh`** (PreToolUse/Bash) — fires before `git commit` / `git push` / `gh pr create` / `gh pr merge`. **Soft** (warns via `systemMessage`, never blocks). The step-3.5 reminder fires on **every** matched mutation (always `warn`) — a running dev server is now only an *informational hint*, **not** a silence condition, because a port probe can't distinguish "the assistant started + curl-checked a server itself" from "the user confirmed in-browser" (the #430 false-pass; #415 2026-05-19 gap). Also flags `--no-verify` / `--no-gpg-sign`.
 - **`stop-nag-gate.sh`** (Stop) — reads the just-finished assistant message from the transcript; if its closing line is an auto-proceed nag ("shall I proceed/merge/continue?", "진행할까요?", "다음 작업 진행할까요?", …) it **re-prompts** (`decision: block`) to re-send the closing without the nag. `stop_hook_active` guards the loop.
+- **`tooling-trigger.sh`** (PreToolUse/Edit|Write|MultiEdit) — soft path-based reminder (`systemMessage`, never blocks) to run **chub** first on external-integration files or **modern-web-guidance** first on frontend HTML/CSS/JS; the #415 backstop for those skills' probabilistic triggers. Logged as `inject`. Trigger map: **[docs/reference/reference-tooling.md](docs/reference/reference-tooling.md)**.
 
 > **Coverage limit (#415 2026-05-19)**: no `PreToolUse(Bash)` hook can *enforce* step 3.5 — the user's in-browser confirmation is a user message the hook never sees, and the violating action (launching PR review via the `Agent` tool) isn't even a Bash command. The reminder + always-on git-gate raise salience; the actual step-3.5 wait remains **behavioral** (STOP after requesting verification until the user answers).
 

--- a/docs/reference/reference-tooling.md
+++ b/docs/reference/reference-tooling.md
@@ -1,0 +1,66 @@
+# Reference Tooling — chub + modern-web-guidance + the decision-moment backstop
+
+AIWatch wires two external "reference" tools that ground code in current sources instead of
+training-cutoff memory. Both carry their own model-invoked skill triggers, but those are passive
+context = probabilistic compliance (the #415 failure mode that left chub "documented but unused").
+So a deterministic PreToolUse hook reinforces them at the moment a relevant file is edited.
+
+## The two tools
+
+### chub (Context Hub) — `get-api-docs` skill
+External API/SDK/library **ground-truth**. Fetch current docs **before** writing code against an
+external service. Full flow, AIWatch stack coverage, and the Cloudflare/Anthropic footguns are in
+**CLAUDE.md → "API Docs via Context Hub (chub)"**. Quick flow:
+
+```bash
+chub search "<keywords>" --json   # find the doc id
+chub get <id> --lang js           # fetch (always pass --lang)
+chub annotate <id> "<gotcha>"     # save project-specific battle scars
+```
+
+### modern-web-guidance — Claude Code plugin (Google Chrome marketplace)
+Expert-vetted, **Baseline-current** skills for the web platform (accessibility, Core Web Vitals,
+modern HTML/CSS/JS APIs). Install once — `/plugin` is a REPL command the user runs, not something
+Claude can execute:
+
+```
+/plugin marketplace add GoogleChrome/modern-web-guidance
+/plugin install modern-web-guidance@googlechrome
+/reload-plugins
+```
+
+The `modern-web-guidance` skill auto-triggers on **HTML/CSS/client-JS** work — modals/dialogs,
+container queries, `:has()`, View Transitions, scroll-driven animations, Core Web Vitals (LCP/INP),
+forms/autofill, and React layout/style adaptation. Run it **first**, before hand-writing patterns
+from memory (web APIs evolve faster than training weights). **Skip** for backend/SQL/ORM, CI/CD,
+Docker, and generic local scripts. (The plugin also ships a `chrome-extensions` skill — not used by
+AIWatch.)
+
+## Which tool, when (the trigger map)
+
+`.claude/hooks/tooling-trigger.sh` (PreToolUse / `Edit|Write|MultiEdit`) inspects the target
+`file_path` and emits a **soft** `systemMessage` reminder (exit 0, never blocks) — the deterministic
+backstop for the two skills' probabilistic triggers:
+
+| Editing this surface | Run BEFORE coding |
+|---|---|
+| `worker/src/parsers/**`, `services.ts`, `ai-analysis.ts`, `changelog.ts`, `security-monitor.ts`, `platform-monitor.ts`, `reddit.ts`, `package.json` (external API / SDK / Cloudflare binding) | **chub** (`get-api-docs`) — current API shape |
+| `src/components/**`, `src/pages/**`, `*.jsx`, `*.css`, Edge SSR `*html-template.ts`, `api/is-down.ts`, `api/intro.ts` (markup / styles / UI components) | **modern-web-guidance** skill — a11y / CWV / Baseline |
+| anything else — incl. non-UI client logic (`src/utils/*.js`, `src/hooks/*.js`), backend/score logic, and `*__tests__*` / `*.test.*` / `*.spec.*` | (silent — no reminder) |
+
+> Scope note: the frontend arm targets **markup/styles/UI components**, not all client-side JS — pure
+> logic/data modules (`src/utils`, `src/hooks`, `src/locales`) and test files stay silent on purpose
+> (they don't involve web-platform APIs). Globs are soft + logged as `inject`; widen them only if the
+> audit log shows real misses.
+
+Every fire is logged to `.claude/hook-audit.jsonl` as `inject` (`npm run hook-audit` summarizes). Soft
+on purpose; if the audit shows the reminders are ignored, tighten the path globs or escalate. The hook
+is wired in `.claude/settings.json` alongside the #415 gates — a new `settings.json` only takes effect
+after `/hooks` is opened once or a restart.
+
+## Why both layers
+- **Skill trigger** (model-invoked): fires whenever the model recognizes a relevant *task* from the
+  conversation — broad but probabilistic.
+- **PreToolUse hook** (deterministic): fires whenever a relevant *file* is actually edited — precise,
+  survives compaction, and is measurable via the audit log. Together they make the tools fire at the
+  decision moment instead of sitting as inert documentation (the #415 lesson, applied to tooling).


### PR DESCRIPTION
refs #415

## Why
The **chub** (`get-api-docs`) integration was documented in CLAUDE.md but went **unused in practice** — the exact probabilistic-compliance failure #415's workflow-gate hooks exist to fix: a "should" in passive context that's forgotten precisely when it matters (a new worker parser, a new Cloudflare binding, the Anthropic Messages API). The newly installed **modern-web-guidance** plugin would sit just as inert without a trigger.

## What
Add `.claude/hooks/tooling-trigger.sh` (PreToolUse / `Edit|Write|MultiEdit`): inspects the edited file path and emits a **soft** `systemMessage` reminder (never blocks; logged as `inject`) to run the right reference tool **first**:
- **chub** for external-integration files (`worker/src/parsers/**`, `services.ts`, `ai-analysis.ts`, `changelog.ts`, security/platform monitors, `package.json`)
- **modern-web-guidance** for frontend markup/styles/UI components (`src/components`, `src/pages`, `*.jsx`, `*.css`, Edge SSR `*html-template.ts`, `api/is-down.ts`, `api/intro.ts`)

Test/spec files and non-UI client logic (`src/utils`, `src/hooks`) stay silent. This is the **deterministic backstop** for the two skills' own (probabilistic) model-invoked triggers — the #415 lesson applied to reference tooling.

## Files
- `.claude/hooks/tooling-trigger.sh` (new) — the hook, mirrors `git-mutation-gate.sh` conventions (jq guard, `_audit.sh` logging, `jq -Rs` escaping, always exit 0).
- `.claude/settings.json` — wire the hook (matcher `Edit|Write|MultiEdit`).
- `docs/reference/reference-tooling.md` (new) — the two tools + trigger map + hook details (extracted to keep CLAUDE.md under the 40k limit, #462).
- `CLAUDE.md` — modern-web-guidance install + pointer; hooks section now lists four hooks.

## Verification
- Hook self-tested across 6 cases: external-integration → chub, frontend → modern-web, test files / non-UI logic / unrelated → silent, empty/null/malformed input → exit 0 (never blocks). `bash -n` clean.
- `.claude/settings.json` valid JSON; existing Bash/Stop/UserPromptSubmit hooks untouched.
- CLAUDE.md 38725 bytes (< 40000, #462).
- Code review converged (0 Critical / 0 Important).

No app code changed (bash + docs only), so no build/test or step-3.5 in-browser verification applies.

## Note
A changed `.claude/settings.json` only takes effect after `/hooks` is opened once or a session restart (same caveat as the existing #415 gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)