### PR TITLE
feat(worker): server-side per-user Discord subscription backend — PR1 of #486

### DIFF
--- a/worker/src/__tests__/webhook-subscriptions.test.ts
+++ b/worker/src/__tests__/webhook-subscriptions.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  sha256Hex,
+  generateCode,
+  encryptUrl,
+  decryptUrl,
+  isValidEncKey,
+  normalizeFilters,
+  shouldDeliver,
+  classifyDelivery,
+  reserveConfirmBudget,
+  listConfirmedHashes,
+  subscribe,
+  confirm,
+  updateFilters,
+  unsubscribe,
+  deliverToSubscribers,
+  readConfirmed,
+  readPending,
+  CONFIRM_BUDGET_MAX,
+  MAX_FAIL_COUNT,
+  SUB_PREFIX,
+  type SubscriptionFilters,
+} from '../webhook-subscriptions'
+import type { AlertFeedEntry } from '../alert-feed'
+// Parity guard: the former client-side relay decision (#475) the worker must stay byte-identical to.
+// Namespace import (not named) — the SPA module lives outside the worker vitest root and a named
+// import trips a vitest module-resolution quirk; the namespace form resolves cleanly.
+import * as clientRelay from '../../../src/utils/webhookAlerts'
+
+// In-memory KV mock supporting get/put(+metadata)/delete/list(prefix,cursor). TTL ignored (tests
+// don't advance wall-clock across TTLs).
+function makeKV() {
+  const store = new Map<string, string>()
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v) },
+    delete: async (k: string) => { store.delete(k) },
+    list: async ({ prefix, cursor }: { prefix?: string; cursor?: string } = {}) => {
+      const all = [...store.keys()].filter((k) => !prefix || k.startsWith(prefix)).sort()
+      // Paginate in pages of 2 to exercise the cursor loop in listConfirmedHashes.
+      const start = cursor ? parseInt(cursor, 10) : 0
+      const page = all.slice(start, start + 2)
+      const next = start + 2
+      const complete = next >= all.length
+      return { keys: page.map((name) => ({ name })), list_complete: complete, cursor: complete ? undefined : String(next) }
+    },
+    _store: store,
+  } as unknown as KVNamespace & { _store: Map<string, string> }
+}
+
+const KEY = 'a'.repeat(64) // valid AES-256 hex key
+const URL_OK = 'https://discord.com/api/webhooks/123456789/abcdefgABCDEFG_token-xyz'
+const URL_LEGACY = 'https://discordapp.com/api/webhooks/123/tok'
+const URL_BAD = 'https://evil.example.com/api/webhooks/123/tok'
+
+const FILTERS_ALL: SubscriptionFilters = { alertCondition: 'all', alertTarget: 'all', alertServices: [], alertIncidents: true }
+
+function feedEntry(over: Partial<AlertFeedEntry>): AlertFeedEntry {
+  return { key: 'alerted:new:i1', kind: 'new', svcIds: ['claude'], embed: { title: 't', description: 'd', color: 1 }, ts: 1, ...over }
+}
+
+describe('sha256Hex / generateCode', () => {
+  it('hashes deterministically (64 hex)', async () => {
+    const h1 = await sha256Hex(URL_OK)
+    const h2 = await sha256Hex(URL_OK)
+    expect(h1).toBe(h2)
+    expect(h1).toMatch(/^[a-f0-9]{64}$/)
+  })
+  it('generates 6-digit codes', () => {
+    for (let i = 0; i < 50; i++) expect(generateCode()).toMatch(/^\d{6}$/)
+  })
+})
+
+describe('AES-GCM encrypt/decrypt', () => {
+  it('round-trips the URL', async () => {
+    const enc = await encryptUrl(URL_OK, KEY)
+    expect(enc.startsWith('v1.')).toBe(true)
+    expect(enc).not.toContain(URL_OK) // ciphertext, not plaintext
+    expect(await decryptUrl(enc, KEY)).toBe(URL_OK)
+  })
+  it('uses a fresh IV each time (ciphertext differs)', async () => {
+    expect(await encryptUrl(URL_OK, KEY)).not.toBe(await encryptUrl(URL_OK, KEY))
+  })
+  it('fails closed on invalid key', async () => {
+    expect(isValidEncKey(undefined)).toBe(false)
+    expect(isValidEncKey('short')).toBe(false)
+    expect(isValidEncKey(KEY)).toBe(true)
+    await expect(encryptUrl(URL_OK, 'short')).rejects.toThrow()
+  })
+  it('returns null on tamper / wrong key / malformation', async () => {
+    const enc = await encryptUrl(URL_OK, KEY)
+    expect(await decryptUrl(enc, 'b'.repeat(64))).toBeNull() // wrong key → GCM auth fail
+    expect(await decryptUrl('garbage', KEY)).toBeNull()
+    expect(await decryptUrl('v2.' + enc.slice(3), KEY)).toBeNull() // unknown keyId
+  })
+})
+
+describe('normalizeFilters', () => {
+  it('defaults missing/invalid to permissive baseline', () => {
+    expect(normalizeFilters(undefined)).toEqual({ alertCondition: 'all', alertTarget: 'all', alertServices: [], alertIncidents: true })
+    expect(normalizeFilters({ alertCondition: 'bogus', alertTarget: 'x', alertIncidents: false }))
+      .toEqual({ alertCondition: 'all', alertTarget: 'all', alertServices: [], alertIncidents: false })
+  })
+  it('keeps valid values + caps services', () => {
+    const f = normalizeFilters({ alertCondition: 'down', alertTarget: 'custom', alertServices: ['claude', 'openai', 5], alertIncidents: true })
+    expect(f.alertCondition).toBe('down')
+    expect(f.alertTarget).toBe('custom')
+    expect(f.alertServices).toEqual(['claude', 'openai'])
+  })
+  it('caps alertServices at 100 entries (stored-size DoS guard)', () => {
+    const many = Array.from({ length: 250 }, (_, i) => `svc${i}`)
+    expect(normalizeFilters({ alertServices: many }).alertServices).toHaveLength(100)
+  })
+})
+
+describe('shouldDeliver (parity with client shouldRelay)', () => {
+  it('custom target requires a matching service', () => {
+    const f: SubscriptionFilters = { ...FILTERS_ALL, alertTarget: 'custom', alertServices: ['openai'] }
+    expect(shouldDeliver(feedEntry({ svcIds: ['claude'] }), f)).toBe(false)
+    expect(shouldDeliver(feedEntry({ svcIds: ['openai'] }), f)).toBe(true)
+  })
+  it('incident kinds gated by alertIncidents', () => {
+    expect(shouldDeliver(feedEntry({ kind: 'new' }), { ...FILTERS_ALL, alertIncidents: false })).toBe(false)
+    expect(shouldDeliver(feedEntry({ kind: 'resolved' }), FILTERS_ALL)).toBe(true)
+  })
+  it("condition 'down' drops degraded but keeps down/recovered", () => {
+    const f: SubscriptionFilters = { ...FILTERS_ALL, alertCondition: 'down' }
+    expect(shouldDeliver(feedEntry({ kind: 'degraded' }), f)).toBe(false)
+    expect(shouldDeliver(feedEntry({ kind: 'down' }), f)).toBe(true)
+    expect(shouldDeliver(feedEntry({ kind: 'recovered' }), f)).toBe(true)
+  })
+  // Pins the #475 "byte-identical" contract: the worker's shouldDeliver must agree with the former
+  // client shouldRelay (src/utils/webhookAlerts.js) for every (kind × filter) combination, so server
+  // delivery (PR3) matches what the browser relay did. If either drifts, this fails.
+  it('agrees with the client shouldRelay over the full kind × filter matrix', () => {
+    const kinds: AlertFeedEntry['kind'][] = ['new', 'resolved', 'down', 'degraded', 'recovered']
+    const conditions: Array<'down' | 'all'> = ['down', 'all']
+    const targets: Array<'all' | 'custom'> = ['all', 'custom']
+    const serviceSets = [[], ['claude'], ['openai']]
+    const incidentsFlags = [true, false]
+    const svcIdSets = [['claude'], ['openai'], ['claude', 'openai'], []]
+    for (const kind of kinds)
+      for (const alertCondition of conditions)
+        for (const alertTarget of targets)
+          for (const alertServices of serviceSets)
+            for (const alertIncidents of incidentsFlags)
+              for (const svcIds of svcIdSets) {
+                const entry = feedEntry({ kind, svcIds })
+                const filters = { alertCondition, alertTarget, alertServices, alertIncidents }
+                expect(shouldDeliver(entry, filters)).toBe(clientRelay.shouldRelay(entry, filters))
+              }
+  })
+})
+
+describe('reserveConfirmBudget — fail-open on KV read error', () => {
+  it('allows (returns true) and does not throw when the KV read fails', async () => {
+    const kv = { get: async () => { throw new Error('kv down') }, put: async () => {} } as unknown as KVNamespace
+    expect(await reserveConfirmBudget(kv, '2026-05-29T00')).toBe(true)
+  })
+})
+
+describe('classifyDelivery', () => {
+  it('prunes on 410/404, succeeds on 2xx, retries otherwise', () => {
+    expect(classifyDelivery(410)).toBe('prune')
+    expect(classifyDelivery(404)).toBe('prune')
+    expect(classifyDelivery(204)).toBe('success')
+    expect(classifyDelivery(200)).toBe('success')
+    expect(classifyDelivery(429)).toBe('retry')
+    expect(classifyDelivery(500)).toBe('retry')
+    expect(classifyDelivery(null)).toBe('retry')
+  })
+})
+
+describe('reserveConfirmBudget', () => {
+  it('allows up to the cap then blocks', async () => {
+    const kv = makeKV()
+    kv._store.set('webhook:confirm:budget:2026-05-29T00', String(CONFIRM_BUDGET_MAX - 1))
+    expect(await reserveConfirmBudget(kv, '2026-05-29T00')).toBe(true)  // hits the cap
+    expect(await reserveConfirmBudget(kv, '2026-05-29T00')).toBe(false) // over
+  })
+})
+
+describe('listConfirmedHashes (cursor pagination)', () => {
+  it('returns every hash across pages', async () => {
+    const kv = makeKV()
+    for (let i = 0; i < 5; i++) kv._store.set(`${SUB_PREFIX}hash${i}`, '{}')
+    kv._store.set('webhook:pending:other', '{}') // must be ignored (wrong prefix)
+    const hashes = await listConfirmedHashes(kv)
+    expect(hashes.sort()).toEqual(['hash0', 'hash1', 'hash2', 'hash3', 'hash4'])
+  })
+})
+
+describe('subscribe → confirm flow', () => {
+  it('rejects bad host (SSRF), incl. accepting legacy discordapp.com', async () => {
+    const kv = makeKV()
+    const post = vi.fn(async () => true)
+    const bad = await subscribe(kv, KEY, URL_BAD, FILTERS_ALL, '2026-05-29T00', 'now', post)
+    expect(bad).toEqual({ ok: false, status: 403, error: 'Webhook URL not allowed' })
+    expect(post).not.toHaveBeenCalled()
+    const legacy = await subscribe(kv, KEY, URL_LEGACY, FILTERS_ALL, '2026-05-29T00', 'now', post)
+    expect(legacy.ok).toBe(true)
+  })
+  it('fails closed without a valid enc key', async () => {
+    const kv = makeKV()
+    const r = await subscribe(kv, undefined, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', async () => true)
+    expect(r).toEqual({ ok: false, status: 503, error: 'Subscriptions unavailable' })
+  })
+  it('does not store pending if the confirm message fails to send', async () => {
+    const kv = makeKV()
+    const r = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', async () => false)
+    expect(r.ok).toBe(false)
+    expect(await readPending(kv, await sha256Hex(URL_OK))).toBeNull()
+  })
+  it('stores pending then confirms with the right code → permanent sub', async () => {
+    const kv = makeKV()
+    let captured = ''
+    const r = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', async (_u, code) => { captured = code; return true })
+    expect(r.ok).toBe(true)
+    const hash = (r as { ok: true; hash: string }).hash
+    expect(await readPending(kv, hash)).not.toBeNull()
+
+    // A wrong code (guaranteed != captured) is rejected and must NOT consume the pending row.
+    const wrong = captured === '111111' ? '222222' : '111111'
+    expect((await confirm(kv, hash, wrong, 'now')).ok).toBe(false)
+    expect(await readPending(kv, hash)).not.toBeNull()
+    const good = await confirm(kv, hash, captured, 'now')
+    expect(good.ok).toBe(true)
+    const sub = await readConfirmed(kv, hash)
+    expect(sub?.type).toBe('discord')
+    expect(sub?.failCount).toBe(0)
+    expect(await readPending(kv, hash)).toBeNull() // pending consumed
+    // stored URL is encrypted, decryptable back to the original
+    expect(sub!.encUrl).not.toContain(URL_OK)
+    expect(await decryptUrl(sub!.encUrl, KEY)).toBe(URL_OK)
+  })
+  it('confirm on missing/expired pending → 410', async () => {
+    const kv = makeKV()
+    const r = await confirm(kv, 'a'.repeat(64), '123456', 'now')
+    expect(r).toEqual({ ok: false, status: 410, error: 'Confirmation expired or not found' })
+  })
+  it('confirm rejects malformed hash/code with 400 and does not touch KV', async () => {
+    const kv = makeKV()
+    const getSpy = vi.spyOn(kv, 'get')
+    expect((await confirm(kv, 'short', '123456', 'now')).ok).toBe(false)
+    expect((await confirm(kv, 'a'.repeat(64), '12', 'now'))).toEqual({ ok: false, status: 400, error: 'Invalid request' })
+    expect(getSpy).not.toHaveBeenCalled() // validation rejects before any KV read
+  })
+  it('re-subscribe on an already-confirmed channel is an idempotent no-op (no send, no budget charge)', async () => {
+    const kv = makeKV()
+    const hash = await sha256Hex(URL_OK)
+    kv._store.set(`${SUB_PREFIX}${hash}`, JSON.stringify({ encUrl: await encryptUrl(URL_OK, KEY), filters: FILTERS_ALL, type: 'discord', registeredAt: 'x', failCount: 0 }))
+    const post = vi.fn(async () => true)
+    const r = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', post)
+    expect(r).toEqual({ ok: true, hash, status: 'confirmed' })
+    expect(post).not.toHaveBeenCalled() // no channel re-spam
+    expect(kv._store.has('webhook:confirm:budget:2026-05-29T00')).toBe(false) // no budget charged
+  })
+  it('re-subscribe while a confirmation is pending does not re-send or re-charge', async () => {
+    const kv = makeKV()
+    const post = vi.fn(async () => true)
+    const first = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', post)
+    expect(first.ok && first.status).toBe('sent')
+    expect(post).toHaveBeenCalledTimes(1)
+    const second = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', post)
+    expect(second.ok && second.status).toBe('pending')
+    expect(post).toHaveBeenCalledTimes(1) // not re-sent
+  })
+  it('confirm maps a KV write failure to 500 (not 400)', async () => {
+    const kv = makeKV()
+    let captured = ''
+    const r = await subscribe(kv, KEY, URL_OK, FILTERS_ALL, '2026-05-29T00', 'now', async (_u, c) => { captured = c; return true })
+    const hash = (r as { ok: true; hash: string }).hash
+    vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('kv down'))
+    const c = await confirm(kv, hash, captured, 'now')
+    expect(c).toEqual({ ok: false, status: 500, error: 'Storage error' })
+  })
+})
+
+describe('updateFilters / unsubscribe', () => {
+  it('updates filters on a confirmed sub without OTP', async () => {
+    const kv = makeKV()
+    const hash = await sha256Hex(URL_OK)
+    kv._store.set(`${SUB_PREFIX}${hash}`, JSON.stringify({ encUrl: await encryptUrl(URL_OK, KEY), filters: FILTERS_ALL, type: 'discord', registeredAt: 'x', failCount: 0 }))
+    const r = await updateFilters(kv, hash, { alertCondition: 'down', alertTarget: 'custom', alertServices: ['claude'], alertIncidents: false })
+    expect(r.ok).toBe(true)
+    const sub = await readConfirmed(kv, hash)
+    expect(sub?.filters.alertCondition).toBe('down')
+    expect(sub?.filters.alertServices).toEqual(['claude'])
+  })
+  it('update on unknown hash → 404', async () => {
+    const kv = makeKV()
+    expect(await updateFilters(kv, 'b'.repeat(64), FILTERS_ALL)).toEqual({ ok: false, status: 404, error: 'Subscription not found' })
+  })
+  it('unsubscribe deletes the sub (idempotent)', async () => {
+    const kv = makeKV()
+    const hash = await sha256Hex(URL_OK)
+    kv._store.set(`${SUB_PREFIX}${hash}`, '{}')
+    expect((await unsubscribe(kv, hash)).ok).toBe(true)
+    expect(await readConfirmed(kv, hash)).toBeNull()
+    expect((await unsubscribe(kv, hash)).ok).toBe(true) // idempotent
+  })
+})
+
+describe('deliverToSubscribers', () => {
+  async function seedSub(kv: ReturnType<typeof makeKV>, url: string, filters: SubscriptionFilters, failCount = 0) {
+    const hash = await sha256Hex(url)
+    kv._store.set(`${SUB_PREFIX}${hash}`, JSON.stringify({ encUrl: await encryptUrl(url, KEY), filters, type: 'discord', registeredAt: 'x', failCount }))
+    return hash
+  }
+
+  it('delivers matching entries, dedups on re-run', async () => {
+    const kv = makeKV()
+    await seedSub(kv, URL_OK, FILTERS_ALL)
+    const feed = [feedEntry({ key: 'alerted:new:i1' })]
+    const post = vi.fn(async () => 204)
+    const s1 = await deliverToSubscribers(kv, KEY, feed, post, 1)
+    expect(s1.delivered).toBe(1)
+    expect(post).toHaveBeenCalledTimes(1)
+    // second run: same entry already marked sent → no re-deliver
+    const s2 = await deliverToSubscribers(kv, KEY, feed, post, 2)
+    expect(s2.delivered).toBe(0)
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+  it('applies per-sub filters', async () => {
+    const kv = makeKV()
+    await seedSub(kv, URL_OK, { ...FILTERS_ALL, alertTarget: 'custom', alertServices: ['openai'] })
+    const feed = [feedEntry({ svcIds: ['claude'] })] // not in custom list
+    const post = vi.fn(async () => 204)
+    const stats = await deliverToSubscribers(kv, KEY, feed, post, 1)
+    expect(stats.delivered).toBe(0)
+    expect(post).not.toHaveBeenCalled()
+  })
+  it('prunes immediately on 410', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL)
+    const stats = await deliverToSubscribers(kv, KEY, [feedEntry({})], async () => 410, 1)
+    expect(stats.pruned).toBe(1)
+    expect(kv._store.has(`${SUB_PREFIX}${hash}`)).toBe(false)
+  })
+  it('prunes after MAX_FAIL_COUNT consecutive failures, not before', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL, MAX_FAIL_COUNT - 1)
+    const stats = await deliverToSubscribers(kv, KEY, [feedEntry({})], async () => 500, 1)
+    expect(stats.pruned).toBe(1) // failCount was MAX-1, this failure tips it over
+    expect(kv._store.has(`${SUB_PREFIX}${hash}`)).toBe(false)
+  })
+  it('does not prune on a single transient failure', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL, 0)
+    await deliverToSubscribers(kv, KEY, [feedEntry({})], async () => 500, 1)
+    const sub = await readConfirmed(kv, hash)
+    expect(sub?.failCount).toBe(1)
+    expect(kv._store.has(`${SUB_PREFIX}${hash}`)).toBe(true)
+  })
+  it('resets failCount on a successful cycle', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL, 3)
+    await deliverToSubscribers(kv, KEY, [feedEntry({})], async () => 204, 1)
+    expect((await readConfirmed(kv, hash))?.failCount).toBe(0)
+  })
+  it('no-ops without a valid enc key', async () => {
+    const kv = makeKV()
+    await seedSub(kv, URL_OK, FILTERS_ALL)
+    const post = vi.fn(async () => 204)
+    const stats = await deliverToSubscribers(kv, undefined, [feedEntry({})], post, 1)
+    expect(stats).toEqual({ attempted: 0, delivered: 0, pruned: 0, failed: 0, rejected: 0 })
+    expect(post).not.toHaveBeenCalled()
+  })
+  it('no-ops on an empty feed', async () => {
+    const kv = makeKV()
+    await seedSub(kv, URL_OK, FILTERS_ALL)
+    const post = vi.fn(async () => 204)
+    const stats = await deliverToSubscribers(kv, KEY, [], post, 1)
+    expect(stats).toEqual({ attempted: 0, delivered: 0, pruned: 0, failed: 0, rejected: 0 })
+    expect(post).not.toHaveBeenCalled()
+  })
+  it('prunes an undecryptable row (corrupt/rotated-away encUrl) without delivering', async () => {
+    const kv = makeKV()
+    const hash = await sha256Hex(URL_OK)
+    // Structurally malformed encUrl (not the keyId.iv.ct shape) → decryptUrl returns null → prune.
+    kv._store.set(`${SUB_PREFIX}${hash}`, JSON.stringify({ encUrl: 'garbage-no-dots', filters: FILTERS_ALL, type: 'discord', registeredAt: 'x', failCount: 0 }))
+    const post = vi.fn(async () => 204)
+    const stats = await deliverToSubscribers(kv, KEY, [feedEntry({})], post, 1)
+    expect(stats.pruned).toBe(1)
+    expect(post).not.toHaveBeenCalled()
+    expect(kv._store.has(`${SUB_PREFIX}${hash}`)).toBe(false)
+  })
+  it('multi-entry feed: bumps failCount once per cycle, not per entry', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL, 0)
+    const feed = [feedEntry({ key: 'alerted:new:i1' }), feedEntry({ key: 'alerted:new:i2' })]
+    await deliverToSubscribers(kv, KEY, feed, async () => 500, 1)
+    expect((await readConfirmed(kv, hash))?.failCount).toBe(1) // one bump for the whole cycle, not 2
+  })
+  it('multi-entry feed: a 410 mid-loop prunes and stops delivering remaining entries', async () => {
+    const kv = makeKV()
+    const hash = await seedSub(kv, URL_OK, FILTERS_ALL)
+    const feed = [feedEntry({ key: 'alerted:new:i1' }), feedEntry({ key: 'alerted:new:i2' })]
+    const post = vi.fn(async () => 410)
+    const stats = await deliverToSubscribers(kv, KEY, feed, post, 1)
+    expect(stats.pruned).toBe(1)
+    expect(post).toHaveBeenCalledTimes(1) // stopped after the first entry's 410
+    expect(kv._store.has(`${SUB_PREFIX}${hash}`)).toBe(false)
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -10,6 +10,7 @@ import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration, 
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, classifyLead, appendLeadDiag, readLeadDiag, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
 import { appendAlertFeed, readAlertFeed, buildFeedEntry, type AlertFeedEntry } from './alert-feed'
+import { subscribe as subscribeWebhook, confirm as confirmWebhook, updateFilters as updateWebhookFilters, unsubscribe as unsubscribeWebhook, sha256Hex as webhookSha256Hex } from './webhook-subscriptions'
 import { corsHeaders } from './cors'
 import { buildStatuslinePayload, isStatuslineRequest } from './statusline'
 import { EDGE_FALLBACK_ALERT_TTL_S, EDGE_FALLBACK_ALERT_KEY_PREFIX } from './edge-fallback-alert-keys'
@@ -18,6 +19,10 @@ interface Env {
   ALLOWED_ORIGIN: string
   DISCORD_WEBHOOK_URL?: string
   ANTHROPIC_API_KEY?: string
+  // #486: AES-256 key (64 hex chars) encrypting stored per-user webhook URLs. Set via
+  // `wrangler secret put WEBHOOK_ENC_KEY`. Absent/invalid → /api/webhook/subscribe fails closed
+  // (503), so server-side per-user delivery is simply disabled rather than storing plaintext URLs.
+  WEBHOOK_ENC_KEY?: string
   // #299: operator-only shared secret for POST /api/admin/analyze. Set via
   // `wrangler secret put ADMIN_API_KEY`. Separate from ANTHROPIC_API_KEY so it
   // can be rotated independently; absent secret → endpoint always 401.
@@ -44,6 +49,23 @@ const alertProxyRate = new Map<string, { start: number; count: number }>() // ra
 const deliveryCounter = { discord: 0, failed: 0 } // in-memory counter, flushed to KV by daily summary cron (Discord-only since #467)
 const webhookPingRate = new Map<string, { start: number; count: number }>() // rate limit for /api/webhook/ping
 const publicApiRate = new Map<string, { start: number; count: number }>() // rate limit for /api/v1/*
+// #486: per-IP rate limits for the server-side subscription endpoints. subscribe/update trigger an
+// outbound message to (or mutate) an arbitrary channel → 10/hour/IP; confirm is a code check →
+// 20/hour/IP (brute-force hardening atop the 10^6 code space + the KV-side global confirm budget).
+const webhookSubRate = new Map<string, { start: number; count: number }>()   // /subscribe + /update: 10/hour/IP
+const webhookConfirmRate = new Map<string, { start: number; count: number }>() // /confirm: 20/hour/IP
+const HOUR_MS = 3_600_000
+/** Fixed-window per-IP limiter (in-memory, per-isolate — same mechanism as the existing
+ *  alertProxyRate/webhookPingRate counters, just an hour window). Returns true if over the limit.
+ *  Fixed-window means up to 2× the limit can pass across a window boundary; acceptable for these
+ *  low-frequency endpoints where the KV global confirm budget is the real abuse ceiling. */
+function overRateLimit(map: Map<string, { start: number; count: number }>, ip: string, max: number, now: number): boolean {
+  const entry = map.get(ip)
+  if (entry && entry.count >= max && now - entry.start < HOUR_MS) return true
+  if (!entry || now - entry.start >= HOUR_MS) map.set(ip, { start: now, count: 1 })
+  else entry.count++
+  return false
+}
 
 interface DailyCounters {
   [serviceId: string]: { ok: number; total: number }
@@ -1873,6 +1895,118 @@ export default {
     // doesn't exist; this endpoint unconditionally overwrites.
     if (request.method === 'POST' && url.pathname === '/api/admin/rebuild-archive') {
       return handleAdminRebuildArchive(request, env, cors)
+    }
+
+    // #486 — server-side per-user Discord subscription endpoints. The browser POSTs the raw URL +
+    // filters here; the worker stores the AES-GCM-encrypted URL and (PR3) the cron fan-out delivers
+    // directly, so alerts fire tab-independently. Ownership is proven by a confirm code sent THROUGH
+    // the webhook channel (double opt-in / challenge-response) — channel control = identity, no
+    // account/PII. CORS-guarded like /api/alert; per-IP rate limited via overRateLimit.
+    if (request.method === 'POST' && url.pathname === '/api/webhook/subscribe') {
+      const origin = request.headers.get('Origin')
+      const cors = corsHeaders(origin, env.ALLOWED_ORIGIN)
+      const ip = request.headers.get('CF-Connecting-IP') || 'unknown'
+      const now = Date.now()
+      if (overRateLimit(webhookSubRate, ip, 10, now)) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+      try {
+        const body = await request.json() as { url?: string; filters?: unknown }
+        const hourBucket = new Date(now).toISOString().slice(0, 13) // YYYY-MM-DDTHH — hourly budget bucket
+        const result = await subscribeWebhook(
+          env.STATUS_CACHE, env.WEBHOOK_ENC_KEY, body.url ?? '', body.filters, hourBucket,
+          new Date(now).toISOString(),
+          // The confirm message is the channel-control challenge: posted to the webhook itself. The
+          // link is crawler-safe — /confirm GET only renders a page; activation is the button POST.
+          async (target, code) => {
+            try {
+              const h = await webhookSha256Hex(target)
+              const r = await fetch(target, {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: `🔔 **AIWatch** — confirm alerts for this channel:\nhttps://ai-watch.dev/confirm?h=${h}&c=${code}\n\n*(Ignore this message if you didn't request AIWatch alerts.)*` }),
+              })
+              r.body?.cancel()
+              if (!r.ok) console.warn(`[webhook/subscribe] confirm post rejected by Discord (${r.status})`)
+              return r.ok
+            } catch (err) {
+              console.warn('[webhook/subscribe] confirm post network error:', err instanceof Error ? err.message : err)
+              return false
+            }
+          },
+        )
+        if (!result.ok) {
+          return new Response(JSON.stringify({ error: result.error }), { status: result.status, headers: { ...cors, 'Content-Type': 'application/json' } })
+        }
+        // status: 'sent' (code dispatched) | 'pending' (code already in-flight) | 'confirmed'
+        // (already subscribed) — lets the SPA (PR2) show the right message without re-charging budget.
+        return new Response(JSON.stringify({ ok: true, hash: result.hash, status: result.status }), { headers: { ...cors, 'Content-Type': 'application/json' } })
+      } catch (err) {
+        console.error('[webhook/subscribe] error:', err instanceof Error ? err.message : err)
+        return new Response(JSON.stringify({ error: 'Internal error' }), { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+    }
+
+    if (request.method === 'POST' && url.pathname === '/api/webhook/confirm') {
+      const origin = request.headers.get('Origin')
+      const cors = corsHeaders(origin, env.ALLOWED_ORIGIN)
+      const ip = request.headers.get('CF-Connecting-IP') || 'unknown'
+      const now = Date.now()
+      if (overRateLimit(webhookConfirmRate, ip, 20, now)) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+      try {
+        const body = await request.json() as { hash?: string; code?: string }
+        const result = await confirmWebhook(env.STATUS_CACHE, body.hash ?? '', body.code ?? '', new Date(now).toISOString())
+        if (!result.ok) {
+          return new Response(JSON.stringify({ error: result.error }), { status: result.status, headers: { ...cors, 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify({ ok: true }), { headers: { ...cors, 'Content-Type': 'application/json' } })
+      } catch (err) {
+        console.error('[webhook/confirm] error:', err instanceof Error ? err.message : err)
+        return new Response(JSON.stringify({ error: 'Internal error' }), { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+    }
+
+    // Filters-only update on a confirmed sub — no new OTP (channel control already proven). A URL
+    // change is a new channel ⇒ the client must re-subscribe instead.
+    if (request.method === 'POST' && url.pathname === '/api/webhook/update') {
+      const origin = request.headers.get('Origin')
+      const cors = corsHeaders(origin, env.ALLOWED_ORIGIN)
+      const ip = request.headers.get('CF-Connecting-IP') || 'unknown'
+      const now = Date.now()
+      if (overRateLimit(webhookSubRate, ip, 10, now)) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+      try {
+        const body = await request.json() as { hash?: string; filters?: unknown }
+        const result = await updateWebhookFilters(env.STATUS_CACHE, body.hash ?? '', body.filters)
+        if (!result.ok) {
+          return new Response(JSON.stringify({ error: result.error }), { status: result.status, headers: { ...cors, 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify({ ok: true }), { headers: { ...cors, 'Content-Type': 'application/json' } })
+      } catch (err) {
+        console.error('[webhook/update] error:', err instanceof Error ? err.message : err)
+        return new Response(JSON.stringify({ error: 'Internal error' }), { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
+    }
+
+    // Unsubscribe = immediate complete deletion (privacy deletion path). hash-only, idempotent KV
+    // deletes; no rate limit (deleting a sub requires knowing the SHA-256 of the exact webhook URL,
+    // infeasible without the URL itself, so there's no useful abuse surface to throttle).
+    if (request.method === 'POST' && url.pathname === '/api/webhook/unsubscribe') {
+      const origin = request.headers.get('Origin')
+      const cors = corsHeaders(origin, env.ALLOWED_ORIGIN)
+      try {
+        const body = await request.json() as { hash?: string }
+        const result = await unsubscribeWebhook(env.STATUS_CACHE, body.hash ?? '')
+        if (!result.ok) {
+          return new Response(JSON.stringify({ error: result.error }), { status: result.status, headers: { ...cors, 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify({ ok: true }), { headers: { ...cors, 'Content-Type': 'application/json' } })
+      } catch (err) {
+        console.error('[webhook/unsubscribe] error:', err instanceof Error ? err.message : err)
+        return new Response(JSON.stringify({ error: 'Internal error' }), { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } })
+      }
     }
 
     // POST/DELETE /api/webhook/ping — track active webhook registrations (hashed, no raw URLs stored)

--- a/worker/src/webhook-subscriptions.ts
+++ b/worker/src/webhook-subscriptions.ts
@@ -1,0 +1,481 @@
+// Server-side per-user Discord alert subscriptions (#486).
+//
+// Why this exists: per-user Discord alerts were delivered browser-side (#467, #475) — the worker
+// only stored a hash of the URL and the browser did the POST. That meant alerts fired ONLY while a
+// dashboard tab was open (and were exposed to SW-cache version drift, multi-tab dupes, etc.). #486
+// moves delivery server-side: the worker stores the (encrypted) URL + filters and the cron fan-out
+// POSTs directly, so alerts fire tab-independently.
+//
+// AIWatch is anonymous (no login). To stop anyone registering SOMEONE ELSE'S webhook (a spam
+// vector), we prove **control of the channel**, not mere possession of the URL: subscribe sends a
+// one-time code THROUGH the webhook channel; the user must read it there and confirm. This combines
+// email double-opt-in with the webhook challenge-response pattern (webhooks.fyi). Channel control is
+// the identity — no account, email, or PII.
+//
+// This module is pure logic + Web Crypto + KV-key helpers; HTTP wiring lives in index.ts. The cron
+// fan-out (deliverToSubscribers) is defined here but NOT called yet — PR3 wires it after the browser
+// relay is removed in the same release, so the two paths never double-send (#486 cutover).
+
+import { kvPut, kvDel, isAllowedAlertWebhook } from './utils'
+import type { AlertFeedEntry, AlertKind } from './alert-feed'
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+/** Per-user delivery filters — mirrors the SPA Settings shape (alertCondition/Target/Services/
+ *  Incidents) so `shouldDeliver` stays byte-parity with the former client `shouldRelay` (#475). */
+export interface SubscriptionFilters {
+  alertCondition: 'down' | 'all'
+  alertTarget: 'all' | 'custom'
+  alertServices: string[]
+  alertIncidents: boolean
+}
+
+/** A pending (unconfirmed) subscription — holds the encrypted URL + the one-time code until the
+ *  user proves channel control via /confirm. TTL 15min (PENDING_TTL_S). */
+export interface PendingSubscription {
+  encUrl: string
+  code: string
+  filters: SubscriptionFilters
+  createdAt: string
+}
+
+/** A confirmed subscription — permanent (no TTL); pruned only on user unsubscribe or dead-webhook
+ *  detection. `failCount` tracks consecutive delivery failures for the prune rule. */
+export interface ConfirmedSubscription {
+  encUrl: string
+  filters: SubscriptionFilters
+  type: 'discord'
+  registeredAt: string
+  failCount: number
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+export const PENDING_PREFIX = 'webhook:pending:'
+export const SUB_PREFIX = 'webhook:sub:'
+export const SENT_PREFIX = 'webhook:sent:' // webhook:sent:{hash}:{alertKey} — per-sub delivery dedup
+export const CONFIRM_BUDGET_PREFIX = 'webhook:confirm:budget:' // hourly global confirm-message cap
+
+export const PENDING_TTL_S = 900 // 15 min — window to read the code in Discord and click confirm
+export const SENT_TTL_S = 7200 // 2h — per-sub dedup across overlapping crons (mirrors the 2h status-alert dedup TTL)
+export const CONFIRM_BUDGET_TTL_S = 7200 // 2h — covers the hourly bucket plus slack
+
+/** Global cap on confirm-messages sent per hour (abuse backstop — subscribe POSTs to an arbitrary
+ *  channel). Per-IP limits live in index.ts; this KV counter is the cross-isolate ceiling. */
+export const CONFIRM_BUDGET_MAX = 5000
+
+/** Consecutive delivery failures before a confirmed sub is pruned (~25min at the 5-min cron). 410/404
+ *  bypass this and prune immediately (handled in deliverToSubscribers). */
+export const MAX_FAIL_COUNT = 5
+
+// ── Hashing + code generation ───────────────────────────────────────────────
+
+/** SHA-256 hex of the webhook URL — the KV key suffix. Lets us dedup + delete without the raw URL
+ *  ever appearing in a key (matches the #467 ping-hash construction). */
+export async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** A 6-digit confirmation code (zero-padded). Uses crypto.getRandomValues — not Math.random — so
+ *  the code isn't predictable from timing. ~10^6 space + the per-IP confirm rate limit (index.ts). */
+export function generateCode(): string {
+  const buf = new Uint32Array(1)
+  crypto.getRandomValues(buf)
+  return String(buf[0] % 1_000_000).padStart(6, '0')
+}
+
+// ── AES-GCM encryption of the webhook URL ───────────────────────────────────
+//
+// Format (string): `{keyId}.{ivB64}.{ctB64}` — keyId lets the secret rotate without orphaning old
+// rows (decrypt picks the key by id). IV is a fresh 12-byte nonce per encryption (GCM requirement:
+// never reuse an IV under the same key). The key material is the WEBHOOK_ENC_KEY secret as 64 hex
+// chars (AES-256). Fail-closed: callers must treat a missing/short key as "subscriptions disabled".
+
+const ENC_KEY_ID = 'v1'
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+function bytesToB64(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin)
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+/** True if the secret is a usable AES-256 key (64 hex chars). Used to fail-closed at the endpoint. */
+export function isValidEncKey(keyHex: string | undefined): keyHex is string {
+  return typeof keyHex === 'string' && /^[0-9a-fA-F]{64}$/.test(keyHex)
+}
+
+async function importKey(keyHex: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', hexToBytes(keyHex), { name: 'AES-GCM' }, false, ['encrypt', 'decrypt'])
+}
+
+/** Encrypt a webhook URL → `{keyId}.{ivB64}.{ctB64}`. Throws if the key is invalid (caller fail-closes). */
+export async function encryptUrl(plaintext: string, keyHex: string): Promise<string> {
+  if (!isValidEncKey(keyHex)) throw new Error('WEBHOOK_ENC_KEY missing or invalid')
+  const key = await importKey(keyHex)
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(plaintext))
+  return `${ENC_KEY_ID}.${bytesToB64(iv)}.${bytesToB64(new Uint8Array(ct))}`
+}
+
+/** Decrypt `{keyId}.{ivB64}.{ctB64}` → URL. Returns null on any malformation / wrong key / tamper
+ *  (GCM auth failure) so a single bad row never throws inside the fan-out loop. */
+export async function decryptUrl(payload: string, keyHex: string): Promise<string | null> {
+  if (!isValidEncKey(keyHex)) return null
+  const parts = payload.split('.')
+  if (parts.length !== 3 || parts[0] !== ENC_KEY_ID) return null
+  try {
+    const key = await importKey(keyHex)
+    const iv = b64ToBytes(parts[1])
+    const ct = b64ToBytes(parts[2])
+    const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct)
+    return new TextDecoder().decode(pt)
+  } catch {
+    return null
+  }
+}
+
+// ── Filter validation + delivery decision ────────────────────────────────────
+
+const VALID_CONDITIONS = new Set(['down', 'all'])
+const VALID_TARGETS = new Set(['all', 'custom'])
+
+/** Coerce untrusted JSON into a safe SubscriptionFilters, defaulting anything missing/invalid to the
+ *  permissive baseline (all conditions, all services, incidents on) — the same defaults the SPA uses. */
+export function normalizeFilters(raw: unknown): SubscriptionFilters {
+  const r = (raw ?? {}) as Record<string, unknown>
+  const alertCondition = VALID_CONDITIONS.has(r.alertCondition as string) ? (r.alertCondition as 'down' | 'all') : 'all'
+  const alertTarget = VALID_TARGETS.has(r.alertTarget as string) ? (r.alertTarget as 'all' | 'custom') : 'all'
+  const alertServices = Array.isArray(r.alertServices)
+    ? r.alertServices.filter((s): s is string => typeof s === 'string').slice(0, 100)
+    : []
+  const alertIncidents = r.alertIncidents !== false // default on
+  return { alertCondition, alertTarget, alertServices, alertIncidents }
+}
+
+const INCIDENT_KINDS = new Set<AlertKind>(['new', 'resolved'])
+const STATUS_KINDS = new Set<AlertKind>(['down', 'degraded', 'recovered'])
+
+/** Whether a feed entry should be delivered to a subscriber, given their filters. Ported verbatim
+ *  from the former client `shouldRelay` (webhookAlerts.js) so server delivery matches what the
+ *  browser relay did (pinned by a parity test):
+ *   - alertTarget 'custom' → at least one covered service must be in alertServices.
+ *   - incident kinds (new/resolved) → gated by alertIncidents (default on).
+ *   - status kinds → alertCondition 'down' drops degraded; 'all' keeps everything. */
+export function shouldDeliver(entry: AlertFeedEntry, filters: SubscriptionFilters): boolean {
+  if (filters.alertTarget === 'custom' && !entry.svcIds?.some((id) => filters.alertServices.includes(id))) {
+    return false
+  }
+  if (INCIDENT_KINDS.has(entry.kind)) return filters.alertIncidents !== false
+  if (STATUS_KINDS.has(entry.kind)) {
+    if (filters.alertCondition === 'down' && entry.kind === 'degraded') return false
+    return true
+  }
+  return false // unknown kind — never deliver
+}
+
+// ── KV operations ────────────────────────────────────────────────────────────
+
+/** Reserve one unit of the hourly confirm-message budget. Returns false if the bucket is exhausted
+ *  (caller returns 503). Best-effort + APPROXIMATE: a KV read failure is treated as "allow" (see
+ *  below), and the get-then-put is non-atomic (KV has no atomic increment), so under concurrency the
+ *  cap can be slightly overshot and increments lost. That's acceptable — it's a coarse global
+ *  backstop, not a precise quota; the per-IP limiter does the fine-grained work. */
+export async function reserveConfirmBudget(kv: KVNamespace, hourBucket: string): Promise<boolean> {
+  const key = `${CONFIRM_BUDGET_PREFIX}${hourBucket}`
+  let count = 0
+  try {
+    const raw = await kv.get(key)
+    count = raw ? parseInt(raw, 10) || 0 : 0
+  } catch (err) {
+    // KV read failed — fail OPEN (don't hard-block subscribes on a transient KV blip); the per-IP
+    // limiter is still the first line of defense. Log loudly: this disables the global abuse cap, so
+    // a persistent KV failure here is a real (if rare) weakening of the spam ceiling.
+    console.warn('[webhook-budget] KV read failed, allowing (global cap disabled this call):', err instanceof Error ? err.message : err)
+    return true
+  }
+  if (count >= CONFIRM_BUDGET_MAX) return false
+  await kvPut(kv, key, String(count + 1), { expirationTtl: CONFIRM_BUDGET_TTL_S })
+  return true
+}
+
+/** Store a pending subscription (15min TTL). Caller has already validated the URL + reserved budget. */
+export async function putPending(kv: KVNamespace, hash: string, pending: PendingSubscription): Promise<boolean> {
+  return kvPut(kv, `${PENDING_PREFIX}${hash}`, JSON.stringify(pending), { expirationTtl: PENDING_TTL_S })
+}
+
+export async function readPending(kv: KVNamespace, hash: string): Promise<PendingSubscription | null> {
+  try {
+    const raw = await kv.get(`${PENDING_PREFIX}${hash}`)
+    return raw ? (JSON.parse(raw) as PendingSubscription) : null
+  } catch {
+    return null
+  }
+}
+
+/** Promote a confirmed sub to permanent storage (no TTL). Metadata carries type for fast list reads. */
+export async function putConfirmed(kv: KVNamespace, hash: string, sub: ConfirmedSubscription): Promise<boolean> {
+  try {
+    await kv.put(`${SUB_PREFIX}${hash}`, JSON.stringify(sub), { metadata: { type: sub.type } })
+    return true
+  } catch (err) {
+    console.warn('[webhook-sub] putConfirmed failed:', err instanceof Error ? err.message : err)
+    return false
+  }
+}
+
+export async function readConfirmed(kv: KVNamespace, hash: string): Promise<ConfirmedSubscription | null> {
+  try {
+    const raw = await kv.get(`${SUB_PREFIX}${hash}`)
+    return raw ? (JSON.parse(raw) as ConfirmedSubscription) : null
+  } catch {
+    return null
+  }
+}
+
+export async function deletePending(kv: KVNamespace, hash: string): Promise<void> {
+  await kvDel(kv, `${PENDING_PREFIX}${hash}`)
+}
+
+export async function deleteConfirmed(kv: KVNamespace, hash: string): Promise<void> {
+  await kvDel(kv, `${SUB_PREFIX}${hash}`)
+}
+
+/** List all confirmed-sub hashes, paginating the KV `list` cursor until complete (1000 keys/page —
+ *  never assume a single call; #486 acceptance criterion). Returns the bare hashes (key minus prefix). */
+export async function listConfirmedHashes(kv: KVNamespace): Promise<string[]> {
+  const hashes: string[] = []
+  let cursor: string | undefined
+  for (;;) {
+    const res = await kv.list({ prefix: SUB_PREFIX, cursor })
+    for (const k of res.keys) hashes.push(k.name.slice(SUB_PREFIX.length))
+    if (res.list_complete) break
+    cursor = res.cursor
+    if (!cursor) break
+  }
+  return hashes
+}
+
+// ── Subscribe / confirm / update / unsubscribe (pure-ish orchestration) ──────
+//
+// These return a small result object the HTTP layer maps to a status code, keeping index.ts thin and
+// the decision logic unit-testable.
+
+export type SubscribeResult =
+  | { ok: true; hash: string; status: 'confirmed' | 'pending' | 'sent' }
+  | { ok: false; status: 400 | 403 | 500 | 502 | 503; error: string }
+
+/** Validate URL → dedup → reserve budget → send the confirm message → store pending. The confirm
+ *  message is posted to the webhook itself (the channel-control challenge). On a Discord POST failure
+ *  we return 502 and store nothing (the user has no code, so there's nothing to confirm) — the user
+ *  can simply retry.
+ *
+ *  Dedup (the anti-abuse guard the double-opt-in exists for): if this channel is ALREADY confirmed,
+ *  or a pending confirmation is still in its 15-min window, we return ok WITHOUT charging the global
+ *  budget or re-posting to the channel. Otherwise a client re-POSTing /subscribe for a channel it
+ *  controls would re-spam the channel and drain the 5000/hour global budget (only the per-isolate
+ *  per-IP limit would push back). `status` tells the caller which case fired. */
+export async function subscribe(
+  kv: KVNamespace,
+  encKey: string | undefined,
+  url: string,
+  rawFilters: unknown,
+  hourBucket: string,
+  now: string,
+  postConfirmMessage: (url: string, code: string) => Promise<boolean>,
+): Promise<SubscribeResult> {
+  if (!isValidEncKey(encKey)) return { ok: false, status: 503, error: 'Subscriptions unavailable' } // fail-closed
+  if (typeof url !== 'string' || !isAllowedAlertWebhook(url)) return { ok: false, status: 403, error: 'Webhook URL not allowed' }
+
+  const hash = await sha256Hex(url)
+  // Already subscribed → idempotent no-op (no send, no budget charge). Prevents re-spam of a channel
+  // the caller already controls. Filter changes go through /update, not a re-subscribe.
+  if (await readConfirmed(kv, hash)) return { ok: true, hash, status: 'confirmed' }
+  // A confirmation is still pending in its window → don't re-send / re-charge; tell the user to check
+  // their channel for the code that's already there.
+  if (await readPending(kv, hash)) return { ok: true, hash, status: 'pending' }
+
+  const budgetOk = await reserveConfirmBudget(kv, hourBucket)
+  if (!budgetOk) return { ok: false, status: 503, error: 'Confirmation budget exceeded, try later' }
+
+  const code = generateCode()
+  const sent = await postConfirmMessage(url, code)
+  if (!sent) return { ok: false, status: 502, error: 'Could not deliver confirmation to the webhook' }
+
+  const encUrl = await encryptUrl(url, encKey)
+  const pending: PendingSubscription = { encUrl, code, filters: normalizeFilters(rawFilters), createdAt: now }
+  const stored = await putPending(kv, hash, pending)
+  if (!stored) return { ok: false, status: 500, error: 'Storage error' }
+  return { ok: true, hash, status: 'sent' }
+}
+
+export type ConfirmResult =
+  | { ok: true }
+  | { ok: false; status: 400 | 410 | 500; error: string }
+
+/** Confirm a pending subscription: match the code, promote to a permanent confirmed sub, drop the
+ *  pending row. Constant-ish-time code compare is unnecessary (per-IP rate limit + 10^6 space), but
+ *  we still require an exact match. Expired/missing pending (TTL gone) → 410. A KV write failure
+ *  (server fault) → 500, not 400, so the client knows to retry rather than treating it as bad input. */
+export async function confirm(
+  kv: KVNamespace,
+  hash: string,
+  code: string,
+  now: string,
+): Promise<ConfirmResult> {
+  if (!/^[a-f0-9]{64}$/.test(hash) || !/^\d{6}$/.test(code)) return { ok: false, status: 400, error: 'Invalid request' }
+  const pending = await readPending(kv, hash)
+  if (!pending) return { ok: false, status: 410, error: 'Confirmation expired or not found' }
+  if (pending.code !== code) return { ok: false, status: 400, error: 'Incorrect code' }
+  const sub: ConfirmedSubscription = {
+    encUrl: pending.encUrl,
+    filters: pending.filters,
+    type: 'discord',
+    registeredAt: now,
+    failCount: 0,
+  }
+  const ok = await putConfirmed(kv, hash, sub)
+  if (!ok) return { ok: false, status: 500, error: 'Storage error' }
+  // Promote-then-delete: if this delete fails the pending row TTLs out in ≤15min (benign), whereas
+  // deleting first then failing to promote would lose a confirmed sub — so this ordering is correct.
+  await deletePending(kv, hash)
+  return { ok: true }
+}
+
+export type UpdateResult = { ok: true } | { ok: false; status: 400 | 404 | 500; error: string }
+
+/** Filters-only update on an already-confirmed sub — no new OTP (channel control already proven).
+ *  A URL change is NOT this path: it's a new channel ⇒ must re-subscribe (new hash + OTP). A KV write
+ *  failure → 500 (server fault, retryable), not 400. */
+export async function updateFilters(kv: KVNamespace, hash: string, rawFilters: unknown): Promise<UpdateResult> {
+  if (!/^[a-f0-9]{64}$/.test(hash)) return { ok: false, status: 400, error: 'Invalid request' }
+  const sub = await readConfirmed(kv, hash)
+  if (!sub) return { ok: false, status: 404, error: 'Subscription not found' }
+  sub.filters = normalizeFilters(rawFilters)
+  const ok = await putConfirmed(kv, hash, sub)
+  if (!ok) return { ok: false, status: 500, error: 'Storage error' }
+  return { ok: true }
+}
+
+/** Unsubscribe = immediate complete deletion (the privacy deletion path). Also clears any pending. */
+export async function unsubscribe(kv: KVNamespace, hash: string): Promise<UpdateResult> {
+  if (!/^[a-f0-9]{64}$/.test(hash)) return { ok: false, status: 400, error: 'Invalid request' }
+  await deleteConfirmed(kv, hash)
+  await deletePending(kv, hash)
+  return { ok: true }
+}
+
+// ── Cron fan-out (defined here, wired in PR3) ────────────────────────────────
+
+export interface DeliveryStats {
+  attempted: number
+  delivered: number
+  pruned: number
+  failed: number
+  /** Per-sub async fns that rejected unexpectedly (should be ~0 — the loop body catches its own KV/
+   *  fetch errors). A non-zero count means an un-guarded await slipped in; surfaced so the cron can
+   *  log it rather than have allSettled swallow it invisibly. */
+  rejected: number
+}
+
+/** Classify a Discord delivery HTTP status into the prune/retry decision (#486):
+ *   - 410/404 → prune immediately (webhook deleted / gone — unrecoverable)
+ *   - 2xx     → success (reset failCount)
+ *   - else (429/5xx/network) → retry; increment failCount; prune at MAX_FAIL_COUNT */
+export type DeliveryOutcome = 'success' | 'prune' | 'retry'
+export function classifyDelivery(status: number | null): DeliveryOutcome {
+  if (status === 410 || status === 404) return 'prune'
+  if (status !== null && status >= 200 && status < 300) return 'success'
+  return 'retry'
+}
+
+/** Fan-out the recent alert feed to all confirmed subscribers. Each sub: decrypt URL → filter →
+ *  dedup (webhook:sent:) → POST. Isolated per sub (one dead webhook never blocks the rest). Dead
+ *  webhooks (410/404, or MAX_FAIL_COUNT consecutive retries) are pruned. NOT called yet — PR3 wires
+ *  this into the cron AFTER the browser relay is removed, so the two paths never double-send.
+ *
+ *  `postEmbed` returns the HTTP status (or null on network error) so classifyDelivery can decide. */
+export async function deliverToSubscribers(
+  kv: KVNamespace,
+  encKey: string | undefined,
+  feed: AlertFeedEntry[],
+  postEmbed: (url: string, entry: AlertFeedEntry) => Promise<number | null>,
+  now: number,
+): Promise<DeliveryStats> {
+  const stats: DeliveryStats = { attempted: 0, delivered: 0, pruned: 0, failed: 0, rejected: 0 }
+  if (!isValidEncKey(encKey) || feed.length === 0) return stats
+
+  const hashes = await listConfirmedHashes(kv)
+  const results = await Promise.allSettled(
+    hashes.map(async (hash) => {
+      const sub = await readConfirmed(kv, hash)
+      if (!sub) return
+      const url = await decryptUrl(sub.encUrl, encKey)
+      if (!url) {
+        // Undecryptable row (key rotated away / corrupt) — prune so it can't wedge the loop forever.
+        await deleteConfirmed(kv, hash)
+        stats.pruned++
+        return
+      }
+      let sawFailure = false
+      for (const entry of feed) {
+        if (!shouldDeliver(entry, sub.filters)) continue
+        const sentKey = `${SENT_PREFIX}${hash}:${entry.key}`
+        const already = await kv.get(sentKey).catch(() => null)
+        if (already) continue
+        stats.attempted++
+        const status = await postEmbed(url, entry).catch(() => null)
+        const outcome = classifyDelivery(status)
+        if (outcome === 'prune') {
+          await deleteConfirmed(kv, hash)
+          stats.pruned++
+          return // webhook is gone — stop delivering to it this cycle
+        }
+        if (outcome === 'success') {
+          stats.delivered++
+          await kvPut(kv, sentKey, '1', { expirationTtl: SENT_TTL_S })
+        } else {
+          sawFailure = true
+          stats.failed++
+        }
+      }
+      // Update failCount once per sub per cycle: reset on a clean cycle, bump (and maybe prune) on failure.
+      if (sawFailure) {
+        const next = (sub.failCount ?? 0) + 1
+        if (next >= MAX_FAIL_COUNT) {
+          await deleteConfirmed(kv, hash)
+          stats.pruned++
+        } else {
+          sub.failCount = next
+          await putConfirmed(kv, hash, sub)
+        }
+      } else if ((sub.failCount ?? 0) > 0) {
+        sub.failCount = 0
+        await putConfirmed(kv, hash, sub)
+      }
+    }),
+  )
+  // allSettled is used so one bad sub can't block the rest — but a swallowed rejection would make a
+  // subscriber silently vanish from delivery with no breadcrumb. Surface it: count + log the first few
+  // reasons so an operator can diagnose, instead of trusting the per-sub catches forever.
+  const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+  if (rejected.length > 0) {
+    stats.rejected = rejected.length
+    console.error('[webhook-deliver] unexpected per-sub rejections:', rejected.length, rejected.slice(0, 3).map((r) => r.reason instanceof Error ? r.reason.message : r.reason))
+  }
+  return stats
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -5,5 +5,9 @@ export default defineConfig({
   test: {
     root: path.resolve(__dirname),
     include: ['src/**/*.test.ts'],
+    // Map global `crypto` to Node's webcrypto when the test runtime doesn't expose it (older Node in
+    // CI). The worker uses crypto.subtle (AES-GCM + SHA-256, webhook-subscriptions.ts) as a Workers
+    // runtime global; Node 20+ provides it, this is a no-op there and a safety net otherwise.
+    setupFiles: ['vitest.setup.ts'],
   },
 })

--- a/worker/vitest.setup.ts
+++ b/worker/vitest.setup.ts
@@ -1,0 +1,10 @@
+// Vitest (node env) does not expose the Web Crypto API as a global the way the Cloudflare Workers
+// runtime does. The worker uses `crypto.subtle` / `crypto.getRandomValues` (e.g. webhook-
+// subscriptions.ts AES-GCM + SHA-256, index.ts rate-limit hashing), so map the global to Node's
+// webcrypto when missing. No-op in any environment that already provides a working subtle.
+import { webcrypto } from 'node:crypto'
+
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle === 'undefined') {
+  // @ts-expect-error — assigning the Node webcrypto implementation to the global slot
+  globalThis.crypto = webcrypto
+}


### PR DESCRIPTION
**PR1 of #486** — worker backend for tab-independent per-user Discord alert delivery. Replaces the browser relay (#467/#475) whose alerts only fired while a dashboard tab was open. This PR adds storage + endpoints + a **dormant** cron fan-out; PR2 adds the SPA UI, PR3 wires the fan-out and removes the relay in a single cutover (so the two paths never double-send).

## Design — channel-control double opt-in
AIWatch is anonymous (no login), so we prove **control of the channel** rather than mere possession of the URL: `subscribe` posts a 6-digit code THROUGH the webhook channel; the user reads it there and confirms. Channel control = identity (anti-spam). Combines email double-opt-in + the webhook challenge-response pattern (webhooks.fyi).

## What's in this PR
- **`worker/src/webhook-subscriptions.ts`** (new): AES-256-GCM URL encryption (`WEBHOOK_ENC_KEY`, keyId envelope for rotation, **fail-closed** when absent → 503), `shouldDeliver` (verbatim parity with the client `shouldRelay`), `classifyDelivery` (410/404 prune vs retry), `reserveConfirmBudget` (hourly global cap, fail-open + logged), cursor-paginated `listConfirmedHashes`, subscribe/confirm/updateFilters/unsubscribe, and `deliverToSubscribers` (**defined, NOT wired** — PR3).
- **`worker/src/index.ts`**: `/api/webhook/subscribe|confirm|update|unsubscribe` with a fixed-window per-IP limiter (subscribe/update 10/h, confirm 20/h); `WEBHOOK_ENC_KEY` env; the channel-control confirm-message sender.
- **KV keys**: `webhook:pending:{hash}` (15m), `webhook:sub:{hash}` (permanent), `webhook:sent:{hash}:{alertKey}` (2h dedup), `webhook:confirm:budget:{YYYY-MM-DDTHH}` (5000/h global cap).
- Subscribe **dedup**: already-confirmed/pending → no re-send, no budget charge (the anti-abuse guard the opt-in exists for).

## Out of scope (later PRs)
- **PR2**: SPA Settings 2-step UI + `/confirm` landing page + re-subscribe prompt.
- **PR3**: wire `deliverToSubscribers` into the cron, remove the browser relay (`runWebhookAlerts`), Privacy policy update.

## Deploy note
Needs a `WEBHOOK_ENC_KEY` worker secret (`openssl rand -hex 32` → `wrangler secret put`). Until set, subscribe fail-closes at 503 — safe for PR1 since the fan-out isn't wired.

## Test plan
- [x] `npm run test:worker` — **1384 pass** (52 files; new `webhook-subscriptions.test.ts`: crypto round-trip/tamper/wrong-key, fail-closed, SSRF + legacy `discordapp.com`, subscribe→confirm, wrong-code, dedup, prune 410/404 + MAX_FAIL_COUNT, failCount reset, budget cap, cursor pagination, `shouldDeliver`↔`shouldRelay` parity matrix, multi-entry fan-out)
- [x] `wrangler deploy --config worker/wrangler.toml --dry-run` — clean build
- [x] Local verify (`wrangler dev` + curl): subscribe 403/503, confirm 400/410, update 404, unsubscribe 200, rate-limit 429
- [x] `/pr-review-toolkit:review-pr` — 2 rounds, converged (0 Critical/Important)
- [ ] Verify Vercel Preview (worker-only — no frontend surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)