### PR TITLE
fix(worker): fix weekly briefing — incidents always empty, changelog date bleed, cron timing

### DIFF
--- a/worker/src/__tests__/weekly-briefing.test.ts
+++ b/worker/src/__tests__/weekly-briefing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary, type WeeklyBriefingData } from '../weekly-briefing'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary, parseMonthlyIncidents, filterChangelogToWeek, type WeeklyBriefingData } from '../weekly-briefing'
 
 describe('getWeekRange', () => {
   it('returns Mon–Sun for a Wednesday', () => {
@@ -144,6 +144,100 @@ describe('buildWeeklyBriefing', () => {
     }
     const result = buildWeeklyBriefing(data)
     expect(result).not.toContain('Security')
+  })
+})
+
+describe('filterChangelogToWeek', () => {
+  it('excludes entries before weekStart and includes entries within the window', () => {
+    // Regression: changelog:entries KV accumulates 14 days; without this filter
+    // the weekly briefing showed entries from before the current week (e.g. 5/22 in 5/25-5/31).
+    const entries = [
+      { source: 'anthropic', title: 'Project Glasswing', url: 'https://anthropic.com/glasswing', date: '2026-05-22T00:00:00Z' }, // outside week
+      { source: 'openai', title: 'Codex Enterprise', url: 'https://openai.com/blog/codex', date: '2026-05-27T00:00:00Z' },       // inside week
+      { source: 'anthropic', title: 'Claude Opus 4.8', url: 'https://anthropic.com/news/opus', date: '2026-05-29T00:00:00Z' },    // inside week
+    ]
+    const result = filterChangelogToWeek(entries, '2026-05-25', '2026-05-31')
+    expect(result).toHaveLength(2)
+    expect(result.every((e) => e.title !== 'Project Glasswing')).toBe(true)
+  })
+
+  it('includes entries on weekEnd day up to 23:59:59Z', () => {
+    const entries = [
+      { source: 'openai', title: 'Last day entry', url: 'https://openai.com', date: '2026-05-31T23:59:00Z' },
+      { source: 'openai', title: 'Next day entry', url: 'https://openai.com', date: '2026-06-01T00:00:00Z' },
+    ]
+    const result = filterChangelogToWeek(entries, '2026-05-25', '2026-05-31')
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Last day entry')
+  })
+
+  it('returns empty array when no entries fall in the window', () => {
+    const entries = [
+      { source: 'anthropic', title: 'Old news', url: 'https://anthropic.com', date: '2026-05-10T00:00:00Z' },
+    ]
+    expect(filterChangelogToWeek(entries, '2026-05-25', '2026-05-31')).toEqual([])
+  })
+})
+
+describe('parseMonthlyIncidents', () => {
+  const svcNames = { claude: 'Claude API', openai: 'OpenAI API' }
+
+  it('flattens nested services.incidents into a flat list with serviceId/serviceName', () => {
+    const raw = {
+      services: {
+        claude: {
+          incidents: [
+            { id: 'inc-1', title: 'Outage', startedAt: '2026-05-28T10:00:00Z', durationMin: 90 },
+          ],
+        },
+        openai: {
+          incidents: [
+            { id: 'inc-2', title: 'Degraded', startedAt: '2026-05-29T08:00:00Z', durationMin: 30 },
+          ],
+        },
+      },
+    }
+    const result = parseMonthlyIncidents(raw, svcNames)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ id: 'inc-1', serviceId: 'claude', serviceName: 'Claude API', duration: '1h 30m' })
+    expect(result[1]).toMatchObject({ id: 'inc-2', serviceId: 'openai', serviceName: 'OpenAI API', duration: '30m' })
+  })
+
+  it('returns empty array for a root-level incidents key (old bug: was reading .incidents at root)', () => {
+    // This validates that the old pattern JSON.parse(mRaw).incidents would have returned undefined
+    const raw = { incidents: [{ id: 'inc-1' }] } as unknown as Parameters<typeof parseMonthlyIncidents>[0]
+    const result = parseMonthlyIncidents(raw, svcNames)
+    expect(result).toHaveLength(0) // no .services → empty, not the stale root .incidents
+  })
+
+  it('handles services with no incidents array (backward compat)', () => {
+    const raw = { services: { claude: { count: 2, totalMinutes: 60 } } } as unknown as Parameters<typeof parseMonthlyIncidents>[0]
+    const result = parseMonthlyIncidents(raw, svcNames)
+    expect(result).toHaveLength(0)
+  })
+
+  it('converts durationMin to duration string correctly', () => {
+    const raw = {
+      services: {
+        claude: {
+          incidents: [
+            { id: 'a', title: 'T', startedAt: '2026-05-01T00:00:00Z', durationMin: 120 },
+            { id: 'b', title: 'T', startedAt: '2026-05-01T00:00:00Z', durationMin: 45 },
+            { id: 'c', title: 'T', startedAt: '2026-05-01T00:00:00Z', durationMin: 0 },
+          ],
+        },
+      },
+    }
+    const result = parseMonthlyIncidents(raw, svcNames)
+    expect(result[0].duration).toBe('2h')
+    expect(result[1].duration).toBe('45m')
+    expect(result[2].duration).toBeNull()
+  })
+
+  it('uses svcId as fallback serviceName when not in map', () => {
+    const raw = { services: { unknown_svc: { incidents: [{ id: 'x', title: 'T', startedAt: '2026-05-01T00:00:00Z' }] } } }
+    const result = parseMonthlyIncidents(raw, {})
+    expect(result[0].serviceName).toBe('unknown_svc')
   })
 })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -870,7 +870,7 @@ import { detectSecurityAlerts, fetchOSVAlerts, formatSecurityDigest, securityDet
 import { detectNewRepos, formatGitHubAlert } from './competitive'
 import { buildDailySummary, isInSummaryWindow } from './daily-summary'
 import { collectChangelogs, getStaleSources } from './changelog'
-import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary } from './weekly-briefing'
+import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyBriefing, buildSecuritySummary, parseMonthlyIncidents, filterChangelogToWeek } from './weekly-briefing'
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, cacheProbeSummaries, getCachedProbeSummaries, type ProbeDailyData } from './probe-archival'
 import type { ProbeSummary, Incident } from './types'
@@ -1229,7 +1229,10 @@ async function handleAdminRebuildArchive(request: Request, env: Env, cors: Recor
 }
 
 export default {
-  async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
+  async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
+    // Use the scheduled trigger time (not wall-clock) so time-of-day checks like
+    // `minutes === 0` remain accurate even when cronAlertCheck takes 60+ seconds.
+    const scheduledNow = new Date(event.scheduledTime)
     // Health check probing (Phase 2) — runs every cron cycle
     if (env.STATUS_CACHE) {
       await writeProbeSnapshot(env.STATUS_CACHE).catch((err) =>
@@ -1316,7 +1319,7 @@ export default {
 
     // Reddit community monitoring — runs once per hour (minute 0-4) to respect rate limits
     // KV budget: max 5 writes/hour = 120/day (trivial against the Workers Paid 1M/month inclusion)
-    const now = new Date()
+    const now = scheduledNow
     if (env.STATUS_CACHE && env.DISCORD_WEBHOOK_URL && now.getUTCMinutes() < 5) {
       try {
         const redditAlerts = await detectRedditPosts(env.STATUS_CACHE)
@@ -1492,21 +1495,35 @@ export default {
         if (!alreadySent) {
           const { start: weekStart, end: weekEnd } = getWeekRange(now)
 
-          // Read changelog entries accumulated this week
+          // Read changelog entries accumulated this week, filtered to the briefing window
           const changelogRaw = await env.STATUS_CACHE.get('changelog:entries').catch(() => null)
-          let changelog: unknown[] = []
-          if (changelogRaw) { try { changelog = JSON.parse(changelogRaw) } catch { console.warn('[cron] changelog entries parse failed') } }
+          let changelog: import('./changelog').ChangelogEntry[] = []
+          if (changelogRaw) {
+            try {
+              const all = JSON.parse(changelogRaw)
+              if (!Array.isArray(all)) {
+                console.warn('[cron] changelog entries: expected array, got', typeof all)
+              } else {
+                changelog = filterChangelogToWeek(all, weekStart, weekEnd)
+              }
+            } catch (err) { console.warn('[cron] changelog entries parse failed:', err instanceof Error ? err.message : String(err)) }
+          }
 
-          // Read monthly incidents for incident summary (check both current and previous month for week spanning month boundary)
-          const allMonthlyIncidents: unknown[] = []
-          const currMonthKey = `incidents:monthly:${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+          // Read monthly incidents for incident summary (current + previous month for week spanning boundary).
+          const allMonthlyIncidents: Parameters<typeof buildIncidentSummary>[0] = []
+          const serviceNameMap: Record<string, string> = {}
+          for (const svc of SERVICES) serviceNameMap[svc.id] = svc.name
+          const currMonthKey = `incidents:monthly:${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
           const prevMonth = new Date(now); prevMonth.setUTCMonth(prevMonth.getUTCMonth() - 1)
-          const prevMonthKey = `incidents:monthly:${prevMonth.getFullYear()}-${String(prevMonth.getMonth() + 1).padStart(2, '0')}`
+          const prevMonthKey = `incidents:monthly:${prevMonth.getUTCFullYear()}-${String(prevMonth.getUTCMonth() + 1).padStart(2, '0')}`
           for (const mk of [currMonthKey, prevMonthKey]) {
             const mRaw = await env.STATUS_CACHE.get(mk).catch(() => null)
-            if (mRaw) { try { allMonthlyIncidents.push(...(JSON.parse(mRaw).incidents ?? [])) } catch { console.warn(`[cron] ${mk} parse failed`) } }
+            if (!mRaw) continue
+            try {
+              allMonthlyIncidents.push(...parseMonthlyIncidents(JSON.parse(mRaw), serviceNameMap))
+            } catch (err) { console.warn(`[cron] ${mk} parse failed:`, err instanceof Error ? err.message : String(err)) }
           }
-          const incidents = buildIncidentSummary(allMonthlyIncidents as Parameters<typeof buildIncidentSummary>[0], weekStart, weekEnd)
+          const incidents = buildIncidentSummary(allMonthlyIncidents, weekStart, weekEnd)
 
           // Read daily uptime counters for stability comparison
           const thisWeekCounters: Record<string, { ok: number; total: number }> = {}

--- a/worker/src/weekly-briefing.ts
+++ b/worker/src/weekly-briefing.ts
@@ -3,6 +3,7 @@
 
 import type { ChangelogEntry, StaleSourceInfo } from './changelog'
 import { formatChangelogSection, formatStaleSourcesWarning } from './changelog'
+import type { MonthlyIncidentEntry } from './monthly-archive'
 
 export interface WeeklyIncidentSummary {
   serviceId: string
@@ -33,6 +34,55 @@ export interface WeeklyBriefingData {
   security?: WeeklySecuritySummary
   /** Per-source last-fetch staleness — surfaces silent collection gaps (#274) */
   staleSources?: StaleSourceInfo[]
+}
+
+/**
+ * Filter accumulated changelog entries to the given week window (Mon 00:00Z – Sun 23:59:59Z).
+ * changelog:entries KV keeps the last 50 entries over 14 days; without this filter
+ * the briefing would include entries from before the current week.
+ */
+export function filterChangelogToWeek(entries: ChangelogEntry[], weekStart: string, weekEnd: string): ChangelogEntry[] {
+  const startMs = new Date(weekStart).getTime()
+  const endMs = new Date(weekEnd + 'T23:59:59Z').getTime()
+  return entries.filter((e) => {
+    if (!e.date) return false
+    const ts = new Date(e.date).getTime()
+    return !isNaN(ts) && ts >= startMs && ts <= endMs
+  })
+}
+
+/**
+ * Flatten incidents:monthly:YYYY-MM KV value into the flat array expected by
+ * buildIncidentSummary. The KV format is { services: { [svcId]: { incidents: [] } } }
+ * — incidents are nested per service, not at the root level.
+ */
+export function parseMonthlyIncidents(
+  raw: unknown,
+  serviceNames: Record<string, string>,
+): Parameters<typeof buildIncidentSummary>[0] {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    console.warn('[weekly-briefing] parseMonthlyIncidents: unexpected root type', typeof raw)
+    return []
+  }
+  const services = (raw as Record<string, unknown>).services
+  if (services !== undefined && (typeof services !== 'object' || Array.isArray(services) || services === null)) {
+    console.warn('[weekly-briefing] parseMonthlyIncidents: services is not an object', typeof services)
+    return []
+  }
+  const out: Parameters<typeof buildIncidentSummary>[0] = []
+  for (const [svcId, svcData] of Object.entries((services ?? {}) as Record<string, { incidents?: MonthlyIncidentEntry[] }>)) {
+    for (const inc of (svcData.incidents ?? [])) {
+      if (!inc.id || !inc.startedAt || !inc.title) {
+        console.warn(`[weekly-briefing] parseMonthlyIncidents: skipping ${svcId} incident with missing required fields`, { id: inc.id, startedAt: inc.startedAt })
+        continue
+      }
+      const dm = inc.durationMin ?? 0
+      const h = Math.floor(dm / 60), m = dm % 60
+      const duration = dm > 0 ? (h > 0 && m > 0 ? `${h}h ${m}m` : h > 0 ? `${h}h` : `${m}m`) : null
+      out.push({ id: inc.id, serviceId: svcId, serviceName: serviceNames[svcId] ?? svcId, title: inc.title, startedAt: inc.startedAt, duration })
+    }
+  }
+  return out
 }
 
 /**


### PR DESCRIPTION
## Summary

Three bugs in the Sunday weekly Discord briefing:

- **Incident summary always "No incidents"**: code read `JSON.parse(mRaw).incidents` but `incidents:monthly` KV stores `{ services: { [svcId]: { incidents: [] } } }` — no `.incidents` at the root. Extracted `parseMonthlyIncidents()` with proper nested-service flattening + field validation.

- **Entries from outside the week (e.g. 5/22 in 5/25–5/31 briefing)**: `changelog:entries` KV accumulates 14 days but was passed unfiltered. Extracted `filterChangelogToWeek()` and apply it before building.

- **Hourly changelog RSS silently skipped**: `const now = new Date()` was called AFTER `cronAlertCheck()` (33 parallel fetches, 60+ s wall-clock), so `now.getUTCMinutes()` read `1` instead of `0` — failing the `=== 0` gate every hour. Fixed with `event.scheduledTime`.

## Additional improvements (from PR review)

- Import canonical `MonthlyIncidentEntry` from `monthly-archive.ts` instead of re-defining it
- Add array shape-check before filtering changelog JSON; pass `unknown` to `parseMonthlyIncidents`
- Add root/services shape-check in `parseMonthlyIncidents` with warn logs
- Log actual error messages in catch blocks (not just "parse failed")
- Switch month key builders to `getUTCFullYear()`/`getUTCMonth()` for UTC consistency

## Test plan

- [ ] 8 new Vitest tests added (1407 → 1415); all 55 test files pass
- [ ] `wrangler deploy --dry-run` passes
- [ ] Anthropic news page confirmed to contain "Introducing Claude Opus 4.8" (2026-05-28) — parser correctly extracts it; next UTC :00 cron will pick it up after deploy