### PR TITLE
feat(worker): add Workers Analytics Engine for statusline traffic measurement (closes #494)

### DIFF
--- a/worker/src/__tests__/statusline.test.ts
+++ b/worker/src/__tests__/statusline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildStatuslinePayload, isStatuslineRequest } from '../statusline'
 import type { ServiceStatus } from '../types'
 
@@ -71,6 +71,60 @@ describe('/api/status/cached statusline routing contract (#438)', () => {
   it('routes untagged + non-statusline requests to the full path', () => {
     expect(dispatch('', { services: [] }).path).toBe('full')
     expect(dispatch('src=dashboard', { services: [] }).path).toBe('full')
+  })
+})
+
+describe('WAE writeDataPoint contract (#494)', () => {
+  // Mirrors the WAE branch in the index.ts statusline handler.
+  // Pins: blob1/double1/index shape, 32-byte safeSrc cap, optional-binding guard.
+  function dispatchWithWae(
+    search: string,
+    analytics: { writeDataPoint: ReturnType<typeof vi.fn> } | undefined,
+  ) {
+    const sp = new URLSearchParams(search)
+    if (!isStatuslineRequest(sp)) return
+    const src = sp.get('src')
+    if (src && analytics) {
+      try {
+        const safeSrc = src.slice(0, 32)
+        analytics.writeDataPoint({ blobs: [safeSrc], doubles: [1], indexes: [safeSrc] })
+      } catch { /* best-effort */ }
+    }
+  }
+
+  it('writes one data point with correct blob/double/index for a statusline request', () => {
+    const wae = { writeDataPoint: vi.fn() }
+    dispatchWithWae('src=statusline-compact_badge', wae)
+    expect(wae.writeDataPoint).toHaveBeenCalledOnce()
+    expect(wae.writeDataPoint).toHaveBeenCalledWith({
+      blobs: ['statusline-compact_badge'],
+      doubles: [1],
+      indexes: ['statusline-compact_badge'],
+    })
+  })
+
+  it('does not write when env.ANALYTICS is absent (local dev / tests)', () => {
+    const wae = { writeDataPoint: vi.fn() }
+    dispatchWithWae('src=statusline-compact_badge', undefined)
+    expect(wae.writeDataPoint).not.toHaveBeenCalled()
+  })
+
+  it('does not write for non-statusline requests', () => {
+    const wae = { writeDataPoint: vi.fn() }
+    dispatchWithWae('', wae)
+    dispatchWithWae('src=dashboard', wae)
+    expect(wae.writeDataPoint).not.toHaveBeenCalled()
+  })
+
+  it('caps src to 32 bytes to stay within WAE index limit', () => {
+    const wae = { writeDataPoint: vi.fn() }
+    const longSrc = 'statusline-' + 'x'.repeat(60) // 71 chars total
+    dispatchWithWae(`src=${longSrc}`, wae)
+    expect(wae.writeDataPoint).toHaveBeenCalledOnce()
+    const call = wae.writeDataPoint.mock.calls[0][0]
+    expect(call.blobs[0]).toHaveLength(32)
+    expect(call.indexes[0]).toHaveLength(32)
+    expect(call.blobs[0]).toBe(call.indexes[0]) // same safeSrc used for both
   })
 })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -40,6 +40,10 @@ interface Env {
   EDGE_ALERT_TOKEN?: string
   AI?: Ai
   STATUS_CACHE: KVNamespace
+  // #494: Workers Analytics Engine dataset for statusline traffic measurement.
+  // Optional so local dev (wrangler dev --local) and test environments without the
+  // binding continue to work — writeDataPoint is skipped when absent.
+  ANALYTICS?: AnalyticsEngineDataset
 }
 
 // ── KV Cache + Daily Counters ──
@@ -2341,6 +2345,25 @@ export default {
       // still using ai-watch.dev get the small payload here via the rewrite.
       if (isStatuslineRequest(url.searchParams)) {
         const liteCache = env.STATUS_CACHE ? await cacheRead(env.STATUS_CACHE) : null
+        // Record per-preset statusline request count in WAE (#494) so we can
+        // isolate ?src=statusline-* traffic from regular cached-endpoint traffic
+        // when evaluating #400 Phase 1 distribution gates. writeDataPoint is
+        // synchronous (void return) but can throw on payload validation errors
+        // or binding misconfiguration — wrap in try/catch so a WAE failure never
+        // aborts the statusline response. WAE index entries are capped at 32 bytes.
+        const src = url.searchParams.get('src') // e.g. "statusline-compact_badge"
+        if (src && env.ANALYTICS) {
+          try {
+            const safeSrc = src.slice(0, 32)
+            env.ANALYTICS.writeDataPoint({
+              blobs: [safeSrc],   // blob1: full src tag (preset slug)
+              doubles: [1],       // double1: request counter (sum in GraphQL queries)
+              indexes: [safeSrc], // fast dimension filter (max 32 bytes)
+            })
+          } catch (err) {
+            console.warn('[wae] writeDataPoint failed:', err instanceof Error ? err.message : err)
+          }
+        }
         // Intentional: 200 with empty services when the cache is missing (fail-silent
         // — the jq over an empty array shows a clean statusline) rather than the
         // non-lite branch's 503; CORS `*` since this is public, unauthenticated,

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -17,5 +17,9 @@ id = "e49508d80bb144e9a7ff872f2be771a4" # Not a secret — KV namespace IDs are 
 [ai]
 binding = "AI"
 
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "aiwatch_statusline" # #494: statusline per-preset traffic counts (queried via CF GraphQL)
+
 [triggers]
 crons = ["*/5 * * * *"]


### PR DESCRIPTION
## Summary

- Adds `aiwatch_statusline` WAE dataset to count per-preset `?src=statusline-*` requests
- Enables isolation of statusline traffic from dashboard/cron traffic for #400 Phase 1 gate evaluation (Reddit: 50 tagged req/day; Anthropic docs: 10× baseline)
- `ANALYTICS` binding is optional — local dev and tests with no binding continue to work

## Changes

- **`worker/wrangler.toml`**: `[[analytics_engine_datasets]]` binding `ANALYTICS` → `aiwatch_statusline`
- **`worker/src/index.ts`**: `ANALYTICS?: AnalyticsEngineDataset` in `Env`; `writeDataPoint()` in `/api/status/cached` statusline branch with try/catch + 32-byte src cap
- **`worker/src/__tests__/statusline.test.ts`**: 4 new tests (1407 → 1411)

## CF GraphQL query (after deploy)

```graphql
{
  viewer {
    accounts(filter: { accountTag: "11485987aa7d4639df5ba09d671b5615" }) {
      analyticsEngineAdaptiveGroups(
        dataset: "aiwatch_statusline"
        limit: 10
        orderBy: [sum_double1_DESC]
      ) {
        dimensions { blob1 date }
        sum { double1 }
      }
    }
  }
}
```

## Test plan

- [x] 4 new Vitest tests: blob/double/index shape, absent-binding guard, non-statusline no-op, 32-byte cap
- [x] All 1411 tests pass
- [x] `wrangler deploy --dry-run` shows `env.ANALYTICS (aiwatch_statusline) Analytics Engine Dataset`
- [ ] After worker deploy: CF GraphQL returns data within one statusline poll cycle

closes #494
refs #400