### PR TITLE
fix(worker): use deepseek.statuspage.io instead of status.deepseek.com (closes #498)

### DIFF
--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -12,3 +12,19 @@ Per-service status is resolved in `worker/src/services.ts` with this priority:
    - If service is `degraded` from fetch failure (no incidents) AND probe RTT is normal → override to `operational`
    - If 70%+ of services on the same platform (Atlassian/incident.io/etc.) fail simultaneously → platform outage → override all to `operational`
    - Conservative: only overrides when evidence is strong (≥2 recent probes healthy, or quorum failure detected)
+
+## Status page URL selection
+
+`apiUrl` (the machine-readable fetch endpoint) and `statusUrl` (the human-facing link) can differ. When selecting `apiUrl`, **verify it is reachable from Cloudflare Workers** — some providers host their status page on a custom domain that blocks Workers IPs while the canonical Atlassian/incident.io host remains accessible.
+
+**Verification method**: `curl -sv "<url>" 2>&1 | head -20` — look for SSL connection reset or HTTP 000 (curl's notation for a connection-level failure — no HTTP response received at all), which indicate Workers-IP blocking even when a browser can reach the page.
+
+### Known case: DeepSeek (2026-05, #498)
+
+`status.deepseek.com/api/v2/summary.json` resets the connection from Workers IPs (Alibaba Cloud CDN with geo/bot filtering). `deepseek.statuspage.io/api/v2/summary.json` is the Atlassian-hosted mirror — identical component IDs and data, always accessible.
+
+**Fix**: set `apiUrl` to the `.statuspage.io` URL; keep `statusUrl` as the branded domain for the dashboard link.
+
+**Symptom pattern**: `fetch-fail:{svcId}` KV key reaches `3` (threshold) and stops refreshing — the write-back guard (`next <= threshold`) skips writes once the counter would exceed 3, so the TTL is last refreshed on the 3rd failure (writes on failures 1, 2, and 3 each extend it; no writes occur after that) and expires 1800s (~30 min) later. After expiry the counter resets; the threshold is crossed again after 3 more cron cycles (~15 min), so the re-alert fires roughly 45 min after the original alert rather than exactly 30 min. Probe cross-validation (Phase 1) may not fully suppress these if the API probe has a concurrent RTT blip, or if fewer than 2 recent probe snapshots are available (e.g., after a probe disruption).
+
+**General rule**: when adding or updating a service with an Atlassian Statuspage, check both `{custom-domain}/api/v2/summary.json` and `{slug}.statuspage.io/api/v2/summary.json`. Use whichever responds with HTTP 200 from a non-browser client. Also confirm that the `statusComponentId` value in the service config resolves correctly against the chosen endpoint's component list — component IDs are not always identical between a custom domain and its `.statuspage.io` mirror.

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -45,7 +45,9 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'cerebras', name: 'Cerebras Inference', provider: 'Cerebras', category: 'api', statusUrl: 'https://status.cerebras.ai', apiUrl: 'https://status.cerebras.ai/api/v2/summary.json', statusComponentId: '83h1cchw4vs4', statusComponentIds: ['83h1cchw4vs4', '7xvps6c9lqwc', 'bhqw2gr7r710', 'hgfykfsb36gn', '8ygyx5vydlm2'] },
   { id: 'perplexity', name: 'Perplexity', provider: 'Perplexity AI', category: 'api', statusUrl: 'https://status.perplexity.com', apiUrl: null, instatusUrl: 'https://status.perplexity.com' },
   { id: 'xai', name: 'xAI (Grok)', provider: 'xAI', category: 'api', statusUrl: 'https://status.x.ai', apiUrl: null, rssFeedUrl: 'https://status.x.ai/feed.xml', incidentKeywords: ['api'], incidentExclude: ['[API Console]', 'Test+Incident'] },
-  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://status.deepseek.com/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'] },
+  // status.deepseek.com blocks Cloudflare Workers IPs (SSL reset); deepseek.statuspage.io is the
+  // Atlassian-hosted mirror that's accessible from Workers — same component IDs, same data (#498).
+  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://deepseek.statuspage.io/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'] },
   { id: 'openrouter', name: 'OpenRouter', provider: 'OpenRouter', category: 'api', statusUrl: 'https://status.openrouter.ai', apiUrl: null, onlineOrNotUrl: 'https://status.openrouter.ai', onlineOrNotComponent: 'Chat (/api/v1/chat/completions)' },
   // Voice & Speech AI
   { id: 'elevenlabs', name: 'ElevenLabs', provider: 'ElevenLabs', category: 'api', statusUrl: 'https://status.elevenlabs.io', apiUrl: 'https://status.elevenlabs.io/api/v2/summary.json', incidentIoBaseUrl: 'https://status.elevenlabs.io/incidents', incidentIoComponentId: '01JP2RQVGDHPEEDAFM5KV2MH9P', incidentExclude: ['webpage'] },


### PR DESCRIPTION
## Summary

- `status.deepseek.com` blocks Cloudflare Workers IP ranges with SSL connection reset, causing `fetch-fail:deepseek` KV counter to always reach the degraded threshold (3 consecutive failures) and generate false-positive alerts
- `deepseek.statuspage.io` is the Atlassian-hosted mirror — identical component IDs (`j4n367d9mh3x` = API Service), same JSON structure, accessible from Workers (HTTP 200 verified)
- `statusUrl` kept as `status.deepseek.com` for the dashboard's human-facing "View Status Page" link (not used for data fetching)

## Root cause

The daily pattern was: status page fetch fails → counter hits threshold → `degraded` → probe cross-validation should override → but probe also had brief RTT spikes simultaneously → alert fires. With the correct URL, the status page will be reachable and component status will be read directly, eliminating the fetch-failure path entirely.

## Test plan
- [ ] Worker dry-run passes (`npx wrangler deploy --dry-run`) ✓
- [ ] Worker unit tests pass (1407/1407) ✓
- [ ] Verify `fetch-fail:deepseek` KV key clears after deploy (cron resets on successful fetch)
- [ ] No DeepSeek false-positive alerts after deploy

closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)