### PR TITLE
feat(worker): surface status page fetch failures in daily summary for early URL-block detection (refs #500)

### DIFF
--- a/docs/reference/adding-a-service.md
+++ b/docs/reference/adding-a-service.md
@@ -6,6 +6,12 @@ When adding a new monitored service, update ALL of the following:
 
 ## Worker (backend)
 1. `worker/src/services.ts` — add `ServiceConfig` entry at correct position in `SERVICES` array (determines API response order: LLM → voice → infra → apps → agents). If the status page hosts unrelated components (multi-tenant Atlassian / incident.io / metastatuspage feeds — e.g. `githubstatus.com`, `status.openai.com`, `status.claude.com`), set `incidentKeywords` to scope the visible incident list — otherwise the service card will surface every incident on the page (#397)
+
+   **`apiUrl` reachability check (required)**: verify the chosen `apiUrl` responds from a non-browser client before committing — some providers block Cloudflare Workers IPs on their custom domain while the canonical host remains accessible (DeepSeek case, #498):
+   ```bash
+   curl -sf --max-time 5 "{apiUrl}" -o /dev/null && echo "OK" || echo "BLOCKED — check .statuspage.io mirror"
+   ```
+   For Atlassian Statuspage services, if the custom domain is blocked, use `https://{slug}.statuspage.io/api/v2/summary.json` instead. Confirm `statusComponentId` resolves on the chosen endpoint. See `docs/reference/status-determination.md` § "Status page URL selection".
 2. `worker/src/probe.ts` — add `ProbeTarget` if API endpoint exists for RTT measurement
 3. `worker/src/fallback.ts` — update ALL of:
    - `EXCLUDE_FALLBACK` — remove if fallback-eligible

--- a/worker/src/__tests__/daily-summary.test.ts
+++ b/worker/src/__tests__/daily-summary.test.ts
@@ -318,6 +318,82 @@ describe('buildDailySummary', () => {
   })
 })
 
+describe('buildDailySummary — Status Page Fetch Failures section (#500)', () => {
+  const BASE = {
+    services: [
+      makeSvc({ id: 'deepseek', name: 'DeepSeek API' }),
+      makeSvc({ id: 'claude', name: 'Claude API' }),
+    ],
+    aiUsage: null,
+    latencySnapshots: [],
+    incidentCountToday: { newCount: 0, resolvedCount: 0 },
+    redditCount: 0,
+  }
+
+  it('omits section when no fetch failures today', () => {
+    const result = buildDailySummary({ ...BASE })
+    expect(result).not.toContain('Status Page Fetch Failures')
+  })
+
+  it('shows section with threshold-hit count when failures present', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      fetchFailureCounts: { deepseek: 5 },
+    })
+    expect(result).toContain('Status Page Fetch Failures Today')
+    expect(result).toContain('DeepSeek API: 5× threshold hit')
+    expect(result).toContain('5 real')
+  })
+
+  it('labels all as false positives when suppressed count equals total', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      fetchFailureCounts: { deepseek: 3 },
+      crossValidSuppressed: { deepseek: 3 },
+    })
+    expect(result).toContain('all false positives — probe healthy')
+  })
+
+  it('shows partial suppression breakdown', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      fetchFailureCounts: { deepseek: 5 },
+      crossValidSuppressed: { deepseek: 2 },
+    })
+    expect(result).toContain('3 real, 2 probe-suppressed')
+  })
+
+  it('sorts services by failure count descending', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      fetchFailureCounts: { claude: 1, deepseek: 8 },
+    })
+    // Extract only the fetch failures section to avoid matching 'Claude API' in earlier sections
+    const sectionStart = result.indexOf('Status Page Fetch Failures Today')
+    expect(sectionStart).toBeGreaterThan(-1)
+    const section = result.slice(sectionStart)
+    expect(section.indexOf('DeepSeek API')).toBeLessThan(section.indexOf('Claude API'))
+  })
+
+  it('clamps real to 0 when suppressed exceeds total (data race guard)', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      fetchFailureCounts: { deepseek: 2 },
+      crossValidSuppressed: { deepseek: 5 },
+    })
+    expect(result).not.toMatch(/-\d+ real/)
+    expect(result).toContain('Status Page Fetch Failures Today')
+  })
+
+  it('omits section when crossValidSuppressed has entries but fetchFailureCounts is empty', () => {
+    const result = buildDailySummary({
+      ...BASE,
+      crossValidSuppressed: { deepseek: 3 },
+    })
+    expect(result).not.toContain('Status Page Fetch Failures')
+  })
+})
+
 describe('isInSummaryWindow', () => {
   it('returns inWindow=true in normal window (UTC 09:00-09:04)', () => {
     expect(isInSummaryWindow(9, 0)).toEqual({ inWindow: true, isCatchUp: false })

--- a/worker/src/__tests__/utils.test.ts
+++ b/worker/src/__tests__/utils.test.ts
@@ -124,10 +124,39 @@ describe('trackFetchFailure', () => {
     expect(await trackFetchFailure(kv, 'azure')).toBe(true)
   })
 
-  it('returns true when already above threshold and skips write', async () => {
+  it('increments daily accumulator when threshold is reached', async () => {
+    const store: Record<string, string> = { 'fetch-fail:azure': '2' }
+    const kv = mockKV(store)
+    expect(await trackFetchFailure(kv, 'azure')).toBe(true)
+    const today = new Date().toISOString().split('T')[0]
+    expect(store[`fetch-fail:daily:azure:${today}`]).toBe('1')
+  })
+
+  it('accumulates daily counter across multiple threshold hits', async () => {
+    const today = new Date().toISOString().split('T')[0]
+    const store: Record<string, string> = {
+      'fetch-fail:azure': '2',
+      [`fetch-fail:daily:azure:${today}`]: '3',
+    }
+    const kv = mockKV(store)
+    await trackFetchFailure(kv, 'azure')
+    expect(store[`fetch-fail:daily:azure:${today}`]).toBe('4')
+  })
+
+  it('does not increment daily accumulator when threshold is not yet reached', async () => {
+    const store: Record<string, string> = { 'fetch-fail:azure': '1' }
+    const kv = mockKV(store)
+    expect(await trackFetchFailure(kv, 'azure')).toBe(false) // count=2, below threshold
+    const today = new Date().toISOString().split('T')[0]
+    expect(store[`fetch-fail:daily:azure:${today}`]).toBeUndefined()
+  })
+
+  it('returns true when already above threshold, but does NOT write daily key (not a rising edge)', async () => {
+    // count=5 → next=6 ≥ threshold, so shouldDegrade=true, but 6 ≠ threshold(3) → no daily write.
+    // This prevents double-counting cycles where the failure is sustained above threshold.
     const kv = mockKV({ 'fetch-fail:azure': '5' })
     expect(await trackFetchFailure(kv, 'azure')).toBe(true)
-    expect(kv.put).not.toHaveBeenCalled() // already above, skip write
+    expect(kv.put).not.toHaveBeenCalled()
   })
 
   it('handles corrupted (non-numeric) KV value gracefully', async () => {

--- a/worker/src/daily-summary.ts
+++ b/worker/src/daily-summary.ts
@@ -23,10 +23,12 @@ export interface DailySummaryData {
   probeSnapshots?: ProbeSnapshot[]
   detectionLeadEntries?: DetectionLeadEntry[]
   leadDiag?: LeadDiag | null
+  fetchFailureCounts?: Record<string, number>   // svcId → times degraded threshold hit today
+  crossValidSuppressed?: Record<string, number> // svcId → times probe overrode to operational
 }
 
 export function buildDailySummary(data: DailySummaryData): string {
-  const { services, aiUsage, latencySnapshots, incidentCountToday, alertCounts, webhookCounts, deliveryCounts, redditCount, vitals, detectionLeadEntries, leadDiag } = data
+  const { services, aiUsage, latencySnapshots, incidentCountToday, alertCounts, webhookCounts, deliveryCounts, redditCount, vitals, detectionLeadEntries, leadDiag, fetchFailureCounts, crossValidSuppressed } = data
   const total = services.length
   const operational = services.filter(s => s.status === 'operational').length
   const degraded = services.filter(s => s.status === 'degraded').length
@@ -146,6 +148,27 @@ export function buildDailySummary(data: DailySummaryData): string {
   if (leadDiag) {
     const diagSection = formatLeadDiagSection(leadDiag)
     if (diagSection) lines.push(diagSection)
+  }
+
+  // Section: Status page fetch failures (#500) — surfaces structural URL blocks early.
+  // fetch-fail:daily = times the degraded threshold was hit today (transient: 1-2, structural: 5+).
+  // cross-valid:suppressed = subset where probe confirmed the API was healthy (false positives caught).
+  if (fetchFailureCounts && Object.keys(fetchFailureCounts).length > 0) {
+    const nameMap = new Map(services.map(s => [s.id, s.name]))
+    const items = Object.entries(fetchFailureCounts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([id, total]) => {
+        const suppressed = crossValidSuppressed?.[id] ?? 0
+        const real = Math.max(0, total - suppressed)
+        const detail = suppressed === total
+          ? `all false positives — probe healthy`
+          : suppressed > 0
+            ? `${real} real, ${suppressed} probe-suppressed`
+            : `${real} real`
+        return `   ${nameMap.get(id) ?? id}: ${total}× threshold hit (${detail})`
+      })
+      .join('\n')
+    lines.push(`\n⚠️ **Status Page Fetch Failures Today** (#500)\n${items}`)
   }
 
   return lines.join('\n')

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1825,6 +1825,25 @@ export default {
               return null
             })
 
+          // #500 — status page fetch failure observability: read per-service daily counters.
+          // fetch-fail:daily:{svcId}:{date}: threshold crossings today (rising-edge incremented).
+          // cross-valid:suppressed:{svcId}:{date}: times probe overrode degraded → operational.
+          // Individual .catch(() => null) absorb KV I/O errors; missing keys are treated as 0.
+          const fetchFailureCounts: Record<string, number> = {}
+          const crossValidSuppressed: Record<string, number> = {}
+          await Promise.all(SERVICES.filter(s => s.apiUrl).map(async (svc) => {
+            const [failRaw, supRaw] = await Promise.all([
+              env.STATUS_CACHE.get(`fetch-fail:daily:${svc.id}:${today}`).catch(() => null),
+              env.STATUS_CACHE.get(`cross-valid:suppressed:${svc.id}:${today}`).catch(() => null),
+            ])
+            const failCount = parseInt(failRaw ?? '0', 10) || 0
+            const supCount = parseInt(supRaw ?? '0', 10) || 0
+            if (failCount > 0) fetchFailureCounts[svc.id] = failCount
+            if (supCount > 0) crossValidSuppressed[svc.id] = supCount
+          })).catch((err) => {
+            console.warn('[daily-summary] fetch failure counts read failed:', err instanceof Error ? err.message : err)
+          })
+
           const description = buildDailySummary({
             services: dailyServices,
             aiUsage,
@@ -1839,6 +1858,8 @@ export default {
             probeSnapshots,
             detectionLeadEntries,
             leadDiag,
+            fetchFailureCounts,
+            crossValidSuppressed,
           })
 
           if (isCatchUp) console.log(`[daily-summary] catch-up run for ${today}`)

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -995,10 +995,19 @@ export async function fetchAllServices(kv?: KVNamespace, probeSnapshots?: ProbeS
 
     // Phase 1: Probe-based cross-validation (requires probe data)
     if (probeSnapshots && probeSnapshots.length > 0) {
+      const date = new Date().toISOString().split('T')[0]
       for (const svc of degradedFromFetch) {
         if (svc.status === 'degraded' && isProbeHealthy(probeSnapshots, svc.id)) {
           console.log(`[cross-validation] ${svc.id}: status page down but probe RTT normal — holding operational`)
           svc.status = 'operational'
+          // Daily suppression counter: how many times was this service's degraded status
+          // overridden by probe health? Surfaced in daily summary alongside fetch-fail:daily
+          // to distinguish "probe healthy → false positive" from "probe also spiking → real outage".
+          if (kv) {
+            const supKey = `cross-valid:suppressed:${svc.id}:${date}`
+            const prev = parseInt(await kv.get(supKey).catch(() => null) ?? '0', 10) || 0
+            await kvPut(kv, supKey, String(prev + 1), { expirationTtl: 172800 })
+          }
         }
       }
     }

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -89,7 +89,19 @@ export async function trackFetchFailure(kv: KVLike | undefined, svcId: string, t
   if (next <= threshold) {
     await kvPut(kv, failKey, String(next), { expirationTtl: 1800 })
   }
-  return next >= threshold
+  const shouldDegrade = next >= threshold
+  if (next === threshold) {
+    // Daily accumulator: counts threshold *crossings* (distinct failure episodes), not polling cycles.
+    // Fires only on the rising edge (count going from threshold-1 → threshold) so each 30-min
+    // fetch-fail TTL cycle contributes exactly one crossing. Expected scale:
+    //   transient: 1–3 crossings/day  (occasional blips that recover quickly)
+    //   structural: 10+ crossings/day (URL blocked — one crossing per ~45-min cycle all day)
+    const date = new Date().toISOString().split('T')[0]
+    const dailyKey = `fetch-fail:daily:${svcId}:${date}`
+    const dailyCount = parseInt(await kv.get(dailyKey).catch(() => null) ?? '0', 10) || 0
+    await kvPut(kv, dailyKey, String(dailyCount + 1), { expirationTtl: 172800 }) // 48h
+  }
+  return shouldDegrade
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds daily KV counters to surface status page URL blocks in the morning Discord report — had this existed before #498, the DeepSeek block would have appeared within one day
- Two new counters per service: threshold crossings (`fetch-fail:daily`) + probe-suppressed events (`cross-valid:suppressed`)
- Rising-edge-only increment: counts distinct failure episodes, not polling volume (structural: 10+/day vs transient: 1-3/day)
- `Math.max(0, ...)` guard prevents negative display if KV data races
- Adds `apiUrl` reachability check step to the adding-a-service checklist

## Example daily report output

```
⚠️ Status Page Fetch Failures Today (#500)
   DeepSeek API: 12× threshold hit (all false positives — probe healthy)
   SomeOtherAPI: 5× threshold hit (3 real, 2 probe-suppressed)
```

## Test plan
- [ ] Worker unit tests pass (1429/1429) ✓
- [ ] Worker dry-run passes ✓
- [ ] After deploy: verify no fetch failure section in daily summary for healthy services
- [ ] If a service URL becomes blocked: verify section appears next morning

refs #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)