### PR TITLE
fix(worker): filter BetterStack maintenance events from incident list (closes #504)

### DIFF
--- a/worker/src/parsers/__tests__/betterstack.test.ts
+++ b/worker/src/parsers/__tests__/betterstack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { parseRssIncidents, parseXaiRssIncidents, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackPartialCount } from '../betterstack'
+import { parseRssIncidents, parseXaiRssIncidents, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackMaintenanceIds, parseBetterStackPartialCount } from '../betterstack'
 
 describe('parseRssIncidents', () => {
   it('groups RSS items by guid into incidents', () => {
@@ -472,11 +472,52 @@ describe('parseRssIncidents', () => {
       expect(parseRssIncidents(xml)).toHaveLength(1)
     })
 
+    it('skips titles ending with "maintenance" standalone — "Network maintenance", "Volume v2 maintenance" (#503)', () => {
+      // The third alternation `\bmaintenance\s*$` catches Modal-style planned maintenance titles
+      // that end with the word "maintenance" but lack a "scheduled/planned" qualifier.
+      const xml = `
+        <item>
+          <guid>https://status.modal.com/incident/764951#hash</guid>
+          <title>Volume version 2 maintenance</title>
+          <pubDate>Wed, 19 Nov 2025 09:00:00 GMT</pubDate>
+          <description>We are upgrading core systems.</description>
+        </item>
+        <item>
+          <guid>https://status.modal.com/incident/265716#hash</guid>
+          <title>Network maintenance</title>
+          <pubDate>Fri, 29 Sep 2023 18:00:00 GMT</pubDate>
+          <description>Scheduled network maintenance.</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-01-01T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(0)
+    })
+
+    it('still passes "Stuck in maintenance mode" and "Planned maintenance window exceeded" (#503 negative contract)', () => {
+      // These are real incidents — a service got stuck in maintenance mode unexpectedly,
+      // or a planned maintenance window ran over. The third alternation `\bmaintenance\s*$`
+      // must NOT match when "maintenance" is not the final word of the title.
+      const xml = `
+        <item>
+          <guid>https://status.example.com/stuck#1</guid>
+          <title>Stuck in maintenance mode</title>
+          <pubDate>Sat, 01 Mar 2026 10:00:00 GMT</pubDate>
+          <description>Deploy pipeline hung.</description>
+        </item>
+        <item>
+          <guid>https://status.example.com/exceed#1</guid>
+          <title>Planned maintenance window exceeded</title>
+          <pubDate>Sat, 01 Mar 2026 11:00:00 GMT</pubDate>
+          <description>Still ongoing past scheduled end.</description>
+        </item>
+      `
+      const fixedNow = new Date('2026-03-15T00:00:00Z').getTime()
+      expect(parseRssIncidents(xml, fixedNow)).toHaveLength(2)
+    })
+
     it('matches the second regex alternation: "Maintenance — scheduled for tonight"', () => {
-      // The regex has two alternations; the first matches "scheduled ... maintenance",
-      // the second matches "maintenance ... scheduled". Together's current title
-      // exercises branch 1. A future provider might use branch 2. Without this test
-      // a regex refactor could silently delete that branch.
+      // Three alternations in the regex; this exercises alternation 2.
+      // Alternation 1: "scheduled ... maintenance"; alternation 3: title ends with "maintenance".
       const xml = `
         <item>
           <guid>https://status.example.com/m2branch#h</guid>
@@ -524,7 +565,7 @@ describe('parseRssIncidents', () => {
       // order is title first; if a refactor flipped the order it would still
       // function (same net result) but logs would mis-categorize. Spy on
       // console.debug to confirm the specific skip-reason path.
-      // NOTE: test is coupled to the literal log strings "scheduled maintenance"
+      // NOTE: test is coupled to the literal log strings "maintenance title" (#331/#503)
       // and "future-dated" in parseRssIncidents. Update both sides together if
       // the log wording changes.
       const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
@@ -539,7 +580,7 @@ describe('parseRssIncidents', () => {
       const fixedNow = new Date('2026-04-24T00:00:00Z').getTime()  // before pubDate
       parseRssIncidents(xml, fixedNow)
       const calls = debugSpy.mock.calls.map(c => String(c[0]))
-      expect(calls.some(m => m.includes('scheduled maintenance'))).toBe(true)
+      expect(calls.some(m => m.includes('maintenance title'))).toBe(true)
       expect(calls.some(m => m.includes('future-dated'))).toBe(false)
       debugSpy.mockRestore()
     })
@@ -979,6 +1020,26 @@ describe('parseBetterStackDailyImpact', () => {
       '2026-03-21': 'critical',  // 5h duration
       '2026-03-22': 'minor',     // 30min, 3% ratio
     })
+  })
+})
+
+describe('parseBetterStackMaintenanceIds (#503)', () => {
+  it('extracts report_type=maintenance IDs from index.json status_reports', () => {
+    const data = {
+      included: [
+        { type: 'status_report', id: '908255', attributes: { report_type: 'maintenance', aggregate_state: 'investigating' } },
+        { type: 'status_report', id: '111', attributes: { report_type: 'manual', aggregate_state: 'investigating' } },
+        { type: 'status_report', id: '222', attributes: { report_type: 'maintenance', aggregate_state: 'resolved' } },
+        { type: 'status_page_resource', id: '999', attributes: { status: 'operational' } },
+      ],
+    }
+    expect(parseBetterStackMaintenanceIds(data)).toEqual(new Set(['908255', '222']))
+  })
+
+  it('returns empty set when no maintenance reports', () => {
+    expect(parseBetterStackMaintenanceIds({})).toEqual(new Set())
+    const data = { included: [{ type: 'status_report', id: '1', attributes: { report_type: 'manual' } }] }
+    expect(parseBetterStackMaintenanceIds(data)).toEqual(new Set())
   })
 })
 

--- a/worker/src/parsers/betterstack.ts
+++ b/worker/src/parsers/betterstack.ts
@@ -14,13 +14,19 @@ function isValidDate(s: string): boolean {
   return !isNaN(new Date(s).getTime())
 }
 
-// #331: BetterStack RSS occasionally carries planned-maintenance announcements
-// that share the same item shape as real incidents. Detect them via two signals:
-// a "scheduled (network) maintenance" phrase in the title, or a future pubDate
-// (RSS entries describe things that have happened — recovered/went down — so a
-// future timestamp is structurally impossible for a real incident). Skip both
-// rather than rendering a phantom "— down" card.
-const SCHEDULED_MAINTENANCE_TITLE = /scheduled\s+(?:\w+\s+)?maintenance|maintenance[^a-z]{0,20}scheduled/i
+// #331 / #503: BetterStack RSS carries planned-maintenance announcements alongside real incidents.
+// Detect and skip them via three signals (any one is sufficient):
+//   1. Title pattern — three alternations:
+//      a) "scheduled ... maintenance" (e.g., "Scheduled Network Maintenance")
+//      b) "maintenance ... scheduled" (e.g., "Maintenance — scheduled for tonight")
+//      c) title ENDS with "maintenance" (e.g., "Network maintenance", "Volume version 2 maintenance")
+//      Deliberately does NOT match "Stuck in maintenance mode" or "Planned maintenance window exceeded"
+//      — those describe real incidents where a maintenance-labeled state caused unexpected degradation.
+//   2. Future pubDate — structurally impossible for a real incident (recovered/went down).
+//   3. index.json report_type === 'maintenance' — used in services.ts after index.json parse.
+//      Handles custom-titled events like "Authorization System Restart" (#503) where no title
+//      keyword is present.
+const MAINTENANCE_TITLE = /scheduled\s+(?:\w+\s+)?maintenance|maintenance[^a-z]{0,20}scheduled|\bmaintenance\s*$/i
 const FUTURE_PUBDATE_BUFFER_MS = 60_000  // clock-skew tolerance
 
 export function parseRssIncidents(xml: string, now = Date.now()): Incident[] {
@@ -59,12 +65,10 @@ export function parseRssIncidents(xml: string, now = Date.now()): Incident[] {
     const startMs = new Date(first.date).getTime()
     const endMs = new Date(last.date).getTime()
 
-    // #331: planned-maintenance / future announcements — not real incidents.
-    // Checked here (not at item-level) so a group legitimately named "maintenance"
-    // with a past pubDate and real downtime in its description wouldn't be dropped
-    // — title regex + future-date are AND-independent skip conditions.
-    if (SCHEDULED_MAINTENANCE_TITLE.test(first.title)) {
-      console.debug(`[parseRssIncidents] skipped scheduled maintenance: ${groupKey} ("${first.title}")`)
+    // #331 / #503: planned-maintenance title filter (signal 1 of 3).
+    // Signal 2 (future pubDate) and signal 3 (index.json report_type) are below.
+    if (MAINTENANCE_TITLE.test(first.title)) {
+      console.debug(`[parseRssIncidents] skipped maintenance title (#331/#503): ${groupKey} ("${first.title}")`)
       continue
     }
     if (startMs > now + FUTURE_PUBDATE_BUFFER_MS) {
@@ -189,10 +193,27 @@ export interface BetterStackIndex {
       status?: string
       status_history?: BetterStackStatusHistory[]
       aggregate_state?: string
+      report_type?: string  // 'manual' | 'maintenance' | 'calculated' (#503)
       title?: string
       starts_at?: string
     }
   }>
+}
+
+/**
+ * Extract IDs of planned-maintenance reports from index.json status_reports.
+ * BetterStack sets report_type='maintenance' for maintenance windows. These are
+ * passed to parseRssIncidents so custom-titled maintenance events (e.g. "Authorization
+ * System Restart") are filtered out even when their title contains no maintenance keyword.
+ */
+export function parseBetterStackMaintenanceIds(data: BetterStackIndex): Set<string> {
+  const ids = new Set<string>()
+  for (const r of data.included ?? []) {
+    if (r.type === 'status_report' && r.attributes?.report_type === 'maintenance' && r.id) {
+      ids.add(r.id)
+    }
+  }
+  return ids
 }
 
 /** Extract resolved incident IDs from index.json status_reports */

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -17,7 +17,7 @@ import {
   computeDailyImpactFromIncidents,
 } from './parsers/aistudio'
 import { parseInstatusIncidents } from './parsers/instatus'
-import { parseRssIncidents, parseXaiRssIncidents, type BetterStackIndex, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackPartialCount } from './parsers/betterstack'
+import { parseRssIncidents, parseXaiRssIncidents, type BetterStackIndex, parseBetterStackStatus, parseBetterStackUptime, parseBetterStackDailyImpact, parseBetterStackResolvedIds, parseBetterStackMaintenanceIds, parseBetterStackPartialCount } from './parsers/betterstack'
 import { parseOnlineOrNotIncidents, parseOnlineOrNotUptime } from './parsers/onlineornot'
 import { parseAwsRssIncidents, deriveAwsStatus } from './parsers/aws'
 
@@ -722,6 +722,17 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
           betterStackStat = parseBetterStackStatus(bsData)
           betterStackPartial = parseBetterStackPartialCount(bsData)
           bsDailyImpact = parseBetterStackDailyImpact(bsData)
+          // Filter out planned-maintenance events (report_type='maintenance') — signal 3 of 3.
+          // Catches custom-titled maintenance events like "Authorization System Restart" (#503)
+          // where the title contains no maintenance keyword (signal 1) and pubDate is not future (signal 2).
+          const maintenanceIds = parseBetterStackMaintenanceIds(bsData)
+          if (maintenanceIds.size > 0) {
+            const before = incidents.length
+            incidents = incidents.filter(inc => !maintenanceIds.has(inc.id))
+            if (incidents.length < before) {
+              console.debug(`[fetchService] ${config.id} filtered ${before - incidents.length} maintenance incident(s) via index.json report_type`)
+            }
+          }
           // Reconcile RSS incidents with index.json resolved status (authoritative)
           const resolvedIds = parseBetterStackResolvedIds(bsData)
           if (resolvedIds.size > 0) {


### PR DESCRIPTION
## Summary

BetterStack status pages mix planned maintenance announcements with real incidents in the RSS feed. Modal's \"Authorization System Restart\" (scheduled 30-min maintenance 2026-05-31) appeared as an active incident and triggered a Discord alert. Root cause: `parseRssIncidents` only matched \"scheduled maintenance\" / \"maintenance scheduled\" — standalone titles like \"Network maintenance\" and custom titles like \"Authorization System Restart\" slipped through.

**Three detection signals now (any one sufficient):**

| Signal | Mechanism | Example |
|--------|-----------|---------|
| 1 (expanded) | Title regex: added `\bmaintenance\s*$` | \"Network maintenance\", \"Volume version 2 maintenance\" |
| 2 (existing) | Title regex: \"scheduled...maintenance\" / \"maintenance...scheduled\" | \"Scheduled Network Maintenance\" |
| 3 (new) | `index.json report_type='maintenance'` → post-hoc filter | \"Authorization System Restart\" (#504) |

**Negative contract preserved**: \"Stuck in maintenance mode\" and \"Planned maintenance window exceeded\" correctly still pass as real incidents (regression tests added).

## Test plan
- [ ] Worker unit tests pass (1423/1423) ✓
- [ ] Worker dry-run passes ✓
- [ ] After deploy: verify Modal/Together/Fireworks maintenance windows are no longer shown as incidents

closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)