### PR TITLE
feat: Vercel Edge probe for DeepSeek Flashduty API accessibility

### DIFF
--- a/api/deepseek-status-probe.ts
+++ b/api/deepseek-status-probe.ts
@@ -1,0 +1,65 @@
+/**
+ * Vercel Edge Function — DeepSeek Flashduty accessibility probe (#504 follow-up)
+ *
+ * DeepSeek migrated from Atlassian Statuspage to Flashduty (Flashcat.cloud).
+ * Cloudflare Workers IPs are blocked by status.deepseek.com. This endpoint tests
+ * whether Vercel Edge Functions can reach the Flashduty API (different IP ranges).
+ *
+ * GET /api/deepseek-status-probe
+ *   → { reachable: boolean, status: string, sample?: object, error?: string, ms: number }
+ *
+ * Used for one-time validation only — remove or gate behind admin auth before shipping.
+ */
+export const config = { runtime: 'edge' }
+
+const FLASHDUTY_PAGE_ID = '6410630422455'
+const ACTIVE_URL = `https://status.deepseek.com/api/status-page/${FLASHDUTY_PAGE_ID}/summary/active`
+
+export default async function handler(): Promise<Response> {
+  const start = Date.now()
+  try {
+    const res = await fetch(ACTIVE_URL, {
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': 'AIWatch-Status-Monitor/1.0',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+
+    const ms = Date.now() - start
+
+    if (!res.ok) {
+      return Response.json({
+        reachable: false,
+        status: `HTTP ${res.status}`,
+        ms,
+      })
+    }
+
+    const data = await res.json() as Record<string, unknown>
+
+    // Extract a minimal sample to confirm the shape
+    const sample = {
+      keys: Object.keys(data),
+      // Show top-level structure without leaking sensitive data
+      hasData: 'data' in data,
+      hasComponents: 'components' in data || 'services' in data,
+    }
+
+    return Response.json({
+      reachable: true,
+      status: 'ok',
+      sample,
+      ms,
+    })
+  } catch (err) {
+    const ms = Date.now() - start
+    const message = err instanceof Error ? err.message : String(err)
+    return Response.json({
+      reachable: false,
+      status: 'error',
+      error: message,
+      ms,
+    })
+  }
+}


### PR DESCRIPTION
## Summary

DeepSeek migrated from Atlassian Statuspage to Flashduty (Flashcat.cloud). Cloudflare Workers' IP ranges are blocked by `status.deepseek.com`. This PR adds a minimal validation endpoint to test whether **Vercel Edge Functions** can access the Flashduty API (different IP ranges than Workers).

## Endpoint

```
GET /api/deepseek-status-probe
→ { reachable: boolean, status: string, sample?: object, error?: string, ms: number }
```

Target URL: `https://status.deepseek.com/api/status-page/6410630422455/summary/active`

## Validation steps

After Vercel preview deploys:
1. Hit `{preview-url}/api/deepseek-status-probe`
2. If `reachable: true` → proceed with full Flashduty parser implementation
3. If `reachable: false` → plan B (probe-only mode or alternative source)

## Note
Temporary validation endpoint — will be removed or secured with admin auth before full implementation ships.