### PR TITLE
fix: probe majority rule + DeepSeek transparency note (refs #507)

### DIFF
--- a/api/is-down/seo-content.ts
+++ b/api/is-down/seo-content.ts
@@ -229,7 +229,7 @@ const SEO_CONTENT: Record<string, ServiceSEO> = {
   deepseek: {
     displayName: 'DeepSeek',
     description: 'DeepSeek API provides access to DeepSeek\'s frontier reasoning models (V3, R1) at significantly lower price points than Western providers. It is a Chinese AI lab whose models have gained rapid adoption since early 2026.',
-    insight: 'DeepSeek API can experience capacity-driven outages during demand spikes (model release events, viral moments). Geographic latency varies more than US-based providers given DeepSeek\'s primarily Asian infrastructure. Check AIWatch probe data for response time trends.',
+    insight: 'DeepSeek API can experience capacity-driven outages during demand spikes (model release events, viral moments). Geographic latency varies more than US-based providers given DeepSeek\'s primarily Asian infrastructure. Note: DeepSeek migrated their status page to Flashduty (a Chinese-hosted platform) in May 2026. That platform blocks non-Chinese IPs, so AIWatch monitors DeepSeek via direct API probe only — incident history may be incomplete after May 2026.',
     whenDown: 'When DeepSeek API is down, applications relying on its low-cost reasoning models will fail. Cost-sensitive deployments that switched from OpenAI/Claude to DeepSeek for affordability lose their primary backend.',
     faqs: [
       { q: 'Is DeepSeek API down right now?', a: 'Check the live status indicator at the top of this page. AIWatch monitors DeepSeek every 5 minutes and shows real-time operational status.' },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -196,6 +196,7 @@ const en = {
   'svc.cal.ago.suffix': 'ago',
   'svc.cal.today': 'Today',
   'svc.status.link': 'Official Status',
+  'svc.deepseek.probeNote': 'Status page (Flashduty) not accessible outside China — monitoring via API probe only since May 2026',
   'svc.rss': 'RSS',
   'svc.rss.copied': 'Copied ✓',
   'svc.rss.title': 'Copy this service\'s incident RSS feed URL',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -196,6 +196,7 @@ const ko = {
   'svc.cal.ago.suffix': '전',
   'svc.cal.today': '오늘',
   'svc.status.link': '공식 Status',
+  'svc.deepseek.probeNote': '상태 페이지(Flashduty)가 중국 외 IP에서 접근 불가 — 2026년 5월부터 API probe만으로 모니터링',
   'svc.rss': 'RSS',
   'svc.rss.copied': '복사됨 ✓',
   'svc.rss.title': '이 서비스 인시던트 RSS 피드 URL 복사',

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -707,6 +707,11 @@ export default function ServiceDetails({ serviceId }) {
             )}
             {feedUrl && <RssLink feedUrl={feedUrl} serviceId={service.id} t={t} />}
           </div>
+          {service.id === 'deepseek' && (
+            <div className="mono text-[10px] text-[var(--text2)]" style={{ marginTop: '6px' }}>
+              ⚠ {t('svc.deepseek.probeNote')}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-1.5">
           {!!recentlyRecovered[service.id] && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}

--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -275,23 +275,48 @@ describe('isProbeHealthy', () => {
     expect(isProbeHealthy(snapshots, 'claude')).toBe(true)
   })
 
-  it('returns false when recent probes show RTT spike', () => {
+  it('returns true when only 1 of 3 recent probes has an RTT spike (majority healthy)', () => {
+    // Majority rule: 2/3 healthy → healthy. A single transient spike is noise, not evidence
+    // of genuine degradation. Previously "every" required all probes healthy, which caused
+    // false-positive degraded alerts for services with structural status page failures (#507).
     const snapshots: ProbeSnapshot[] = [
-      { t: recentTime(0), data: { claude: { status: 200, rtt: 2000 } } }, // spike
+      { t: recentTime(0), data: { claude: { status: 200, rtt: 2000 } } }, // spike (1 of 3 recent)
       { t: recentTime(5), data: { claude: { status: 200, rtt: 200 } } },
       { t: recentTime(10), data: { claude: { status: 200, rtt: 210 } } },
-      { t: recentTime(15), data: { claude: { status: 200, rtt: 190 } } },
-      { t: recentTime(20), data: { claude: { status: 200, rtt: 205 } } },
+      { t: recentTime(20), data: { claude: { status: 200, rtt: 205 } } }, // outside 15-min window
     ]
-    expect(isProbeHealthy(snapshots, 'claude')).toBe(false)
+    expect(isProbeHealthy(snapshots, 'claude')).toBe(true)
   })
 
-  it('returns false when probe has failures (rtt=-1)', () => {
+  it('returns false when 2 of 3 recent probes have RTT spikes (majority unhealthy)', () => {
+    // Establish a healthy median baseline via historical probes (outside the 15-min window),
+    // then have 2 of 3 recent probes spike above 3× that median.
+    const historical = Array.from({ length: 6 }, (_, i) => ({
+      t: recentTime(20 + i * 5), // 20–45 min ago — outside 15-min recent window
+      data: { claude: { status: 200, rtt: 200 } },
+    }))
+    const recent: ProbeSnapshot[] = [
+      { t: recentTime(0), data: { claude: { status: 200, rtt: 800 } } }, // >3×200 → spike
+      { t: recentTime(5), data: { claude: { status: 200, rtt: 750 } } }, // >3×200 → spike
+      { t: recentTime(10), data: { claude: { status: 200, rtt: 210 } } },
+    ]
+    expect(isProbeHealthy([...recent, ...historical], 'claude')).toBe(false)
+  })
+
+  it('returns true when only 1 of 3 recent probes has a failure rtt=-1 (majority healthy)', () => {
     const snapshots: ProbeSnapshot[] = [
-      { t: recentTime(0), data: { claude: { status: 0, rtt: -1 } } },
+      { t: recentTime(0), data: { claude: { status: 0, rtt: -1 } } },  // 1 failure
       { t: recentTime(5), data: { claude: { status: 200, rtt: 200 } } },
       { t: recentTime(10), data: { claude: { status: 200, rtt: 210 } } },
-      { t: recentTime(15), data: { claude: { status: 200, rtt: 190 } } },
+    ]
+    expect(isProbeHealthy(snapshots, 'claude')).toBe(true)
+  })
+
+  it('returns false when 2 of 3 recent probes have failures rtt=-1 (majority unhealthy)', () => {
+    const snapshots: ProbeSnapshot[] = [
+      { t: recentTime(0), data: { claude: { status: 0, rtt: -1 } } },
+      { t: recentTime(5), data: { claude: { status: 0, rtt: -1 } } },
+      { t: recentTime(10), data: { claude: { status: 200, rtt: 200 } } },
     ]
     expect(isProbeHealthy(snapshots, 'claude')).toBe(false)
   })

--- a/worker/src/probe.ts
+++ b/worker/src/probe.ts
@@ -164,9 +164,16 @@ export function isProbeHealthy(
   if (median === null || median <= 0) return false
 
   const threshold = median * 3
-  // All recent probes must be healthy (no failures, no spikes)
-  return recent.every(s => {
+  // Majority rule: ≥ ⌈2/3⌉ of recent probes must be healthy.
+  // Previously required ALL probes healthy, which caused false-positive degraded alerts
+  // when a single transient RTT blip coincided with a structural status-page fetch failure
+  // (e.g. DeepSeek — status.deepseek.com blocks Workers IPs, so degradedFromFetch fires
+  // every cron cycle; one probe blip prevented cross-validation from overriding to operational).
+  // A single outlier probe in 3 cycles is network noise; a genuine degradation spikes
+  // multiple consecutive probes, which majority correctly identifies as unhealthy.
+  const healthyCount = recent.filter(s => {
     const probe = s.data[serviceId]
     return probe.rtt > 0 && probe.rtt <= threshold
-  })
+  }).length
+  return healthyCount >= Math.ceil(recent.length * 2 / 3)
 }


### PR DESCRIPTION
## Summary

Two independent improvements triggered by DeepSeek's Flashduty migration (#507):

### 1. `isProbeHealthy` majority rule (`worker/src/probe.ts`)
- **Before**: all recent probes must be healthy (strict `every`)
- **After**: ≥ ⌈2/3⌉ recent probes must be healthy
- For 2 probes (minimum): still requires both healthy — no behavioral change at floor
- For 3 probes: one transient blip tolerated; 2+ spikes still returns `false`

**Why**: DeepSeek's `status.deepseek.com` blocks Workers IPs (structural failure → `degradedFromFetch` fires every cron cycle). A single concurrent probe RTT blip previously prevented cross-validation from overriding to `operational` → false-positive alert. With majority rule, transient blips no longer suppress the override while genuine sustained degradations still fire correctly.

### 2. DeepSeek transparency display
- **ServiceDetails** (`/#deepseek`): `⚠ Status page (Flashduty) not accessible outside China — monitoring via API probe only since May 2026`
- **`/is-deepseek-down`** insight: note about Flashduty migration and probe-only limitation
- **i18n**: `svc.deepseek.probeNote` in en.js + ko.js

## Test plan
- [ ] Worker tests pass (1421/1421) ✓
- [ ] Build passes ✓
- [ ] Verified in browser: DeepSeek detail page shows probe note ✓
- [ ] Verified in browser: /is-deepseek-down insight shows limitation note ✓

refs #507, #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)