### PR TITLE
feat(worker): add p95 + spike fields to monthly archive (aiwatch-reports#17 follow-up)

### DIFF
--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   computeMonthlyUptime,
   computeMonthlyLatency,
+  computeMonthlyLatencyStats,
   getMonthDates,
   isInMonthlyArchiveWindow,
   buildMonthlyArchive,
@@ -140,6 +141,44 @@ describe('computeMonthlyLatency', () => {
 
   it('handles empty data', () => {
     expect(Object.keys(computeMonthlyLatency({}))).toHaveLength(0)
+  })
+})
+
+describe('computeMonthlyLatencyStats (#17 — p95 + spikes)', () => {
+  it('averages valid daily p95 and sums spikes', () => {
+    const probeData = {
+      '2026-03-01': { claude: { p50: 100, p75: 200, p95: 300, min: 50, max: 400, count: 100, spikes: 2 } },
+      '2026-03-02': { claude: { p50: 110, p75: 220, p95: 320, min: 55, max: 410, count: 100, spikes: 3 } },
+    }
+    expect(computeMonthlyLatencyStats(probeData).claude).toEqual({ p95: 310, spikes: 5 })
+  })
+
+  it('p95 is null when no day has a valid (>0) p95, but spikes still accumulate', () => {
+    // A probe-failure-only day stores p95=0 — must not render a misleading "0 ms".
+    const probeData = {
+      '2026-03-01': { openai: { p50: 0, p75: 0, p95: 0, min: 0, max: 0, count: 5, spikes: 5 } },
+      '2026-03-02': { openai: { p50: 0, p75: 0, p95: 0, min: 0, max: 0, count: 3, spikes: 3 } },
+    }
+    expect(computeMonthlyLatencyStats(probeData).openai).toEqual({ p95: null, spikes: 8 })
+  })
+
+  it('excludes p95=0 days from the average but keeps valid ones', () => {
+    const probeData = {
+      '2026-03-01': { groq: { p50: 0, p75: 0, p95: 0, min: 0, max: 0, count: 5, spikes: 1 } },
+      '2026-03-02': { groq: { p50: 50, p75: 100, p95: 150, min: 30, max: 200, count: 50, spikes: 0 } },
+    }
+    expect(computeMonthlyLatencyStats(probeData).groq).toEqual({ p95: 150, spikes: 1 })
+  })
+
+  it('spikes total is 0 (not null) when service has valid p95 but no spikes', () => {
+    const probeData = {
+      '2026-03-01': { cohere: { p50: 80, p75: 160, p95: 240, min: 40, max: 300, count: 100, spikes: 0 } },
+    }
+    expect(computeMonthlyLatencyStats(probeData).cohere).toEqual({ p95: 240, spikes: 0 })
+  })
+
+  it('handles empty data', () => {
+    expect(Object.keys(computeMonthlyLatencyStats({}))).toHaveLength(0)
   })
 })
 

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -41,6 +41,8 @@ export interface MonthlyServiceData {
   totalDowntimeMin: number | null // sum of all incident durations for the month (null if no resolved incidents — unresolved durations are tracked as 0 upstream)
   longestIncidentMin: number | null // max single-incident duration for the month (null if no resolved incidents)
   avgLatencyMs: number | null    // average probe RTT p75 in ms (null if no probe data)
+  p95LatencyMs: number | null    // mean of daily probe RTT p95 in ms (#17 — null if no valid p95 data)
+  latencySpikes: number | null   // total RTT spikes this month (rtt>3×median or failed probe; #17 — null if no probe data)
   // Per-incident detail (#375). Capped at MAX_INCIDENTS_PER_SERVICE_IN_ARCHIVE to bound KV size;
   // when the cap is hit, oldest entries are truncated (the most-recent-N policy keeps the
   // dashboard's 30-90d filter useful even on high-frequency services like Together AI).
@@ -393,6 +395,41 @@ export function computeMonthlyLatency(
   return result
 }
 
+/**
+ * Monthly p95 (mean of valid daily p95) + total spike count per service (#17 follow-up).
+ * Same daily probe source as computeMonthlyLatency; kept separate so the existing p75 callers
+ * and tests are unaffected. p95 is null when no day had a valid (>0) p95 — a probe-failure-only
+ * day stores p95=0, which would otherwise render a misleading "0 ms" in the report. Spikes
+ * accumulate across all days (a failed-probe day contributes spikes even with p95=0).
+ */
+export function computeMonthlyLatencyStats(
+  probeData: Record<string, ProbeDailyData>,
+): Record<string, { p95: number | null; spikes: number }> {
+  const p95Sums: Record<string, number> = {}
+  const p95Counts: Record<string, number> = {}
+  const spikeTotals: Record<string, number> = {}
+  for (const daily of Object.values(probeData)) {
+    for (const [id, stat] of Object.entries(daily)) {
+      if (stat.p95 > 0) {
+        p95Sums[id] = (p95Sums[id] ?? 0) + stat.p95
+        p95Counts[id] = (p95Counts[id] ?? 0) + 1
+      }
+      if (typeof stat.spikes === 'number' && stat.spikes > 0) {
+        spikeTotals[id] = (spikeTotals[id] ?? 0) + stat.spikes
+      }
+    }
+  }
+  const result: Record<string, { p95: number | null; spikes: number }> = {}
+  const ids = new Set([...Object.keys(p95Sums), ...Object.keys(spikeTotals)])
+  for (const id of ids) {
+    result[id] = {
+      p95: p95Counts[id] ? Math.round(p95Sums[id] / p95Counts[id]) : null,
+      spikes: spikeTotals[id] ?? 0,
+    }
+  }
+  return result
+}
+
 // ── Security summary builder ─────────────────────────────────────────
 
 const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 }
@@ -658,6 +695,7 @@ export async function buildMonthlyArchive(
 
   const uptimeMap = computeMonthlyUptime(dailyData)
   const latencyMap = computeMonthlyLatency(probeData)
+  const latencyStats = computeMonthlyLatencyStats(probeData) // p95 + spikes (#17)
 
   // Guard: 0 days with data is almost certainly a KV failure
   if (daysCollected === 0) {
@@ -666,7 +704,7 @@ export async function buildMonthlyArchive(
 
   // Build per-service archive
   const services: Record<string, MonthlyServiceData> = {}
-  const allIds = new Set([...Object.keys(uptimeMap), ...Object.keys(latencyMap)])
+  const allIds = new Set([...Object.keys(uptimeMap), ...Object.keys(latencyMap), ...Object.keys(latencyStats)])
 
   if (scoreData) {
     for (const svc of scoreData) allIds.add(svc.id)
@@ -705,6 +743,8 @@ export async function buildMonthlyArchive(
       totalDowntimeMin,
       longestIncidentMin,
       avgLatencyMs: latencyMap[id] ?? null,
+      p95LatencyMs: latencyStats[id]?.p95 ?? null,
+      latencySpikes: latencyStats[id]?.spikes ?? null,
       ...(incidentList ? { incidentList } : {}),
     }
   }


### PR DESCRIPTION
## Summary

aiwatch-reports#17 (PR aiwatch-reports#25) dropped the monthly report's empty **p95 / Spikes** latency columns because `MonthlyServiceData` only carried `avgLatencyMs` (p75) — every other cell rendered `—`. The probe source (`ProbeDailyStat`) already has `p95` + `spikes`; this surfaces them into the permanent archive so the report can re-enable those columns.

## Changes (`worker/src/monthly-archive.ts`)
- `MonthlyServiceData` gains `p95LatencyMs: number | null` + `latencySpikes: number | null`.
- New `computeMonthlyLatencyStats(probeData)`:
  - **p95** = mean of valid (>0) daily p95; `null` when no day had a valid p95 (a probe-failure-only day stores p95=0 → must not render a misleading "0 ms").
  - **spikes** = sum of daily spike counts; accumulates even on p95-null days.
  - Kept separate from `computeMonthlyLatency` so the p75 callers/tests are untouched.
- `buildMonthlyArchive` fills both fields; `/api/report` returns the archive verbatim → surfaces automatically. `spikes=0` preserved as `0` (not null) for present ids.

## Tests
5 new `computeMonthlyLatencyStats` cases (averaging+summing, all-zero-p95 → null p95 + accumulating spikes, mixed valid/zero days, zero-spikes-not-null, empty). 1471 worker tests pass. Code review: 0 Critical/Important.

## Test plan
- [ ] Worker unit (1471) ✓ + wrangler dry-run ✓
- [ ] Post-deploy: next monthly archive carries `p95LatencyMs`/`latencySpikes`; `/api/report?month=YYYY-MM` exposes them

## Unblocks
aiwatch-reports re-enabling the p95 / Spikes columns — the `generate-report.js` comment marker (added in aiwatch-reports#17/#25) already points at `p95LatencyMs` / `latencySpikes`. (`vs Last Month` / `prevMonthLatencyMs` remains separate — needs prior-month archive deltas.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)