### PR TITLE
refactor: migrate Modal to native <dialog> (#481)

### DIFF
--- a/src/components/LegalContent.jsx
+++ b/src/components/LegalContent.jsx
@@ -131,7 +131,7 @@ export function TermsContent() {
       <h3 style={headingStyle}>6. Disclaimer</h3>
       <p style={paraStyle}>AIWatch is provided "as is" without warranties of any kind. We are not responsible for decisions made based on the information displayed, including but not limited to business, operational, or financial decisions.</p>
       <h3 style={headingStyle}>7. Open Source and Licensing</h3>
-      <p style={paraStyle}>AIWatch is open-source software licensed under the <a href="https://github.com/bentleypark/aiwatch/blob/main/LICENSE" style={linkStyle}>GNU Affero General Public License v3.0 (AGPL-3.0)</a>. The source code is available on GitHub. Contributions and usage are subject to the terms of this license.</p>
+      <p style={paraStyle}>AIWatch is open-source software licensed under the <a href="https://github.com/bentleypark/aiwatch/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" style={linkStyle}>GNU Affero General Public License v3.0 (AGPL-3.0)</a>. The source code is available on GitHub. Contributions and usage are subject to the terms of this license.</p>
       <h3 style={headingStyle}>8. Governing Law</h3>
       <p style={paraStyle}>These terms are governed by and construed in accordance with the laws of the Republic of Korea.</p>
       <h3 style={headingStyle}>9. Changes to Terms</h3>
@@ -160,7 +160,7 @@ export function TermsContent() {
       <h3 style={headingStyle}>6. 면책 조항</h3>
       <p style={paraStyle}>AIWatch는 어떠한 종류의 보증 없이 "있는 그대로" 제공됩니다. 표시된 정보를 기반으로 내린 비즈니스, 운영, 재무 등 모든 결정에 대해 AIWatch는 책임을 지지 않습니다.</p>
       <h3 style={headingStyle}>7. 오픈소스 및 라이선스</h3>
-      <p style={paraStyle}>AIWatch는 <a href="https://github.com/bentleypark/aiwatch/blob/main/LICENSE" style={linkStyle}>GNU Affero General Public License v3.0 (AGPL-3.0)</a> 라이선스에 따라 배포되는 오픈소스 소프트웨어입니다. 소스 코드는 GitHub에서 확인할 수 있으며, 기여 및 이용은 해당 라이선스 조건을 따릅니다.</p>
+      <p style={paraStyle}>AIWatch는 <a href="https://github.com/bentleypark/aiwatch/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" style={linkStyle}>GNU Affero General Public License v3.0 (AGPL-3.0)</a> 라이선스에 따라 배포되는 오픈소스 소프트웨어입니다. 소스 코드는 GitHub에서 확인할 수 있으며, 기여 및 이용은 해당 라이선스 조건을 따릅니다.</p>
       <h3 style={headingStyle}>8. 준거법</h3>
       <p style={paraStyle}>본 약관은 대한민국 법률에 따라 해석됩니다.</p>
       <h3 style={headingStyle}>9. 약관 변경</h3>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,95 +1,90 @@
-// Modal — accessible overlay dialog
-// Closes on: backdrop click, ESC key, ✕ button
-// Focus is trapped inside the dialog while open; restored to prior element on close.
+// Modal — native <dialog> overlay (#481)
+// Opens via showModal(): top-layer rendering, native focus-trap, inert background,
+// native ESC handling, and focus return to the trigger on close — all for free.
+// Closes on: backdrop click, ESC, ✕ button. Backdrop light-dismiss is driven by the JS
+// click handler below (universal — works everywhere); closedby="any" is a progressive
+// enhancement for engines that support it (not yet Baseline; absent in Firefox).
+//
+// Conditional render (return null when closed): each <Modal> instance only puts its
+// <dialog> in the DOM while open. App.jsx mounts two instances (privacy + terms); an
+// always-rendered <dialog> would leave two in the DOM at once, breaking `getByRole('dialog')`
+// and any single-dialog selector. Closed = unmounted, so at most one <dialog> exists.
 
 import { useEffect, useId, useRef } from 'react'
 import { useLang } from '../hooks/useLang'
 
-// Selectors for focusable elements within the dialog
-const FOCUSABLE =
-  'a[href], button:not([disabled]), input:not([disabled]), ' +
-  'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-
 export default function Modal({ isOpen, onClose, title, children }) {
   const { t } = useLang()
   const titleId = useId()
-  const panelRef = useRef(null)
+  const dialogRef = useRef(null)
 
-  // onCloseRef avoids re-running the effect when parent re-renders with new onClose reference
+  // onCloseRef avoids re-running the effect when the parent re-renders with a new onClose
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
 
+  // On open: showModal() (top-layer, native focus-trap + inert + ESC), lock body scroll, and wire
+  // the close paths. EVERY close routes through the native dialog.close() — it runs the focus-restore
+  // algorithm (returns focus to the trigger) that a plain React unmount would skip. The native `close`
+  // event then syncs state back: onClose() → parent clears isOpen → this unmounts. So `close` is the
+  // single sync point and there's no re-open footgun (state always follows the dialog).
+  // - `close` = fired by ESC, closedby="any", and our own .close() calls → onClose() syncs React.
+  // - `click` = backdrop light-dismiss fallback (universal). A backdrop click reports e.target === dialog,
+  //   but so does a click on the dialog's own scrollbar (overflow-y-auto) — guard with getBoundingClientRect
+  //   so only a click OUTSIDE the panel rect closes (matches native closedby, avoids the scrollbar footgun).
+  // showModal() does NOT lock body scroll, so we still do.
   useEffect(() => {
-    if (!isOpen) return
-
-    const previouslyFocused = document.activeElement
-    // Move focus into dialog on open
-    const initialFocusable = panelRef.current
-      ? Array.from(panelRef.current.querySelectorAll(FOCUSABLE))
-      : []
-    initialFocusable[0]?.focus()
-
-    function onKeyDown(e) {
-      if (e.key === 'Escape') { onCloseRef.current(); return }
-      // Re-query focusable elements each time (content may have changed)
-      const focusable = panelRef.current
-        ? Array.from(panelRef.current.querySelectorAll(FOCUSABLE))
-        : []
-      if (e.key !== 'Tab' || focusable.length === 0) return
-      const first = focusable[0]
-      const last = focusable[focusable.length - 1]
-      if (e.shiftKey) {
-        if (document.activeElement === first) { e.preventDefault(); last.focus() }
-      } else {
-        if (document.activeElement === last) { e.preventDefault(); first.focus() }
-      }
-    }
-
-    document.addEventListener('keydown', onKeyDown)
+    const dialog = dialogRef.current
+    if (!isOpen || !dialog) return
+    if (!dialog.open) dialog.showModal()
     document.body.style.overflow = 'hidden'
 
+    const handleClose = () => onCloseRef.current?.()
+    const handleClick = (e) => {
+      if (e.target !== dialog) return
+      const r = dialog.getBoundingClientRect()
+      const outsidePanel = e.clientX < r.left || e.clientX > r.right || e.clientY < r.top || e.clientY > r.bottom
+      if (outsidePanel) dialog.close()
+    }
+    dialog.addEventListener('close', handleClose)
+    dialog.addEventListener('click', handleClick)
     return () => {
-      document.removeEventListener('keydown', onKeyDown)
+      dialog.removeEventListener('close', handleClose)
+      dialog.removeEventListener('click', handleClick)
       document.body.style.overflow = ''
-      previouslyFocused?.focus()
     }
   }, [isOpen])
 
   if (!isOpen) return null
 
   return (
-    // Clicking the backdrop closes the modal; clicking the panel does not propagate
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60"
-      onClick={onClose}
-      aria-modal="true"
-      role="dialog"
+    // Native <dialog> has implicit role="dialog"; showModal() makes it modal (no aria-modal needed).
+    // `margin: auto` MUST be inline, not a Tailwind `.m-auto` util: index.css's unlayered
+    // `* { margin: 0 }` reset beats @layer-utilities classes, which would kill the UA dialog's
+    // margin:auto centering and pin the panel to the top-left. Inline style outranks both.
+    <dialog
+      ref={dialogRef}
+      closedby="any"
       aria-labelledby={titleId}
+      className="bg-[var(--bg1)] border border-[var(--border-hi)] overflow-y-auto p-0"
+      style={{ width: 'min(600px, 90vw)', maxHeight: '80vh', borderRadius: '12px', margin: 'auto' }}
     >
-      <div
-        ref={panelRef}
-        className="relative bg-[var(--bg1)] border border-[var(--border-hi)] overflow-y-auto"
-        style={{ width: 'min(600px, 90vw)', maxHeight: '80vh', borderRadius: '12px' }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between sticky top-0 z-10 bg-[var(--bg1)]"
-             style={{ padding: '18px 20px', borderBottom: '1px solid var(--border)' }}>
-          <h2 id={titleId} style={{ fontSize: '14px', fontWeight: 500, color: 'var(--text0)' }}>
-            {title}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-[var(--text1)] hover:text-[var(--text0)] transition-colors"
-            style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: '18px', lineHeight: 1, padding: '2px 6px' }}
-            aria-label={t('modal.close')}
-          >
-            ✕
-          </button>
-        </div>
-        <div style={{ padding: '20px', fontSize: '13px', color: 'var(--text1)', lineHeight: 1.8 }}>
-          {children}
-        </div>
+      <div className="flex items-center justify-between sticky top-0 z-10 bg-[var(--bg1)]"
+           style={{ padding: '18px 20px', borderBottom: '1px solid var(--border)' }}>
+        <h2 id={titleId} style={{ fontSize: '14px', fontWeight: 500, color: 'var(--text0)' }}>
+          {title}
+        </h2>
+        <button
+          onClick={() => dialogRef.current?.close()}
+          className="text-[var(--text1)] hover:text-[var(--text0)] transition-colors"
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: '18px', lineHeight: 1, padding: '2px 6px' }}
+          aria-label={t('modal.close')}
+        >
+          ✕
+        </button>
       </div>
-    </div>
+      <div style={{ padding: '20px', fontSize: '13px', color: 'var(--text1)', lineHeight: 1.8 }}>
+        {children}
+      </div>
+    </dialog>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -181,6 +181,14 @@ pre,
 ::-webkit-scrollbar-track { background: var(--bg1); }
 ::-webkit-scrollbar-thumb { background: var(--bg4); border-radius: 3px; }
 
+/* ─── Modal backdrop (native <dialog>::backdrop, #481) ───── */
+/* Theme-adaptive scrim: ::backdrop inherits custom properties from its originating
+   element (the <dialog>, which inherits --bg0 from :root), so it tracks the
+   [data-theme="light"] remap — verified in-browser in both themes. color-mix is Baseline 2023. */
+dialog::backdrop {
+  background: color-mix(in srgb, var(--bg0) 60%, transparent);
+}
+
 /* ─── Ticker Bar Animation ───────────────────────────────── */
 @keyframes ticker-scroll {
   from { transform: translateX(0); }

--- a/tests/modal.spec.js
+++ b/tests/modal.spec.js
@@ -23,23 +23,44 @@ test.describe('Modal / Detail Panel', () => {
     await expect(closeBtn).toBeHidden({ timeout: 5000 })
   })
 
-  test('Privacy modal opens from footer and closes on ESC', async ({ page }) => {
+  test('Privacy modal opens from footer and closes on ESC, restoring focus', async ({ page }) => {
     await page.goto('/')
     await waitForDataLoad(page)
 
-    // Scroll to footer and click privacy link
+    // Scroll to footer and open privacy link. focus() before click() so the trigger is the
+    // document.activeElement at showModal() time — native <dialog> returns focus there on close.
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
     const privacyBtn = page.getByRole('button', { name: /개인정보|Privacy/i })
     await privacyBtn.waitFor({ state: 'visible' })
-    await privacyBtn.evaluate((el) => el.click())
+    await privacyBtn.evaluate((el) => { el.focus(); el.click() })
 
     // Modal should be visible
     await expect(page.getByRole('dialog')).toBeVisible()
     await expect(page.getByText(/수집하는 정보|Information We Collect/)).toBeVisible()
 
-    // Close with ESC
+    // Close with ESC (native <dialog> cancel→close)
     await page.keyboard.press('Escape')
     await expect(page.getByRole('dialog')).toBeHidden()
+    // Native <dialog> restores focus to the trigger (AC: "focus returns to trigger")
+    await expect(privacyBtn).toBeFocused()
+  })
+
+  test('Privacy modal closes on the ✕ button', async ({ page }) => {
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    const privacyBtn = page.getByRole('button', { name: /개인정보|Privacy/i })
+    await privacyBtn.waitFor({ state: 'visible' })
+    await privacyBtn.evaluate((el) => el.click())
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // ✕ is the one app-owned close path (ESC/backdrop are browser-native). It must call onClose()
+    // → setModal(null) → unmount; a regression to a direct dialog.close() would leave isOpen=true.
+    await dialog.getByRole('button', { name: /닫기|Close/i }).evaluate((el) => el.click())
+    await expect(dialog).toBeHidden()
   })
 
   test('Terms modal opens and closes on backdrop click', async ({ page }) => {
@@ -55,8 +76,30 @@ test.describe('Modal / Detail Panel', () => {
     await expect(page.getByRole('dialog')).toBeVisible()
     await expect(page.getByText(/서비스 개요|Service Overview/)).toBeVisible()
 
-    // Close by clicking backdrop (the fixed overlay outside the modal panel)
-    await page.locator('[role="dialog"]').click({ position: { x: 10, y: 10 } })
+    // Close by clicking the backdrop. boundingBox() returns the PANEL rect (the <dialog> is the panel);
+    // a click 20px above it lands on the ::backdrop region, where e.target === dialog and the point is
+    // outside the panel rect → the JS handleClick guard (and native closedby) closes it. Assumes the
+    // panel is centered with backdrop above (true at min(600,90vw)/80vh on the default test viewport).
+    const box = await page.locator('dialog').boundingBox()
+    await page.mouse.click(box.x + box.width / 2, Math.max(2, box.y - 20))
     await expect(page.getByRole('dialog')).toBeHidden()
+  })
+
+  test('Terms modal external license link opens in a new tab', async ({ page }) => {
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    const termsBtn = page.getByRole('button', { name: /이용약관|Terms/i })
+    await termsBtn.waitFor({ state: 'visible' })
+    await termsBtn.evaluate((el) => el.click())
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    // The AGPL link is external; without target="_blank" it navigates the SPA away (full reload on
+    // back → modal lost). Assert it opens in a new tab with a safe rel. Regression guard for the
+    // same-tab-navigation bug found during #481 verification.
+    const license = page.getByRole('dialog').getByRole('link', { name: /AGPL-3\.0/i })
+    await expect(license).toHaveAttribute('target', '_blank')
+    await expect(license).toHaveAttribute('rel', /noopener/)
   })
 })


### PR DESCRIPTION
closes #481

## Summary
Migrate `src/components/Modal.jsx` from a hand-rolled `role="dialog"` div to the native `<dialog>` element. `showModal()` provides top-layer rendering, focus-trap, `inert` background, ESC handling, and focus-return-to-trigger natively — removing the manual ESC keydown, Tab focus-trap loop, backdrop div, scroll-lock-only effect, and `previouslyFocused.focus()` restore.

## Key decisions
- **Conditional render** (`if(!isOpen) return null`): App.jsx mounts two `<Modal>` instances (privacy + terms). Always-rendering would leave two `<dialog>` elements in the DOM and break every `getByRole('dialog')` selector. Closed = unmounted → at most one `<dialog>` exists.
- **Close routes through `dialog.close()`**, not React unmount — so the native focus-restore algorithm runs (closing via unmount silently skipped it, a real AC violation the focus test caught). The native `close` event syncs React state back: single sync point, no re-open footgun.
- **Backdrop light-dismiss** via JS `click` handler (universal), guarded by `getBoundingClientRect` so the dialog's own scrollbar doesn't close it. `closedby="any"` is progressive enhancement (not yet Baseline).
- **`margin: auto` inline** (not `.m-auto`): index.css's unlayered `* { margin: 0 }` reset beats `@layer utilities`, which was pinning the panel top-left. Inline style outranks both.
- **`::backdrop` scrim** via `color-mix(in srgb, var(--bg0) 60%, transparent)` → theme-adaptive (dark + light), design-token only.

## Also fixed (found during verification)
The Terms modal's **AGPL-3.0 external link** opened in the same tab → back button caused a full SPA reload and lost the modal. Added `target="_blank" rel="noopener noreferrer"` to both en + ko license links. `mailto:contact@ai-watch.dev` links left unchanged (standard `mailto:` behavior, not a code bug).

## Tests
5 modal E2E: open + ESC-close (with focus-restore assertion), ✕-button close, backdrop close, external-link-new-tab regression guard. Full suite: 316 unit + 120 E2E green; build + lint clean.

## Review
3 rounds (code / comments / tests), converged to **0 Critical/Important**. Round 1 surfaced the scrollbar-close, focus-restore, and ✕-test gaps; the focus-restore fix triggered a close-lifecycle redesign re-reviewed in Round 2; the AGPL fix reviewed in Round 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)