### PR TITLE
feat(worker): collapse multi-surface incidents into one /feed.xml item (#520)

### DIFF
--- a/worker/src/__tests__/rss.test.ts
+++ b/worker/src/__tests__/rss.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildRssFeed, feedSlug, resolveFeedService, isValidFeedSegment, buildFeedResponse } from '../rss'
+import { buildRssFeed, feedSlug, resolveFeedService, isValidFeedSegment, buildFeedResponse, dedupeSharedIncidents } from '../rss'
 import type { ServiceStatus, Incident } from '../types'
 
 function incident(over: Partial<Incident> = {}): Incident {
@@ -408,11 +408,24 @@ describe('buildRssFeed — shared incident (per-surface providers)', () => {
     service({ id: 'claudecode', name: 'Claude Code', incidents: [incident({ id: 'shared', title: 'Elevated errors' })] }),
   ]
 
-  it('annotates each item with the other services sharing the incident ID', () => {
+  it('collapses a multi-surface incident into ONE all-feed item, keeping the SERVICES-order primary (#520)', () => {
     const xml = buildRssFeed(anthropic, { scope: 'all' }, NOW)
+    // One item, not three — the Slack /feed subscriber gets a single consolidated message
+    expect((xml.match(/<item>/g) ?? []).length).toBe(1)
+    // Primary = first in SERVICES order (Claude API); its "Also affecting" names the rest
+    expect(xml).toContain('🔴 Claude API: Elevated errors') // default incident impact 'major' → 🔴
     expect(xml).toContain('Also affecting: claude.ai, Claude Code')
-    expect(xml).toContain('Also affecting: Claude API, Claude Code')
-    expect(xml).toContain('Also affecting: Claude API, claude.ai')
+    // The other surfaces' items (and their inverse "Also affecting" lines) are gone
+    expect(xml).not.toContain('Also affecting: Claude API, Claude Code')
+    expect(xml).not.toContain('Also affecting: Claude API, claude.ai')
+  })
+
+  it('uses a per-incident guid for the collapsed item (no Slack re-post churn)', () => {
+    const xml = buildRssFeed(anthropic, { scope: 'all' }, NOW)
+    expect((xml.match(/aiwatch:claude:shared/g) ?? []).length).toBe(1)
+    // no per-surface guids leak through for the deduped incident
+    expect(xml).not.toContain('aiwatch:claudeai:shared')
+    expect(xml).not.toContain('aiwatch:claudecode:shared')
   })
 
   it('omits the note for an incident unique to one service', () => {
@@ -420,10 +433,53 @@ describe('buildRssFeed — shared incident (per-surface providers)', () => {
     expect(xml).not.toContain('Also affecting:')
   })
 
-  it('keeps the note in a service-scoped feed using the full service list', () => {
+  it('keeps the note + single item in a service-scoped feed using the full service list', () => {
     const xml = buildRssFeed(anthropic, { scope: 'service', service: anthropic[0] }, NOW)
     expect(xml).toContain('Also affecting: claude.ai, Claude Code')
     expect((xml.match(/<item>/g) ?? []).length).toBe(1)
+  })
+
+  it('keeps an active and a resolved item separate (dedup is per incidentId+kind)', () => {
+    // If one surface is resolved while another is still active under the same incidentId, both kinds survive.
+    const mixed = [
+      service({ id: 'claude', name: 'Claude API', status: 'operational', incidents: [incident({ id: 'shared', title: 'Elevated errors', status: 'resolved', resolvedAt: '2026-05-10T14:00:00.000Z', duration: '34m' })] }),
+      service({ id: 'claudeai', name: 'claude.ai', status: 'degraded', incidents: [incident({ id: 'shared', title: 'Elevated errors', status: 'investigating' })] }),
+    ]
+    const xml = buildRssFeed(mixed, { scope: 'all' }, NOW)
+    expect((xml.match(/<item>/g) ?? []).length).toBe(2)
+  })
+})
+
+describe('dedupeSharedIncidents (#520)', () => {
+  const e = (id: string, kind: 'active' | 'resolved', tag: string) => ({ incident: { id }, kind, tag })
+
+  it('keeps the first occurrence per incidentId+kind', () => {
+    const out = dedupeSharedIncidents([
+      e('shared', 'active', 'claude'),
+      e('shared', 'active', 'claudeai'),
+      e('shared', 'active', 'claudecode'),
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].tag).toBe('claude') // first = primary
+  })
+
+  it('treats active and resolved of the same incident as distinct entries', () => {
+    const out = dedupeSharedIncidents([
+      e('shared', 'resolved', 'claude'),
+      e('shared', 'active', 'claudeai'),
+      e('shared', 'resolved', 'claudecode'),
+    ])
+    expect(out).toHaveLength(2)
+    expect(out.map(o => o.tag)).toEqual(['claude', 'claudeai'])
+  })
+
+  it('leaves distinct incidents untouched and preserves order', () => {
+    const out = dedupeSharedIncidents([
+      e('a', 'active', 'x'),
+      e('b', 'active', 'y'),
+      e('a', 'active', 'dup'),
+    ])
+    expect(out.map(o => o.tag)).toEqual(['x', 'y'])
   })
 })
 

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -259,6 +259,32 @@ function itemXml(
     </item>`
 }
 
+/**
+ * Collapse feed entries sharing an incidentId+kind into a single entry (#520), keeping the FIRST
+ * occurrence. A per-surface provider (Anthropic: Claude API / claude.ai / Claude Code) links one
+ * root incident to several services, which would otherwise emit N near-identical items in the
+ * all-services feed — and N Slack /feed messages. Callers pass entries in SERVICES order, so the
+ * survivor is the deterministic "primary" surface (e.g. Claude API ahead of claude.ai / Claude Code);
+ * itemXml's "Also affecting" line still names the rest. Exported for unit testing.
+ *
+ * Accepted edge: the survivor's guid is the primary's (`aiwatch:{primaryId}:{incId}`). If the primary
+ * surface recovers BEFORE its siblings (partial recovery), the still-active item's primary shifts to the
+ * next SERVICES-order surface, so its guid changes and Slack/RSS re-notifies the ongoing incident once.
+ * Rare and arguably informative ("still active on claude.ai"); the alternative — an incident-scoped guid
+ * — would re-post the entire feed on deploy (every guid changes), which is worse churn. Left as-is.
+ */
+export function dedupeSharedIncidents<T extends { incident: { id: string }; kind: ItemKind }>(entries: T[]): T[] {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const e of entries) {
+    const key = `${e.incident.id}:${e.kind}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(e)
+  }
+  return out
+}
+
 export type FeedScope =
   | { scope: 'all' }
   | { scope: 'service'; service: ServiceStatus }
@@ -293,8 +319,14 @@ export function buildRssFeed(
       }
     }
   }
-  items.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
-  const capped = items.slice(0, MAX_ITEMS)
+  // All-services feed (#520): collapse a multi-surface incident (one incidentId across Claude API /
+  // claude.ai / Claude Code) into ONE item per (incidentId, kind) so a Slack /feed subscriber to
+  // /feed.xml gets a single consolidated message instead of N near-identical ones. `sources` iterates
+  // in SERVICES order so the surviving "primary" is deterministic; itemXml's "Also affecting" lists
+  // the rest. Per-service feeds (scope:'service') have a single source, so this is a no-op there.
+  const deduped = opts.scope === 'all' ? dedupeSharedIncidents(items) : items
+  deduped.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
+  const capped = deduped.slice(0, MAX_ITEMS)
 
   const title =
     opts.scope === 'service'


### PR DESCRIPTION
closes #520

## Summary
A per-surface provider (Anthropic: Claude API / claude.ai / Claude Code) links one root incident to several services under the same `incidentId`. The all-services feed `/feed.xml` previously emitted one `<item>` per `{service, incident}` pair → **N near-identical items → N Slack `/feed` messages for one event** (the reported case: 3 messages for one "Opus 4.7 elevated errors" incident, all from a single `/feed.xml` subscription).

## Fix
`dedupeSharedIncidents` (exported) collapses entries to **one per `(incidentId, kind)`**, applied only in `buildRssFeed` when `scope === 'all'`:
- Keeps the **first occurrence**; `sources` iterates in SERVICES order so the surviving **primary** is deterministic (Claude API ahead of claude.ai / Claude Code).
- `itemXml`'s "Also affecting: …" line still names the co-affected surfaces.
- Per-service feeds (`scope: 'service'`) are single-source → **unchanged**.
- `active` vs `resolved` kinds stay distinct (separate keys), so a partial recovery still shows both.

Resolves the reporter's case **with no subscription change** — they're already on `/feed.xml`.

## Verified
A live `buildRssFeed` run for a 3-surface incident now yields exactly one item:
```
<title>🟢 Claude API: Resolved — Opus 4.7 elevated errors</title>
<guid>aiwatch:claude:opus47:resolved</guid>
Also affecting: claude.ai, Claude Code
```

## Accepted edge (documented)
The survivor's guid is the primary's. If the primary recovers **before** its siblings, the still-active item's primary shifts (next SERVICES-order surface) and Slack re-notifies the ongoing incident once. Rarer and less churny than an incident-scoped guid, which would re-post the entire feed on deploy (every guid changes). Left as-is, documented in the `dedupeSharedIncidents` doc comment.

## Tests
rss.test.ts: multi-surface → 1 item + primary selection + per-incident guid + active/resolved-distinct + per-service-feed-unchanged, plus `dedupeSharedIncidents` unit tests (first-wins, kind-distinct, order-preserving). **rss 52 pass**, full worker suite green, `wrangler --dry-run` clean.

## Note (follow-up)
The "primary = first in SERVICES order" rule is the same group-order selection that #521 tracks improving for the X tweet draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)