### PR TITLE
feat(worker): operator-selectable multi-service tweet drafts (#521)

### DIFF
--- a/worker/src/__tests__/tweet-draft.test.ts
+++ b/worker/src/__tests__/tweet-draft.test.ts
@@ -1,7 +1,7 @@
 // #348 — outage-tweet draft attached to operator Discord alerts for the Claude/OpenAI family.
 import { describe, it, expect } from 'vitest'
-import { buildTweetDraft } from '../alerts'
-import type { AlertCandidate, ScoredService } from '../alerts'
+import { buildTweetDraft, buildTweetDrafts, appendTweetDraftSection, DISCORD_EMBED_DESC_MAX } from '../alerts'
+import type { AlertCandidate, ScoredService, TweetDraft } from '../alerts'
 
 const X_INTENT = 'https://twitter.com/intent/tweet?text='
 
@@ -147,5 +147,116 @@ describe('buildTweetDraft', () => {
     expect(draft!.text).not.toContain('\n')
     expect(draft!.text).not.toContain('`')
     expect(draft!.text).toContain('line1 line2 code')
+  })
+})
+
+describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
+  // A multi-surface Anthropic incident: one incidentId carried by all three surfaces.
+  const sharedInc = (id: string) => ({ id, title: 'Opus 4.7 elevated errors', status: 'investigating', startedAt: new Date().toISOString(), impact: 'minor' } as any)
+  const anthropic = [
+    mockService({ id: 'claude', name: 'Claude API', status: 'degraded', incidents: [sharedInc('opus47')] }),
+    mockService({ id: 'claudeai', name: 'claude.ai', status: 'degraded', incidents: [sharedInc('opus47')] }),
+    mockService({ id: 'claudecode', name: 'Claude Code', status: 'degraded', incidents: [sharedInc('opus47')] }),
+  ]
+
+  it('returns one draft per affected in-scope surface, each with its OWN name + is-down url', () => {
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)
+    expect(drafts.map((d) => d.serviceId)).toEqual(['claude', 'claudeai', 'claudecode'])
+    expect(drafts[0].text).toContain('Claude API')
+    expect(drafts[0].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-down'))
+    expect(drafts[1].text).toContain('claude.ai')
+    expect(drafts[1].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-ai-down'))
+    expect(drafts[2].text).toContain('Claude Code')
+    expect(drafts[2].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-code-down'))
+  })
+
+  it('filters out non-in-scope services in the group (e.g. Gemini)', () => {
+    const withGemini = [
+      mockService({ id: 'gemini', name: 'Gemini API', provider: 'Google', incidents: [sharedInc('opus47')] }),
+      ...anthropic,
+    ]
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), withGemini)
+    expect(drafts.map((d) => d.serviceId)).toEqual(['claude', 'claudeai', 'claudecode']) // gemini excluded
+  })
+
+  it('single-surface incident yields exactly one draft (matches buildTweetDraft)', () => {
+    const svc = mockService({ id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'down', incidents: [sharedInc('solo')] })
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:new:solo' }), [svc])
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0].text).toBe(buildTweetDraft(alert({ key: 'alerted:new:solo' }), [svc])!.text)
+  })
+
+  it('returns [] when no in-scope service is covered', () => {
+    const svc = mockService({ id: 'gemini', name: 'Gemini API', provider: 'Google', incidents: [sharedInc('g1')] })
+    expect(buildTweetDrafts(alert({ key: 'alerted:new:g1' }), [svc])).toEqual([])
+  })
+
+  it('builds recovery drafts per surface for a resolved multi-surface incident', () => {
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:res:opus47', title: '🟢 Claude API — Incident Resolved (34m)' }), anthropic)
+    expect(drafts).toHaveLength(3)
+    expect(drafts[0].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-down')
+    expect(drafts[1].text).toContain('🟢 claude.ai recovered after 34m')
+  })
+})
+
+describe('appendTweetDraftSection (#521 — Discord 4096 length guard)', () => {
+  const DIV = '┈┈┈┈┈┈'
+  const draft = (serviceId: string, serviceName: string, text: string): TweetDraft =>
+    ({ serviceId, serviceName, text, intentUrl: 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(text) })
+  const three = [
+    draft('claude', 'Claude API', '🔴 Claude API is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-down'),
+    draft('claudeai', 'claude.ai', '🔴 claude.ai is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-ai-down'),
+    draft('claudecode', 'Claude Code', '🔴 Claude Code is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-code-down'),
+  ]
+
+  it('returns the description unchanged when there are no drafts', () => {
+    expect(appendTweetDraftSection('desc', [], DIV)).toBe('desc')
+  })
+
+  it('single draft → original preview+link shape', () => {
+    const out = appendTweetDraftSection('desc', [three[0]], DIV)
+    expect(out).toContain('🐦 **TWEET DRAFT** — [✍️ Post on X](')
+    expect(out).toContain('> 🔴 Claude API is reporting')
+  })
+
+  it('multiple drafts → one labeled compose link per service, no single preview', () => {
+    const out = appendTweetDraftSection('desc', three, DIV)
+    expect(out).toContain('pick a service to post:')
+    expect(out).toContain('[✍️ Claude API](')
+    expect(out).toContain('[✍️ claude.ai](')
+    expect(out).toContain('[✍️ Claude Code](')
+    expect(out).not.toContain('> 🔴') // no blockquote preview in the multi case
+  })
+
+  it('never exceeds the Discord 4096-char limit, truncating links with "+N more"', () => {
+    const longDesc = 'x'.repeat(3900) // already near the cap
+    const out = appendTweetDraftSection(longDesc, three, DIV)
+    expect(out.length).toBeLessThanOrEqual(DISCORD_EMBED_DESC_MAX)
+    // not all three links fit → either truncated to fewer (+N more) or section skipped entirely
+    expect(out.startsWith(longDesc)).toBe(true)
+  })
+
+  it('partially fits links and appends a "+N more" suffix, still under the limit', () => {
+    // Pick a description length that leaves room for some but not all 3 links → exercises the
+    // truncation branch (the prior test lands on "none fit"). Each link is ~235 chars.
+    const linkLen = `[✍️ Claude API](${three[0].intentUrl})`.length
+    const intro = '\n' + DIV + '\n🐦 **TWEET DRAFT** — pick a service to post:\n'
+    // Budget that fits exactly 2 links (2*linkLen + 3) but not 3: target budget ≈ 2*linkLen + 10
+    const targetBudget = 2 * linkLen + 10
+    const descLen = DISCORD_EMBED_DESC_MAX - 16 - intro.length - targetBudget
+    const out = appendTweetDraftSection('x'.repeat(descLen), three, DIV)
+    expect(out.length).toBeLessThanOrEqual(DISCORD_EMBED_DESC_MAX)
+    expect(out).toContain(' more') // some links dropped → "+N more"
+    expect(out).toContain('[✍️ Claude API](') // at least one link kept
+  })
+
+  it('skips the whole section (description unchanged) when not even one link fits', () => {
+    const longDesc = 'x'.repeat(4090)
+    expect(appendTweetDraftSection(longDesc, three, DIV)).toBe(longDesc)
+  })
+
+  it('skips a single draft that would overflow rather than dropping the alert', () => {
+    const longDesc = 'x'.repeat(4090)
+    expect(appendTweetDraftSection(longDesc, [three[0]], DIV)).toBe(longDesc)
   })
 })

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -4,7 +4,7 @@
 import { getFallbacks, buildFallbackText } from './fallback'
 import { sanitize, formatDuration } from './utils'
 import { computeLeadMs } from './detection-lead-log'
-import { kindFromKey, svcIdsForAlert } from './alert-feed'
+import { kindFromKey, svcIdsForAlert, type AlertKind } from './alert-feed'
 // #422 Phase 2 — region-switch hint in Discord alerts. We reuse the existing
 // Edge TS port rather than adding a third copy of SERVICE_REGIONS: the Worker
 // bundler (esbuild via wrangler) can import across dirs (unlike Vercel Edge,
@@ -399,28 +399,16 @@ function findIncident(services: ServiceStatus[], incId: string): Incident | null
   return null
 }
 
-/**
- * Build the outage/recovery tweet draft for an alert, or null when the alert doesn't cover any
- * Claude/OpenAI-family service (the only services in scope for #348). Returns the canonical tweet
- * `text` (≤ TWEET_MAX, single line) plus the `intentUrl` that opens X's compose window prefilled.
- *
- * - outage (new / down / degraded): 🔴 {name} is reporting {impact}[: {title}]. Live status → …
- * - recovery (resolved / recovered): 🟢 {name} recovered after {duration}. / 🟢 {name} has recovered. …
- */
-export function buildTweetDraft(
+/** Build the tweet text + X compose link for ONE specific in-scope service. The caller has already
+ *  confirmed `svc.id` is in TWEET_DRAFT_SERVICES. The incident title/impact (for `new` alerts) comes
+ *  from the shared incident, but the phrasing/status/url are the service's own. */
+function buildTweetForService(
+  svc: ScoredService,
+  kind: AlertKind,
   alert: AlertCandidate,
   services: ScoredService[],
-): { text: string; intentUrl: string } | null {
-  const kind = kindFromKey(alert.key)
-  if (!kind) return null
-  const keys = alert._mergedKeys ?? [alert.key]
-  const svcIds = svcIdsForAlert(keys, kind, services)
-  // Pick the first covered service that's in scope (a grouped incident may list a non-target sibling first).
-  const targetId = svcIds.find((id) => Boolean(TWEET_DRAFT_SERVICES[id]))
-  if (!targetId) return null
-  const svc = services.find((s) => s.id === targetId)
-  if (!svc) return null
-  const url = `https://ai-watch.dev/is-${TWEET_DRAFT_SERVICES[targetId]}-down`
+): { text: string; intentUrl: string } {
+  const url = `https://ai-watch.dev/is-${TWEET_DRAFT_SERVICES[svc.id]}-down`
 
   let text: string
   if (kind === 'resolved' || kind === 'recovered') {
@@ -446,6 +434,91 @@ export function buildTweetDraft(
     }
   }
   return { text, intentUrl: X_INTENT_BASE + encodeURIComponent(text) }
+}
+
+export interface TweetDraft {
+  serviceId: string
+  serviceName: string
+  text: string
+  intentUrl: string
+}
+
+/**
+ * Build a tweet draft per in-scope (Claude/OpenAI-family) service the alert covers (#521). A grouped
+ * multi-surface incident (one incidentId across Claude API / claude.ai / Claude Code) yields one draft
+ * per affected surface, in svcIds order, so the operator PICKS which surface to tweet about instead of
+ * being locked to a single auto-chosen "primary". Empty when the alert covers no in-scope service.
+ * Operator-only (the caller appends these after the per-user feed entry — never relayed, #475).
+ */
+export function buildTweetDrafts(
+  alert: AlertCandidate,
+  services: ScoredService[],
+): TweetDraft[] {
+  const kind = kindFromKey(alert.key)
+  if (!kind) return []
+  const keys = alert._mergedKeys ?? [alert.key]
+  const svcIds = svcIdsForAlert(keys, kind, services)
+  const drafts: TweetDraft[] = []
+  for (const id of svcIds) {
+    if (!TWEET_DRAFT_SERVICES[id]) continue // not a Claude/OpenAI-family service in scope
+    const svc = services.find((s) => s.id === id)
+    if (!svc) continue
+    const { text, intentUrl } = buildTweetForService(svc, kind, alert, services)
+    drafts.push({ serviceId: id, serviceName: svc.name, text, intentUrl })
+  }
+  return drafts
+}
+
+/**
+ * Single-draft convenience: the first in-scope service's draft (legacy shape). Retained for the
+ * existing contract/tests; new callers should prefer buildTweetDrafts for the operator's pick-a-service UX.
+ */
+export function buildTweetDraft(
+  alert: AlertCandidate,
+  services: ScoredService[],
+): { text: string; intentUrl: string } | null {
+  const [first] = buildTweetDrafts(alert, services)
+  return first ? { text: first.text, intentUrl: first.intentUrl } : null
+}
+
+// Discord rejects an embed description over this with HTTP 400 — which would drop the WHOLE operator
+// alert, not just the draft section (sendDiscordAlert does no truncation). The tweet draft is an
+// optional nicety, so it must never push the description over the limit.
+export const DISCORD_EMBED_DESC_MAX = 4096
+
+/**
+ * Append the operator-only tweet-draft section to a Discord embed description, guaranteeing the result
+ * stays within Discord's 4096-char limit (#521). One draft → the original preview+link shape; many →
+ * labeled per-service compose links the operator picks from. Links that wouldn't fit are dropped with a
+ * "+N more" suffix; if not even one fits (or there are no drafts), the description is returned unchanged
+ * so the critical operator alert always sends.
+ */
+export function appendTweetDraftSection(description: string, drafts: TweetDraft[], div: string): string {
+  if (drafts.length === 0) return description
+  const SAFETY = 16 // headroom for the "+N more" suffix / multibyte rounding
+
+  if (drafts.length === 1) {
+    const d = drafts[0]
+    const section = `\n${div}\n🐦 **TWEET DRAFT** — [✍️ Post on X](${d.intentUrl})\n> ${d.text}`
+    return description.length + section.length <= DISCORD_EMBED_DESC_MAX - SAFETY
+      ? description + section
+      : description
+  }
+
+  const intro = `\n${div}\n🐦 **TWEET DRAFT** — pick a service to post:\n`
+  const budget = DISCORD_EMBED_DESC_MAX - SAFETY - description.length - intro.length
+  const links = drafts.map((d) => `[✍️ ${d.serviceName}](${d.intentUrl})`)
+  const fit: string[] = []
+  let used = 0
+  for (const link of links) {
+    const add = (fit.length ? 3 : 0) /* " · " */ + link.length
+    if (used + add > budget) break
+    fit.push(link)
+    used += add
+  }
+  if (fit.length === 0) return description
+  const more = drafts.length - fit.length
+  return `${description}${intro}${fit.join(' · ')}${more > 0 ? ` · +${more} more` : ''}`
 }
 
 /** Detect service count drop — returns missing service IDs if below threshold */

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type ServiceStatus } from './services'
 import { calculateAIWatchScore, classifyProbe } from './score'
-import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop, isFlapSuppressible, flapSuppressionKey, buildTweetDraft } from './alerts'
+import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop, isFlapSuppressible, flapSuppressionKey, buildTweetDrafts, appendTweetDraftSection } from './alerts'
 import { analyzeIncident, analyzeWithSonnet, refreshOrReanalyze, analysisKey, buildAnalysisPrompt, findSimilarIncidents, formatRecoveryDisplay, shouldSkipInitialAnalysis, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration, isAllowedAlertWebhook } from './utils'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
@@ -711,18 +711,20 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
     // visitor's webhook.
     const feedEntry = buildFeedEntry(alert, description, scored)
     if (feedEntry) feedEntries.push(feedEntry)
-    // #348 — operator-only tweet draft + X compose link for Claude/OpenAI-family alerts.
-    // Guarded: the draft is an optional nicety, so a bug here must never abort the send loop or
-    // the post-loop feed append (the operator alert is the critical path). Log so it's diagnosable.
-    let draft: { text: string; intentUrl: string } | null = null
+    // #348/#521 — operator-only tweet draft(s) + X compose link(s) for Claude/OpenAI-family alerts.
+    // A grouped multi-surface incident yields one draft per affected surface so the operator PICKS
+    // which to post (instead of a single auto-chosen primary). Guarded: the draft is an optional
+    // nicety, so a bug here must never abort the send loop or the post-loop feed append (the operator
+    // alert is the critical path). Log so it's diagnosable.
+    let drafts: ReturnType<typeof buildTweetDrafts> = []
     try {
-      draft = buildTweetDraft(alert, scored)
+      drafts = buildTweetDrafts(alert, scored)
     } catch (err) {
       console.error('[cron] tweet draft build failed (alert still sent):', alert.key, err instanceof Error ? err.message : err)
     }
-    const operatorDescription = draft
-      ? `${description}\n${DIV}\n🐦 **TWEET DRAFT** — [✍️ Post on X](${draft.intentUrl})\n> ${draft.text}`
-      : description
+    // appendTweetDraftSection is length-guarded (Discord 4096 cap) so a multi-link draft can never
+    // push the description over the limit and drop the whole operator alert.
+    const operatorDescription = appendTweetDraftSection(description, drafts, DIV)
     await sendDiscordAlert(env.DISCORD_WEBHOOK_URL, {
       title: alert.title,
       description: operatorDescription,


### PR DESCRIPTION
closes #521

## Summary
The operator-only X tweet draft (#348) auto-picked a single "primary" service for a multi-surface incident (one `incidentId` across Claude API / claude.ai / Claude Code), so an Anthropic incident **always** tweeted as "Claude API" (first in group order). This lets the operator **pick** which surface to post.

## Why "pick", not "smartest primary"
Production data (today's `rk70zc69m54p` "Opus 4.7 elevated errors" + history) confirmed **grouped incidents carry uniform impact across surfaces** — divergent-impact incidents have *different* incidentIds and are never grouped into one tweet anyway. So a "pick the worst-status service" heuristic would be a near no-op. Letting the operator choose is the robust fix and sidesteps the selection problem entirely.

## Changes
- `buildTweetForService` — extracted per-service text builder (faithful: same text/url/truncation).
- `buildTweetDrafts` (exported) — one draft per affected in-scope service, in svcIds order.
- `buildTweetDraft` — thin first-draft wrapper, kept for the legacy single-shape contract/tests.
- `appendTweetDraftSection` (exported) — renders the operator section **length-guarded under Discord's 4096-char limit**: single → preview+link; many → labeled per-service compose links, dropping overflow with "+N more" (or skipping the section) so a long description can never drop the whole alert. (Fixes an overflow risk caught in review — `sendDiscordAlert` does no truncation, and a >4096 description → HTTP 400 → the entire operator alert is lost.)
- `index.ts` cron call site simplified to the guarded helper.

Operator embed renders e.g. `🐦 **TWEET DRAFT** — pick a service to post:` then `[✍️ Claude API] · [✍️ claude.ai] · [✍️ Claude Code]`, each link prefilling X with that service's own text + `is-{slug}-down` URL.

## Q2 (claude.ai tweet thumbnail) — verified, no code change
The fetched production OG image for `is-claude-ai-down` is **AIWatch-branded** ("Is claude.ai Down?" + ai-watch.dev) — no Anthropic asset in anything we control. Any "Anthropic" look on X is X's own entity card for "claude.ai", not overridable via OG tags. The operator can also just pick a different surface. Left as-is.

## Invariants
Still **operator-only** — the draft section is appended to `operatorDescription` only, *after* the clean per-user feed entry is built (#475: never relayed to subscribers).

## Tests + verification
`buildTweetDrafts` (order / cross-family filter / single=wrapper-parity / empty / recovery) + `appendTweetDraftSection` (no-drafts / single / multi / overflow ≤4096 / partial-fit "+N more" / none-fit-skip). Worker suite **1478 pass**, `wrangler --dry-run` clean. **Verified live in Discord**: the multi-link section renders with clickable per-service links, each opening X compose prefilled correctly.

## Note
`CLAUDE.md` line 270 still says `buildTweetDraft` — left untouched here because CLAUDE.md currently carries the unresolved #516 merge-conflict markers (and is over the 40k budget because of them). The `buildTweetDrafts` rename should be folded into #516's conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)