### PR TITLE
test(#375): pin estimate-only handling in service-filter archive merge (closes #375)

### DIFF
--- a/src/utils/__tests__/archiveMerge.test.js
+++ b/src/utils/__tests__/archiveMerge.test.js
@@ -240,6 +240,19 @@ describe('archiveSupplementForService (service filter mode)', () => {
     expect(archiveSupplementForService(liveCompositeIds, 'mistral', archives, services)).toEqual([])
   })
 
+  it('skips an estimate-only filtered service (#375 — Bedrock/Azure: archive entry has no incidentList)', () => {
+    // Symmetric to the no-filter mode's estimate-only test: a user selecting an estimate-only service
+    // in the 90d Incidents view must get nothing from the archive. These services carry no incidents,
+    // so their archive entry omits incidentList — current (live-only) behavior stays unchanged.
+    const svcs = [...services, { id: 'bedrock', name: 'Amazon Bedrock' }]
+    const liveCompositeIds = new Set()
+    const archives = {
+      '2026-04': { services: { bedrock: { uptime: null, score: 92 /* estimate-only — no incidentList */ } } },
+    }
+    expect(archiveSupplementForService(liveCompositeIds, 'bedrock', archives, svcs)).toEqual([])
+    expect(liveCompositeIds.size).toBe(0) // nothing added to the dedup set either
+  })
+
   it('does not throw when an archive month is null (404 path)', () => {
     const liveCompositeIds = new Set()
     const archives = { '2026-04': null }


### PR DESCRIPTION
closes #375

## Context
Investigation found #375 ("persist incident detail to monthly archive so the 90-day filter works") is **already fully implemented** — the `deferred` label was stale:
- **Write**: `monthly-archive.ts` `incidentList` (≤200/service) ← `incidents:monthly:{YYYY-MM}` accumulator → permanent `archive:monthly:{YYYY-MM}`. Verified live: `/api/report?month=2026-05` carries the `incidentList` field.
- **Read**: `useMonthlyArchives.js` → `Incidents.jsx` merge (90d only) → `archiveMerge.js` (id-dedup, live-wins). Covered by `tests/incidents-archive-merge.spec.js` (3 passed).

Checklist items 1–4 done + E2E; item 5 is time-gated (the May archive already produces `incidentList`, so the mechanism is live).

## This PR — item 6 ("estimate-only — explicit handling")
The no-filter merge (`mergeArchiveIntoMap`) already had an explicit estimate-only test. This adds the **symmetric case for the service-filter path** (`archiveSupplementForService`): selecting an estimate-only service (Bedrock/Azure — archive entry omits `incidentList`) in the 90d view returns `[]` and adds nothing to the dedup set. Closes the last checklist gap.

Test-only. `npm run test:src` 317 passed (+1), lint clean.