### PR TITLE
feat(worker): persistent structural-block alert (1h+ unreachable) (#500)

### DIFF
--- a/worker/src/__tests__/persistent-failure.test.ts
+++ b/worker/src/__tests__/persistent-failure.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import { checkPersistentFetchFailures } from '../persistent-failure'
+
+const NOW = Date.parse('2026-06-02T12:00:00.000Z')
+const twoHoursAgo = new Date(NOW - 2 * 3_600_000).toISOString()
+const tenMinAgo = new Date(NOW - 10 * 60_000).toISOString()
+const DISCORD = 'https://discord.com/api/webhooks/1/abc'
+
+function mockKV(store: Record<string, string> = {}) {
+  return {
+    store,
+    list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+      keys: Object.keys(store).filter((k) => k.startsWith(prefix)).map((name) => ({ name })),
+    })),
+    get: vi.fn(async (k: string) => store[k] ?? null),
+    put: vi.fn(async (k: string, v: string) => { store[k] = v }),
+    delete: vi.fn(async (k: string) => { delete store[k] }), // unused by the sweep; satisfies KVSweep
+  }
+}
+
+const svcs = [{ id: 'deepseek', name: 'DeepSeek API' }, { id: 'mistral', name: 'Mistral API' }]
+
+describe('checkPersistentFetchFailures (#500)', () => {
+  it('alerts the operator + writes the 24h dedup when a service has been unreachable >= 1h', async () => {
+    const kv = mockKV({ 'fetch-fail:since:deepseek': twoHoursAgo })
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send).toHaveBeenCalledOnce()
+    const [url, embed] = send.mock.calls[0]
+    expect(url).toBe(DISCORD) // operator webhook
+    expect(embed.title).toContain('DeepSeek API')
+    expect(embed.description).toContain('2h+')
+    expect(kv.store['alerted:fetch-persistent:deepseek']).toBe('1') // dedup written
+  })
+
+  it('does NOT alert when the failure is younger than 1h', async () => {
+    const kv = mockKV({ 'fetch-fail:since:deepseek': tenMinAgo })
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send).not.toHaveBeenCalled()
+    expect(kv.store['alerted:fetch-persistent:deepseek']).toBeUndefined()
+  })
+
+  it('skips a service already alerted this 24h (dedup)', async () => {
+    const kv = mockKV({
+      'fetch-fail:since:deepseek': twoHoursAgo,
+      'alerted:fetch-persistent:deepseek': '1',
+    })
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does NOT write the dedup marker when the send fails (so it retries next cron)', async () => {
+    const kv = mockKV({ 'fetch-fail:since:deepseek': twoHoursAgo })
+    const send = vi.fn(async () => false) // Discord POST failed
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send).toHaveBeenCalledOnce()
+    expect(kv.store['alerted:fetch-persistent:deepseek']).toBeUndefined()
+  })
+
+  it('falls back to the svcId when the service is not in the name map', async () => {
+    const kv = mockKV({ 'fetch-fail:since:ghost': twoHoursAgo })
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send.mock.calls[0][1].title).toContain('ghost')
+  })
+
+  it('no-ops when kv or discord url is absent', async () => {
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(undefined, DISCORD, svcs, NOW, send)
+    await checkPersistentFetchFailures(mockKV({ 'fetch-fail:since:deepseek': twoHoursAgo }), undefined, svcs, NOW, send)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('handles multiple blocked services in one sweep', async () => {
+    const kv = mockKV({
+      'fetch-fail:since:deepseek': twoHoursAgo,
+      'fetch-fail:since:mistral': twoHoursAgo,
+    })
+    const send = vi.fn(async () => true)
+    await checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  it('never throws — a KV list failure is swallowed (best-effort, cron-safe)', async () => {
+    const kv = { list: vi.fn(async () => { throw new Error('KV down') }), get: vi.fn(), put: vi.fn() }
+    const send = vi.fn(async () => true)
+    await expect(checkPersistentFetchFailures(kv, DISCORD, svcs, NOW, send)).resolves.toBeUndefined()
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/worker/src/__tests__/utils.test.ts
+++ b/worker/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss, isAllowedAlertWebhook, type KVLike } from '../utils'
+import { formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss, isAllowedAlertWebhook, shouldAlertPersistentFailure, formatPersistentFailureAlert, PERSISTENT_FAILURE_THRESHOLD_MS, type KVLike } from '../utils'
 
 function mockKV(store: Record<string, string> = {}): KVLike {
   return {
@@ -174,6 +174,29 @@ describe('trackFetchFailure', () => {
     const kv2 = mockKV({ 'fetch-fail:azure': '4' })
     expect(await trackFetchFailure(kv2, 'azure', 5)).toBe(true) // 4+1=5 >= 5
   })
+
+  it('sets fetch-fail:since on the rising edge when absent (#500)', async () => {
+    const store: Record<string, string> = { 'fetch-fail:azure': '2' }
+    const kv = mockKV(store)
+    await trackFetchFailure(kv, 'azure') // next=3 = threshold → rising edge
+    expect(store['fetch-fail:since:azure']).toBeDefined()
+    expect(Number.isNaN(Date.parse(store['fetch-fail:since:azure']))).toBe(false) // valid ISO
+  })
+
+  it('does NOT overwrite an existing fetch-fail:since (preserves first-failure time across re-climbs)', async () => {
+    const original = '2026-06-01T00:00:00.000Z'
+    const store: Record<string, string> = { 'fetch-fail:azure': '2', 'fetch-fail:since:azure': original }
+    const kv = mockKV(store)
+    await trackFetchFailure(kv, 'azure') // rising edge again, but since already set
+    expect(store['fetch-fail:since:azure']).toBe(original)
+  })
+
+  it('does not set fetch-fail:since below the rising edge', async () => {
+    const store: Record<string, string> = { 'fetch-fail:azure': '0' }
+    const kv = mockKV(store)
+    await trackFetchFailure(kv, 'azure') // next=1, below threshold
+    expect(store['fetch-fail:since:azure']).toBeUndefined()
+  })
 })
 
 describe('resetFetchFailure', () => {
@@ -193,6 +216,58 @@ describe('resetFetchFailure', () => {
 
   it('does nothing when kv is undefined', async () => {
     await resetFetchFailure(undefined, 'azure') // no throw
+  })
+
+  it('also clears fetch-fail:since on recovery (#500)', async () => {
+    const store: Record<string, string> = { 'fetch-fail:azure': '3', 'fetch-fail:since:azure': '2026-06-01T00:00:00.000Z' }
+    const kv = mockKV(store)
+    await resetFetchFailure(kv, 'azure')
+    expect(store['fetch-fail:azure']).toBeUndefined()
+    expect(store['fetch-fail:since:azure']).toBeUndefined()
+  })
+})
+
+describe('shouldAlertPersistentFailure (#500)', () => {
+  const now = Date.parse('2026-06-02T12:00:00.000Z')
+
+  it('false when no since timestamp', () => {
+    expect(shouldAlertPersistentFailure(null, now)).toBe(false)
+    expect(shouldAlertPersistentFailure(undefined, now)).toBe(false)
+  })
+
+  it('false when unreachable < 1h', () => {
+    const since = new Date(now - 59 * 60_000).toISOString() // 59 min ago
+    expect(shouldAlertPersistentFailure(since, now)).toBe(false)
+  })
+
+  it('true at exactly the 1h threshold', () => {
+    const since = new Date(now - PERSISTENT_FAILURE_THRESHOLD_MS).toISOString()
+    expect(shouldAlertPersistentFailure(since, now)).toBe(true)
+  })
+
+  it('true when unreachable well over 1h', () => {
+    const since = new Date(now - 5 * 3_600_000).toISOString()
+    expect(shouldAlertPersistentFailure(since, now)).toBe(true)
+  })
+
+  it('false on an unparseable timestamp (no false alert)', () => {
+    expect(shouldAlertPersistentFailure('not-a-date', now)).toBe(false)
+  })
+
+  it('respects a custom threshold', () => {
+    const since = new Date(now - 90 * 60_000).toISOString() // 90 min ago
+    expect(shouldAlertPersistentFailure(since, now, 2 * 3_600_000)).toBe(false) // < 2h
+  })
+})
+
+describe('formatPersistentFailureAlert (#500)', () => {
+  it('reports the elapsed whole hours and names the service', () => {
+    const now = Date.parse('2026-06-02T12:00:00.000Z')
+    const since = new Date(now - 3 * 3_600_000 - 20 * 60_000).toISOString() // 3h 20m ago
+    const out = formatPersistentFailureAlert('DeepSeek API', since, now)
+    expect(out).toContain('DeepSeek API')
+    expect(out).toContain('3h+') // floor of 3h20m
+    expect(out).toContain('structural block')
   })
 })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7,6 +7,7 @@ import { calculateAIWatchScore, classifyProbe } from './score'
 import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, formatDetectionLead, detectServiceCountDrop, isFlapSuppressible, flapSuppressionKey, buildTweetDrafts, appendTweetDraftSection } from './alerts'
 import { analyzeIncident, analyzeWithSonnet, refreshOrReanalyze, analysisKey, buildAnalysisPrompt, findSimilarIncidents, formatRecoveryDisplay, shouldSkipInitialAnalysis, type AIAnalysisResult } from './ai-analysis'
 import { kvPut, kvDel, detectComponentMismatches, isCacheStale, formatDuration, isAllowedAlertWebhook } from './utils'
+import { checkPersistentFetchFailures } from './persistent-failure'
 import { parseDetectionEntry, resolveDetectionUpdate, serializeDetectionEntry, getDetectionTimestamp, isProbeEarlier } from './detection'
 import { appendDetectionLead, readDetectionLeadEntries, formatDetectionLeadSection, computeLeadMs, classifyLead, appendLeadDiag, readLeadDiag, classifyDegradation, DAYS_FOR_DAILY_SUMMARY } from './detection-lead-log'
 import { appendAlertFeed, readAlertFeed, buildFeedEntry, type AlertFeedEntry } from './alert-feed'
@@ -839,6 +840,10 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
   // the sibling cacheWrite uses for KV failures.
   if (refreshed) lastKvWrite = Date.now()
   else if (sent.length > 0) console.error('[cron] status-change cache refresh failed — OG/SEO previews may show pre-incident state until the next /api/status write')
+
+  // #500 — persistent (1h+) status-page block alert. Independent of the status-alert path above:
+  // sweeps the fetch-fail:since markers and warns the operator once per blocked service per 24h.
+  await checkPersistentFetchFailures(env.STATUS_CACHE, env.DISCORD_WEBHOOK_URL, services, Date.now(), sendDiscordAlert)
 
   // Refresh TTL on existing AI analyses / re-analyze missing ones (max 2 per cron)
   // monitoring = "recovery confirmed, verifying" — treat as inactive (no TTL refresh)

--- a/worker/src/persistent-failure.ts
+++ b/worker/src/persistent-failure.ts
@@ -1,0 +1,55 @@
+// #500 — persistent structural-block alert.
+//
+// Sweeps the `fetch-fail:since:{svcId}` markers (written by trackFetchFailure on first failure,
+// cleared by resetFetchFailure on recovery — see utils.ts) and fires ONE operator Discord warning
+// per service whose status page has been continuously unreachable >= 1h. Operator-only ops signal:
+// it never builds a feed entry or touches the per-user relay. Deduped 24h. Best-effort — the whole
+// sweep is wrapped so a failure can't affect the cron's main alert path.
+//
+// Extracted from index.ts (not inlined) so the orchestration is unit-testable with an injected
+// `send` + a mock KV, per the "new worker logic → exported fn + unit test" rule.
+
+import { kvPut, shouldAlertPersistentFailure, formatPersistentFailureAlert, type KVLike } from './utils'
+
+const SINCE_PREFIX = 'fetch-fail:since:'
+
+type DiscordSend = (
+  webhookUrl: string,
+  embed: { title: string; description: string; color: number },
+) => Promise<boolean>
+
+/** The KV surface this sweep needs: a KVLike (get/put/delete — accepted by kvPut) plus list. */
+interface KVSweep extends KVLike {
+  list(opts: { prefix: string }): Promise<{ keys: Array<{ name: string }> }>
+}
+
+export async function checkPersistentFetchFailures(
+  kv: KVSweep | undefined,
+  discordUrl: string | undefined,
+  services: Array<{ id: string; name: string }>,
+  nowMs: number,
+  send: DiscordSend,
+): Promise<void> {
+  if (!kv || !discordUrl) return
+  try {
+    const nameById = new Map(services.map((s) => [s.id, s.name]))
+    const listed = await kv.list({ prefix: SINCE_PREFIX })
+    for (const key of listed.keys) {
+      const svcId = key.name.slice(SINCE_PREFIX.length)
+      const since = await kv.get(key.name).catch(() => null)
+      if (!shouldAlertPersistentFailure(since, nowMs)) continue
+      const dedupKey = `alerted:fetch-persistent:${svcId}`
+      if (await kv.get(dedupKey).catch(() => null)) continue // already warned this 24h
+      const name = nameById.get(svcId) ?? svcId
+      const ok = await send(discordUrl, {
+        title: `⚠️ ${name} — status page unreachable 1h+`,
+        description: formatPersistentFailureAlert(name, since as string, nowMs),
+        color: 0xe67e22, // warning amber — distinct from down (red) / degraded
+      })
+      // Write the dedup marker only on a successful send, so a failed Discord POST retries next cron.
+      if (ok) await kvPut(kv, dedupKey, '1', { expirationTtl: 86_400 }) // 24h
+    }
+  } catch (err) {
+    console.error('[cron] persistent fetch-failure check failed:', err instanceof Error ? err.message : err)
+  }
+}

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -100,18 +100,56 @@ export async function trackFetchFailure(kv: KVLike | undefined, svcId: string, t
     const dailyKey = `fetch-fail:daily:${svcId}:${date}`
     const dailyCount = parseInt(await kv.get(dailyKey).catch(() => null) ?? '0', 10) || 0
     await kvPut(kv, dailyKey, String(dailyCount + 1), { expirationTtl: 172800 }) // 48h
+
+    // #500: record the FIRST-failure timestamp for the persistent (1h+) structural-block alert.
+    // Set only if absent so it survives the short fetch-fail key's 30-min expiry + re-climb cycles
+    // (and is immune to call frequency — trackFetchFailure also runs on every /api/status request,
+    // not just the 5-min cron, so a count-of-cycles would alert well under an hour). resetFetchFailure
+    // clears it on recovery. 25h TTL > the alert's 24h dedup window so it can't lapse mid-incident.
+    const sinceKey = `fetch-fail:since:${svcId}`
+    const existingSince = await kv.get(sinceKey).catch(() => null)
+    if (existingSince === null) {
+      await kvPut(kv, sinceKey, new Date().toISOString(), { expirationTtl: 90_000 }) // 25h
+    }
   }
   return shouldDegrade
 }
 
 /**
- * Reset fetch failure counter on successful fetch.
+ * Reset fetch failure counter on successful fetch. Also clears the #500 persistent
+ * first-failure timestamp so a later failure episode times its own fresh hour.
  */
 export async function resetFetchFailure(kv: KVLike | undefined, svcId: string): Promise<void> {
   if (!kv) return
   const key = `fetch-fail:${svcId}`
   const existing = await kv.get(key).catch(() => null)
   if (existing !== null) await kvDel(kv, key)
+  const sinceKey = `fetch-fail:since:${svcId}`
+  const sinceExisting = await kv.get(sinceKey).catch(() => null)
+  if (sinceExisting !== null) await kvDel(kv, sinceKey)
+}
+
+/** Threshold for the #500 persistent structural-block alert: a status page unreachable this long
+ *  is a structural block (URL/IP), not a transient blip. */
+export const PERSISTENT_FAILURE_THRESHOLD_MS = 3_600_000 // 1h
+
+/** Pure decision: has the status page been continuously unreachable for >= threshold? Frequency-
+ *  independent — keys off the first-failure wall-clock timestamp, not a count of polling cycles. */
+export function shouldAlertPersistentFailure(
+  sinceIso: string | null | undefined,
+  nowMs: number,
+  thresholdMs: number = PERSISTENT_FAILURE_THRESHOLD_MS,
+): boolean {
+  if (!sinceIso) return false
+  const sinceMs = new Date(sinceIso).getTime()
+  if (isNaN(sinceMs)) return false
+  return nowMs - sinceMs >= thresholdMs
+}
+
+/** Operator Discord alert body for a persistent (structural) status-page block (#500). */
+export function formatPersistentFailureAlert(serviceName: string, sinceIso: string, nowMs: number): string {
+  const elapsedH = Math.floor((nowMs - new Date(sinceIso).getTime()) / 3_600_000)
+  return `⚠️ **${serviceName}** status page has been unreachable for **${elapsedH}h+** — likely a structural block (URL moved / IP blocked), not a transient blip. Probe-based status may still be accurate; verify the configured status-page URL.`
 }
 
 /**


### PR DESCRIPTION
closes #500

## Summary
Fire ONE operator Discord warning when a service status page has been continuously unreachable for **>= 1h** — a structural block (URL moved / IP blocked, e.g. DeepSeek→Flashduty #507), distinct from the transient degraded path. Surfaces in real time instead of only the daily summary (#501).

## Design pivot — timestamp-based, not count-based
The issue sketched "increment a counter whenever trackFetchFailure returns true; alert at 12 (~1h at 5-min cron)". But **`trackFetchFailure` runs on every `/api/status` request (60s browser polling) AND the cron** — so a count-of-cycles hits 12 in ~12 min under any traffic, false-alarming well under an hour. (Confirmed: `fetchAllServices` is called from both the request path and the cron.)

Instead we key off the **first-failure wall-clock timestamp** — frequency-independent:
- `trackFetchFailure`: on the rising edge, set `fetch-fail:since:{svcId}` = now (25h TTL) **only if absent** → survives the short counter's 30-min expiry + re-climb, immune to request-path frequency.
- `resetFetchFailure`: clears it on recovery → a later episode times its own fresh hour.
- `shouldAlertPersistentFailure(since, now, 1h)` + `formatPersistentFailureAlert` — pure, tested.
- `persistent-failure.ts` (new, exported + unit-tested): `checkPersistentFetchFailures` sweeps the markers, **operator-only** (never the per-user feed/relay), **24h dedup**, **best-effort** (wrapped). `send` injected for testability. Wired at the end of `cronAlertCheck`.

(#500's acceptance is updated to this timestamp model — see the issue comment.)

## Review — 2 rounds, converged 0 Critical/Important
Verified: since lifecycle (set-if-absent / cleared-on-success / survives re-climb), frequency-independence, operator-only, 24h dedup, best-effort isolation. Round 2 confirmed the extraction (S2) preserves behavior; the sub-threshold `KVSweep`/`kvPut` type nit was fixed (`KVSweep extends KVLike`).

## Tests
utils (+11) + persistent-failure (8). Worker suite **1528 pass**, `wrangler --dry-run` clean, lint OK.

## Deploy
Requires a worker deploy (`npm run deploy:worker`) to take effect — operator-only, no frontend/Vercel impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)