### PR TITLE
chore(skills): two-axis triage rubric (area × urgency) + retire deferred label

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -29,7 +29,7 @@ skill is the periodic backstop — run it over the whole open board.
      → comment *why* + name the superseding issue/PR, then close.
    - **③ Premise invalidated?** Did a later finding retire the assumption it rests on?
      → re-scope (new issue with the corrected hook) or close.
-   - Pay special attention to `deferred` / `tracking` / `phase-N` labels — their blocker may have
+   - Pay special attention to `U3-someday` / `tracking` / `phase-N` labels — their blocker may have
      cleared, or incremental work may have quietly completed them.
 
 3. **Verify before closing** (parity with ship-issue step 11): `gh issue view N`, read every
@@ -40,27 +40,44 @@ skill is the periodic backstop — run it over the whole open board.
      that can't be checked yet is a **remaining** item → keep the issue open with a labeled exit
      condition; do NOT close on the strength of code alone.
 
-4. **Label hygiene**: every `deferred`/`tracking` issue must carry a **written exit condition** in its
+4. **Label hygiene**: every `U3-someday`/`tracking` issue must carry a **written exit condition** in its
    body ("close when X"). If the condition has cleared → close or drop the label. If a label has no
-   exit condition, add one.
+   exit condition, add one. (The legacy `deferred` label is retired — relabel any survivor to `U3-someday`.)
 
 5. **Cross-issue reconciliation backstop**: for each recently-merged PR this sweep surfaces, check
    whether it *also* closes/supersedes OTHER open issues that weren't reconciled at PR time.
 
-## Prioritize what's left
+## Classify + prioritize (two persistent axes → derived priority)
 
-Tier the genuinely-live issues (don't just list — recommend the next pick):
-- **P1 — high value, scoped**: clear acceptance, reasonable effort, ties to a current pain point or
-  the stated strategy (e.g. the monthly service-expansion cadence). Security/observability fixes.
-- **P2 — strategic, needs scoping**: larger features / infra / monetization-adjacent — flag that they
-  need a design pass first.
-- **P3 — docs / community / marketing**: low effort, low urgency.
-- **Tracking / deferred**: leave as-is *if* the exit condition still holds; otherwise step 2 applies.
+Label every live issue on TWO axes (persistent labels), then DERIVE priority each sweep.
+
+**Axis 1 — area (domain / which hat):**
+`area:dev` (features/bugs/tests) · `area:design` (UX/UI) · `area:ops` (infra/deploy/self-reliability/
+internal tooling) · `area:biz` (monetization/pricing/partnerships/licensing) · `area:marketing`
+(SEO/social/community/outreach/press). Pick ONE primary; add a second only when genuinely split
+(e.g. self-host template = biz+ops). `ui`→area:design; `backend` is a sub-tag of dev/ops.
+
+**Axis 2 — urgency:**
+`U0-now` (prod break / security / data loss) · `U1-soon` (high value, this cycle) · `U2-later`
+(valuable, no time pressure) · `U3-someday` (nice-to-have / signal-gated — the urgency-axis successor
+to the now-retired `deferred` label); `tracking` stays for meta umbrellas.
+
+**Derived priority** = Impact × Urgency × (1 / Effort) — Impact and Effort are per-sweep judgments
+(NOT labels); only `area`/`urgency` persist. Do NOT store priority as a label; recompute each sweep:
+- **P0** — any `U0-now`. Drop everything.
+- **P1** — high impact + `U1-soon` + small/medium effort. The "do next" set.
+- **P2** — high impact + large effort (needs a scoping/design pass first), OR medium impact + `U2-later`.
+- **P3** — low impact / `U3-someday`.
+
+Recommend the next pick **balanced across areas** — don't starve biz/marketing/design by always
+picking dev. Surface the per-area counts (count a dual-area issue under its primary) so a lopsided
+board is visible.
 
 ## Output + norms
 
-- Produce a **triage table**: per issue → `close` / `re-scope` / `keep + label` / `priority tier`,
-  with the one-line reason. Then state the **recommended next action**.
+- Produce a **triage table**: per issue → action (`close` / `re-scope` / `keep + label`) and, for the
+  live ones, `area` · `urgency` · effort → derived `P`, with a one-line reason. End with per-area
+  counts + the **recommended next pick** (balanced across areas).
 - **Act on confirmation**: closing/commenting/relabeling issues follows the same norm as the rest of
   the workflow — propose the triage, then apply the closes/labels the user confirms (issue ops are
   reversible, but the project norm is to confirm closes; see the gates in `ship-issue`).

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -77,10 +77,10 @@ is the *procedure* — follow it top to bottom.
       output says `Uploaded aiwatch-worker`), once, after user approval. If several worker PRs are open,
       merge + resolve all THEN deploy once (no half-deploys).
 11. **Verify checklist** — `gh issue view N`; confirm **every** `- [ ]` item is actually implemented in
-    code before closing. Re-run step-11-style verification on `deferred`/`tracking` issues periodically —
+    code before closing. Re-run step-11-style verification on `U3-someday`/`tracking` issues periodically —
     later/incremental work may have completed one without any PR claiming `closes`.
-12. **Close** — only after verification: `gh issue close N`. Unverified/deferred items remain → keep the
-    issue open with a label whose **exit condition is written in the body** (e.g. "close when secrets set
+12. **Close** — only after verification: `gh issue close N`. Unverified/not-yet-done items remain → keep the
+    issue open with a label (`U3-someday`) whose **exit condition is written in the body** (e.g. "close when secrets set
     & data confirmed"). Never close immediately after merge.
 
 ## Why this is a skill, not just CLAUDE.md


### PR DESCRIPTION
Codifies the issue priority-classification standard requested: **2 persistent axes → derived priority**.

## Labels (created on the repo)
- **area** (5): `area:dev` · `area:design` · `area:ops` · `area:biz` · `area:marketing`
- **urgency** (4): `U0-now` · `U1-soon` · `U2-later` · `U3-someday`
- All 16 open issues relabeled (area + urgency). The legacy `deferred` label is **retired** → `U3-someday` (only #514/#507 used it; migrated + label deleted).

## Skill rubric (`issue-triage`)
Replaced the ad-hoc P1/P2/P3 tiers with:
- **Axis 1 area** = which hat / owner. **Axis 2 urgency** = time sensitivity.
- **Derived priority** = Impact × Urgency × (1/Effort) → P0–P3, **recomputed each sweep, never stored as a label** (Impact/Effort are per-sweep judgments, not labels).
- Next-pick **balanced across areas** (don't starve biz/marketing/design); per-area counts surfaced (dual-area counted under primary).

## Consistency
Both skills (`issue-triage` + `ship-issue`) updated so no reference points at the retired `deferred` label.

## Review (comment-analyzer) — 1 Important fixed
- The "U3 replaces deferred" claim contradicted the skill still treating `deferred` as live + the label still existing. Fully resolved: migrated issues, deleted the label, updated all references in both skills, fixed the P3 bucket name. Plus the Impact/Effort-not-labels + dual-area-counting clarifications.

Skill/label-config only — no code/build/test impact. Becomes active on the next Claude Code reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)