### PR TITLE
fix(worker): import kvPut in services.ts — fixes fetchAllServices crash (regression from #501)

### DIFF
--- a/worker/src/__tests__/probe-suppression.test.ts
+++ b/worker/src/__tests__/probe-suppression.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { recordProbeSuppression } from '../services'
+
+// Regression guard for #501: the probe cross-validation suppression counter shipped with
+// `kvPut` un-imported in services.ts, so the inline write threw `ReferenceError: kvPut is not
+// defined`. That throw is uncaught inside fetchAllServices(), so the WHOLE 33-service fetch
+// rejected → "fetchAllServices() 전체 실패 / kvPut is not defined" Worker Error alert.
+// These tests exercise the exact write path; if the import regresses, they throw at runtime
+// (esbuild/wrangler dry-run does NOT type-check, so only a runtime test catches this).
+
+function makeKV() {
+  const store = new Map<string, string>()
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: vi.fn(async (k: string, v: string) => { store.set(k, v) }),
+    delete: async (k: string) => { store.delete(k) },
+    _store: store,
+  } as unknown as KVNamespace & { _store: Map<string, string>; put: ReturnType<typeof vi.fn> }
+}
+
+describe('recordProbeSuppression (#501)', () => {
+  it('does not throw and writes the counter at 1 on first suppression', async () => {
+    const kv = makeKV()
+    await expect(recordProbeSuppression(kv, 'claude', '2026-06-02')).resolves.toBeUndefined()
+    expect(kv._store.get('cross-valid:suppressed:claude:2026-06-02')).toBe('1')
+    expect(kv.put).toHaveBeenCalledWith(
+      'cross-valid:suppressed:claude:2026-06-02',
+      '1',
+      { expirationTtl: 172800 },
+    )
+  })
+
+  it('increments an existing same-day counter', async () => {
+    const kv = makeKV()
+    kv._store.set('cross-valid:suppressed:openai:2026-06-02', '4')
+    await recordProbeSuppression(kv, 'openai', '2026-06-02')
+    expect(kv._store.get('cross-valid:suppressed:openai:2026-06-02')).toBe('5')
+  })
+
+  it('keys per service and per day (no cross-contamination)', async () => {
+    const kv = makeKV()
+    await recordProbeSuppression(kv, 'gemini', '2026-06-02')
+    await recordProbeSuppression(kv, 'gemini', '2026-06-03')
+    expect(kv._store.get('cross-valid:suppressed:gemini:2026-06-02')).toBe('1')
+    expect(kv._store.get('cross-valid:suppressed:gemini:2026-06-03')).toBe('1')
+  })
+
+  it('treats a corrupt/non-numeric stored value as 0', async () => {
+    const kv = makeKV()
+    kv._store.set('cross-valid:suppressed:groq:2026-06-02', 'not-a-number')
+    await recordProbeSuppression(kv, 'groq', '2026-06-02')
+    expect(kv._store.get('cross-valid:suppressed:groq:2026-06-02')).toBe('1')
+  })
+
+  it('does not throw when kv.get rejects (the .catch fallback)', async () => {
+    const kv = makeKV()
+    kv.get = async () => { throw new Error('KV read failed') }
+    await expect(recordProbeSuppression(kv, 'mistral', '2026-06-02')).resolves.toBeUndefined()
+    expect(kv._store.get('cross-valid:suppressed:mistral:2026-06-02')).toBe('1')
+  })
+
+  it('does not throw when kv.put rejects (kvPut swallows it — the "never throws" write-side contract)', async () => {
+    // The helper's docstring promises it never throws; the write-side guarantee lives in kvPut's
+    // try/catch (utils.ts). Pin it: if someone swaps kvPut for a raw kv.put, this test fails.
+    const kv = makeKV()
+    kv.put = vi.fn(async () => { throw new Error('KV write failed') })
+    await expect(recordProbeSuppression(kv, 'cohere', '2026-06-02')).resolves.toBeUndefined()
+  })
+})

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -2,7 +2,7 @@
 
 import type { Incident, ServiceStatus, ServiceConfig, DailyImpactLevel } from './types'
 export type { ServiceStatus } from './types'
-import { fetchWithTimeout, formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss } from './utils'
+import { fetchWithTimeout, formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss, kvPut } from './utils'
 import { isProbeHealthy, type ProbeSnapshot } from './probe'
 import { platformStatusKey, type PlatformStatus } from './platform-monitor'
 import { type StatuspageResponse, normalizeStatus, parseIncidents, parseUptimeData } from './parsers/statuspage'
@@ -869,6 +869,20 @@ export function detectPlatformOutage(
   return affected
 }
 
+/**
+ * Increment the daily "probe overrode a status-page degraded status" suppression counter.
+ * Surfaced in the daily summary alongside fetch-fail:daily to distinguish a probe-healthy
+ * false positive from a real outage where the probe also spiked. Never throws — kvPut
+ * swallows + logs its own KV failures (returns false). Extracted + unit-tested because the
+ * inline call previously shipped with `kvPut` un-imported, throwing a ReferenceError that
+ * crashed all of fetchAllServices() (#501).
+ */
+export async function recordProbeSuppression(kv: KVNamespace, svcId: string, date: string): Promise<void> {
+  const supKey = `cross-valid:suppressed:${svcId}:${date}`
+  const prev = parseInt(await kv.get(supKey).catch(() => null) ?? '0', 10) || 0
+  await kvPut(kv, supKey, String(prev + 1), { expirationTtl: 172800 })
+}
+
 export async function fetchAllServices(kv?: KVNamespace, probeSnapshots?: ProbeSnapshot[]): Promise<{ raw: ServiceStatus[]; enriched: ServiceStatus[] }> {
   // Pre-fetch unique Atlassian status API endpoints once.
   // Services sharing a status page (claude+claudeai+claudecode, openai+chatgpt) would each fetch
@@ -1011,14 +1025,8 @@ export async function fetchAllServices(kv?: KVNamespace, probeSnapshots?: ProbeS
         if (svc.status === 'degraded' && isProbeHealthy(probeSnapshots, svc.id)) {
           console.log(`[cross-validation] ${svc.id}: status page down but probe RTT normal — holding operational`)
           svc.status = 'operational'
-          // Daily suppression counter: how many times was this service's degraded status
-          // overridden by probe health? Surfaced in daily summary alongside fetch-fail:daily
-          // to distinguish "probe healthy → false positive" from "probe also spiking → real outage".
-          if (kv) {
-            const supKey = `cross-valid:suppressed:${svc.id}:${date}`
-            const prev = parseInt(await kv.get(supKey).catch(() => null) ?? '0', 10) || 0
-            await kvPut(kv, supKey, String(prev + 1), { expirationTtl: 172800 })
-          }
+          // Daily suppression counter — see recordProbeSuppression() docstring.
+          if (kv) await recordProbeSuppression(kv, svc.id, date)
         }
       }
     }


### PR DESCRIPTION
## Production incident

`🔴 Worker Error — API 장애 / fetchAllServices() 전체 실패 / kvPut is not defined` (Discord alert, 2026-06-02 12:03).

## Root cause

The probe cross-validation suppression counter in `fetchAllServices()` called `kvPut` at `worker/src/services.ts:1020`, but `kvPut` was **never imported** — the `./utils` import on line 5 omitted it. The branch only runs when a status-page-`degraded` service is overridden by a healthy probe (`isProbeHealthy`), so it stayed dormant until that exact condition first occurred today. When it did, `kvPut` threw `ReferenceError: kvPut is not defined`, which is **uncaught** inside `fetchAllServices()` → the entire 33-service fetch rejected → the Worker Error alert.

Introduced by merged PR #501 (2026-06-01), which added the suppression counter with the `kvPut` call but never added the import. `wrangler --dry-run` bundles via esbuild (no type-checking), so the missing import passed the build gate and shipped.

## Fix

- Add `kvPut` to the `./utils` import in `services.ts`.
- Extract the suppression-counter write into an exported `recordProbeSuppression(kv, svcId, date)` helper — **byte-identical** key (`cross-valid:suppressed:{svcId}:{date}`), TTL (`172800` / 48h), and parse/increment semantics — so it's unit-testable.
- Replace the inline block with a one-line call.

## Regression test

`worker/src/__tests__/probe-suppression.test.ts` (6 cases) reproduces the **exact** production error (`ReferenceError: kvPut is not defined`) on the broken import and passes on the fix. Covers: first write = 1, increment, per-service/per-day keying, corrupt-value → 0, `kv.get` rejection, and `kv.put` rejection (the "never throws" write-side contract). A runtime test is required because the dry-run build does not type-check.

## Verification

- `npx wrangler deploy --config worker/wrangler.toml --dry-run` — builds clean ✅
- `npm run test:worker` — **1534 passed** (58 files) ✅
- Verified the new test FAILS on the broken import and PASSES on the fix ✅
- PR review (code / silent-failure / test / comment analyzers): **0 Critical / 0 Important** ✅

## Deploy note

Worker is **manual-deploy** — this fix is not live until `npm run deploy:worker` runs after merge. The outage continues until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)