### PR TITLE
chore(worker): add TS2304 type-check CI gate to catch missing-import bugs (refs #533)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run test:worker
+      # #533 Phase 1: fail on undefined-name / missing-import (TS2304) in worker
+      # source — the #532 bug class that esbuild / `wrangler --dry-run` can't catch.
+      - run: npm run typecheck:worker
 
   e2e:
     name: E2E Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ npm run lint       # Run ESLint
 npm test           # Run Playwright E2E tests
 npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js)
 npm run test:worker # Run Worker unit tests (vitest)
+npm run typecheck:worker # tsc gate — fails on undefined-name/missing-import (TS2304) in worker source (#533)
 ```
 
 ### Local verification by page type
@@ -159,7 +160,7 @@ gh pr merge --squash --delete-branch
 2. **Design check** (UI only) — diff against `docs/AIWatch_화면디자인_초안_v2.html`; list every difference first
 3. **Code**
 3.5. **Local verify** — start the right dev server (see "Local verification by page type"); get the USER's **in-browser confirmation** (curl/Playwright/tests do NOT count). Reachability gate: if the change needs a specific state (incident / `down` / error / flag), set up the trigger + verify yourself first, revert it before commit. **STOP and wait.**
-4. **Build + test** by scope — frontend: `npm run build` + `npm run test:src` + `npm test`; worker: `npx wrangler deploy --config worker/wrangler.toml --dry-run` + `npm run test:worker`. New worker/util logic → exported fn + unit test; **every bug fix → a test that catches it**
+4. **Build + test** by scope — frontend: `npm run build` + `npm run test:src` + `npm test`; worker: `npx wrangler deploy --config worker/wrangler.toml --dry-run` + `npm run test:worker` + `npm run typecheck:worker` (the dry-run uses esbuild — it does **not** type-check, so the TS2304 gate is what catches a missing import like #532). New worker/util logic → exported fn + unit test; **every bug fix → a test that catches it**
 5. **PR review** before commit — `/pr-review-toolkit:review-pr`
 6. **Fix → re-test → re-review, auto-loop** until 0 Critical/Important (Suggestions-only = converged)
 7. **Docs update** — CLAUDE.md (lean, **~40k-char guideline**; detail → `docs/reference/`), the relevant `docs/reference/*`, README(.ko), `CONTRIBUTING.md`, `index.html` SEO, `aiwatch-reports/`

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "happy-dom": "^15.11.7",
         "prettier": "^3.4.2",
         "tailwindcss": "^4.0.0",
+        "typescript": "^5.0.0",
         "vite": "^6.0.5",
         "vitest": "^4.1.0",
         "wrangler": "^4.76.0"
@@ -5248,6 +5249,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
@@ -5257,14 +5272,6 @@
       "engines": {
         "node": ">=20.18.1"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npx playwright test --project=desktop --project=mobile",
     "test:is-down": "npx playwright test --project=is-down",
     "test:worker": "npx vitest run --config worker/vitest.config.ts",
+    "typecheck:worker": "node scripts/typecheck-worker.mjs",
     "test:ui": "npx playwright test --ui",
     "deploy": "npm run build && wrangler deploy",
     "deploy:worker": "npx wrangler deploy --config worker/wrangler.toml",
@@ -43,6 +44,7 @@
     "happy-dom": "^15.11.7",
     "prettier": "^3.4.2",
     "tailwindcss": "^4.0.0",
+    "typescript": "^5.0.0",
     "vite": "^6.0.5",
     "vitest": "^4.1.0",
     "wrangler": "^4.76.0"

--- a/scripts/typecheck-worker.mjs
+++ b/scripts/typecheck-worker.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Phase 1 of #533: narrow type-check gate for the worker.
+//
+// Runs `tsc --noEmit` over production worker source and FAILS only on TS2304
+// (undefined name / missing import) — the exact class that caused the #532
+// production outage: `kvPut` was used in services.ts but never imported, which
+// esbuild/`wrangler deploy --dry-run` does NOT catch (esbuild strips types
+// without checking them), so it shipped and threw `ReferenceError` at runtime,
+// crashing all of fetchAllServices().
+//
+// The worker has ~20 pre-existing *type-mismatch* errors (TS2345/TS2339/...) on
+// hot paths, so tsc exits non-zero even on good code; fixing those + promoting
+// this to a full zero-error gate is tracked in #533 Phases 2-4. This gate is
+// green today and locks in the one bug class that silently reaches production.
+//
+// Scope note: TS2304 catches *undefined* names, not un-imported names that
+// happen to collide with a runtime global (e.g. forgetting to import a local
+// `crypto`/`Response` helper resolves to the Workers/DOM global → no TS2304).
+// Those don't ReferenceError at runtime, so they're out of this gate's #532
+// scope; a later phase (full type gate) is what catches shadowing mistakes.
+
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// tsc prints diagnostic paths relative to cwd; pin cwd to the repo root so the
+// path filter below is correct regardless of where the script is invoked from.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const res = spawnSync(
+  'npx',
+  ['tsc', '--noEmit', '--pretty', 'false', '-p', 'worker/tsconfig.typecheck.json'],
+  { encoding: 'utf8', cwd: repoRoot },
+)
+
+if (res.error) {
+  console.error('❌ worker type-check: failed to spawn tsc:', res.error.message)
+  process.exit(1)
+}
+if (res.status === null) {
+  console.error('❌ worker type-check: tsc was killed by signal', res.signal)
+  process.exit(1)
+}
+
+const out = `${res.stdout || ''}${res.stderr || ''}`
+
+// Fail-closed: a config/invocation-level failure (bad/missing tsconfig, no
+// inputs, an npx/registry download miss, a compiler crash) means tsc never
+// type-checked anything. Detect it explicitly so the gate never disables itself
+// silently. TS5xxx = CLI/config errors; TS18003 = "no inputs found".
+const FATAL_INVOCATION = /error TS(5\d{3}|18003)\b/
+const diagnosticLines = out.split('\n').filter((line) => /error TS\d+/.test(line))
+if (FATAL_INVOCATION.test(out) || (res.status !== 0 && diagnosticLines.length === 0)) {
+  console.error(
+    '❌ worker type-check: tsc could not run (config/invocation error) — gate cannot vouch for the code.',
+  )
+  console.error(out.trim() || `   (no output; exit status ${res.status})`)
+  process.exit(1)
+}
+
+// Undefined-name errors in any worker-bundled source — `worker/src/**` AND the
+// cross-boundary files it imports and ships at runtime (e.g.
+// api/is-down/region-status.ts via alerts.ts). Exclude only node_modules and
+// test files. (The typecheck tsconfig already excludes tests; this is
+// belt-and-suspenders.)
+const undefErrors = diagnosticLines
+  .filter((line) => line.includes('error TS2304'))
+  .filter((line) => !line.includes('node_modules'))
+  .filter((line) => !line.includes('__tests__') && !/\.test\.ts/.test(line))
+
+if (undefErrors.length > 0) {
+  console.error(
+    '❌ worker type-check: undefined name(s) / missing import(s) detected (TS2304).',
+  )
+  console.error(
+    '   This is the #532 bug class — esbuild / `wrangler deploy --dry-run` does NOT catch it.\n',
+  )
+  for (const err of undefErrors) console.error('   ' + err)
+  process.exit(1)
+}
+
+console.log(
+  '✅ worker type-check: 0 undefined-name errors in worker-bundled source (TS2304). [#533 Phase 1]',
+)

--- a/worker/tsconfig.typecheck.json
+++ b/worker/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "//": "Type-check-only config for the worker (#533). Extends the build tsconfig but scopes to production source (src, excluding __tests__) and never emits. rootDir is widened to the repo root so the legitimate cross-boundary import in alerts.ts (api/is-down/region-status.ts) resolves without TS6059. Consumed by scripts/typecheck-worker.mjs. Phase 1 of #533 only gates on TS2304 (undefined name / missing import); promoting this to a full zero-error gate is tracked in #533 Phases 2-4.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
Phase 1 of #533.

## Why

The #532 outage (`🔴 Worker Error — fetchAllServices() 전체 실패 / kvPut is not defined`) shipped because **nothing in CI or the deploy path runs `tsc`**. `wrangler deploy --dry-run` bundles via esbuild, which strips types without type-checking, so a used-but-unimported identifier passes the build gate and only throws `ReferenceError` at runtime. `npm run test:worker` only exercises code paths a test happens to hit, and the crashing branch was dormant until the exact production condition occurred.

## What

A CI gate that fails on **`TS2304` (undefined name / missing import)** in worker-bundled source — the exact #532 class. It gates on TS2304 **only** by design: the worker has ~20 pre-existing type-mismatch errors on hot paths (`index.ts`, `services.ts`, `ai-analysis.ts`), tracked in #533 Phases 2–4, so a full zero-error gate would be red today.

- **`worker/tsconfig.typecheck.json`** — prod-source-only typecheck config (`noEmit`, `rootDir` widened to repo root so the cross-boundary `api/is-down/region-status.ts` import the worker bundles resolves; excludes tests).
- **`scripts/typecheck-worker.mjs`** — runs `tsc --noEmit --pretty false`; **fail-closed** on invocation/config errors (TS5xxx/TS18003, or non-zero exit with no diagnostics — so a broken config or download miss never silently passes); fails on TS2304 in any worker-bundled non-test file. Explicit `cwd` so the path filter is invocation-independent.
- **`package.json`** — `typecheck:worker` script + pinned `typescript@^5.0.0` in root devDeps so CI `npm ci` provides a deterministic local `tsc` (no runtime `npx` download).
- **`.github/workflows/test.yml`** — runs the gate in the Worker Unit Tests job.
- **`CLAUDE.md`** — notes the command + why the dry-run doesn't substitute for it.

## Verification (UI-less backend — real-artifact)

| Scenario | Result |
|---|---|
| Clean code | ✅ pass (exit 0) |
| Reintroduce #532 bug (drop `kvPut` import) | ❌ caught — `services.ts TS2304: Cannot find name 'kvPut'` |
| TS2304 in cross-boundary `region-status.ts` | ❌ caught |
| Broken/missing tsconfig | ❌ **fail-closed** (exit 1, TS5058) — not a silent green |
| `npm run test:worker` | ✅ 1534 passing |

## Review

PR review auto-looped: round 1 surfaced 2 Critical (fail-open on tsc error; unpinned runtime tsc download) + 1 Important (cross-boundary file excluded from the filter) → all fixed → round 2 **0 Critical / 0 Important**, verified by reproduction.

## Scope

`refs #533` (not `closes`) — this is Phase 1 of a 4-phase issue; #533 stays open for Phases 2–4 (fix the 20 type errors → full `tsc` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)