### PR TITLE
fix(overview): stop stat cards rendering the label twice (closes #537)

### DIFF
--- a/src/locales/__tests__/stats-labels.test.js
+++ b/src/locales/__tests__/stats-labels.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import en from '../en.js'
+import ko from '../ko.js'
+
+// #537 — Overview stat cards must render a SHORT label (top) + a DISTINCT descriptive
+// sub (bottom), not the same phrase twice. The bug: operational/degraded cards passed the
+// same i18n key to both `labelKey` and `sub` (Overview.jsx StatCard), so "services running"
+// / "partially affected" printed twice. This pins the i18n contract the fix established:
+// every stat card has a non-empty `.sub` key whose text differs from its label, in both locales.
+const CARDS = ['operational', 'degraded', 'down', 'uptime']
+
+describe('Overview stat-card label/sub i18n contract (#537)', () => {
+  for (const [name, map] of [['en', en], ['ko', ko]]) {
+    describe(name, () => {
+      for (const card of CARDS) {
+        const labelKey = `overview.stats.${card}`
+        const subKey = `overview.stats.${card}.sub`
+        it(`${card}: label + sub both present and not identical`, () => {
+          expect(map[labelKey], `${labelKey} missing`).toBeTruthy()
+          expect(map[subKey], `${subKey} missing`).toBeTruthy()
+          expect(map[labelKey]).not.toBe(map[subKey])
+        })
+      }
+    })
+  }
+})

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -38,10 +38,13 @@ const en = {
 
   // Overview
   'overview.last.updated': 'Last updated',
-  'overview.stats.operational': 'services running',
-  'overview.stats.degraded': 'partially affected',
-  'overview.stats.down': 'service down',
+  'overview.stats.operational': 'Operational',
+  'overview.stats.degraded': 'Degraded',
+  'overview.stats.down': 'Down',
   'overview.stats.uptime': 'avg uptime',
+  'overview.stats.operational.sub': 'services running',
+  'overview.stats.degraded.sub': 'partially affected',
+  'overview.stats.down.sub': 'service down',
   'overview.filter.all': 'All',
   'overview.filter.operational': 'Operational',
   'overview.filter.issues': 'Issues',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -38,10 +38,13 @@ const ko = {
 
   // Overview
   'overview.last.updated': '마지막 업데이트',
-  'overview.stats.operational': '서비스 운영 중',
-  'overview.stats.degraded': '부분 영향',
-  'overview.stats.down': '서비스 중단',
+  'overview.stats.operational': '정상',
+  'overview.stats.degraded': '저하',
+  'overview.stats.down': '중단',
   'overview.stats.uptime': '평균 업타임',
+  'overview.stats.operational.sub': '서비스 운영 중',
+  'overview.stats.degraded.sub': '부분 영향',
+  'overview.stats.down.sub': '서비스 중단',
   'overview.filter.all': '전체',
   'overview.filter.operational': '정상',
   'overview.filter.issues': '이슈',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -714,9 +714,9 @@ export default function Overview() {
 
       {/* ── Summary Stats ── */}
       <div className="grid grid-cols-2 md:grid-cols-4" style={{ gap: '10px' }}>
-        <StatCard index={0} value={operationalCount} sub={t('overview.stats.operational')} labelKey="overview.stats.operational" colorClass="text-[var(--green)]" t={t} />
-        <StatCard index={1} value={degradedCount}    sub={t('overview.stats.degraded')}    labelKey="overview.stats.degraded"    colorClass="text-[var(--amber)]" t={t} />
-        <StatCard index={2} value={downCount}         sub="—"                                labelKey="overview.stats.down"         colorClass="text-[var(--red)]"   t={t} />
+        <StatCard index={0} value={operationalCount} sub={t('overview.stats.operational.sub')} labelKey="overview.stats.operational" colorClass="text-[var(--green)]" t={t} />
+        <StatCard index={1} value={degradedCount}    sub={t('overview.stats.degraded.sub')}    labelKey="overview.stats.degraded"    colorClass="text-[var(--amber)]" t={t} />
+        <StatCard index={2} value={downCount}         sub={t('overview.stats.down.sub')}        labelKey="overview.stats.down"         colorClass="text-[var(--red)]"   t={t} />
         <StatCard index={3} value={avgUptime === '—' ? '—' : `${avgUptime}%`}  sub={t('overview.stats.uptime.sub')}  labelKey="overview.stats.uptime"       colorClass="text-[var(--blue)]"  t={t} />
       </div>
 


### PR DESCRIPTION
Closes #537.

## Bug

The Overview summary stat cards rendered the **same text twice** — "services running" / "partially affected" appeared as both the top label and the bottom sub:

```
SERVICES RUNNING        PARTIALLY AFFECTED
29                      4
services running        partially affected   ← duplicate
```

## Root cause

`StatCard` (`src/pages/Overview.jsx:50`) renders both `labelKey` (top) and `sub` (bottom). The operational/degraded cards passed the **same** i18n key to both props, and the label keys (`overview.stats.operational` = "services running", `…degraded` = "partially affected") held the **descriptive phrase** instead of a short status word. The **uptime** card was already correct (distinct `overview.stats.uptime` label + `overview.stats.uptime.sub`); this brings the other three into the same shape — matching the design draft (`docs/AIWatch_화면디자인_초안_v2.html:1415-1420`: short label + value + descriptive sub).

## Fix

- **`en.js` / `ko.js`** — repurpose the label keys to short status words (`Operational/Degraded/Down` · `정상/저하/중단`) and add `overview.stats.{operational,degraded,down}.sub` for the phrases.
- **`Overview.jsx`** — point each card's `sub` at the new `.sub` key; drop the stray `"—"` on the down card (now `service down` / `서비스 중단`).
- **`SkeletonUI.jsx`** — its labels read the same keys, so the loading skeleton now shows the short word too (consistent with the loaded card).

Result:
```
정상            저하            중단            평균 업타임
29              4               0               99.x%
서비스 운영 중   부분 영향        서비스 중단      전체 평균
```

## Verification

- **Browser-verified on Overview (KO + EN)** — each card shows label + value + sub, no duplicate (reporter confirmed).
- `npm run build` clean · `npm run test:src` → **325 passing** + **8 new** (`src/locales/__tests__/stats-labels.test.js`: every stat card has a non-empty `.sub` distinct from its label, both locales — fails on the old code where `.sub` keys didn't exist).
- PR review (code-reviewer): **0 Critical / 0 Important** — en/ko in parity (320 keys each), all consumers traced safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)