### PR TITLE
feat(ci): daily verify-after reminder → operator Discord when a production-data check is due (refs #541)

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -67,6 +67,11 @@ is the *procedure* — follow it top to bottom.
      time/production-gated verification (e.g. "queryable after deploy", "shows after next cron"):
      if such an item can't be verified yet, it's a **remaining** item → use **`refs #N`** and close
      manually after verifying (do NOT let `closes` auto-close it prematurely).
+   - **Production-gated → add a `verify-after` line (#541)** so the check isn't forgotten: when an
+     item needs a production-data check after a delay, add a line to the issue body
+     `- [ ] **verify-after YYYY-MM-DD** — what to check + where` (pick a realistic date). The daily
+     `verify-reminders` GitHub Action pings the operator Discord when due (and weekly while open);
+     closing the issue / removing the line cancels it. This replaces "remember to check the board".
    - **Cross-issue reconciliation** — also scan OTHER open issues this change touches:
      fully implements another → add `closes #M`; partially advances → `refs #M` + comment;
      **supersedes/invalidates** another (a newer finding/feature makes it moot) → comment the why + close it.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
       # #533 Phase 1: fail on undefined-name / missing-import (TS2304) in worker
       # source — the #532 bug class that esbuild / `wrangler --dry-run` can't catch.
       - run: npm run typecheck:worker
+      # #541: node:test unit tests for scripts/*.mjs (verify-reminders parse/fire logic)
+      - run: npm run test:scripts
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/verify-reminders.yml
+++ b/.github/workflows/verify-reminders.yml
@@ -1,0 +1,34 @@
+name: Verify Reminders
+
+# #541 — daily scan of open issues for `verify-after <YYYY-MM-DD>` lines; pings the operator Discord
+# when a production-data verification is due (and weekly while the issue stays open). Issue = source
+# of truth, so closing the issue / removing the line cancels the reminder.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'   # 00:00 UTC daily = 09:00 KST
+  workflow_dispatch: {}    # manual trigger (used to verify the first real send post-merge)
+
+permissions:
+  issues: write           # add the `verify-overdue` label on fire
+  contents: read
+
+# A scheduled run + a manual dispatch should never double-post.
+concurrency:
+  group: verify-reminders
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    name: Verify-after reminders
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Scan issues + notify
+        run: node scripts/verify-reminders.mjs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}             # `gh` CLI auth (preinstalled on the runner)
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}  # reuse the operator channel (#541)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ npm test           # Run Playwright E2E tests
 npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js)
 npm run test:worker # Run Worker unit tests (vitest)
 npm run typecheck:worker # tsc gate — fails on undefined-name/missing-import (TS2304) in worker source (#533)
+npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders, #541)
 ```
 
 ### Local verification by page type
@@ -168,7 +169,7 @@ gh pr merge --squash --delete-branch
 9. **Verify Vercel Preview** (frontend)
 10. **Merge** `gh pr merge --squash --delete-branch` — worker deploy is manual (`npm run deploy:worker`, once, after approval; batch multi-PR deploys)
 11. **Verify checklist** against code before closing; periodically re-verify `deferred`/`tracking` issues (later work may have completed one)
-12. **Close** only after verification; deferred items → keep open with a label carrying a **written exit condition**
+12. **Close** only after verification; deferred items → keep open with a label carrying a **written exit condition**. Production-data check needed after a delay → add a `- [ ] **verify-after YYYY-MM-DD** — …` line; the daily `verify-reminders` Action (`.github/workflows/verify-reminders.yml` + `scripts/verify-reminders.mjs`, #541) pings the operator Discord when due so the check isn't missed
 
 > Never close an issue immediately after merging. Verify each checklist item against the code first; deferred → keep open with a labeled exit condition.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:worker": "npx wrangler dev --config worker/wrangler.toml --port 8788",
     "dev:all": "npx wrangler dev --config worker/wrangler.toml --port 8788 & vite",
     "test:src": "npx vitest run --config vitest.config.js",
-    "test:scripts": "node --test \"scripts/*.test.mjs\"",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "hook-audit": "node scripts/hook-audit-summary.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:worker": "npx wrangler dev --config worker/wrangler.toml --port 8788",
     "dev:all": "npx wrangler dev --config worker/wrangler.toml --port 8788 & vite",
     "test:src": "npx vitest run --config vitest.config.js",
+    "test:scripts": "node --test \"scripts/*.test.mjs\"",
     "hook-audit": "node scripts/hook-audit-summary.mjs"
   },
   "dependencies": {

--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// #541 — production-data "verify-after" reminders.
+//
+// Some features/fixes need a production-data check after a delay (e.g. "confirm the Slack unfurl is
+// fresh after the next incident", "check p95 after 3 months of archives"). Tracked only as issue
+// comments, these are missed unless the board is reviewed. This script — run daily by
+// .github/workflows/verify-reminders.yml — scans OPEN issues for a `verify-after <YYYY-MM-DD>` line
+// and pings the operator Discord when due (and weekly while the issue stays open).
+//
+// Issue = single source of truth: closing the issue (or removing the line) cancels the reminder.
+// Pure helpers (parseVerifyAfter / daysSinceDue / shouldFire) are exported + unit-tested in
+// scripts/verify-reminders.test.mjs. `--dry-run` (or DRY_RUN=1) prints actions without side effects.
+
+import { execFileSync } from 'node:child_process'
+
+// Matches a `verify-after 2026-09-01` token anywhere on a line; captures the date + the rest of the
+// line as a free-form note. Case-insensitive; `after` may be followed by space, `:` or `-`.
+const VERIFY_RE = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})([^\n]*)/gi
+
+/** True only for a real calendar date (rejects 2026-02-30, which Date would silently roll over). */
+export function isValidIsoDate(s) {
+  const d = new Date(`${s}T00:00:00Z`)
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s
+}
+
+/** Extract every {date, note} pair from an issue body. Calendar-invalid dates are skipped. */
+export function parseVerifyAfter(body) {
+  const out = []
+  if (!body) return out
+  for (const m of body.matchAll(VERIFY_RE)) {
+    if (!isValidIsoDate(m[1])) continue
+    const note = m[2].replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
+    out.push({ date: m[1], note })
+  }
+  return out
+}
+
+/**
+ * Trusted issue authors whose `verify-after` lines are honored. #541 abuse-gate: this runs on a
+ * PUBLIC repo, so without a gate anyone could open an issue to fire an operator Discord ping + apply
+ * a label. Default to the repo OWNER (from GITHUB_REPOSITORY, always set in Actions) plus an explicit
+ * VERIFY_TRUSTED_AUTHORS allow-list (comma-separated). Empty set (e.g. local dev with neither env) →
+ * the caller does NOT filter, so the maintainer can test against their own board.
+ */
+export function parseTrustedAuthors(env = process.env) {
+  const explicit = (env.VERIFY_TRUSTED_AUTHORS || '').split(',').map((s) => s.trim()).filter(Boolean)
+  const owner = (env.GITHUB_REPOSITORY || '').split('/')[0].trim()
+  return new Set([...explicit, ...(owner ? [owner] : [])])
+}
+
+/** Whole-day difference today − due (UTC midnight). Negative = due is in the future. NaN on bad input. */
+export function daysSinceDue(dueISO, todayISO) {
+  const due = Date.parse(`${dueISO}T00:00:00Z`)
+  const today = Date.parse(`${todayISO}T00:00:00Z`)
+  if (Number.isNaN(due) || Number.isNaN(today)) return NaN
+  return Math.round((today - due) / 86_400_000)
+}
+
+// Fire on the due date AND every 7th day after, while the issue stays open. Stateless by design: the
+// daily cron runs once/day so this never double-fires the same day, and the weekly cadence (vs daily)
+// avoids spamming the operator channel — no marker file / "last fired" state to maintain.
+export function shouldFire(dueISO, todayISO) {
+  const d = daysSinceDue(dueISO, todayISO)
+  return Number.isInteger(d) && d >= 0 && d % 7 === 0
+}
+
+function todayUTC() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' })
+}
+
+async function postDiscord(webhook, items) {
+  const lines = items.map((it) => {
+    const when = it.overdueDays > 0 ? `due ${it.date}, ${it.overdueDays}d overdue` : 'due today'
+    return `• **#${it.number}** ${it.title}\n  → ${it.note || 'verify production data'} _(${when})_`
+  })
+  const body = {
+    embeds: [{
+      title: '🔔 Production-data verification due',
+      description: `${items.length} item(s) need a production-data check now:\n\n${lines.join('\n')}`,
+      color: 0xfee75c,
+      footer: { text: 'AIWatch · verify-after reminders (#541)' },
+    }],
+  }
+  const res = await fetch(webhook, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`Discord webhook ${res.status}: ${await res.text().catch(() => '')}`)
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run') || process.env.DRY_RUN === '1'
+  const today = todayUTC()
+  const issues = JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', '200', '--json', 'number,title,body,author']))
+
+  // #541 abuse-gate (public repo): only honor verify-after lines from trusted authors. Empty trusted
+  // set (local dev with no GITHUB_REPOSITORY/override) → no filter, so the maintainer can test.
+  const trusted = parseTrustedAuthors()
+  const considered = trusted.size > 0 ? issues.filter((i) => trusted.has(i.author?.login)) : issues
+
+  const due = []
+  for (const iss of considered) {
+    for (const { date, note } of parseVerifyAfter(iss.body)) {
+      if (shouldFire(date, today)) {
+        due.push({ number: iss.number, title: iss.title, date, note, overdueDays: daysSinceDue(date, today) })
+      }
+    }
+  }
+
+  if (due.length === 0) {
+    console.log(`[verify-reminders] ${today}: nothing due.`)
+    return
+  }
+  console.log(`[verify-reminders] ${today}: ${due.length} due → ${due.map((d) => `#${d.number}`).join(', ')}`)
+
+  if (dryRun) {
+    console.log('[verify-reminders] --dry-run: would post:\n' + JSON.stringify(due, null, 2))
+    return
+  }
+
+  const webhook = process.env.DISCORD_WEBHOOK_URL
+  if (!webhook) {
+    console.error('[verify-reminders] DISCORD_WEBHOOK_URL not set — cannot send. (Add it as a repo Actions secret.)')
+    process.exit(1)
+  }
+  await postDiscord(webhook, due)
+  // Board visibility: label each fired issue so issue-triage sees what's past its verify date.
+  // Best-effort — a label failure must not fail the run after a successful Discord send.
+  for (const number of [...new Set(due.map((d) => d.number))]) {
+    try {
+      gh(['issue', 'edit', String(number), '--add-label', 'verify-overdue'])
+    } catch (e) {
+      console.warn(`[verify-reminders] could not label #${number}: ${e.message}`)
+    }
+  }
+  console.log('[verify-reminders] posted to Discord + labeled verify-overdue.')
+}
+
+// Only run main when executed directly (so importing the helpers in the test has no side effects).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.error('[verify-reminders] failed:', e)
+    process.exit(1)
+  })
+}

--- a/scripts/verify-reminders.test.mjs
+++ b/scripts/verify-reminders.test.mjs
@@ -1,0 +1,67 @@
+// #541 — unit tests for the verify-after reminder logic. Run with `npm run test:scripts`
+// (= `node --test "scripts/*.test.mjs"`). Uses node:test (no vitest) since this is a CI/automation
+// script, not src/worker code.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseVerifyAfter, daysSinceDue, shouldFire, isValidIsoDate, parseTrustedAuthors } from './verify-reminders.mjs'
+
+test('parseVerifyAfter — extracts date + note from a checklist line', () => {
+  const body = '- [ ] **verify-after 2026-09-01** — check p95 after 3 months (#511)\nother text'
+  assert.deepEqual(parseVerifyAfter(body), [{ date: '2026-09-01', note: 'check p95 after 3 months (#511)' }])
+})
+
+test('parseVerifyAfter — none, multiple, and `:`/`-` separators', () => {
+  assert.deepEqual(parseVerifyAfter('no token here'), [])
+  assert.deepEqual(parseVerifyAfter(''), [])
+  assert.deepEqual(parseVerifyAfter(null), [])
+  const multi = parseVerifyAfter('verify-after 2026-01-01 first thing\nverify-after: 2026-02-02 second')
+  assert.equal(multi.length, 2)
+  assert.equal(multi[0].note, 'first thing')
+  assert.equal(multi[1].date, '2026-02-02')
+  assert.equal(multi[1].note, 'second')
+})
+
+test('parseVerifyAfter — is case-insensitive', () => {
+  assert.deepEqual(parseVerifyAfter('VERIFY-AFTER 2026-03-03 note'), [{ date: '2026-03-03', note: 'note' }])
+})
+
+test('daysSinceDue — whole-day diff, sign, and NaN on bad input', () => {
+  assert.equal(daysSinceDue('2026-06-01', '2026-06-03'), 2)
+  assert.equal(daysSinceDue('2026-06-10', '2026-06-03'), -7)
+  assert.equal(daysSinceDue('2026-06-03', '2026-06-03'), 0)
+  assert.ok(Number.isNaN(daysSinceDue('not-a-date', '2026-06-03')))
+})
+
+test('shouldFire — due date + every 7th day after, not between, not before', () => {
+  assert.equal(shouldFire('2026-06-03', '2026-06-03'), true)  // day 0 (due)
+  assert.equal(shouldFire('2026-06-03', '2026-06-04'), false) // day 1
+  assert.equal(shouldFire('2026-06-03', '2026-06-09'), false) // day 6
+  assert.equal(shouldFire('2026-05-27', '2026-06-03'), true)  // day 7
+  assert.equal(shouldFire('2026-05-20', '2026-06-03'), true)  // day 14
+  assert.equal(shouldFire('2026-06-10', '2026-06-03'), false) // future (not yet due)
+  assert.equal(shouldFire('bad', '2026-06-03'), false)        // unparseable
+})
+
+test('parseVerifyAfter — skips calendar-invalid dates (rollover guard)', () => {
+  assert.deepEqual(parseVerifyAfter('verify-after 2026-02-30 typo'), []) // Feb 30 would roll over
+  assert.deepEqual(parseVerifyAfter('verify-after 2026-13-01 bad month'), [])
+  assert.equal(parseVerifyAfter('verify-after 2026-02-28 ok')[0].date, '2026-02-28')
+})
+
+test('isValidIsoDate', () => {
+  assert.equal(isValidIsoDate('2026-06-03'), true)
+  assert.equal(isValidIsoDate('2026-02-29'), false) // 2026 not a leap year
+  assert.equal(isValidIsoDate('2026-02-30'), false)
+  assert.equal(isValidIsoDate('nope'), false)
+})
+
+test('parseTrustedAuthors — owner from GITHUB_REPOSITORY + explicit override; empty by default', () => {
+  assert.deepEqual([...parseTrustedAuthors({ GITHUB_REPOSITORY: 'bentleypark/aiwatch' })], ['bentleypark'])
+  assert.deepEqual([...parseTrustedAuthors({ VERIFY_TRUSTED_AUTHORS: 'a, b', GITHUB_REPOSITORY: 'o/r' })], ['a', 'b', 'o'])
+  assert.equal(parseTrustedAuthors({}).size, 0) // local dev → empty → caller does not filter
+})
+
+test('importing the module runs no side effects (main is guarded)', () => {
+  // Reaching here proves importing did not invoke main() (which shells out to `gh` / posts Discord).
+  assert.ok(true)
+})


### PR DESCRIPTION
Closes the "I forget to check production data weeks later" gap.

## Problem

Some features/fixes need a **production-data check after a delay** (e.g. #535/#539 "confirm at the next incident", monthly-archive "check p95 after 3 months"). Tracked only as issue comments, these are **missed** unless the board is reviewed periodically.

## Solution (option C — GitHub Action, issue = source of truth)

A daily Action scans **open** issues for a `verify-after <YYYY-MM-DD>` line and pings the **operator Discord** when due. Closing the issue / removing the line cancels it — no drift, no worker change, `GITHUB_TOKEN` auto-provided.

### Convention
```
- [ ] **verify-after 2026-09-01** — what to check + where (#NNN)
```

### Pieces
- **`scripts/verify-reminders.mjs`** — parse `verify-after` lines; fire on the due date **and every 7th day after while open** (stateless: daily cron + weekly cadence, no marker file). Posts one embed to `DISCORD_WEBHOOK_URL` + adds `verify-overdue` label. Pure helpers (`parseVerifyAfter` / `daysSinceDue` / `shouldFire` / `isValidIsoDate` / `parseTrustedAuthors`) exported + unit-tested. `--dry-run` skips side effects.
  - **Abuse-gate (public repo):** only honors lines from trusted authors (`GITHUB_REPOSITORY` owner + optional `VERIFY_TRUSTED_AUTHORS`) — without it, anyone could open an issue to fire a ping. Fail-closed on null author. Calendar-invalid dates skipped.
- **`.github/workflows/verify-reminders.yml`** — daily cron (09:00 KST) + `workflow_dispatch`, `permissions: issues: write`, concurrency guard.
- **`scripts/verify-reminders.test.mjs`** (node:test, 9 cases) + `test:scripts` npm script + `verify-overdue` label.
- **Docs**: CLAUDE.md (step 12 + commands) + ship-issue skill (step 8 — production-gated items get a `verify-after` line).

## Verification

- `npm run test:scripts` → **9/9**; eslint clean.
- Live `--dry-run` runs the real `gh`→parse→decide pipeline ("nothing due" — no tokens yet); sample shows `verify-after 2026-06-03` fires today, `2026-09-01` doesn't.
- CI-sim (`GITHUB_REPOSITORY` set) confirms the owner author-gate applies.
- PR review: round 1 found 1 Important (public-repo abuse) → author-gate → round 2 **0 Critical / 0 Important**.

## Setup / scope
- **Done:** `DISCORD_WEBHOOK_URL` registered as a repo Actions secret (reuses the operator channel).
- `refs #541` — real Discord send verified **post-merge via `workflow_dispatch`** (the issue's exit condition). CI-only change; **no worker/frontend deploy** needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)