### PR TITLE
feat(statusline): always-on clickable AIWatch branded preset → default (closes #543)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -296,7 +296,7 @@ README, 문서, 블로그에 실시간 상태 배지를 임베드할 수 있습�
 
 ## Claude Code Statusline 통합
 
-Claude API, OpenAI, Gemini, GitHub Copilot 등 33개 AI 서비스의 장애 여부를 [Claude Code 스테이터스라인](https://docs.claude.com/en/docs/claude-code/statusline)에 직접 표시합니다. 모든 서비스가 정상일 때는 출력이 비어 있어 statusline 공간을 차지하지 않고, 장애가 발생하면 빨간색 표시와 함께 서비스명이 나타나 업스트림 문제와 로컬 문제를 즉시 구분할 수 있습니다.
+Claude API, OpenAI, Gemini, GitHub Copilot 등 33개 AI 서비스의 장애 여부를 [Claude Code 스테이터스라인](https://docs.claude.com/en/docs/claude-code/statusline)에 직접 표시합니다. 추천 프리셋은 항상 표시되는 클릭 가능한 **AIWatch** 라벨을 유지합니다 — 모두 정상이면 `AIWatch 🟢`, 장애 시 `AIWatch 🔴 Claude API`, 라벨 cmd/ctrl+클릭 시 대시보드 열림. 정상일 때 공간을 비우고 싶으면 [프리셋 페이지](https://ai-watch.dev/#statusline)의 minimalist 프리셋을 쓰면 됩니다.
 
 가장 빠른 설정 — `~/.claude/settings.json`에 추가:
 
@@ -304,12 +304,14 @@ Claude API, OpenAI, Gemini, GitHub Copilot 등 33개 AI 서비스의 장애 여�
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached?src=statusline-degraded_only | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"🔴 \" + .name] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
   }
 }
 ```
 
-프리셋 모음 (컴팩트 배지, 전체 목록, 특정 프로바이더만, Powerline 친화 등): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
+> 클릭 가능한 라벨은 OSC 8 지원 터미널(iTerm2, Warp, kitty, WezTerm, VS Code 터미널, macOS 12+ Terminal.app)에서 동작하고, 미지원은 plain text로 표시됩니다. Worker 도메인을 직접 호출해 렌더링당 폴링이 Vercel 대역폭으로 잡히지 않습니다.
+
+프리셋 모음 — **minimalist**(정상 시 빈 출력), 컴팩트 배지, 전체 목록, 특정 프로바이더만, 서비스별 clickable 링크: **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
 
 특성: 렌더링당 단일 GET, Cloudflare edge에 5분 KV 캐시, 2초 타임아웃, 네트워크 에러 시 silent fail, Anthropic API 호출 없음, 클라이언트 식별자 미수집. `?src=statusline-<preset>` 쿼리 태그는 요청 로그에서 statusline 트래픽을 일반 cached-endpoint 호출과 구분하기 위한 용도일 뿐이며, Worker는 경로만 매칭하므로 캐시/응답 속도에 영향이 없고 사용자 식별자도 포함하지 않습니다. shell 명령 출력을 지원하는 모든 statusline 도구와 호환 (`ccstatusline`의 Custom Command 위젯 포함).
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -304,7 +304,7 @@ Claude API, OpenAI, Gemini, GitHub Copilot 등 33개 AI 서비스의 장애 여�
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"🔴 \" + .name] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\\"] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Embed real-time status badges in your README, docs, or blog.
 
 ## Claude Code Statusline Integration
 
-Surface AI service outages — Claude API, OpenAI, Gemini, GitHub Copilot, and 29 more — directly in your [Claude Code statusline](https://docs.claude.com/en/docs/claude-code/statusline). Output stays empty while every service is operational; degraded/down services appear with a red indicator so upstream issues are visually distinct from local ones.
+Surface AI service outages — Claude API, OpenAI, Gemini, GitHub Copilot, and 29 more — directly in your [Claude Code statusline](https://docs.claude.com/en/docs/claude-code/statusline). The recommended preset keeps an always-on, clickable **AIWatch** label (`AIWatch 🟢` while all healthy, `AIWatch 🔴 Claude API` when something breaks — cmd/ctrl+click opens the dashboard). Prefer zero footprint when healthy? A minimalist preset that stays empty until something degrades is on the [presets page](https://ai-watch.dev/#statusline).
 
 Quickest install — add to `~/.claude/settings.json`:
 
@@ -305,12 +305,14 @@ Quickest install — add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached?src=statusline-degraded_only | jq -r '[.services[] | select(.status != \"operational\") | \"🔴 \" + .name] | .[0:3] | join(\" \")' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"🔴 \" + .name] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
   }
 }
 ```
 
-Full guide with presets (compact badge, full list, scoped to specific providers, Powerline-friendly): **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
+> Requires an OSC 8-compatible terminal (iTerm2, Warp, kitty, WezTerm, VS Code terminal, Terminal.app on macOS 12+) for the clickable label; others show it as plain text. Targets the Worker domain directly so per-prompt polls don't count as Vercel bandwidth.
+
+Other presets — **minimalist** (empty when healthy), compact badge, full list, scoped to specific providers, and clickable per-service links: **[ai-watch.dev/#statusline](https://ai-watch.dev/#statusline)**
 
 Properties: single GET per render, 5-min KV-cached on Cloudflare's edge, 2-second timeout, fail-silent on network error, no Anthropic API requests, no client identifier. The `?src=statusline-<preset>` query tag just lets us split statusline traffic from regular cached-endpoint hits in request logs — Worker matches on path only, so it doesn't affect caching or freshness, and carries no user identifier. Compatible with any statusline tool that supports shell-command output (including `ccstatusline`'s Custom Command widget).
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Quickest install — add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"🔴 \" + .name] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
+    "command": "( curl -sf --max-time 2 https://aiwatch-worker.p2c2kbf.workers.dev/api/status/cached?src=statusline-branded | jq -r '([.services[] | select(.status != \"operational\")]) as $d | \"\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ \" + (if ($d | length) == 0 then \"🟢\" else ([$d[] | \"\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\\"] | .[0:3] | join(\" \")) end)' ) 2>/dev/null || true"
   }
 }
 ```

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -163,13 +163,14 @@ const PRESET_CLICKABLE = JSON.stringify({
 // PRESET_BRANDED keeps an always-on, clickable "AIWatch" label (OSC 8 → dashboard
 // home) so the brand is present even when every service is healthy — unlike the
 // other presets, which are empty when healthy. Healthy → `AIWatch 🟢`; degraded →
-// `AIWatch 🔴 <name>` (≤3). Same OSC 8 escaping as PRESET_CLICKABLE (\\u001b = ESC,
-// \\\\ = a literal "\" that jq emits, forming the ESC]8;;URL ESC\ … ESC]8;; ESC\
-// hyperlink). Terminals without OSC 8 support show the text as plain (no harm).
+// `AIWatch 🔴 <name>` (≤3) where EACH red service name is itself an OSC 8 link to
+// its detail page (https://ai-watch.dev/#<id>), like PRESET_CLICKABLE. Same OSC 8
+// escaping (\\u001b = ESC, \\\\ = a literal "\" that jq emits, forming the
+// ESC]8;;URL ESC\ … ESC]8;; ESC\ hyperlink). Terminals without OSC 8 → plain text.
 export const PRESET_BRANDED = JSON.stringify({
   statusLine: {
     type: 'command',
-    command: `( curl -sf --max-time 2 ${taggedUrl(SLUG_BRANDED)} | jq -r '([.services[] | select(.status != "operational")]) as $d | "\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ " + (if ($d | length) == 0 then "🟢" else ([$d[] | "🔴 " + .name] | .[0:3] | join(" ")) end)' ) 2>/dev/null || true`,
+    command: `( curl -sf --max-time 2 ${taggedUrl(SLUG_BRANDED)} | jq -r '([.services[] | select(.status != "operational")]) as $d | "\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ " + (if ($d | length) == 0 then "🟢" else ([$d[] | "\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\"] | .[0:3] | join(" ")) end)' ) 2>/dev/null || true`,
   },
 }, null, 2)
 
@@ -206,7 +207,7 @@ export default function Statusline() {
 
       <Section title="Quick start (recommended preset)">
         <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '12px' }}>
-          Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Always-on, clickable <code className="mono text-[var(--text0)]">AIWatch</code> label: <code className="mono text-[var(--text0)]">AIWatch 🟢</code> when all healthy, <code className="mono text-[var(--text0)]">AIWatch 🔴 Claude API</code> (up to 3) when something breaks — <code className="mono text-[var(--text0)]">cmd+click</code> (macOS) / <code className="mono text-[var(--text0)]">ctrl+click</code> (Linux) the label to open the dashboard. Needs an OSC 8-compatible terminal (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+); others show it as plain text — no harm.
+          Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Always-on, clickable <code className="mono text-[var(--text0)]">AIWatch</code> label: <code className="mono text-[var(--text0)]">AIWatch 🟢</code> when all healthy, <code className="mono text-[var(--text0)]">AIWatch 🔴 Claude API</code> (up to 3) when something breaks — <code className="mono text-[var(--text0)]">cmd+click</code> (macOS) / <code className="mono text-[var(--text0)]">ctrl+click</code> (Linux) the <code className="mono text-[var(--text0)]">AIWatch</code> label to open the dashboard, or a red service name to jump to its detail page. Needs an OSC 8-compatible terminal (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+); others show it as plain text — no harm.
         </p>
         <Snippet code={PRESET_BRANDED} eventLabel={SLUG_BRANDED} />
       </Section>

--- a/src/pages/Statusline.jsx
+++ b/src/pages/Statusline.jsx
@@ -35,6 +35,7 @@ const SLUG_COMPACT_BADGE = 'compact_badge'
 const SLUG_FULL_LIST = 'full_list'
 const SLUG_SCOPED = 'scoped'
 const SLUG_CLICKABLE = 'clickable'
+export const SLUG_BRANDED = 'branded'
 
 function CopyButton({ text, eventLabel }) {
   const [copied, setCopied] = useState(false)
@@ -159,6 +160,19 @@ const PRESET_CLICKABLE = JSON.stringify({
   },
 }, null, 2)
 
+// PRESET_BRANDED keeps an always-on, clickable "AIWatch" label (OSC 8 → dashboard
+// home) so the brand is present even when every service is healthy — unlike the
+// other presets, which are empty when healthy. Healthy → `AIWatch 🟢`; degraded →
+// `AIWatch 🔴 <name>` (≤3). Same OSC 8 escaping as PRESET_CLICKABLE (\\u001b = ESC,
+// \\\\ = a literal "\" that jq emits, forming the ESC]8;;URL ESC\ … ESC]8;; ESC\
+// hyperlink). Terminals without OSC 8 support show the text as plain (no harm).
+export const PRESET_BRANDED = JSON.stringify({
+  statusLine: {
+    type: 'command',
+    command: `( curl -sf --max-time 2 ${taggedUrl(SLUG_BRANDED)} | jq -r '([.services[] | select(.status != "operational")]) as $d | "\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\ " + (if ($d | length) == 0 then "🟢" else ([$d[] | "🔴 " + .name] | .[0:3] | join(" ")) end)' ) 2>/dev/null || true`,
+  },
+}, null, 2)
+
 export default function Statusline() {
   const { lang } = useLang()
   return (
@@ -186,15 +200,15 @@ export default function Statusline() {
           >
             Claude Code statusline
           </a>
-          . When everything is healthy nothing is shown — your statusline real estate is preserved. When a service degrades or goes down, it appears with a red indicator so you can tell upstream issues from local ones at a glance.
+          . The recommended preset keeps an always-on, clickable <code className="mono text-[var(--text0)]">AIWatch</code> label — <code className="mono text-[var(--text0)]">AIWatch 🟢</code> while all healthy, <code className="mono text-[var(--text0)]">AIWatch 🔴 Claude API</code> (up to 3) when something breaks — so a click opens the dashboard at any time. Prefer zero footprint when healthy? The minimalist preset under <em>Other presets</em> stays empty until a service degrades.
         </p>
       </div>
 
       <Section title="Quick start (recommended preset)">
         <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '12px' }}>
-          Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Output stays empty while every monitored service is operational; up to 3 degraded/down services appear with a red dot when something breaks.
+          Add to <code className="mono text-[var(--text0)]">~/.claude/settings.json</code>. Always-on, clickable <code className="mono text-[var(--text0)]">AIWatch</code> label: <code className="mono text-[var(--text0)]">AIWatch 🟢</code> when all healthy, <code className="mono text-[var(--text0)]">AIWatch 🔴 Claude API</code> (up to 3) when something breaks — <code className="mono text-[var(--text0)]">cmd+click</code> (macOS) / <code className="mono text-[var(--text0)]">ctrl+click</code> (Linux) the label to open the dashboard. Needs an OSC 8-compatible terminal (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+); others show it as plain text — no harm.
         </p>
-        <Snippet code={PRESET_DEGRADED_ONLY} eventLabel={SLUG_DEGRADED_ONLY} />
+        <Snippet code={PRESET_BRANDED} eventLabel={SLUG_BRANDED} />
       </Section>
 
       <Section title="Other presets">
@@ -238,6 +252,14 @@ export default function Statusline() {
               Each service name becomes a clickable hyperlink that opens the AIWatch service detail page (<code className="mono text-[var(--text0)]">cmd+click</code> on macOS, <code className="mono text-[var(--text0)]">ctrl+click</code> on Linux). Useful for jumping straight to incident details when the statusline shows something is wrong. Requires an OSC 8-compatible terminal — most modern emulators (iTerm2, Warp, kitty, WezTerm, VS Code integrated terminal, Terminal.app on macOS 12+) support it; tmux and some older shells may render the escape sequence as raw text instead.
             </p>
             <Snippet code={PRESET_CLICKABLE} eventLabel={SLUG_CLICKABLE} />
+          </div>
+
+          <div>
+            <h3 className="text-[var(--text0)] text-[13px] font-medium" style={{ marginBottom: '6px' }}>Minimalist (empty when healthy)</h3>
+            <p className="text-[var(--text2)] text-[12px]" style={{ lineHeight: '1.6', marginBottom: '8px' }}>
+              No brand label — output stays completely empty while every service is operational, preserving statusline space; up to 3 degraded/down service names appear with a red dot only when something breaks. Choose this if you want zero footprint when all is well.
+            </p>
+            <Snippet code={PRESET_DEGRADED_ONLY} eventLabel={SLUG_DEGRADED_ONLY} />
           </div>
         </div>
       </Section>

--- a/src/pages/__tests__/statusline-presets.test.js
+++ b/src/pages/__tests__/statusline-presets.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { PRESET_BRANDED, SLUG_BRANDED } from '../Statusline.jsx'
+
+// #543 — the "branded" statusline preset: an always-on, clickable AIWatch label
+// (OSC 8 → dashboard) + 🟢 healthy / 🔴 <name> degraded. Pins the escaping contract
+// so the OSC 8 hyperlink, the dashboard target, the worker-domain endpoint (#438),
+// and the analytics tag can't silently drift.
+describe('PRESET_BRANDED statusline snippet (#543)', () => {
+  const parsed = JSON.parse(PRESET_BRANDED) // also asserts it is valid JSON
+  const cmd = parsed.statusLine.command
+
+  it('is the command-type settings.json shape', () => {
+    expect(parsed.statusLine.type).toBe('command')
+    expect(typeof cmd).toBe('string')
+  })
+
+  it('polls the Worker domain with the branded src tag — never the Vercel-proxied path (#438)', () => {
+    expect(SLUG_BRANDED).toBe('branded')
+    expect(cmd).toContain('aiwatch-worker.p2c2kbf.workers.dev/api/status/cached')
+    expect(cmd).toContain('?src=statusline-branded')
+    expect(cmd).not.toContain('ai-watch.dev/api/status') // must not route status polls through Vercel
+  })
+
+  it('wraps an always-on AIWatch label in an OSC 8 hyperlink to the dashboard home', () => {
+    // jq source emits ESC]8;;https://ai-watch.dev ESC\ AIWatch ESC]8;; ESC\
+    expect(cmd).toContain('\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\')
+  })
+
+  it('shows 🟢 when all healthy and 🔴 <name> (≤3) when degraded', () => {
+    expect(cmd).toContain('select(.status != "operational")')
+    expect(cmd).toContain('"🟢"')
+    expect(cmd).toContain('"🔴 " + .name')
+    expect(cmd).toContain('.[0:3]')
+  })
+
+  it('fails silent (no error leaks into the statusline)', () => {
+    expect(cmd).toContain('2>/dev/null || true')
+  })
+})

--- a/src/pages/__tests__/statusline-presets.test.js
+++ b/src/pages/__tests__/statusline-presets.test.js
@@ -26,10 +26,14 @@ describe('PRESET_BRANDED statusline snippet (#543)', () => {
     expect(cmd).toContain('\\u001b]8;;https://ai-watch.dev\\u001b\\\\AIWatch\\u001b]8;;\\u001b\\\\')
   })
 
+  it('also links each degraded service name to its detail page (ai-watch.dev/#<id>)', () => {
+    expect(cmd).toContain('\\u001b]8;;https://ai-watch.dev/#\\(.id)\\u001b\\\\🔴 \\(.name)\\u001b]8;;\\u001b\\\\')
+  })
+
   it('shows 🟢 when all healthy and 🔴 <name> (≤3) when degraded', () => {
     expect(cmd).toContain('select(.status != "operational")')
     expect(cmd).toContain('"🟢"')
-    expect(cmd).toContain('"🔴 " + .name')
+    expect(cmd).toContain('🔴 \\(.name)') // red name inside the per-service OSC 8 link
     expect(cmd).toContain('.[0:3]')
   })
 

--- a/tests/statusline.spec.js
+++ b/tests/statusline.spec.js
@@ -34,14 +34,14 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     expect(text).toContain('|| true')
   })
 
-  test('renders all five documented presets with copy buttons', async ({ page }) => {
+  test('renders all six documented presets with copy buttons', async ({ page }) => {
     await page.goto('/#statusline')
     await waitForDataLoad(page)
-    // 5 presets = 5 <pre> code blocks + 5 Copy buttons.
-    // (degraded_only, compact_badge, full_list, scoped, clickable)
-    await expect(page.locator('pre')).toHaveCount(5)
+    // 6 presets = 6 <pre> code blocks + 6 Copy buttons.
+    // (branded [quick start], compact_badge, full_list, scoped, clickable, degraded_only [minimalist])
+    await expect(page.locator('pre')).toHaveCount(6)
     const copyButtons = page.locator('button').filter({ hasText: /^Copy$/ })
-    await expect(copyButtons).toHaveCount(5)
+    await expect(copyButtons).toHaveCount(6)
   })
 
   test('copy button click does not throw and remains a button', async ({ page }) => {
@@ -160,11 +160,11 @@ test.describe('Statusline guide page (#400 Phase 0)', () => {
     // baseline measurement collapses. A future copy-paste refactor that drops
     // the tag would silently re-block that gate, so pin each preset's slug to
     // its snippet's <pre> contents. Preset order matches Statusline.jsx render
-    // order: Quick start (degraded_only) then Other presets (compact_badge,
-    // full_list, scoped, clickable).
+    // order: Quick start (branded) then Other presets (compact_badge,
+    // full_list, scoped, clickable, degraded_only [minimalist]).
     await page.goto('/#statusline')
     await waitForDataLoad(page)
-    const presetOrder = ['degraded_only', 'compact_badge', 'full_list', 'scoped', 'clickable']
+    const presetOrder = ['branded', 'compact_badge', 'full_list', 'scoped', 'clickable', 'degraded_only']
     const preBlocks = page.locator('pre')
     await expect(preBlocks).toHaveCount(presetOrder.length)
     for (let i = 0; i < presetOrder.length; i++) {


### PR DESCRIPTION
Closes #543.

## Why

The Claude Code statusline is a **free distribution surface** (#347/#348), but every existing preset is **empty when healthy** → an adopter's terminal shows **zero AIWatch brand presence** while things are fine.

## What

A new **branded** preset — an always-on, **clickable** `AIWatch` label (OSC 8 hyperlink → the dashboard) showing `AIWatch 🟢` when all healthy and `AIWatch 🔴 Claude API` (≤3) when degraded. The brand is always visible; cmd/ctrl+click opens the dashboard.

Per the product call (**brand exposure > minimal footprint**), branded is **promoted to the recommended Quick-start preset**; the old `degraded_only` is demoted to *Other presets* as the **Minimalist** (empty-when-healthy) option for users who want zero footprint.

- **`src/pages/Statusline.jsx`** — `SLUG_BRANDED` + `PRESET_BRANDED` (exported); Quick-start ⇄ Other-presets swap + copy. Mirrors the proven `PRESET_CLICKABLE` OSC 8 escaping; targets the **Worker domain** (#438), OSC 8 link → `https://ai-watch.dev`.
- **`README.md` / `README.ko.md`** — quick-install snippet → branded (worker-domain) + OSC 8 terminal caveat; minimalist noted as the alternative.
- **`src/pages/__tests__/statusline-presets.test.js`** — pins the OSC 8 escaping, worker domain, `?src=statusline-branded` tag, 🟢/🔴 branches, fail-silent.
- **Worker:** no change — reuses the lite `?src=statusline-*` projection (id/name/status); the Worker matches the tag by prefix.

## Feasibility & verification

- OSC 8 clickable links are **officially supported** in Claude Code statusLine (docs "Clickable links"); unsupported terminals (Terminal.app/Konsole) show plain text — no harm.
- **Browser-verified** on the `/statusline` page (KO + EN): Quick-start = branded snippet, Other-presets = minimalist.
- `npm run build` clean (377 KB < 400 KB) · `npm run test:src` **322 passing** (5 new) · ESLint clean.
- PR review: **0 Critical / 0 Important** — reviewer ran an end-to-end "copy README JSON → parse → shell → jq" simulation confirming the OSC 8 output is correct.

Frontend-only → **Vercel auto-deploys on merge**; no worker deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)