### PR TITLE
feat(is-down): outage-moment CTA copy + deep-link to the Alerts section (closes #546)

### DIFF
--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -419,14 +419,20 @@ function renderCTA(seo: ServiceSEO, status: string, slug: string, svcId: string)
   // prompt catches the visitor at peak intent — before they bounce after reading
   // the status. GA4 source='status_banner' distinguishes this placement from the
   // footer CTA for the 2-week conversion comparison.
+  // #546: during an outage the visitor is here at peak intent for one reason \u2014
+  // confirm it's down + be told when it's back. Lead with that exact need (status-
+  // accurate: "down" vs "having issues" for degraded), label the button to match.
+  const stateLead = status === 'down'
+    ? `${seo.displayName} is down right now.`
+    : `${seo.displayName} is having issues right now.`
   const message = isDown
-    ? 'Get notified when it recovers \u2014 takes 1 minute'
+    ? `${stateLead} Get notified when it recovers.`
     : `Get notified when ${seo.displayName} goes down`
-  const buttonLabel = isDown ? 'Get Alerts When Fixed' : 'Set Up Alerts'
+  const buttonLabel = isDown ? 'Notify Me When Fixed' : 'Set Up Alerts'
   return `<div class="cta">
 <p class="cta-title">${esc(message)}</p>
 <div class="cta-buttons">
-<a href="https://ai-watch.dev/#settings" class="btn btn-primary" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner'})">${esc(buttonLabel)} &rarr;</a>
+<a href="https://ai-watch.dev/#settings?focus=alerts" class="btn btn-primary" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner'})">${esc(buttonLabel)} &rarr;</a>
 <!-- data-rss uses the page slug (the feed URL is /feed/{slug}); data-svc uses the
      service ID so the copy_rss GA4 event keys on the same id as fallback_click /
      click_service_detail (id and slug diverge for claude-code, github-copilot, etc.) -->

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,10 +84,25 @@ import { initVitals } from './utils/vitals'
 
 const PAGE_NAMES = ['overview', 'latency', 'incidents', 'uptime', 'settings', 'about-score', 'ranking', 'statusline']
 
+// #546: a `?focus=<section>` suffix on a page hash (e.g. #settings?focus=alerts from the
+// Is-X-Down "Notify Me When Fixed" CTA) deep-links to a section so the outage visitor isn't
+// dropped at the page top. The page id itself is still split off before this, so routing is unaffected.
+function hashToFocus(hash) {
+  const q = hash.split('?')[1]
+  return q ? new URLSearchParams(q).get('focus') : null
+}
+
 function hashToPage(hash) {
   const id = hash.replace(/^#/, '').split(/[?&#]/)[0]
   if (!id) return { name: 'overview' }
-  if (PAGE_NAMES.includes(id)) return { name: id }
+  if (PAGE_NAMES.includes(id)) {
+    const page = { name: id }
+    if (id === 'settings') {
+      const focus = hashToFocus(hash)
+      if (focus) page.focus = focus
+    }
+    return page
+  }
   if (ALL_SERVICE_IDS.includes(id)) return { name: 'service', serviceId: id }
   // Invalid hash — clean up URL and fallback to overview
   window.history.replaceState(null, '', window.location.pathname)
@@ -107,7 +122,7 @@ function resolvePage(page) {
     case 'incidents': return <Suspense fallback={<IncidentsSkeleton />}><Incidents /></Suspense>
     case 'uptime':    return <Suspense fallback={<UptimeSkeleton />}><Uptime /></Suspense>
     case 'service':   return <Suspense fallback={<ServiceDetailsSkeleton />}><ServiceDetails serviceId={page.serviceId} /></Suspense>
-    case 'settings':  return <Suspense fallback={<SkeletonUI />}><Settings /></Suspense>
+    case 'settings':  return <Suspense fallback={<SkeletonUI />}><Settings focus={page.focus} /></Suspense>
     case 'about-score': return <Suspense fallback={<SkeletonUI />}><AboutScore /></Suspense>
     case 'ranking':     return <Suspense fallback={<SkeletonUI />}><Ranking /></Suspense>
     case 'statusline':  return <Suspense fallback={<SkeletonUI />}><Statusline /></Suspense>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,7 +1,7 @@
 // Settings page — redesigned to match design mockup.
 // Segment controls, green toggles, description text, service dots+uptime.
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useLang } from '../hooks/useLang'
 import { useTheme } from '../hooks/useTheme'
 import { useSettings } from '../hooks/useSettings'
@@ -100,7 +100,7 @@ function ComingSoonBadge({ t }) {
 
 // ── Main Component ───────────────────────────────────────
 
-export default function Settings() {
+export default function Settings({ focus } = {}) {
   const { t, lang, setLang } = useLang()
   const { theme, setTheme } = useTheme()
   const { settings, save } = useSettings()
@@ -130,8 +130,33 @@ export default function Settings() {
   const [slackFeedCopied, setSlackFeedCopied] = useState(false)
   const saveTimerRef = useRef(null)
   const errorTimerRef = useRef(null)
+  const alertsRef = useRef(null)
+  const didFocusScrollRef = useRef(false)
 
   useEffect(() => () => { clearTimeout(saveTimerRef.current); clearTimeout(errorTimerRef.current) }, [])
+
+  // #546: deep-link from the Is-X-Down "Notify Me When Fixed" CTA (#settings?focus=alerts) lands the
+  // outage visitor straight at the Alerts section instead of the page top — the friction behind the
+  // 3-clicks→0-registers leak. Two scrolls: (1) on mount regardless of data (so it works even when
+  // /api/status is slow/unavailable), and (2) once more after services data first loads, since the
+  // monitored-services list above Alerts reflows the page and shifts the target. rAF lets App's
+  // post-nav scrollTo(0,0) + that frame's layout settle first, so the scroll isn't overridden.
+  const scrollToAlerts = useCallback(() => {
+    requestAnimationFrame(() => {
+      alertsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      // a11y: move keyboard/SR focus to the section so it isn't left at the page top, out of sync
+      // with the visual scroll. preventScroll so it doesn't fight the smooth scroll above.
+      alertsRef.current?.focus?.({ preventScroll: true })
+    })
+  }, [])
+  useEffect(() => {
+    if (focus === 'alerts') scrollToAlerts()
+  }, [focus, scrollToAlerts])
+  useEffect(() => {
+    if (focus !== 'alerts' || rawServices == null || didFocusScrollRef.current) return
+    didFocusScrollRef.current = true
+    scrollToAlerts()
+  }, [focus, rawServices, scrollToAlerts])
   useEffect(() => {
     setPeriod(settings.period)
     setSla(settings.sla)
@@ -465,7 +490,7 @@ export default function Settings() {
       </div>
 
       {/* ── Alerts ── */}
-      <section>
+      <section ref={alertsRef} id="alerts" tabIndex={-1} style={{ scrollMarginTop: '12px', outline: 'none' }}>
         <div style={sectionTitleStyle}>{t('settings.alerts')}</div>
 
         {/* RSS — lead with the zero-friction channel (#433/#428): no account, no

--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -68,7 +68,7 @@ test.describe('Is X Down? SSR pages', () => {
       test(`has CTA alert banner`, async ({ page: p }) => {
         await p.goto(`/is-${page.slug}-down`, { waitUntil: 'domcontentloaded' })
         await expect(p.locator('.cta')).toBeVisible()
-        await expect(p.locator('.cta a.btn-primary')).toHaveAttribute('href', 'https://ai-watch.dev/#settings')
+        await expect(p.locator('.cta a.btn-primary')).toHaveAttribute('href', 'https://ai-watch.dev/#settings?focus=alerts')
       })
 
       test(`has GA4 tag`, async ({ page: p }) => {
@@ -329,16 +329,16 @@ test.describe('Is X Down? SSR pages', () => {
       // fall back to any is-down page — we check the copy's shape, not the status.
       await page.goto('/is-chatgpt-down', { waitUntil: 'domcontentloaded' })
       const ctaText = await page.locator('.cta').textContent()
-      // Accept either down-state copy (benefit-framed, 1-min framing) or
-      // operational copy ("Get notified when X goes down") — both are acceptable.
-      const isDownCopy = /Get notified when it recovers.*takes 1 minute/i.test(ctaText || '')
+      // Accept either down-state copy (#546: "<svc> is down/having issues right now.
+      // Get notified when it recovers.") or operational copy ("Get notified when X
+      // goes down") — both are acceptable; we check shape, not the live status.
+      const isDownCopy = /is (down|having issues) right now\.\s*Get notified when it recovers/i.test(ctaText || '')
       const isOperationalCopy = /Get notified when .* goes down/i.test(ctaText || '')
       expect(isDownCopy || isOperationalCopy).toBe(true)
 
-      // Button label must never regress to the old generic "Set Up Alerts"
-      // when the service is in a down/degraded state.
+      // Button label: outage state → "Notify Me When Fixed" (#546); operational → "Set Up Alerts".
       const btnText = (await page.locator('.cta a.btn-primary').textContent()) || ''
-      expect(btnText.trim()).toMatch(/^(Get Alerts When Fixed|Set Up Alerts)/)
+      expect(btnText.trim()).toMatch(/^(Notify Me When Fixed|Set Up Alerts)/)
     })
   })
 })

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -13,6 +13,21 @@ test.describe('Settings', () => {
     await expect(page.locator('main').getByText('General')).toBeVisible()
   })
 
+  test('#546: deep-link #settings?focus=alerts routes to Settings and scrolls to the Alerts section', async ({ page }) => {
+    // The Is-X-Down "Notify Me When Fixed" CTA links here; the outage visitor must land AT the
+    // Alerts section, not the page top (the 3-clicks→0-registers friction).
+    await page.goto('/#settings?focus=alerts')
+    await page.reload({ waitUntil: 'domcontentloaded' }) // unambiguous fresh mount (beforeEach already sits on #settings; a fragment-only goto may not remount)
+    await expect(page.locator('main').getByText('General')).toBeVisible() // routing unaffected by ?focus
+    // Strict: the window must actually scroll so the Alerts section sits at/near the viewport top —
+    // NOT merely intersect it (a long page can intersect #alerts at scrollY=0, which toBeInViewport
+    // would false-pass). Poll the section's top until the scroll settles.
+    await expect.poll(
+      async () => page.locator('#alerts').evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+      { timeout: 15000 },
+    ).toBeLessThan(120)
+  })
+
   test('theme toggle persists to localStorage', async ({ page }) => {
     const html = page.locator('html')
 


### PR DESCRIPTION
Closes #546. Data-driven (the GA4 outage-day readout).

## Why
On a real outage, X drove ~22 visitors (89% brand-new), but **`click_cta_alerts = 3 → webhook_register = 0`** — everyone who clicked "set up alerts" dropped. Two frictions: the CTA copy didn't match the panic-moment need, and it dropped them at the **Settings page top** (they had to hunt for the Alerts section).

## What
1. **Outage CTA copy** (`api/is-down/html-template.ts` `renderCTA`) — for a non-operational service, lead with the exact need:
   - down → **"{Service} is down right now. Get notified when it recovers."**
   - degraded → **"{Service} is having issues right now. Get notified when it recovers."**
   - button **"Notify Me When Fixed →"** (was "Get Alerts When Fixed")
   - operational copy unchanged. English-only SEO page (no i18n).
2. **Deep-link to the section** — CTA href → `#settings?focus=alerts`:
   - `App.jsx`: `hashToFocus` parses the `?focus` suffix and passes `focus` to `<Settings>`. **Page-id routing is untouched** (split on `[?&#]` happens first; `focus` is honored only for `settings`, never leaks to service/other pages; `pageToHash` drops it so programmatic nav doesn't re-deep-link).
   - `Settings.jsx`: scrolls the Alerts `<section id="alerts" tabIndex={-1}>` into view — **on mount** (works even when `/api/status` is unavailable and `rawServices` is null) **AND once after data first loads** (the monitored-services list above Alerts reflows the page). Keyboard/SR focus moves to the section for parity. `didFocusScrollRef` prevents re-scroll on 60s polls.

## Verification
- **Browser-verified**: is-down outage copy + button (live degraded chatgpt/claude), and the `#settings?focus=alerts` scroll on the local SPA.
- Caught + fixed a real bug mid-review: the scroll was gated on `rawServices` (never loads without the worker) → no scroll; split into mount + post-load. The first e2e false-passed (`toBeInViewport` intersects a long page at scrollY=0) → replaced with a **strict** `boundingBox top < 120` poll (measured `scrollY` 0 → 537 after the fix).
- `npm run build` clean · `test:src` **331** · ESLint clean · e2e (is-down **15**, settings **7** incl the strict deep-link test).
- PR review: **0 Critical / 0 Important**; applied 2 suggestions (test-robustness reload, a11y focus).

> Note: the is-down button links to production `ai-watch.dev/#settings?focus=alerts`, so the full button→scroll flow goes live **after merge** (Vercel auto-deploy). Frontend-only — **no worker deploy**.

This is the immediate-win slice of the outage-conversion work; the structural fix (lowest-friction channel as primary) is **#547**, measurement is **#548**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)