### PR TITLE
fix(overview): Issues filter no longer shows "No Issues" for an agent-only issue (#553)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -730,7 +730,10 @@ export default function Overview() {
       </div>
 
       {/* ── Service Grid ── */}
-      {filter === 'issues' && filteredServices.length === 0 ? (
+      {/* #553: the empty state must consider agents too — issueCount counts all categories, but
+          filteredServices excludes agents, so an agent-only issue otherwise shows "No Issues"
+          here while the Coding Agents section below renders the degraded agent. */}
+      {filter === 'issues' && filteredServices.length === 0 && filteredAgents.length === 0 ? (
         <EmptyState type="good" />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style={{ gap: '8px' }}>

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -375,3 +375,43 @@ test.describe('RSS subscribe affordances (#433)', () => {
     expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('https://ai-watch.dev/feed.xml')
   })
 })
+
+test.describe('#553 Issues filter — agent-only issue', () => {
+  test('does NOT show "No Issues" when only a coding agent is degraded', async ({ page }) => {
+    // usePolling MERGES the API response with MOCK_SERVICES, keeping the mock status for any service
+    // the response omits. MOCK_SERVICES defaults openai/xai/huggingface/elevenlabs to 'degraded', so
+    // the fixture must override ALL of them to operational — otherwise a non-agent issue keeps the
+    // grid non-empty and the empty state never fires (the bug would be masked → false pass).
+    const op = (id, name, category = 'api') => ({ id, category, name, provider: 'x', status: 'operational', latency: 200, uptime30d: 99.9, calendarDays: 30, incidents: [] })
+    const mockData = { json: {
+      services: [
+        op('openai', 'OpenAI API'), op('xai', 'xAI (Grok)'), op('huggingface', 'Hugging Face'), op('elevenlabs', 'ElevenLabs'),
+        { id: 'claudecode', category: 'agent', name: 'Claude Code', provider: 'Anthropic', status: 'degraded', latency: null, uptime30d: 99.05, calendarDays: 30,
+          incidents: [{ id: 'cc1', title: 'Partial outage', status: 'investigating', impact: 'minor', startedAt: new Date(Date.now() - 120_000).toISOString(), timeline: [] }] },
+      ],
+      lastUpdated: new Date().toISOString(),
+    } }
+    await page.route('**/api/status**', (route) => route.fulfill(mockData))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mockData))
+    await page.goto('/')
+    await page.locator('main button').first().waitFor({ state: 'visible', timeout: 20000 })
+
+    // Precondition guard: exactly ONE issue and it is the agent (else the fixture didn't neutralize a
+    // non-agent issue and the test isn't exercising the agent-only path). The Issues tab shows "1".
+    await expect(page.locator('main').getByRole('button', { name: /Issues\s*1\b/ })).toBeVisible()
+
+    // Select Issues → the agent section must render and the "No Issues" empty state must NOT appear.
+    await page.locator('main').getByRole('button', { name: /Issues/ }).click()
+
+    // Positive: assert the *Coding Agents section heading* (renders only when filteredAgents.length > 0),
+    // NOT bare getByText('Claude Code') — the agent name also appears in the Recent Incidents panel below,
+    // which renders regardless of the filter or the fix, so a name-only check would pass even when buggy.
+    await expect(page.locator('main').getByText(/Coding Agents|코딩 에이전트/)).toBeVisible()
+
+    // Negative (load-bearing — this is what fails when the fix is reverted): no "No Issues" empty state.
+    // EmptyState type="good" is shared by the issues-grid AND the Recent Incidents panel, but the fixture's
+    // incident is left UNRESOLVED so the incidents panel is non-empty → the only "No Issues" that can appear
+    // is the issues-grid bug. (If a future edit resolves/removes the incident, also scope this to the grid.)
+    await expect(page.locator('main').getByText(/No Issues|이슈 없음/)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Problem

The Overview **Issues** filter rendered the "No Issues" empty state when the only degraded/down service was a **coding agent** — while the degraded agent card still rendered in the Coding Agents section just below it. (Reported from a desktop screenshot: Claude Code partial outage, "Issues 1", yet "No Issues" shown.)

## Root cause

`src/pages/Overview.jsx` — the empty-state guard checked only `filteredServices` (API/web/app categories, which **exclude** agents), but `issueCount` counts **all** categories including agents, and agents render via a separate `filteredAgents` list in the Coding Agents section. So an agent-only issue satisfied `filteredServices.length === 0` and fired the empty state, contradicting the agent card below.

## Fix

```diff
- {filter === 'issues' && filteredServices.length === 0 ? (
+ {filter === 'issues' && filteredServices.length === 0 && filteredAgents.length === 0 ? (
```

Mirrors the two render sources (main grid `filteredServices` + Coding Agents `filteredAgents`). Tab counts already use `issueCount`/`total` over all categories, so no other blind spot exists.

## Test

Real-browser Playwright regression in `tests/overview.spec.js` reproducing the exact agent-only state:
- Fixture overrides MOCK_SERVICES' four default-degraded api services (openai/xai/huggingface/elevenlabs) to operational — `usePolling` **merges** the response with MOCK_SERVICES, so a naive fixture would leave non-agent issues that mask the bug.
- Precondition guard asserts exactly "Issues 1" (agent-only).
- Positive assertion targets the **Coding Agents section heading** (not the agent name, which also appears in the Recent Incidents panel regardless of the filter/fix).
- Negative assertion (load-bearing): no "No Issues" empty state.
- **Verified pass-on-fix / fail-on-revert.**

## Verification

- Step 3.5 in-browser confirmed by operator (local MOCK forced to agent-only, reverted before commit).
- `npm run build` ✓ · `npm run test:src` (20 files) ✓ · `npm test` overview spec (16 passed) ✓ · lint clean.
- PR review (code-reviewer + pr-test-analyzer): 0 Critical/Important after addressing the one Important (assertion scoping).

Frontend-only → Vercel auto-deploys on merge; no worker deploy.

closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)