### PR TITLE
fix(region): drop dead xAI region docs link — docs.x.ai/docs/regions 404 (#560)

### DIFF
--- a/api/is-down/region-status.ts
+++ b/api/is-down/region-status.ts
@@ -92,7 +92,9 @@ export const SERVICE_REGIONS: Record<string, RegionDef[]> = {
 }
 
 export const REGION_DOCS_URL: Record<string, string> = {
-  xai: 'https://docs.x.ai/docs/regions',
+  // xai intentionally has NO entry (#560): xAI removed its regional-endpoints doc page
+  // (docs.x.ai/docs/regions → 404, no live replacement). Mirrors src/utils/regionStatus.js —
+  // the Edge omits the docs anchor when docsUrl is undefined. Do NOT re-add a guessed URL.
   gemini: 'https://cloud.google.com/vertex-ai/docs/general/locations',
   openai: 'https://platform.openai.com/docs/guides/production-best-practices',
   chatgpt: 'https://status.openai.com',

--- a/src/utils/__tests__/regionStatus.test.js
+++ b/src/utils/__tests__/regionStatus.test.js
@@ -321,6 +321,19 @@ describe('regionStatusOf — docsUrl pass-through', () => {
     )
     expect(result.docsUrl).toBeUndefined()
   })
+
+  test('xai has NO docsUrl — xAI removed its regions doc page (#560)', () => {
+    // xai IS region-aware (SERVICE_REGIONS.xai us-east-1/eu-west-1), so a region incident
+    // yields a result — but its docs page (docs.x.ai/docs/regions) 404s and was removed with
+    // no live replacement, so the "learn more" link must be absent. Pre-fix this returned the
+    // dead URL; this test fails if anyone re-adds a (likely still-dead) REGION_DOCS_URL.xai.
+    const result = regionStatusOf({
+      id: 'xai',
+      incidents: [{ id: 'x1', status: 'investigating', title: 'Elevated errors in eu-west-1' }],
+    })
+    expect(result).not.toBeNull()
+    expect(result.docsUrl).toBeUndefined()
+  })
 })
 
 describe('SERVICE_REGIONS — invariants', () => {

--- a/src/utils/regionStatus.js
+++ b/src/utils/regionStatus.js
@@ -57,7 +57,10 @@ export const SERVICE_REGIONS = {
 }
 
 export const REGION_DOCS_URL = {
-  xai: 'https://docs.x.ai/docs/regions',
+  // xai intentionally has NO entry (#560): xAI removed its regional-endpoints doc page
+  // (docs.x.ai/docs/regions → 404, no live replacement in the current docs nav). The region
+  // card omits the "learn more" link when a service has no docsUrl — do NOT re-add a guessed
+  // URL here without verifying it resolves in a real browser. (region-status.ts mirrors this.)
   gemini: 'https://cloud.google.com/vertex-ai/docs/general/locations',
   openai: 'https://platform.openai.com/docs/guides/production-best-practices',
   chatgpt: 'https://status.openai.com',

--- a/tests/service-details.spec.js
+++ b/tests/service-details.spec.js
@@ -186,8 +186,11 @@ test.describe('xAI Regional Availability', () => {
     await expect(page.locator('main').getByText(/Service Down|서비스 중단/)).toBeVisible()
     // US region should show no active incidents
     await expect(page.locator('main').getByText(/No Active Incidents|활성 장애 없음/)).toBeVisible()
-    // Recommendation + Guide link should be visible
-    await expect(page.locator('main').getByText(/API Guide|API 가이드/)).toBeVisible()
+    // Recommendation line still renders (recommends the healthy region)...
+    await expect(page.locator('main').getByText(/to avoid service interruption|서비스 중단을 피하려면/)).toBeVisible()
+    // ...but the "Check API Guide" link is GONE: xAI removed its regions doc page (#560), so
+    // REGION_DOCS_URL has no xai entry and the card omits the (previously 404ing) link.
+    await expect(page.locator('main').getByText(/API Guide|API 가이드/)).toHaveCount(0)
   })
 
   test('shows all regions affected for global incident (no region keyword)', async ({ page }) => {


### PR DESCRIPTION
## Problem

The xAI **RegionalAvailability** card (ServiceDetails), the **Overview ActionBanner** region line, and the **/is-xai-down** Edge SSR all linked "learn more" → `https://docs.x.ai/docs/regions`, which **404s**. During an xAI region incident, users clicking it hit a dead page.

## Confirmation (real browser)

- `docs.x.ai/docs/regions` → **404 "Page not found"** (verified in a real Chromium session — not an SPA/bot artifact).
- `docs.x.ai/developers/regions` (obvious new-structure candidate) → also 404.
- xAI's current live docs nav has **no Regions / Regional Endpoints page** — it was removed. FAQ "Data & Privacy" only covers retention/ZDR/GDPR, not regional endpoints → no clean replacement.
- **Isolated to xai**: link-checked all six `REGION_DOCS_URL` entries — gemini/openai/azureopenai/bedrock/pinecone return 200; only xai was dead.

## Fix

Remove the `xai` entry from `REGION_DOCS_URL` in **both** cross-mirrored copies:
- `src/utils/regionStatus.js`
- `api/is-down/region-status.ts` (Edge SSR mirror, pinned by `region-status-sync.test.ts`)

All three render sites already omit the link when `docsUrl` is undefined, so the card degrades cleanly to plain text:
- `ServiceDetails.jsx` — `{docsUrl && <a>…</a>}`
- `Overview.jsx` — `rec.docsUrl ? <a> : <span>`
- `api/is-down/html-template.ts` — `rec.docsUrl ? esc(rec.docsUrl) : ''`

A comment in each map warns against re-adding a guessed URL without verifying it resolves. `xai` stays in `SERVICE_REGIONS` (still region-aware) — only the dead docs link is dropped.

## Test

`src/utils/__tests__/regionStatus.test.js` — `regionStatusOf` for an xai region incident now returns a **non-null** result with `docsUrl` **undefined** (the `not.toBeNull()` guard confirms the docsUrl path is genuinely reached, not short-circuited). **Verified fail-on-revert**: re-adding the dead URL fails the test.

## Verification

- Step 3.5 in-browser confirmed by operator (xAI detail → Regional Availability card → no broken "learn more" link; MOCK already carries an xai eu-west-1 incident).
- `npm run build` ✓ · `test:src` 332 ✓ · `test:worker` 1548 ✓ (incl. `region-status-sync`) · worker dry-run ✓ · `typecheck:worker` 0 errors ✓ · lint clean.
- PR review (code-reviewer + pr-test-analyzer): 0 Critical/Important.

## Follow-up (not in this PR)
- `region-status-sync.test.ts`'s `REGION_DOCS_URL` check is one-directional (frontend→Edge); a reverse check would catch a stale key left only in the Edge file. Low priority.
- Periodic external-link-rot guard (suggested in #560) to catch the next dead doc URL before a user does — candidate `area:ops` issue.

Frontend + Edge → Vercel auto-deploys on merge. `region-status.ts` is also imported by the Worker (`alerts.ts` buildRegionHint), so the change rides the next worker deploy — no immediate worker deploy needed.

closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)