### PR TITLE
feat(is-down): lead outage CTA with the zero-friction RSS channel, demote Discord (#547)

### DIFF
--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -599,21 +599,37 @@ describe('RSS feed surfacing on /is-*-down (#430)', () => {
       expect(html, `autodiscovery <link> for ${slug}`).toContain(
         `type="application/rss+xml" title="${seo.displayName} incidents — AIWatch" href="https://ai-watch.dev/feed/${slug}">`,
       )
-      expect(html, `Copy RSS URL button for ${slug}`).toContain(
+      expect(html, `RSS copy button for ${slug}`).toContain(
         `data-rss="https://ai-watch.dev/feed/${slug}"`,
       )
     }
   })
 
-  it('renders a secondary "Copy RSS URL" button that copies the feed URL to the clipboard', () => {
+  it('renders the PRIMARY "Notify me via RSS" button that copies the feed URL (#547)', () => {
     const html = renderPage('claude', mkService(), mkSeo(), [])
+    // #547: RSS is the primary (btn-primary) CTA — the only channel that converted on the
+    // outage day. Lock the exact primary markup + label.
     expect(html).toContain(
-      '<button type="button" class="btn" data-rss="https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copyRss(this)">Copy RSS URL</button>',
+      '<button type="button" class="btn btn-primary" data-rss="https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copyRss(this)">🔔 Notify me via RSS</button>',
     )
     expect(html).toContain('function copyRss(b)')
     expect(html).toContain('navigator.clipboard.writeText(u)')
-    // prompt() fallback for insecure-context / writeText-rejection paths
+    // prompt() fallback for insecure-context / writeText-rejection paths (label text unchanged)
     expect(html).toContain("prompt('Copy RSS URL:',u)")
+  })
+
+  it('demotes the Discord double-opt-in to a de-emphasized secondary text link (#547)', () => {
+    const html = renderPage('claude', mkService(), mkSeo(), [])
+    // The heavy Discord per-user push keeps the #546 deep-link (scrolls to the Alerts section)
+    // but is no longer a btn-primary; it is a .cta-alt text link tagged status_banner_secondary
+    // so the funnel comparison can tell post-reorder clicks from the old primary placement.
+    expect(html).toContain('<p class="cta-alt"><a href="https://ai-watch.dev/#settings?focus=alerts"')
+    expect(html).toContain("gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner_secondary'})")
+    // No "email" channel exists yet — the link must not advertise one.
+    expect(html).toContain('Prefer Discord push alerts?')
+    expect(html).not.toContain('email push')
+    // The Discord path must NOT be a btn-primary anchor anymore (RSS owns btn-primary).
+    expect(html).not.toMatch(/<a[^>]*class="btn btn-primary"/)
   })
 
   it('renders a "Copy Slack command" button with the per-service /feed subscribe command (#467)', () => {

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -227,6 +227,9 @@ button.btn{cursor:pointer;font-family:inherit;line-height:inherit}
 .cta{background:#0d1117;border:1px solid rgba(255,255,255,0.07);border-radius:8px;padding:16px 20px;text-align:center;margin:16px 0}
 .cta-title{font-size:14px;font-weight:600;margin-bottom:10px}
 .cta-buttons{display:flex;gap:8px;justify-content:center;flex-wrap:wrap}
+.cta-alt{font-size:12px;margin-top:10px;color:#8b949e}
+.cta-alt a{color:#8b949e;text-decoration:underline}
+.cta-alt a:hover{color:#c9d1d9}
 .links{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
 .links a{font-size:13px;padding:6px 12px;background:#161b22;border:1px solid rgba(255,255,255,0.07);border-radius:4px;color:#8b949e}
 .links a:hover{color:#e6edf3;text-decoration:none}
@@ -428,24 +431,28 @@ function renderCTA(seo: ServiceSEO, status: string, slug: string, svcId: string)
   const message = isDown
     ? `${stateLead} Get notified when it recovers.`
     : `Get notified when ${seo.displayName} goes down`
-  const buttonLabel = isDown ? 'Notify Me When Fixed' : 'Set Up Alerts'
+  // #547: the outage-day funnel leaked — 3 clicks on the Discord double-opt-in CTA,
+  // 0 webhook_register; the only channel that converted was the zero-config RSS copy
+  // (copy_rss 3×). So lead with the lowest-friction channel: RSS is the PRIMARY button,
+  // Slack /feed the secondary, and the heavy Discord per-user push (double opt-in) is demoted
+  // to a de-emphasized text link so it no longer out-competes the converting channel for the
+  // click. (copy_rss remains the success proxy; we compare its rate vs the 3→0 baseline.)
+  // data-rss uses the page slug (feed URL is /feed/{slug}); data-svc uses the service ID
+  // so copy_rss keys on the same id as fallback_click / click_service_detail (id and slug
+  // diverge for claude-code, github-copilot, etc.).
   return `<div class="cta">
 <p class="cta-title">${esc(message)}</p>
 <div class="cta-buttons">
-<a href="https://ai-watch.dev/#settings?focus=alerts" class="btn btn-primary" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner'})">${esc(buttonLabel)} &rarr;</a>
-<!-- data-rss uses the page slug (the feed URL is /feed/{slug}); data-svc uses the
-     service ID so the copy_rss GA4 event keys on the same id as fallback_click /
-     click_service_detail (id and slug diverge for claude-code, github-copilot, etc.) -->
-<button type="button" class="btn" data-rss="https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copyRss(this)">Copy RSS URL</button>
-<!-- Slack subscribes via its native /feed RSS app (#467) — paste this command into any
-     channel, zero webhook setup. Uses the same per-service feed URL. -->
+<button type="button" class="btn btn-primary" data-rss="https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copyRss(this)">🔔 Notify me via RSS</button>
+<!-- Slack subscribes via its native /feed RSS app (#467) — paste into any channel, zero webhook setup. -->
 <button type="button" class="btn" data-slack="/feed subscribe https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copySlackFeed(this)">Copy Slack command</button>
 </div>
+<p class="cta-alt"><a href="https://ai-watch.dev/#settings?focus=alerts" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner_secondary'})">Prefer Discord push alerts? Set up here &rarr;</a></p>
 </div>
 <script>
 function copyRss(b){
-  var u=b.dataset.rss;
-  function done(){b.textContent='Copied!';setTimeout(function(){b.textContent='Copy RSS URL'},2000);typeof gtag==='function'&&gtag('event','copy_rss',{location:'is_down_page',service_id:b.dataset.svc})}
+  var u=b.dataset.rss, orig=b.textContent;
+  function done(){b.textContent='Copied! Paste into your RSS reader';setTimeout(function(){b.textContent=orig},2200);typeof gtag==='function'&&gtag('event','copy_rss',{location:'is_down_page',service_id:b.dataset.svc})}
   if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(u).then(done).catch(function(){prompt('Copy RSS URL:',u)})}
   else{prompt('Copy RSS URL:',u)}
 }

--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -68,7 +68,12 @@ test.describe('Is X Down? SSR pages', () => {
       test(`has CTA alert banner`, async ({ page: p }) => {
         await p.goto(`/is-${page.slug}-down`, { waitUntil: 'domcontentloaded' })
         await expect(p.locator('.cta')).toBeVisible()
-        await expect(p.locator('.cta a.btn-primary')).toHaveAttribute('href', 'https://ai-watch.dev/#settings?focus=alerts')
+        // #547: the PRIMARY CTA is now the zero-friction RSS copy button (the only channel that
+        // converted on the outage day); the Discord double-opt-in is demoted to a
+        // de-emphasized secondary text link (.cta-alt) that still carries the focus=alerts href.
+        await expect(p.locator('.cta button.btn-primary[data-rss]')).toBeVisible()
+        await expect(p.locator('.cta a.btn-primary')).toHaveCount(0)
+        await expect(p.locator('.cta .cta-alt a')).toHaveAttribute('href', 'https://ai-watch.dev/#settings?focus=alerts')
       })
 
       test(`has GA4 tag`, async ({ page: p }) => {
@@ -316,11 +321,17 @@ test.describe('Is X Down? SSR pages', () => {
       if (aiIdx >= 0) expect(aiIdx).toBeGreaterThan(ctaIdx)
     })
 
-    test('button onclick fires GA4 event with source=status_banner', async ({ page }) => {
+    test('primary CTA is the RSS copy button; Discord demoted to secondary link (#547)', async ({ page }) => {
       await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
-      const onclick = await page.locator('.cta a.btn-primary').getAttribute('onclick')
+      // Primary = zero-friction RSS button → fires copy_rss (success proxy) via copyRss().
+      const primary = page.locator('.cta button.btn-primary[data-rss]')
+      await expect(primary).toBeVisible()
+      expect(await primary.getAttribute('onclick')).toContain('copyRss(this)')
+      // Heavy Discord path is now a de-emphasized text link, tagged source=status_banner_secondary
+      // so the funnel comparison can tell post-reorder clicks apart from the old primary placement.
+      const onclick = await page.locator('.cta .cta-alt a').getAttribute('onclick')
       expect(onclick).toContain("'click_cta_alerts'")
-      expect(onclick).toContain("source:'status_banner'")
+      expect(onclick).toContain("source:'status_banner_secondary'")
       expect(onclick).toContain("location:'is_down_page'")
     })
 
@@ -336,9 +347,10 @@ test.describe('Is X Down? SSR pages', () => {
       const isOperationalCopy = /Get notified when .* goes down/i.test(ctaText || '')
       expect(isDownCopy || isOperationalCopy).toBe(true)
 
-      // Button label: outage state → "Notify Me When Fixed" (#546); operational → "Set Up Alerts".
-      const btnText = (await page.locator('.cta a.btn-primary').textContent()) || ''
-      expect(btnText.trim()).toMatch(/^(Notify Me When Fixed|Set Up Alerts)/)
+      // #547: the primary button is now the zero-friction RSS notify button (both states);
+      // the title copy (#546 benefit framing) is unchanged above.
+      const btnText = (await page.locator('.cta button.btn-primary').textContent()) || ''
+      expect(btnText).toMatch(/Notify me via RSS/i)
     })
   })
 })


### PR DESCRIPTION
## Problem (measured leak)

On the last outage day (GA4, consent-gated floor): the X-reply inflow landed on the is-down pages, **3 clicked the alerts CTA (`click_cta_alerts`) → 0 completed (`webhook_register`)** — the #486 Discord channel-control double opt-in is too heavy for a brand-new panic visitor. The only channel that converted was the zero-config **RSS copy (`copy_rss` 3×)**.

The is-down page already exposed RSS + Slack copy buttons, but the visually-**primary** (`btn-primary`) affordance was the heavy Discord deep-link — so the appealing "Notify Me When Fixed" button kept pulling clicks into the path that converts 0.

## Change — reorder so the converting channel leads (`renderCTA`, `api/is-down/html-template.ts`)

| Slot | Before | After |
|---|---|---|
| **Primary** (`btn-primary`) | Discord deep-link "Notify Me When Fixed" | **"🔔 Notify me via RSS"** → copies `/feed/{slug}`, "Copied! Paste into your RSS reader", fires `copy_rss` |
| Secondary | "Copy RSS URL" + "Copy Slack command" | "Copy Slack command" (unchanged) |
| Demoted | — | Discord push → de-emphasized `.cta-alt` **text link** |

The demoted Discord link **keeps the #546 deep-link** (`#settings?focus=alerts` → scrolls to the dashboard Alerts/Discord section, mechanism verified intact) and its `click_cta_alerts` event, retagged **`source:'status_banner_secondary'`** so the funnel comparison can tell the new placement apart from the old primary. **"email" was removed** from the link copy — no email channel exists yet.

## Measurement (per agreed scope)
Stays on the existing `copy_rss` / `copy_slack_feed` / `click_cta_alerts` events — **no new feed telemetry** (RSS is anonymous; accurate subscriber counts would need a separate feed-fetch WAE layer, deferred). We compare `copy_rss` vs the 3→0 baseline on the next outage. Tracked by a `verify-after 2026-06-18` line on #547.

## Scope notes
- **`refs #547`, not `closes`** — the "measure lift vs 3→0 baseline" checklist item is production-gated (needs the next outage's data).
- The dashboard **ActionBanner has no alerts CTA** to reorder, so it's untouched; the SERP-inflow leak this targets is `is_down_page`-specific.
- Sibling of **#566** (is-down SERP title/description CTR) which touches the same file's title/desc region — ship #566 after this merges to avoid a conflict.

## Verification
- Step 3.5 in-browser confirmed by operator (RSS-primary CTA on `/is-codex-down`; "email" removed; demoted Discord link → #546 scroll on the dashboard deep-link).
- `npm run build` ✓ · `test:src` 21 files ✓ (incl. `html-template.test.ts`, the gate that would have failed) · `test:worker` 1571 ✓ · is-down Playwright CTA tests ✓ · lint clean.
- PR review (code-reviewer): 1 Critical (a stale Vitest assertion on the old RSS markup) → fixed + added a #547 reorder/demote unit guard; re-verified green.

> Pre-existing (not from this PR): 2 is-down rank e2e tests (`rank renders…groq`, `rank excludes estimate-only`) fail on `main` too — a stale `≤30` total-ranked assertion vs the live count. Will file separately.

Edge SSR (api/is-down) → Vercel auto-deploys on merge; no worker deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)