### PR TITLE
test(is-down): derive rank-count bound from canonical service lists (#568)

### DIFF
--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -1,4 +1,13 @@
 import { test, expect } from '@playwright/test'
+// #568: derive the max ranked-services count from the canonical service lists so this
+// assertion never goes stale when a service is added. constants.js is a pure data module
+// (no browser deps) → importable in node/Playwright. NO_FEED_SERVICES (bedrock, azureopenai)
+// is used here as the static proxy for the set api/is-down.ts drops from ranking
+// (`uptimeSource === 'estimate' && incidents.length === 0`); the two are synonymous by
+// convention today. It's an UPPER bound — the real count can be lower when a service lacks a
+// finite score — so a future divergence only weakens the bound, never breaks the test.
+import { ALL_SERVICE_IDS, NO_FEED_SERVICES } from '../src/utils/constants.js'
+const MAX_RANKED = ALL_SERVICE_IDS.length - NO_FEED_SERVICES.length
 
 const PAGES = [
   // Phase A — original 6 services
@@ -231,7 +240,7 @@ test.describe('Is X Down? SSR pages', () => {
     const m = text.match(/is ranked #(\d+)(\s*\(tied\))? of (\d+) AI services/)
     expect(m).not.toBeNull()
     expect(Number(m[1])).toBeGreaterThanOrEqual(1)
-    expect(Number(m[3])).toBeLessThanOrEqual(30) // 32 total − bedrock − azureopenai (estimate-only, no SEO page)
+    expect(Number(m[3])).toBeLessThanOrEqual(MAX_RANKED) // ALL_SERVICE_IDS − estimate-only (bedrock, azureopenai); auto-tracks service additions (#568)
   })
 
   test('tied rank shows "(tied)" marker for services in a stable tie cluster', async ({ page }) => {
@@ -261,7 +270,9 @@ test.describe('Is X Down? SSR pages', () => {
     const text = (await rankLine.textContent()) || ''
     const m = text.match(/of (\d+) AI services/)
     expect(m).not.toBeNull()
-    expect(Number(m && m[1])).toBeLessThanOrEqual(30)
+    // ≤ MAX_RANKED proves the estimate-only services (bedrock, azureopenai) are excluded,
+    // since MAX_RANKED = total − 2 < total. Auto-tracks service additions (#568).
+    expect(Number(m && m[1])).toBeLessThanOrEqual(MAX_RANKED)
   })
 
   test('hides "Uptime (30d): N/A" when no uptime data is available', async ({ page }) => {


### PR DESCRIPTION
## Problem

Two is-down rank e2e tests hardcoded `totalRanked <= 30` ("32 total − bedrock − azureopenai"):
- `rank renders unconditionally … (groq)`
- `rank excludes estimate-only services with zero incidents (pinecone)`

The service count grew to **33**, so the live pages now render **"of 31 AI services"** (33 − 2 estimate-only) → both `<= 30` assertions fail locally (verified on prod `is-groq-down` → 31).

**Why CI didn't catch it:** the is-down Playwright project targets `:3333` (vercel dev) and isn't run by CI's `npm test` (Vite `:5173` webServer only) — these tests only run locally, so the staleness went unnoticed. (Related un-gated-Edge-e2e gap noted in #568 for a possible `area:ops` follow-up.)

## Fix

Import the canonical counts from `src/utils/constants.js` (pure data module, node/Playwright-importable) and derive the bound:
```js
import { ALL_SERVICE_IDS, NO_FEED_SERVICES } from '../src/utils/constants.js'
const MAX_RANKED = ALL_SERVICE_IDS.length - NO_FEED_SERVICES.length  // 33 − 2 = 31
```
Replace both `<= 30` magic numbers with `<= MAX_RANKED` → auto-tracks future service additions (#392 Tavily, #393 Runway, #561 LangSmith are queued).

- `<=` (not `===`) is the correct shape: the real ranked count can be **lower** than MAX_RANKED when a service lacks a finite score (insufficient-data drop), so an upper bound is the only non-flaky assertion. `< total` still proves the estimate-only exclusion for the pinecone test.
- `NO_FEED_SERVICES` is used as the static proxy for api/is-down.ts's `uptimeSource==='estimate' && incidents.length===0` filter (synonymous today); it's an upper bound, so a future divergence only weakens it, never breaks the test (per PR review).

## Verification

- Full **is-down Playwright spec: 136 passed** locally against live data (was 134 + 2 failed). Import resolves; the 2 rank tests now pass (31 ≤ 31).
- Test-only change — no user-facing surface; verification = the spec passes.
- PR review (code-reviewer): 0 Critical/Important; one Suggestion (proxy-coupling) addressed by tightening the comment.

## Coordination
Touches `tests/is-down.spec.js` (rank-test region) — a different region from #547/#567 (CTA-test region). Branched from `main`; merges cleanly with #567 regardless of order.

closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)