### PR TITLE
ci(edge): run Edge-SSR e2e (is-down/intro/reports/consent) against the Vercel preview (#570)

### DIFF
--- a/.github/workflows/edge-e2e.yml
+++ b/.github/workflows/edge-e2e.yml
@@ -1,0 +1,65 @@
+# #570 — run the Edge-SSR e2e (is-down / intro / reports / consent) against the
+# Vercel Preview deployment for each PR/push, since the normal `npm test` CI job
+# only covers the Vite desktop/mobile projects (the Edge projects need a deployed
+# Edge runtime). Triggered by Vercel's deployment_status, so it runs the moment the
+# preview is ready and points Playwright at the real preview URL (no vercel dev in CI).
+name: Edge E2E
+
+on:
+  deployment_status: {}
+
+# Least privilege: this only checks out + runs tests against a remote URL.
+permissions:
+  contents: read
+
+# One run per deployment URL; cancel a superseded preview's run.
+concurrency:
+  group: edge-e2e-${{ github.event.deployment_status.environment_url }}
+  cancel-in-progress: true
+
+jobs:
+  edge-e2e:
+    name: Edge E2E (Vercel Preview)
+    # Only successful deployments that actually expose a URL (Vercel fires several
+    # statuses per deploy — building/error/ready; the ready one carries the URL).
+    # NOTE: this guard does NOT distinguish preview vs production, so a `main` merge's
+    # production deploy ALSO triggers a run against https://ai-watch.dev — intentional
+    # as a post-deploy prod smoke. (Vercel's `environment` string naming is unverified;
+    # filtering on it risks the workflow never firing. The verify-after on #570 inspects
+    # the first real events and tightens to `environment == 'Preview'` if prod runs are noisy.)
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Test the same commit that was deployed, so the spec files match the preview.
+          ref: ${{ github.event.deployment.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Wait for the deployment to be reachable (cold-start guard)
+        env:
+          EDGE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+        run: |
+          for i in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$EDGE_BASE_URL/intro" || echo 000)
+            echo "attempt $i: GET /intro -> HTTP $code"
+            [ "$code" = "200" ] && exit 0
+            sleep 6
+          done
+          echo "::error::preview not reachable after retries"; exit 1
+      - name: Run Edge E2E against the Vercel preview
+        env:
+          # Drives the Edge projects' baseURL in playwright.config.js (#570) and skips
+          # the local Vite webServer.
+          EDGE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+        run: npm run test:edge
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: edge-e2e-report
+          path: playwright-report/
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "npm run build && wrangler dev",
     "test": "npx playwright test --project=desktop --project=mobile",
     "test:is-down": "npx playwright test --project=is-down",
+    "test:edge": "npx playwright test --project=is-down --project=intro --project=reports --project=consent",
     "test:worker": "npx vitest run --config worker/vitest.config.ts",
     "typecheck:worker": "node scripts/typecheck-worker.mjs",
     "test:ui": "npx playwright test --ui",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,12 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// #570: the Edge-SSR projects (is-down/intro/reports/consent) default to a local
+// `vercel dev` on :3333, but in CI we point them at the PR's Vercel Preview deployment
+// via EDGE_BASE_URL (set by the deployment_status-triggered edge-e2e workflow). When
+// EDGE_BASE_URL is set we also skip the Vite webServer — the Edge run needs no local
+// server (the preview is remote) and only the Edge projects run in that job.
+const EDGE_BASE_URL = process.env.EDGE_BASE_URL || 'http://localhost:3333'
+
 export default defineConfig({
   testDir: './tests',
   timeout: 60000,
@@ -26,29 +33,34 @@ export default defineConfig({
     {
       name: 'is-down',
       // Port matches CLAUDE.md "Local verification by page type" table — `vercel dev --listen 3333`
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:3333' },
+      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
       testMatch: /is-down\.spec/,
     },
     {
       name: 'intro',
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:3333' },
+      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
       testMatch: /intro\.spec/,
     },
     {
       name: 'reports',
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:3333' },
+      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
       testMatch: /reports\.spec/,
     },
     {
       name: 'consent',
       // Edge SSR + inline cookie banner gate (#352) — runs against vercel dev :3333.
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:3333' },
+      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
       testMatch: /consent\.spec/,
     },
   ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-  },
+  // Skip the Vite dev server when running only the Edge projects against a remote
+  // preview (EDGE_BASE_URL set) — desktop/mobile aren't run in that job, so :5173
+  // would start unused. Local + the desktop/mobile CI job keep the Vite webServer.
+  webServer: process.env.EDGE_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:5173',
+        reuseExistingServer: !process.env.CI,
+      },
 })


### PR DESCRIPTION
## Problem

CI's E2E job runs `npm test` = `--project=desktop --project=mobile` only. The four **Edge-SSR Playwright projects** (`is-down`, `intro`, `reports`, `consent`) target `:3333` (Vercel Edge via `vercel dev`), which CI never starts — so **Edge regressions (SEO pages, landing, reports proxy, consent banner) ship un-gated**. This is exactly what let #568's stale rank assertions sit failing, invisible to CI.

## Solution (Option 1 from #570 — preview URL, no vercel-dev-in-CI)

- **`playwright.config.js`** — the 4 Edge projects' `baseURL` now reads `EDGE_BASE_URL` (default `http://localhost:3333` for local `vercel dev`); the Vite `webServer` is skipped when `EDGE_BASE_URL` is set (the Edge run is remote; desktop/mobile aren't in that job).
- **`package.json`** — `test:edge` runs the 4 Edge projects.
- **`.github/workflows/edge-e2e.yml`** (new) — `on: deployment_status`; when a deploy succeeds with a URL, checks out the deployed sha and runs `test:edge` with `EDGE_BASE_URL` = the preview URL. Least-privilege `contents: read`, a cold-start preflight (`curl`-retry `/intro`), per-URL concurrency, report artifact on failure.

## Verification (mechanism — local)

`EDGE_BASE_URL=https://ai-watch.dev npm run test:edge` ran **all 4 Edge projects (167 tests) against the remote URL with no `vercel dev`** → **165 passed**. The only 2 failures were the known **#568** stale rank tests (fixed in #569) — which also **demonstrates the gate catches a broken Edge assertion**. Config behavior verified both ways (env set → remote baseURL + `webServer: undefined`; unset → `:3333` + Vite).

## Known limitation / post-merge verify
`deployment_status`-triggered workflows only activate once the file is on `main`, so **this PR's own preview won't trigger it** — the first real run is the next deploy after merge. Tracked by `verify-after 2026-06-11` on #570: confirm the workflow fires + reports, inspect the real `environment` values (tighten to `Preview`-only if prod-merge runs are noisy), and prove a deliberately-broken assertion turns the check RED.

`refs #570` (not `closes`) — the in-CI gate proof is post-merge.

## Review
PR review (code-reviewer): 0 Critical; 2 Important addressed — added least-privilege `permissions:`; documented the prod-deploy smoke firing + deferred the Preview-only filter to the verify-after (Vercel's `environment` string is unverified; a wrong filter would silently disable the workflow). Suggestion (cold-start preflight) added.

## Coordination
- Independent of #567/#569 (different files). Once #569 (#568 rank fix) is on main, the edge-e2e workflow runs the fixed rank tests green.
- CI: this branch's own `npm test` (desktop/mobile) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)