### PR TITLE
ci: fix Edge E2E 401 on Vercel preview via Protection Bypass (refs #570)

### DIFF
--- a/.github/workflows/edge-e2e.yml
+++ b/.github/workflows/edge-e2e.yml
@@ -42,9 +42,15 @@ jobs:
       - name: Wait for the deployment to be reachable (cold-start guard)
         env:
           EDGE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          # #570: Vercel Preview Deployment Protection returns 401 to anonymous requests.
+          # This single-origin curl can safely carry the bypass as a header (it never
+          # fans out cross-origin); Playwright uses a cookie instead (edge-bypass-setup.js).
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           for i in $(seq 1 10); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$EDGE_BASE_URL/intro" || echo 000)
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+              "$EDGE_BASE_URL/intro" || echo 000)
             echo "attempt $i: GET /intro -> HTTP $code"
             [ "$code" = "200" ] && exit 0
             sleep 6
@@ -55,6 +61,8 @@ jobs:
           # Drives the Edge projects' baseURL in playwright.config.js (#570) and skips
           # the local Vite webServer.
           EDGE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          # Consumed by globalSetup to mint a preview-scoped bypass cookie (#570).
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: npm run test:edge
       - name: Upload Playwright report on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ test-results/
 playwright-report/
 blob-report/
 .playwright-mcp/
+playwright/.edge-bypass-state.json
 
 # Env
 .env

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { EDGE_BYPASS_STATE } from './playwright/edge-bypass-setup.js'
 
 // #570: the Edge-SSR projects (is-down/intro/reports/consent) default to a local
 // `vercel dev` on :3333, but in CI we point them at the PR's Vercel Preview deployment
@@ -7,8 +8,19 @@ import { defineConfig, devices } from '@playwright/test'
 // server (the preview is remote) and only the Edge projects run in that job.
 const EDGE_BASE_URL = process.env.EDGE_BASE_URL || 'http://localhost:3333'
 
+// #570: Vercel Preview has Deployment Protection (401 to anonymous requests). globalSetup
+// (playwright/edge-bypass-setup.js) obtains a preview-domain-scoped bypass cookie and saves
+// it to EDGE_BYPASS_STATE; the Edge projects load it via storageState so navigations get
+// through. The setup writes an empty (cookie-less) state when no secret/EDGE_BASE_URL is
+// present, so local `vercel dev` runs are unaffected and the secret never leaves the
+// preview origin (we avoid extraHTTPHeaders, which would leak it cross-origin to GA4/CDNs).
+const EDGE_USE = { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL, storageState: EDGE_BYPASS_STATE }
+
 export default defineConfig({
   testDir: './tests',
+  // #570: runs once before all projects — primes the Vercel preview bypass cookie (no-op
+  // / empty state when EDGE_BASE_URL + the secret aren't both set, i.e. local/desktop runs).
+  globalSetup: './playwright/edge-bypass-setup.js',
   timeout: 60000,
   expect: { timeout: 20000 },
   fullyParallel: true,
@@ -33,23 +45,23 @@ export default defineConfig({
     {
       name: 'is-down',
       // Port matches CLAUDE.md "Local verification by page type" table — `vercel dev --listen 3333`
-      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
+      use: EDGE_USE,
       testMatch: /is-down\.spec/,
     },
     {
       name: 'intro',
-      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
+      use: EDGE_USE,
       testMatch: /intro\.spec/,
     },
     {
       name: 'reports',
-      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
+      use: EDGE_USE,
       testMatch: /reports\.spec/,
     },
     {
       name: 'consent',
       // Edge SSR + inline cookie banner gate (#352) — runs against vercel dev :3333.
-      use: { ...devices['Desktop Chrome'], baseURL: EDGE_BASE_URL },
+      use: EDGE_USE,
       testMatch: /consent\.spec/,
     },
   ],

--- a/playwright/edge-bypass-setup.js
+++ b/playwright/edge-bypass-setup.js
@@ -1,0 +1,52 @@
+// #570 — Vercel Preview deployments have Deployment Protection on, so unauthenticated
+// requests get HTTP 401 and the Edge E2E job can never reach the preview. Vercel's
+// "Protection Bypass for Automation" lets us through with a secret.
+//
+// We deliberately do NOT inject the secret as a Playwright `extraHTTPHeaders` entry:
+// those headers are sent with EVERY request the browser makes, including cross-origin
+// ones (GA4, font CDNs, the Worker API), which would leak the bypass secret to third
+// parties. Instead we make a single request to the preview origin with
+// `x-vercel-set-bypass-cookie=true`, which makes Vercel set a bypass cookie scoped to
+// the preview domain, and persist that cookie via storageState. Subsequent navigations
+// reuse the cookie — no secret ever leaves the preview origin.
+//
+// No-op (and writes an empty state) when EDGE_BASE_URL or the secret is absent — i.e.
+// local `vercel dev` runs and the desktop/mobile CI job are unaffected.
+import { request } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+export const EDGE_BYPASS_STATE = path.join(__dirname, '.edge-bypass-state.json')
+
+export default async function globalSetup() {
+  const base = process.env.EDGE_BASE_URL
+  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  // storageState must always exist once referenced by a project, so write an empty
+  // state even on the no-op path (a project pointing at a missing file would error).
+  const ctx = await request.newContext()
+  if (base && secret) {
+    const res = await ctx.get(`${base}/`, {
+      params: {
+        'x-vercel-protection-bypass': secret,
+        'x-vercel-set-bypass-cookie': 'true',
+      },
+    })
+    if (!res.ok()) {
+      throw new Error(
+        `[edge-bypass] failed to obtain Vercel bypass cookie: HTTP ${res.status()} for ${base}/`,
+      )
+    }
+  }
+  const state = await ctx.storageState({ path: EDGE_BYPASS_STATE })
+  await ctx.dispose()
+  // Fail loudly here, not as a confusing per-spec 401: if the bypass request succeeded but
+  // set no cookie (e.g. Vercel changed its protection-bypass behavior), the empty state would
+  // sail through and every Edge spec would 401. Assert we actually captured a cookie.
+  if (base && secret && state.cookies.length === 0) {
+    throw new Error(
+      '[edge-bypass] bypass request returned OK but set no cookie — Vercel Protection Bypass ' +
+        'behavior may have changed; aborting so the Edge suite fails here instead of 401-ing per spec',
+    )
+  }
+}


### PR DESCRIPTION
## Problem

The **Edge E2E** workflow (`.github/workflows/edge-e2e.yml`, #570) failed on every preview deploy: Vercel Preview **Deployment Protection** returns **HTTP 401** to anonymous requests, so both the curl reachability gate (10 retries, all 401) and `npm run test:edge` could never reach the preview.

```
attempt 1..10: GET /intro -> HTTP 401
##[error]preview not reachable after retries
```

## Fix

Wire the `VERCEL_AUTOMATION_BYPASS_SECRET` repo Actions secret (Vercel "Protection Bypass for Automation"):

- **curl gate** → `x-vercel-protection-bypass` header. Single-origin request, no cross-origin fan-out, so carrying the raw secret as a header is safe here.
- **Playwright** → a preview-domain-scoped bypass **cookie** instead. New `playwright/edge-bypass-setup.js` globalSetup hits the preview with `x-vercel-set-bypass-cookie=true` and persists the cookie via `storageState`, which the 4 Edge projects load.

### Why cookie (not `extraHTTPHeaders`)
`extraHTTPHeaders` attaches to **every** browser request — including cross-origin GA4 / font CDNs / Worker API — which would **leak the secret** to third parties. The cookie is scoped to the preview origin by `storageState`, so it never goes cross-origin. The saved state holds Vercel's signed `_vercel_jwt`, **not** the raw secret; the state file is gitignored.

### Safe in all modes
- **CI preview** (secret + `EDGE_BASE_URL` set): mints + loads the cookie.
- **Local `vercel dev`** / **`npm test` desktop+mobile** (neither set): globalSetup is a **no-op** writing an empty cookie-less state — unaffected.
- **Fails loudly**: throws if the bypass request is non-200, or returns OK but sets no cookie (guards a future Vercel behavior change), instead of 401-ing confusingly per spec.

## Verification

- ✅ `npm test` — **123 passed** (no regression from adding globalSetup to desktop/mobile)
- ✅ `npx playwright test --list` — 290 tests resolve (config loads)
- ✅ globalSetup no-op path: empty state, no throw
- ✅ lint 0 errors, build OK
- ⏳ **Real green requires this PR's preview deploy** to fire the `deployment_status` trigger — confirm the Edge E2E check passes here before merge.

refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)