### PR TITLE
chore(is-down): remove no-op CI-trigger comment leaked by #573 squash (refs #570)

### DIFF
--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -1,5 +1,4 @@
 // Vercel Edge Function — "Is X Down?" SSR pages
-// (no-op touch to force a Vercel preview build so Edge E2E runs with the #570 bypass; squashed on merge)
 
 import { SLUG_TO_SERVICE } from './is-down/slug-map'
 import { getSEOContent } from './is-down/seo-content'


### PR DESCRIPTION
## What

Removes the throwaway comment in `api/is-down.ts`:
```
// (no-op touch to force a Vercel preview build so Edge E2E runs with the #570 bypass; squashed on merge)
```

## Why

To verify the #570 Edge E2E bypass end-to-end, #573 needed a Vercel **preview** deploy — but Vercel's Ignored Build Step skips builds when no deployable file changed. A no-op comment was added to `api/is-down.ts` to force the build (which succeeded: Edge E2E went green on the preview, confirming the bypass).

`gh pr merge --squash` collapses commits but keeps the **cumulative diff**, so the comment landed in `main` rather than being dropped. This restores the intended header.

Pure 1-line deletion, no behavior change. Being a deployable change, this PR also gets its own preview + green Edge E2E run.

refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)