### PR TITLE
ci(edge): run Edge E2E only on Vercel Preview deploys, not Production (refs #570)

### DIFF
--- a/.github/workflows/edge-e2e.yml
+++ b/.github/workflows/edge-e2e.yml
@@ -22,12 +22,17 @@ jobs:
     name: Edge E2E (Vercel Preview)
     # Only successful deployments that actually expose a URL (Vercel fires several
     # statuses per deploy — building/error/ready; the ready one carries the URL).
-    # NOTE: this guard does NOT distinguish preview vs production, so a `main` merge's
-    # production deploy ALSO triggers a run against https://ai-watch.dev — intentional
-    # as a post-deploy prod smoke. (Vercel's `environment` string naming is unverified;
-    # filtering on it risks the workflow never firing. The verify-after on #570 inspects
-    # the first real events and tightens to `environment == 'Preview'` if prod runs are noisy.)
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != ''
+    # Preview-only: Edge E2E is a pre-merge PR gate. The #570 verify-after confirmed
+    # Vercel sends environment == 'Preview' for PR deploys and 'Production' for main
+    # deploys (capitalized), so we filter to 'Preview'. This drops the redundant
+    # post-merge run against the production deployment — its only effect was a second
+    # green run per merge, and a transient prod blip there would have shown as a
+    # confusing main-branch red that isn't a code regression. Prod health is covered
+    # by the app's own monitoring, not this gate.
+    if: >-
+      github.event.deployment_status.state == 'success'
+      && github.event.deployment_status.environment_url != ''
+      && github.event.deployment_status.environment == 'Preview'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds `&& github.event.deployment_status.environment == 'Preview'` to the Edge E2E job guard, so it runs **only on PR preview deploys** — not on the Production deploy that fires on every `main` merge.

## Why (resolves the #570 verify-after)

The Edge E2E workflow (#571/#577) was deliberately left without a preview/prod filter because Vercel's `environment` string value was unverified, and a wrong literal would silently disable the workflow.

This session verified it on **real** `deployment_status` events via the GitHub deployments API:

| deploy | `environment` |
|---|---|
| PR preview | `Preview` (capital P) |
| `main` merge | `Production` |

So filtering to `'Preview'` is safe. Edge E2E is a **pre-merge PR gate**; the prior behavior also ran it post-merge against the Production deployment, which:
- can't block an already-merged change (redundant — just a second green run per merge), and
- would surface a transient prod blip as a confusing **main-branch red** that isn't a code regression.

Prod health is covered by the app's own cron monitoring, not this gate.

## Verification
- YAML validated: the `>-` folded scalar collapses to `state == 'success' && environment_url != '' && environment == 'Preview'`.
- Code review: 0 Critical / 0 Important.
- CI-only change (no deployable files) → no Vercel preview → **Edge E2E does not run on this PR** (expected; the guard change is exercised on the next PR with deployable changes).

Closes the last open item on #570. refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)