### PR TITLE
fix(svc): Recovery card shows "Incident ongoing" when an incident is unresolved (#581)

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -171,6 +171,7 @@ const en = {
   'score.tooltip': 'Based on uptime, incident affected days, and recovery time',
   'uptime.sla.label': 'SLA threshold',
   'svc.mttr.none': 'No incidents in 7 days',
+  'svc.mttr.ongoing': 'Incident ongoing',
   'svc.security': 'Security Alerts',
   'svc.badge': 'Status Badge',
   'svc.badge.copy': 'Copy',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -171,6 +171,7 @@ const ko = {
   'score.tooltip': 'Uptime, 인시던트 영향 일수, 복구 시간 기반 종합 점수',
   'uptime.sla.label': 'SLA 기준',
   'svc.mttr.none': '최근 7일 인시던트 없음',
+  'svc.mttr.ongoing': '인시던트 진행 중',
   'svc.security': '보안 알림',
   'svc.badge': '상태 배지',
   'svc.badge.copy': '복사',

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -627,6 +627,11 @@ export default function ServiceDetails({ serviceId }) {
   const recentIncidents = (service.incidents ?? []).filter(
     (inc) => inc.status !== 'resolved' || new Date(inc.startedAt).getTime() >= cutoff7d
   )
+  // #581 — an unresolved incident has no recovery time yet (computeRecoveryStats counts only
+  // resolved ones), so the Recovery card's value is '—'. Distinguish that from "no incidents":
+  // when an incident is ongoing, the sub must say so, not falsely claim "No incidents in 7 days"
+  // (which contradicts the Incident History showing the active incident right below).
+  const hasOngoingIncident = (service.incidents ?? []).some((inc) => inc.status !== 'resolved')
   // groupIncidents re-sorts purely by date; compareGroupedRows lifts ongoing/
   // monitoring rows back above newer resolved ones. See incidentSort.js.
   const groupedIncidents = groupIncidents(recentIncidents).slice().sort(compareGroupedRows)
@@ -722,7 +727,7 @@ export default function ServiceDetails({ serviceId }) {
           // #557 — headline is the median (typical) recovery; when a longer outage exists in the
           // window, surface it as "worst Xh Ym" so a 29h outage is never hidden by short blips.
           sub={isEstimateNoData ? t('uptime.unavailable')
-            : !recovery ? t('svc.mttr.none')
+            : !recovery ? (hasOngoingIncident ? t('svc.mttr.ongoing') : t('svc.mttr.none'))
             : recovery.maxMin > recovery.medianMin ? t('svc.recovery.worst').replace('{d}', formatRecoveryMin(recovery.maxMin))
             : t('svc.incidents.sub')}
           colorClass={isEstimateNoData ? 'text-[var(--text2)]' : recovery ? 'text-[var(--amber)]' : 'text-[var(--text2)]'}

--- a/tests/service-details.spec.js
+++ b/tests/service-details.spec.js
@@ -52,6 +52,44 @@ test.describe('ServiceDetails page', () => {
   })
 })
 
+test.describe('#581 Recovery card — ongoing (unresolved) incident', () => {
+  const baseSvc = (incidents) => ({
+    id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic',
+    status: incidents.some(i => i.status !== 'resolved') ? 'degraded' : 'operational',
+    latency: 120, uptime30d: 99.5, uptimeSource: 'official', calendarDays: 30, incidents,
+    aiwatchScore: 80, scoreGrade: 'good', scoreConfidence: 'high',
+    scoreBreakdown: { uptime: 39, incidents: 22, recovery: 15, responsiveness: 12, responsivenessStatus: 'available' },
+    scoreMetrics: { uptimePct: 99.5, incidents30d: incidents.length, affectedDays30d: 1, mttrHours: null, probe: { p50: 178, p95: 311, cvCombined: 0.5, validDays: 7 } },
+  })
+  const mount = async (page, incidents) => {
+    const mock = { json: { services: [baseSvc(incidents)], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.goto('/#claude')
+    await expect(page.locator('main').getByText(/Status Calendar|상태 캘린더/)).toBeVisible({ timeout: 20000 })
+  }
+
+  test('shows "Incident ongoing" (not "No incidents in 7 days") when an incident is unresolved', async ({ page }) => {
+    // An unresolved (monitoring) incident has no recovery time yet → computeRecoveryStats returns
+    // null → the Recovery card value is "—". Pre-#581 the sub falsely read "No incidents in 7 days",
+    // contradicting the Incident History showing the active incident.
+    await mount(page, [
+      { id: 'on1', status: 'monitoring', title: 'Auth & licensing service issues',
+        startedAt: new Date(Date.now() - 3 * 3600_000).toISOString(), impact: 'minor', duration: null },
+    ])
+    const main = page.locator('main')
+    await expect(main.getByText(/Incident ongoing|인시던트 진행 중/)).toBeVisible()
+    await expect(main.getByText(/No incidents in 7 days|최근 7일 인시던트 없음/)).toHaveCount(0)
+  })
+
+  test('still shows "No incidents in 7 days" when there is genuinely no incident', async ({ page }) => {
+    await mount(page, [])
+    const main = page.locator('main')
+    await expect(main.getByText(/No incidents in 7 days|최근 7일 인시던트 없음/)).toBeVisible()
+    await expect(main.getByText(/Incident ongoing|인시던트 진행 중/)).toHaveCount(0)
+  })
+})
+
 test.describe('AIWatch Score Breakdown denominators (#132)', () => {
   // Regression guards for the weight redistribution: 40/25/15 + 20 (Responsiveness).
   // Routes are set up before navigation — no beforeEach interference.


### PR DESCRIPTION
## Problem

On ServiceDetails, the **Recovery** card showed **"No incidents in 7 days"** even when the service had an **active unresolved incident** — directly contradicting the **Incident History** below it.

### Observed (live, prod, 2026-06-08)
Junie (`status=degraded`) had a live **"Auth & licensing service issues" — `monitoring`** incident shown in the Incident History, while the Recovery card said "No incidents in 7 days".

## Root cause (frontend copy, not status determination)

The worker is correct — Junie resolves to `degraded` with the monitoring incident attached. `computeRecoveryStats` (`src/utils/recovery.js`) counts only **resolved** incidents (an unresolved one has no recovery time), so it returns `null` → the Recovery card sub fell through to `svc.mttr.none` ("No incidents in 7 days"), which falsely claims zero incidents while the Incident History (`status !== 'resolved'` branch) shows the active one.

## Fix

Branch the empty-state sub on whether an incident is ongoing:
```js
const hasOngoingIncident = (service.incidents ?? []).some(i => i.status !== 'resolved')
// …
sub = !recovery ? (hasOngoingIncident ? t('svc.mttr.ongoing') : t('svc.mttr.none')) : …
```
- New copy `svc.mttr.ongoing` — **"Incident ongoing"** / **"인시던트 진행 중"** (en + ko).
- Value stays **"—"** (MTTR genuinely not measurable yet).
- `hasOngoingIncident` scans **all** incidents (not the 7-day window) — symmetric with the Incident History, which shows ongoing incidents regardless of age (avoids a false "No incidents" for a >7-day-old still-ongoing one).
- Worker/status untouched (correct); the Score's recovery component is a number, unaffected.

## Verification
- Step 3.5 in-browser confirmed by operator (Junie's live incident resolved between report and fix, so reproduced via a temp MOCK monitoring incident; reverted before commit).
- New Playwright tests (unresolved → "Incident ongoing", not "No incidents"; none → "No incidents", not "Incident ongoing") — **pass-on-fix / fail-on-revert** verified.
- `npm run build` ✓ · `test:src` 354 ✓ · service-details e2e 30 ✓ · lint clean (pre-existing deps warning only).
- PR review (code-reviewer): 0 Critical/Important.

Frontend-only → Vercel auto-deploys on merge; no worker deploy.

closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)