### PR TITLE
fix(settings): separate instant-apply (theme/language) from save-required settings (#582)

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -220,6 +220,8 @@ const en = {
 
   // Settings
   'settings.general': 'General',
+  'settings.display': 'Display',
+  'settings.applied.instant': 'Applied instantly — no save needed',
   'settings.theme': 'Theme',
   'settings.theme.desc': 'Select dashboard color mode',
   'settings.lang.desc': 'Select UI language',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -220,6 +220,8 @@ const ko = {
 
   // Settings
   'settings.general': '일반',
+  'settings.display': '화면',
+  'settings.applied.instant': '변경 즉시 적용 · 저장 불필요',
   'settings.theme': '테마',
   'settings.theme.desc': '대시보드 색상 모드를 선택합니다',
   'settings.lang.desc': 'UI 언어를 선택합니다',

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -218,10 +218,11 @@ export default function Settings({ focus } = {}) {
     }
   }
 
-  // #486 PR2 — "Save settings" now persists ONLY general settings (theme/lang/period/SLA + monitored
-  // services). It omits discordUrl + alert filters: useSettings.save() merges, so omitted fields are
-  // preserved from existing settings, and the Discord webhook is managed entirely by its own
-  // Subscribe / Update / Unsubscribe buttons in the Alerts section.
+  // #486 PR2 — "Save settings" persists period/SLA + monitored services. theme/lang are NOT here:
+  // they apply + persist instantly via useTheme/useLang on toggle (live switching, no save needed),
+  // and are visually separated into the "Display" section (#582). It omits discordUrl + alert filters:
+  // useSettings.save() merges, so omitted fields are preserved, and the Discord webhook is managed
+  // entirely by its own Subscribe / Update / Unsubscribe buttons in the Alerts section.
   function handleSave() {
     const slaNum = sla === '' ? DEFAULT_SETTINGS.sla : Number(sla)
     save({ period, sla: slaNum, enabledServices })
@@ -319,9 +320,11 @@ export default function Settings({ focus } = {}) {
     )
   }
 
-  // #486 PR2 — the "Save settings" button now covers ONLY general settings (theme/lang/period/SLA +
-  // monitored-service toggles). The Discord webhook URL + its alert filters live in the Alerts section
-  // and are persisted by the subscription buttons (Subscribe / Update), so they're excluded here.
+  // #486 PR2 / #582 — the "Save settings" button covers ONLY save-required settings (period/SLA +
+  // monitored-service toggles). theme/lang are instant-apply (their own hooks persist on toggle) and
+  // live in the separate "Display" section, so they intentionally do NOT dirty this button. The
+  // Discord webhook URL + its alert filters live in the Alerts section and are persisted by the
+  // subscription buttons (Subscribe / Update), so they're excluded here too.
   const hasNoChanges = period === settings.period
     && sla === settings.sla
     && JSON.stringify([...enabledServices].sort()) === JSON.stringify([...settings.enabledServices].sort())
@@ -333,9 +336,10 @@ export default function Settings({ focus } = {}) {
   return (
     <div className="flex flex-col" style={{ maxWidth: '640px', gap: '28px' }}>
 
-      {/* ── General ── */}
+      {/* ── Display (theme + language — applied instantly, NOT governed by Save) #582 ── */}
       <section>
-        <div style={sectionTitleStyle}>{t('settings.general')}</div>
+        <div style={sectionTitleStyle}>{t('settings.display')}</div>
+        <div className="mono" style={{ fontSize: '10px', color: 'var(--text2)', marginTop: '10px', marginBottom: '2px' }}>{t('settings.applied.instant')}</div>
 
         <FieldRow label={t('settings.theme')} desc={t('settings.theme.desc')}>
           <SegmentControl
@@ -345,13 +349,18 @@ export default function Settings({ focus } = {}) {
           />
         </FieldRow>
 
-        <FieldRow label={t('settings.language')} desc={t('settings.lang.desc')}>
+        <FieldRow label={t('settings.language')} desc={t('settings.lang.desc')} last>
           <SegmentControl
             value={lang}
             onChange={setLang}
             options={VALID_LANGS.map((v) => ({ value: v, label: v === 'ko' ? '한국어' : 'English' }))}
           />
         </FieldRow>
+      </section>
+
+      {/* ── General (period/SLA — saved with the "Save settings" button below) ── */}
+      <section>
+        <div style={sectionTitleStyle}>{t('settings.general')}</div>
 
         <FieldRow label={t('settings.period')} desc={t('settings.period.desc')}>
           <SegmentControl
@@ -461,8 +470,9 @@ export default function Settings({ focus } = {}) {
         )}
       </section>
 
-      {/* ── Save (general settings only — theme/lang/period/SLA + monitored services). The Discord
-          webhook + its alert filters are saved separately by the Subscribe/Update buttons in Alerts. */}
+      {/* ── Save (save-required settings only — period/SLA + monitored services; theme/lang are
+          instant-apply, see the Display section, #582). The Discord webhook + its alert filters are
+          saved separately by the Subscribe/Update buttons in Alerts. */}
       <div className="flex items-center justify-end" style={{ gap: '12px' }}>
         <button
           onClick={handleSave}

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -102,6 +102,30 @@ test.describe('Settings', () => {
     await expect(page.locator('main').getByText(/저장됨|Saved/)).toBeVisible()
     await expect(page.locator('main').getByText(/저장됨|Saved/)).toBeHidden({ timeout: 3000 })
   })
+
+  test('theme & language live in the "Display" section, applied instantly — Save stays disabled (#582)', async ({ page }) => {
+    // #582 — theme/lang are instant-apply (live switching + persisted on toggle), so they are NOT
+    // governed by the Save button. They're separated into a "Display · applied instantly" section so
+    // the user can tell save-required settings apart from instant ones.
+    const main = page.locator('main')
+    await expect(main.getByText(/Display|화면/).first()).toBeVisible()
+    await expect(main.getByText(/Applied instantly|즉시 적용/)).toBeVisible()
+
+    const saveBtn = main.locator('button').filter({ hasText: /저장|Save/ }).first()
+    await expect(saveBtn).toBeDisabled() // fresh Settings, no save-required change
+
+    // Changing language applies instantly (UI switches to Korean) but does NOT enable Save.
+    await main.locator('button').filter({ hasText: '한국어' }).first().evaluate((el) => el.click())
+    await expect(main.getByText('일반')).toBeVisible() // instant-apply confirmed
+    await expect(saveBtn).toBeDisabled()              // language is not save-governed
+  })
+
+  test('a save-required setting (period) DOES enable the Save button — contrast with Display (#582)', async ({ page }) => {
+    const saveBtn = page.locator('main button').filter({ hasText: /저장|Save/ }).first()
+    await expect(saveBtn).toBeDisabled()
+    await page.locator('main button').filter({ hasText: '30' }).first().evaluate((el) => el.click())
+    await expect(saveBtn).toBeEnabled()
+  })
 })
 
 test.describe('Settings — RSS feed (#433)', () => {


### PR DESCRIPTION
## Problem

Changing only the **theme** or **language** in Settings didn't enable the "Save settings" button.

## Root cause + why the obvious fix is wrong

theme/lang are **instant-apply** — `useTheme`/`useLang` write to localStorage on toggle (live switching), so they're **already saved** without the Save button. The first attempt made the button track them, but that was contradictory:
- change language → button enables (implies "unsaved")
- navigate away **without** saving → the change is already applied/persisted
- return to Settings → button disabled again

…i.e. the button would have **lied** about unsaved state.

## Fix (Option A — instant-apply stays; make the UI honest)

Keep theme/lang instant-apply, and **visually distinguish** instant-apply settings from save-required ones so the user knows which need saving:

- New **"Display"** section (theme + language) with an **"Applied instantly — no save needed" / "변경 즉시 적용 · 저장 불필요"** sub-note. These are NOT governed by Save.
- Existing **"General"** section (period + SLA) — save-required; the Save button governs these (+ monitored services).
- Reverted the fake-tracking: `hasNoChanges` is back to `period`/`sla`/`enabledServices` only; `handleSave` no longer re-baselines theme/lang; the stale #486 comments claiming Save persists theme/lang are corrected.

| | Before | After |
|---|---|---|
| Change theme/lang | applied instantly, but Save button inert (confusing) | applied instantly, clearly marked "no save needed" in the Display section |
| Change period/SLA | enables Save | enables Save (unchanged) |

## Verification
- Step 3.5 in-browser confirmed by operator (Display section + instant note + spacing; theme/lang don't enable Save; period does).
- New Playwright tests: language applies instantly + Save stays **disabled**; Display section + note render; contrast — period **enables** Save. **Verified fail-on-revert**.
- `npm run build` ✓ · `test:src` 354 ✓ · settings spec 9 ✓ · lint clean.
- PR review (code-reviewer): 0 Critical/Important; one stale-comment + a test `.first()` suggestion both applied.

Frontend-only → Vercel auto-deploys on merge; no worker deploy.

closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)