### PR TITLE
chore(seo): add /reports/2026-05/ to sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -101,9 +101,15 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-watch.dev/reports/2026-05/</loc>
+    <lastmod>2026-06-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>


### PR DESCRIPTION
Add the May 2026 monthly report URL to the hand-maintained `public/sitemap.xml` so it gets indexed once aiwatch-reports#26 (`published: true`) lands.

- Adds `https://ai-watch.dev/reports/2026-05/` (newest-first, before 2026-04)
- Bumps the `/reports/` index `lastmod` (new report added to the listing)
- XML validated (`xmllint --noout`)

Note: the aiwatch-reports Jekyll site's own sitemap auto-includes the report via `jekyll-sitemap`; this is the separate ai-watch.dev sitemap that lists report URLs explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)