### PR TITLE
fix(worker): accumulate incidents on the */5 cron, not just daily — capture short-lived/RSS incidents (refs #587)

### DIFF
--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -7,6 +7,7 @@ import {
   isInMonthlyArchiveWindow,
   buildMonthlyArchive,
   accumulateMonthlyIncidents,
+  accumulateIncidentsOnlyIfChanged,
   parseDurationMin,
   summarizeSecurityAlerts,
   extractOsvVulnId,
@@ -23,7 +24,7 @@ import {
   summarizeDegradation,
 } from '../monthly-archive'
 import { MIN_LEAD_SAMPLE_SIZE } from '../detection-lead-log'
-import type { ServiceStatus } from '../types'
+import type { ServiceStatus, Incident } from '../types'
 import type { MonthlySecurityEntry, MonthlySecuritySummary } from '../monthly-archive'
 import type { DetectionLeadEntry } from '../detection-lead-log'
 import type { OsvTimeline } from '../security-monitor'
@@ -595,6 +596,68 @@ describe('enrichTopFindingsWithTimelines', () => {
     const enriched = await enrichTopFindingsWithTimelines(kv, baseSummary)
     expect(enriched.topFindings[0].timeline).toBeUndefined()
     expect(enriched.topFindings[1].timeline).toHaveLength(3)
+  })
+})
+
+// ── accumulateIncidentsOnlyIfChanged (#587) ──────────────────────────
+describe('accumulateIncidentsOnlyIfChanged (#587)', () => {
+  const svc = (id: string, incidents: Array<{ id: string; startedAt: string; status: string; duration: string | null }>): ServiceStatus => ({
+    id, name: id, status: 'down', category: 'api', uptime30d: null, latency: null,
+    incidents: incidents.map(i => ({
+      id: i.id, title: `inc ${i.id}`, status: i.status as Incident['status'],
+      startedAt: i.startedAt, duration: i.duration, timeline: [],
+    })),
+  } as unknown as ServiceStatus)
+
+  // In-memory KV with get/put + a write counter so we can assert the budget guard.
+  const makeKV = (seed: Record<string, string> = {}) => {
+    const store: Record<string, string> = { ...seed }
+    let writes = 0
+    return {
+      kv: {
+        get: async (k: string) => store[k] ?? null,
+        put: async (k: string, v: string) => { store[k] = v; writes++ },
+      } as unknown as KVNamespace,
+      store,
+      writes: () => writes,
+    }
+  }
+
+  it('writes a freshly-seen incident into incidents:monthly (captures short-lived/RSS incidents)', async () => {
+    const { kv, store, writes } = makeKV()
+    const services = [svc('azureopenai', [{ id: 'az-1', startedAt: '2026-06-03T10:00:00Z', status: 'investigating', duration: null }])]
+    const res = await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')
+    expect(res).toBe('written')
+    expect(writes()).toBe(1)
+    const stored = JSON.parse(store['incidents:monthly:2026-06'])
+    expect(stored.services.azureopenai.count).toBe(1)
+    expect(stored.services.azureopenai.incidentIds).toContain('az-1')
+  })
+
+  it('skips the write when no incident data changed (budget guard — bumped lastUpdated alone)', async () => {
+    const services = [svc('azureopenai', [{ id: 'az-1', startedAt: '2026-06-03T10:00:00Z', status: 'resolved', duration: '20m' }])]
+    const { kv, writes } = makeKV()
+    expect(await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')).toBe('written') // first write
+    expect(await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')).toBe('unchanged') // no change → no write
+    expect(await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')).toBe('unchanged')
+    expect(writes()).toBe(1) // only the first run wrote, despite three calls
+  })
+
+  it('dedups by id — re-accumulating the same incident never double-counts', async () => {
+    const services = [svc('bedrock', [{ id: 'bd-1', startedAt: '2026-06-04T08:00:00Z', status: 'resolved', duration: '1h' }])]
+    const { kv, store } = makeKV()
+    await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')
+    await accumulateIncidentsOnlyIfChanged(kv, services, '2026-06')
+    expect(JSON.parse(store['incidents:monthly:2026-06']).services.bedrock.count).toBe(1)
+  })
+
+  it('writes again when an active incident progresses (duration grows)', async () => {
+    const { kv, store, writes } = makeKV()
+    await accumulateIncidentsOnlyIfChanged(kv, [svc('chatgpt', [{ id: 'cg-1', startedAt: '2026-06-05T01:00:00Z', status: 'investigating', duration: '30m' }])], '2026-06')
+    const r2 = await accumulateIncidentsOnlyIfChanged(kv, [svc('chatgpt', [{ id: 'cg-1', startedAt: '2026-06-05T01:00:00Z', status: 'resolved', duration: '1h 15m' }])], '2026-06')
+    expect(r2).toBe('written') // progressed → persisted
+    expect(writes()).toBe(2)
+    expect(JSON.parse(store['incidents:monthly:2026-06']).services.chatgpt.count).toBe(1) // still one incident
   })
 })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -464,6 +464,17 @@ async function cronAlertCheck(env: Env): Promise<CronResult> {
     return { ...svc, aiwatchScore: s.score, scoreGrade: s.grade }
   })
 
+  // #587 — accumulate this cycle's incidents into incidents:monthly every */5 (not just the daily
+  // summary), so a short-lived / RSS-sourced incident (Azure/Bedrock) that fires an alert is
+  // captured before it ages out of the upstream feed — previously the once-a-day pass missed those,
+  // leaving the dashboard 90-day filter + monthly archive blind to an incident AIWatch alerted on.
+  // Writes only when the incident data changed (idempotent dedup-by-id), so it's budget-safe.
+  try {
+    await accumulateIncidentsOnlyIfChanged(env.STATUS_CACHE, services, todayUTC().slice(0, 7))
+  } catch (err) {
+    console.error('[cron] incident accumulation failed:', err instanceof Error ? err.message : err)
+  }
+
   // Mistral-only probe cross-validation removed in #373 — same-title incident grouping
   // (src/utils/incidentGrouping.js) now handles auto-monitoring noise uniformly across services.
 
@@ -940,7 +951,7 @@ import { getWeekRange, buildIncidentSummary, buildStabilityChanges, buildWeeklyB
 import { parseVitals, writeVitalsToKV, readVitalsSummary, archiveVitals } from './vitals'
 import { archiveProbeDaily, cacheProbeSummaries, getCachedProbeSummaries, type ProbeDailyData } from './probe-archival'
 import type { ProbeSummary, Incident } from './types'
-import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateMonthlyIncidents, buildArchiveReadyEmbed, archiveNotifiedKey, degradationMonthlyKey, addDegradationToMonthly, normalizeDegradationMonthly, DEGRADATION_MONTHLY_TTL_SECONDS, type MonthlyIncidents, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
+import { buildMonthlyArchive, isInMonthlyArchiveWindow, accumulateIncidentsOnlyIfChanged, buildArchiveReadyEmbed, archiveNotifiedKey, degradationMonthlyKey, addDegradationToMonthly, normalizeDegradationMonthly, DEGRADATION_MONTHLY_TTL_SECONDS, type ArchiveScoreInput, type ScoreGrade } from './monthly-archive'
 import { checkPlatformStatus, formatPlatformOutageAlert, formatPlatformRecoveryAlert, platformStatusKey, platformAlertKey, countPlatformServices, type PlatformStatus } from './platform-monitor'
 
 // ── #299: sticky-aware analysis write ─────────────────────────
@@ -2027,24 +2038,15 @@ export default {
           // Mark today's summary as done (prevents re-send on subsequent cron cycles)
           await kvPut(env.STATUS_CACHE, `daily-summary:${today}`, '1', { expirationTtl: 604800 })
 
-          // Accumulate monthly incident data (runs daily alongside summary)
+          // Accumulate monthly incident data. As of #587 this also runs on the */5 alert cron
+          // (so short-lived / RSS incidents are captured before they age out of the feed); this
+          // daily pass stays as a backstop. accumulateIncidentsOnlyIfChanged writes only when the
+          // incident data changed, so the two cadences don't double-write or double-count.
           if (dailyServices.length > 0) {
             try {
               const currentMonth = today.slice(0, 7) // YYYY-MM
-              const incKey = `incidents:monthly:${currentMonth}`
-              const existingRaw = await env.STATUS_CACHE.get(incKey).catch(() => null)
-              let existingInc: MonthlyIncidents | null = null
-              if (existingRaw) {
-                try { existingInc = JSON.parse(existingRaw) } catch (parseErr) {
-                  console.warn('[daily-summary] corrupt incident accumulation data, resetting:',
-                    parseErr instanceof Error ? parseErr.message : parseErr)
-                }
-              }
-              const updated = accumulateMonthlyIncidents(existingInc, dailyServices, currentMonth)
-              const incWriteOk = await kvPut(env.STATUS_CACHE, incKey, JSON.stringify(updated), { expirationTtl: 60 * 86400 })
-              if (!incWriteOk) {
-                console.error(`[daily-summary] incident accumulation KV write failed for ${currentMonth}`)
-              }
+              const res = await accumulateIncidentsOnlyIfChanged(env.STATUS_CACHE, dailyServices, currentMonth)
+              if (res === 'failed') console.error(`[daily-summary] incident accumulation KV write failed for ${currentMonth}`)
             } catch (err) {
               console.error('[daily-summary] incident accumulation failed:', err instanceof Error ? err.message : err)
             }

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -13,6 +13,7 @@ import { osvTimelineKey } from './security-monitor'
 import type { DetectionLeadEntry } from './detection-lead-log'
 import { detectionLeadMonthlyKey, isValidEntry as isValidDetectionLeadEntry, MIN_LEAD_SAMPLE_SIZE } from './detection-lead-log'
 import { generateMonthlyNarrative, type MonthlyNarrativeDraft, type NarrativeAiOptions } from './monthly-narrative'
+import { kvPut } from './utils'
 
 export type ScoreGrade = 'excellent' | 'good' | 'fair' | 'degrading' | 'unstable'
 
@@ -330,6 +331,38 @@ export function accumulateMonthlyIncidents(
   }
 
   return result
+}
+
+/** #587 — read `incidents:monthly:{month}`, accumulate the current services onto it, and write
+ *  back ONLY when the incident data actually changed.
+ *
+ *  Designed to run on the every-5-minute alert cron (not just the daily summary), so a short-lived
+ *  or RSS-sourced incident (Azure/Bedrock) that fires an alert is captured before it ages out of
+ *  the upstream feed — the daily-only cadence missed those, leaving the dashboard 90-day filter +
+ *  monthly archive blind to an incident that AIWatch alerted on.
+ *
+ *  Write-budget guard: `accumulateMonthlyIncidents` always stamps a fresh `lastUpdated`, so a full
+ *  JSON compare would never match. We compare the `services` payload only — when no incident data
+ *  changed (the overwhelmingly common 5-min case) we skip the write entirely. dedup-by-id inside
+ *  `accumulateMonthlyIncidents` keeps it idempotent, so repeated 5-min runs never double-count. */
+export async function accumulateIncidentsOnlyIfChanged(
+  kv: KVNamespace,
+  services: ServiceStatus[],
+  month: string, // YYYY-MM
+): Promise<'unchanged' | 'written' | 'failed'> {
+  const incKey = `incidents:monthly:${month}`
+  const existingRaw = await kv.get(incKey).catch(() => null)
+  let existing: MonthlyIncidents | null = null
+  if (existingRaw) {
+    try { existing = JSON.parse(existingRaw) } catch { existing = null /* corrupt → rebuild from current */ }
+  }
+  const updated = accumulateMonthlyIncidents(existing, services, month)
+  // Compare incident payload only — `lastUpdated` is bumped every call, so a whole-object compare
+  // would always differ. No service-payload change → nothing to persist → skip the write.
+  const existingServices = existing ? JSON.stringify(existing.services) : null
+  if (existingServices === JSON.stringify(updated.services)) return 'unchanged'
+  const ok = await kvPut(kv, incKey, JSON.stringify(updated), { expirationTtl: 60 * 86400 })
+  return ok ? 'written' : 'failed'
 }
 
 /** Map a runtime ServiceStatus.incidents[].status to the archive's finalStatus enum.


### PR DESCRIPTION
## Problem
Incident accumulation into `incidents:monthly:{YYYY-MM}` ran only on the **daily** summary cron, but alerts run **every 5 min**. A short-lived / RSS-sourced incident (Azure OpenAI `azureRssUrl`, Bedrock `awsRssUrls` — short rolling feeds) could fire an alert at */5 then vanish from the feed before the once-a-day accumulation, so it never landed in the accumulator → **missing from the monthly archive AND the dashboard's 90-day filter** (which backfills from it), despite AIWatch having alerted on it. (This is why Azure OpenAI showed an operator alert but `incidents: 0` in the May archive.)

## Fix
- **`accumulateIncidentsOnlyIfChanged(kv, services, month)`** (monthly-archive.ts): read → `accumulateMonthlyIncidents` → write back **only when the incident data changed**. The accumulator always bumps `lastUpdated`, so the guard compares the `services` payload only (byte-stable when nothing changed) to skip the write on calm cycles. Dedup-by-id keeps it idempotent → running every 5 min never double-counts.
- **`cronAlertCheck`** (the */5 handler) calls it with the already-fetched `services` (best-effort try/catch — can't break alert delivery). The daily block is refactored onto the same helper (was an unconditional inline write).

## Write-budget
Unresolved incidents carry `duration: null` (statuspage/aws parsers) → `dur = 0` for their open lifetime, so an active incident does **not** write every 5 min — only on real status transitions + resolution (a few writes per incident), far under the monthly KV allowance.

## Verification
Worker suite **1589 pass** (4 new: fresh→written; no-change→'unchanged' + zero extra writes; dedup→no double-count; active-progress→writes again). `typecheck:worker` clean; `wrangler deploy --dry-run` OK. PR review: **0 Critical / 0 Important**.

## Remaining (why `refs`, not `closes`)
Prod verification — a real Azure/Bedrock RSS incident appearing in the dashboard 90-day filter after deploy — is a post-deploy check. **Batch the worker deploy with #586's PR #589** (one deploy for both worker PRs, after approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)