### PR TITLE
feat(ranking): exclude stale-source services from Score ranking across all surfaces (#591)

### DIFF
--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -82,7 +82,7 @@ export default async function handler(req: Request) {
             id: string; name: string; category: string; status: string
             latency: number | null; uptime30d: number | null; uptimeSource?: string
             lastChecked: string; incidents: unknown[]; aiwatchScore?: number | null
-            scoreGrade?: string | null; scoreConfidence?: string
+            scoreGrade?: string | null; scoreConfidence?: string; incidentSourceStale?: boolean
           }>
           aiAnalysis?: Record<string, { summary: string; estimatedRecovery: string; affectedScope: string[]; needsFallback?: boolean; analyzedAt: string; incidentId: string; resolvedAt?: string }>
         }
@@ -108,14 +108,14 @@ export default async function handler(req: Request) {
         // 2. Use competition ranking (1, 2, 4=, 4=, 4=, 7=, ...) based on rounded score,
         //    not array index — otherwise tied services display different ranks per service
         if (Number.isFinite(target?.aiwatchScore)) {
-          const hasReliableData = (s: { uptimeSource?: string; incidents?: unknown[] }) =>
-            !(s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0)
+          const hasReliableData = (s: { uptimeSource?: string; incidents?: unknown[]; incidentSourceStale?: boolean }) =>
+            !(s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0) && !s.incidentSourceStale
           const targetScore = Math.round(target!.aiwatchScore as number)
           if (!hasReliableData(target!)) {
             // Target itself fails the reliability filter — dedup'd to avoid log spam
             if (!warnedExcludedSlugs.has(slug)) {
               warnedExcludedSlugs.add(slug)
-              console.warn(`[is-down/${slug}] target excluded from ranked set (estimate source with 0 incidents) — check SLUG_TO_SERVICE vs uptimeSource`)
+              console.warn(`[is-down/${slug}] target excluded from ranked set (estimate source with 0 incidents, or stale incident source #591) — check SLUG_TO_SERVICE vs uptimeSource/incidentSourceStale`)
             }
           } else {
             // Use Number.isFinite instead of != null so NaN scores (from a corrupt pipeline)

--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -163,6 +163,42 @@ describe('renderPage <title> — live status (#566)', () => {
   })
 })
 
+// #591 — a stale-source service (frozen feed; is-down.ts never sets a rank for it) must not surface
+// its frozen uptime/score, and must show the honest "source moved/can't reach" note instead.
+describe('renderPage — stale incident source (#591)', () => {
+  const stale = () => mkService({
+    status: 'operational',
+    uptime30d: 99.92,            // frozen mirror value — must NOT appear
+    aiwatchScore: 88,            // inflated by the empty window — must NOT appear
+    scoreGrade: 'good',
+    incidentSourceStale: true,
+    // rank intentionally unset: is-down.ts excludes stale services from the ranked set
+  })
+
+  it('omits the frozen uptime and inflated score from the header meta', () => {
+    const html = renderPage('deepseek', stale(), mkSeo(), [])
+    expect(html).not.toContain('Uptime (30d): 99.92%')
+    expect(html).not.toContain('AIWatch Score: 88')
+  })
+
+  it('renders the honest stale-source note', () => {
+    const html = renderPage('deepseek', stale(), mkSeo(), [])
+    expect(html).toMatch(/status page moved to a source AIWatch can't reach/i)
+  })
+
+  it('omits the frozen uptime from the SERP meta description', () => {
+    const desc = buildMetaDescription(mkSeo(), stale(), null)
+    expect(desc).not.toContain('30-day uptime: 99.92%')
+  })
+
+  it('a NON-stale service still shows uptime + score (no over-suppression)', () => {
+    const html = renderPage('deepseek', mkService({ status: 'operational', uptime30d: 99.92, aiwatchScore: 88, scoreGrade: 'good' }), mkSeo(), [])
+    expect(html).toContain('Uptime (30d): 99.92%')
+    expect(html).toContain('AIWatch Score: 88')
+    expect(html).not.toMatch(/can't reach/i)
+  })
+})
+
 describe('renderIncidents — 30-day window + grouping', () => {
   it('returns empty string when service is null or incidents array is empty', () => {
     expect(renderIncidents(null)).toBe('')
@@ -178,6 +214,22 @@ describe('renderIncidents — 30-day window + grouping', () => {
     const html = renderIncidents(svc)
     expect(html).toContain('Last 30 days')
     expect(html).toContain('No incidents in the last 30 days')
+  })
+
+  it('#591 stale source: shows "history unavailable", NOT a false "No incidents" all-clear', () => {
+    // frozen feed — incidents exist but are all old (can\'t fetch recent), so the 30-day window is empty
+    const svc = mkService({
+      incidentSourceStale: true,
+      incidents: [mkInc({ startedAt: new Date(Date.now() - 40 * 86_400_000).toISOString() })],
+    })
+    const html = renderIncidents(svc)
+    expect(html).toContain('Incident history unavailable')
+    expect(html).not.toContain('No incidents in the last 30 days')
+  })
+
+  it('#591 stale source with an EMPTY incident array still renders the unavailable message', () => {
+    const html = renderIncidents(mkService({ incidentSourceStale: true, incidents: [] }))
+    expect(html).toContain('Incident history unavailable')
   })
 
   it('30-day boundary: 29d included, 31d excluded', () => {

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -39,6 +39,7 @@ export interface ServiceData {
   rank?: number
   rankTied?: boolean
   totalRanked?: number
+  incidentSourceStale?: boolean
 }
 
 interface Fallback {
@@ -436,9 +437,12 @@ function renderStatusHeader(service: ServiceData | null, seo: ServiceSEO): strin
   const answer = statusAnswer(service.status) // #566 — on-page direct answer (feeds Google's auto-snippet)
   const hasUptime = typeof service.uptime30d === 'number' && !Number.isNaN(service.uptime30d)
   const gradeStr = service.scoreGrade ? ` (${service.scoreGrade.charAt(0).toUpperCase() + service.scoreGrade.slice(1)})` : ''
+  // #591 — a stale-source service carries a frozen uptime30d + an inflated score; omit both here
+  // (the ⚠️ note below explains why). Status/last-checked stay — they're probe-measured + current.
+  const stale = !!service.incidentSourceStale
   const metaParts = [`Last checked: ${esc(timeAgo(service.lastChecked))}`]
-  if (hasUptime) metaParts.push(`Uptime (30d): ${service.uptime30d!.toFixed(2)}%`)
-  if (service.aiwatchScore != null) metaParts.push(`AIWatch Score: ${service.aiwatchScore}${esc(gradeStr)}`)
+  if (hasUptime && !stale) metaParts.push(`Uptime (30d): ${service.uptime30d!.toFixed(2)}%`)
+  if (service.aiwatchScore != null && !stale) metaParts.push(`AIWatch Score: ${service.aiwatchScore}${esc(gradeStr)}`)
   const incidents = Array.isArray(service.incidents) ? service.incidents : []
   const lastIncident = incidents.length > 0 ? incidents[0] : null
 
@@ -448,6 +452,7 @@ function renderStatusHeader(service: ServiceData | null, seo: ServiceSEO): strin
 <p class="meta mono">${metaParts.join(' &middot; ')}</p>
 ${lastIncident ? `<p class="meta">Last incident: ${esc(formatDate(lastIncident.startedAt))} &mdash; ${esc(lastIncident.title)}${lastIncident.duration ? ` (${esc(lastIncident.duration)})` : ' (ongoing)'}</p>` : '<p class="meta">No recent incidents</p>'}
 ${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="${REPORTS_INDEX_HREF}" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">${REPORTS_INDEX_LABEL} &rarr;</a></p>` : ''}
+${service.incidentSourceStale ? `<p class="meta" style="color:var(--amber)">⚠️ ${esc(seo.displayName)}'s status page moved to a source AIWatch can't reach, so its incident feed is frozen — uptime, score, and ranking are omitted until the source is reachable again. Live status above is still measured directly.</p>` : ''}
 </div>`
 }
 
@@ -553,7 +558,8 @@ export function buildMetaDescription(
   const thirtyDayIncidentCount = Array.isArray(service.incidents)
     ? service.incidents.filter((i) => new Date(i.startedAt).getTime() >= Date.now() - 30 * 86_400_000).length
     : 0
-  const uptimeStr = typeof service.uptime30d === 'number' && !Number.isNaN(service.uptime30d)
+  // #591 — don't surface a stale-source service's frozen uptime in the SERP snippet.
+  const uptimeStr = typeof service.uptime30d === 'number' && !Number.isNaN(service.uptime30d) && !service.incidentSourceStale
     ? `${service.uptime30d.toFixed(2)}%`
     : null
   const uptimeClause = uptimeStr ? ` 30-day uptime: ${uptimeStr}.` : ''
@@ -566,11 +572,20 @@ export function buildMetaDescription(
 
 export function renderIncidents(service: ServiceData | null): string {
   const incidents = Array.isArray(service?.incidents) ? service.incidents : []
-  if (!service || incidents.length === 0) return ''
+  // #591 — a stale-source service must still render the section (to say "unavailable"), even if its
+  // frozen incident array is empty; only a non-stale service with no incidents renders nothing.
+  if (!service || (incidents.length === 0 && !service.incidentSourceStale)) return ''
 
   const cutoff = Date.now() - 30 * 86_400_000
   const recent = incidents.filter((inc) => new Date(inc.startedAt).getTime() >= cutoff) as GroupingIncident[]
   const heading = `<h2>Recent Incidents <span class="mono" style="font-size:12px;color:#8b949e;font-weight:400;margin-left:8px">&middot; Last 30 days</span></h2>`
+
+  // #591 — the incident feed is frozen, so we can't fetch recent incidents. A "No incidents" message
+  // here would be a false all-clear; say the history is unavailable instead.
+  if (service.incidentSourceStale) {
+    return `${heading}
+<div class="card"><p style="color:#8b949e;font-size:13px;padding:8px 0">Incident history unavailable &mdash; ${esc(service.name)}'s status source moved to a platform AIWatch can't currently reach, so recent incidents can't be retrieved.</p></div>`
+  }
 
   if (recent.length === 0) {
     return `${heading}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -7,6 +7,7 @@ import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { trackEvent } from '../utils/analytics'
 import { SERVICE_CATEGORIES, ALL_SERVICES_FEED_URL } from '../utils/constants'
+import { isUnreliableUptime } from '../utils/serviceReliability'
 import RssCopyIcon from './RssCopyIcon'
 
 const EMPTY = []
@@ -117,8 +118,7 @@ const uptimeBadgeStyle = { ...badgeStyle, whiteSpace: 'nowrap', minWidth: '46px'
 function ServiceNavItem({ svc, page, setPage, onNavigate }) {
   const active = page.name === 'service' && page.serviceId === svc.id
   const dotClass = STATUS_DOT_CLASS[svc.status] ?? STATUS_DOT_CLASS.operational
-  const isEstimateOnly = svc.uptimeSource === 'estimate' && (svc.incidents ?? []).length === 0
-  const hasUptime = svc.uptime30d != null && !isEstimateOnly
+  const hasUptime = svc.uptime30d != null && !isUnreliableUptime(svc) // #591 — hide frozen stale uptime too
   const badgeCls = hasUptime ? uptimeBadgeCls(svc.uptime30d) : 'bg-[var(--bg3)] text-[var(--text2)]'
   const statusTextCls = svc.status === 'degraded' ? 'text-[var(--amber)]'
     : svc.status === 'down' ? 'text-[var(--red)]' : null

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -304,7 +304,7 @@ const en = {
   'ranking.service': 'Service',
   'ranking.affectedDays': 'Affected Days',
   'ranking.na': 'Insufficient Data',
-  'ranking.naReason': 'Status page does not publish enough data for scoring',
+  'ranking.naReason': 'Not enough comparable data to score fairly — no published uptime metric, or the status source is currently unavailable.',
   'ranking.score': 'Score',
   'ranking.grade': 'Grade',
   'ranking.uptime': 'Uptime',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -304,7 +304,7 @@ const ko = {
   'ranking.service': '서비스',
   'ranking.affectedDays': '영향 일수',
   'ranking.na': '데이터 불충분 서비스',
-  'ranking.naReason': '상태 페이지에서 점수 산정에 필요한 데이터 미제공',
+  'ranking.naReason': '공정하게 점수를 매길 만큼 비교 가능한 데이터가 부족합니다 — 공식 가동률 지표가 없거나, 상태 페이지를 현재 가져올 수 없습니다.',
   'ranking.score': '점수',
   'ranking.grade': '등급',
   'ranking.uptime': 'Uptime',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -8,6 +8,7 @@ import { usePage } from '../utils/pageContext'
 import { usePolling } from '../hooks/usePolling'
 import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
+import { isUnreliableUptime } from '../utils/serviceReliability'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, getGroupedFallbacks, ALL_SERVICES_FEED_URL } from '../utils/constants'
 import RssCopyIcon from '../components/RssCopyIcon'
 import { regionStatusOf } from '../utils/regionStatus'
@@ -91,8 +92,10 @@ function HistoryBars({ history30d, compact }) {
 
 function ServiceCard({ service, index, onClick, t, isRecovered }) {
   const incidentCount = (service.incidents ?? []).filter((i) => i.status !== 'resolved').length
-  const isEstimateOnly = service.uptimeSource === 'estimate' && (service.incidents ?? []).length === 0
-  const hasUptime = service.uptime30d != null && !isEstimateOnly
+  // #591 — estimate-no-data OR stale-source (frozen feed): blank uptime / incident count / score on
+  // the card (showing frozen/assumed figures as current would mislead).
+  const isUnreliable = isUnreliableUptime(service)
+  const hasUptime = service.uptime30d != null && !isUnreliable
   const uptimeColor = !hasUptime ? 'text-[var(--text2)]' : service.uptime30d >= 99 ? 'text-[var(--green)]' : service.uptime30d >= 97 ? 'text-[var(--amber)]' : 'text-[var(--red)]'
   const latencyColor = service.latency == null ? 'text-[var(--text2)]'
     : service.latency < 500 ? 'text-[var(--green)]'
@@ -123,8 +126,8 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
         <div className="flex items-center justify-between" style={{ marginBottom: '4px' }}>
           <span className="mono text-[10px] text-[var(--text2)]">
             <span className={uptimeColor}>{uptimeStr}</span>
-            {!isEstimateOnly && incidentCount > 0 && <>{' · '}<span className="text-[var(--red)]">{incidentCount}{t('overview.card.incidents.compact')}</span></>}
-            {!isEstimateOnly && scoreStr && <>{' · '}{scoreStr}</>}
+            {!isUnreliable && incidentCount > 0 && <>{' · '}<span className="text-[var(--red)]">{incidentCount}{t('overview.card.incidents.compact')}</span></>}
+            {!isUnreliable && scoreStr && <>{' · '}{scoreStr}</>}
           </span>
         </div>
         <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact)} compact />
@@ -155,12 +158,12 @@ function ServiceCard({ service, index, onClick, t, isRecovered }) {
             <div className="mono text-[9px] text-[var(--text2)]" style={{ letterSpacing: '0.04em' }}>{t('overview.card.uptime')}</div>
           </div>
           <div>
-            <div className={`mono text-[13px] font-medium ${isEstimateOnly ? 'text-[var(--text2)]' : 'text-[var(--text0)]'}`}>{isEstimateOnly ? '—' : incidentCount}</div>
+            <div className={`mono text-[13px] font-medium ${isUnreliable ? 'text-[var(--text2)]' : 'text-[var(--text0)]'}`}>{isUnreliable ? '—' : incidentCount}</div>
             <div className="mono text-[9px] text-[var(--text2)]" style={{ letterSpacing: '0.04em' }}>{t('overview.card.incidents')}</div>
           </div>
         </div>
 
-        {service.aiwatchScore != null && !isEstimateOnly && (
+        {service.aiwatchScore != null && !isUnreliable && (
           <div className="flex items-center gap-2" style={{ marginBottom: '8px' }}>
             <span className="mono text-[9px] text-[var(--text2)]">{t('score.bar.label')}</span>
             <div className="flex-1 bg-[var(--bg3)] rounded-full" style={{ height: '4px' }}>
@@ -574,7 +577,7 @@ export default function Overview() {
   const degradedCount    = catServices.filter((s) => s.status === 'degraded').length
   const downCount        = catServices.filter((s) => s.status === 'down').length
   const issueCount       = degradedCount + downCount
-  const uptimeServices = catServices.filter((s) => s.uptime30d != null && !(s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0))
+  const uptimeServices = catServices.filter((s) => s.uptime30d != null && !isUnreliableUptime(s))
   const avgUptime = uptimeServices.length
     ? (uptimeServices.reduce((sum, s) => sum + s.uptime30d, 0) / uptimeServices.length).toFixed(1)
     : '—'

--- a/src/pages/Ranking.jsx
+++ b/src/pages/Ranking.jsx
@@ -7,6 +7,7 @@ import { usePage } from '../utils/pageContext'
 import { useSettings } from '../hooks/useSettings'
 import { SCORE_BG_CLASS, SCORE_TEXT_CLASS } from '../utils/constants'
 import { formatTime } from '../utils/time'
+import { hasReliableScoreData } from '../utils/serviceReliability'
 import SkeletonUI from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
 
@@ -20,9 +21,7 @@ export default function Ranking() {
   const services = (rawServices ?? []).filter((s) => settings.enabledServices.includes(s.id))
 
   const ranked = useMemo(() => {
-    // Exclude services with insufficient data (estimate uptime + no incidents = unreliable score)
-    const hasReliableData = (s) => !(s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0)
-    const scored = services.filter((s) => s.aiwatchScore != null && hasReliableData(s))
+    const scored = services.filter((s) => s.aiwatchScore != null && hasReliableScoreData(s))
       .sort((a, b) => b.aiwatchScore - a.aiwatchScore)
       .map((svc, i, arr) => {
         const score = Math.round(svc.aiwatchScore)
@@ -30,7 +29,7 @@ export default function Ranking() {
         const isTied = arr.filter((s) => Math.round(s.aiwatchScore) === score).length > 1
         return { ...svc, rank, isTied }
       })
-    const na = services.filter((s) => s.aiwatchScore == null || !hasReliableData(s))
+    const na = services.filter((s) => s.aiwatchScore == null || !hasReliableScoreData(s))
     return { scored, na }
   }, [services])
 
@@ -201,12 +200,14 @@ export default function Ranking() {
             </div>
           </div>
           <div style={{ padding: '16px' }}>
+            {/* #591 — the exclusion reason is shared by the whole bucket, so show it once here
+                instead of repeating it on every row. */}
+            <p className="text-[11px] text-[var(--text2)]" style={{ marginBottom: '10px' }}>{t('ranking.naReason')}</p>
             <div className="flex flex-col gap-2">
               {ranked.na.map((svc) => (
                 <div key={svc.id} className="flex items-center gap-2 text-[11px] text-[var(--text2)]">
                   <span>•</span>
                   <span className="text-[var(--text1)]">{svc.name}</span>
-                  <span>— {t('ranking.naReason')}</span>
                 </div>
               ))}
             </div>

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -14,6 +14,7 @@ import { groupIncidents } from '../utils/incidentGrouping'
 import { compareGroupedRows, dominantGroupStatus } from '../utils/incidentSort'
 import { SCORE_TEXT_CLASS, feedUrlOf } from '../utils/constants'
 import { computeRecoveryStats, formatRecoveryMin } from '../utils/recovery'
+import { isUnreliableUptime } from '../utils/serviceReliability'
 import { regionStatusOf, SERVICE_REGIONS } from '../utils/regionStatus'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
@@ -636,8 +637,10 @@ export default function ServiceDetails({ serviceId }) {
   // monitoring rows back above newer resolved ones. See incidentSort.js.
   const groupedIncidents = groupIncidents(recentIncidents).slice().sort(compareGroupedRows)
   const incidentCount = recentIncidents.length
-  const totalIncidents = (service.incidents ?? []).length
-  const isEstimateNoData = service.uptimeSource === 'estimate' && totalIncidents === 0
+  // #591 — estimate-no-data OR stale-source (frozen feed, e.g. DeepSeek → Flashduty): blank the
+  // uptime / incidents / MTTR / score cards + the status calendar (showing a frozen 30-day window as
+  // current would mislead). Latency stays — it's probe-measured + current.
+  const isUnreliableData = isUnreliableUptime(service)
   const calendarDays = service.calendarDays ?? 14
 
   const calendarData = buildCalendarFromIncidents(service.incidents, service.dailyImpact, calendarDays)
@@ -704,38 +707,38 @@ export default function ServiceDetails({ serviceId }) {
           colorClass={probeServiceIds.includes(service.id) ? 'text-[var(--blue)]' : 'text-[var(--text2)]'}
         />
         <MetricCard
-          label={isEstimateNoData
+          label={isUnreliableData
             ? t('svc.uptime30d')
             : t({ official: 'uptime.label.official', platform_avg: 'uptime.label.platform_avg', estimate: 'uptime.label.estimate' }[service.uptimeSource] ?? 'svc.uptime30d')}
-          value={isEstimateNoData
+          value={isUnreliableData
             ? '—'
             : service.uptime30d != null ? `${service.uptime30d.toFixed(2)}%` : '—'}
-          sub={isEstimateNoData
+          sub={isUnreliableData
             ? t('uptime.unavailable')
             : t({ official: 'uptime.sub.official', platform_avg: 'uptime.sub.platform_avg', estimate: 'uptime.sub.estimate' }[service.uptimeSource] ?? 'uptime.unavailable')}
           colorClass="text-[var(--green)]"
         />
         <MetricCard
           label={t('svc.incidents')}
-          value={isEstimateNoData ? '—' : incidentCount}
-          sub={isEstimateNoData ? t('uptime.unavailable') : t('svc.incidents.sub')}
-          colorClass={isEstimateNoData ? 'text-[var(--text2)]' : incidentCount > 0 ? 'text-[var(--amber)]' : 'text-[var(--text1)]'}
+          value={isUnreliableData ? '—' : incidentCount}
+          sub={isUnreliableData ? t('uptime.unavailable') : t('svc.incidents.sub')}
+          colorClass={isUnreliableData ? 'text-[var(--text2)]' : incidentCount > 0 ? 'text-[var(--amber)]' : 'text-[var(--text1)]'}
         />
         <MetricCard
           label={t('svc.mttr')}
-          value={isEstimateNoData ? '—' : (recovery ? formatRecoveryMin(recovery.medianMin) : '—')}
+          value={isUnreliableData ? '—' : (recovery ? formatRecoveryMin(recovery.medianMin) : '—')}
           // #557 — headline is the median (typical) recovery; when a longer outage exists in the
           // window, surface it as "worst Xh Ym" so a 29h outage is never hidden by short blips.
-          sub={isEstimateNoData ? t('uptime.unavailable')
+          sub={isUnreliableData ? t('uptime.unavailable')
             : !recovery ? (hasOngoingIncident ? t('svc.mttr.ongoing') : t('svc.mttr.none'))
             : recovery.maxMin > recovery.medianMin ? t('svc.recovery.worst').replace('{d}', formatRecoveryMin(recovery.maxMin))
             : t('svc.incidents.sub')}
-          colorClass={isEstimateNoData ? 'text-[var(--text2)]' : recovery ? 'text-[var(--amber)]' : 'text-[var(--text2)]'}
+          colorClass={isUnreliableData ? 'text-[var(--text2)]' : recovery ? 'text-[var(--amber)]' : 'text-[var(--text2)]'}
         />
       </div>
 
       {/* ── AIWatch Score Breakdown ── */}
-      {service.aiwatchScore != null && !isEstimateNoData && (
+      {service.aiwatchScore != null && !isUnreliableData && (
         <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
           <div className="flex items-center justify-between border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
             <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
@@ -822,7 +825,7 @@ export default function ServiceDetails({ serviceId }) {
             <span className="mono text-[10px] text-[var(--text2)]">{t('incidents.period.7d')}</span>
           </div>
           <div style={{ padding: '16px' }}>
-            {isEstimateNoData || NO_INCIDENT_SUPPORT.has(service.id) ? (
+            {isUnreliableData || NO_INCIDENT_SUPPORT.has(service.id) ? (
               <div className="flex items-center gap-2 py-4">
                 <span className="text-[var(--text2)] text-sm" aria-hidden="true">—</span>
                 <span className="text-xs text-[var(--text2)]">{t('uptime.unavailable')}</span>
@@ -844,8 +847,11 @@ export default function ServiceDetails({ serviceId }) {
           </div>
         </section>
 
-        {/* Status Calendar — hidden when calendarDays is 0 (no reliable data) */}
-        {calendarDays > 0 && <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
+        {/* Status Calendar — hidden when calendarDays is 0 (no reliable data) or the source is STALE
+            (#591 — a frozen incident feed paints a 30-day all-green calendar, contradicting the
+            blanked cards above). Estimate-only services keep the calendar (existing behaviour — their
+            window isn't frozen, just lacks a published uptime %). */}
+        {calendarDays > 0 && !service.incidentSourceStale && <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
           <div className="flex items-center justify-between border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
             <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
               <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: 'var(--green)' }} />
@@ -946,7 +952,7 @@ export default function ServiceDetails({ serviceId }) {
         <div style={{ padding: '16px' }}>
           <div className="flex items-center gap-3" style={{ marginBottom: '12px' }}>
             <img src={`${(import.meta.env.VITE_API_URL || 'http://localhost:8788').replace('/api/status', '')}/badge/${service.id}`} alt={`${service.name} status`} height="20" />
-            {service.uptime30d != null && !isEstimateNoData && <img src={`${(import.meta.env.VITE_API_URL || 'http://localhost:8788').replace('/api/status', '')}/badge/${service.id}?uptime=true`} alt={`${service.name} uptime`} height="20" />}
+            {service.uptime30d != null && !isUnreliableData && <img src={`${(import.meta.env.VITE_API_URL || 'http://localhost:8788').replace('/api/status', '')}/badge/${service.id}?uptime=true`} alt={`${service.name} uptime`} height="20" />}
           </div>
           <BadgeCode serviceId={service.id} serviceName={service.name} t={t} />
         </div>

--- a/src/pages/Uptime.jsx
+++ b/src/pages/Uptime.jsx
@@ -8,11 +8,11 @@ import { usePolling } from '../hooks/usePolling'
 import { useSettings } from '../hooks/useSettings'
 import { UptimeSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
+import { isUnreliableUptime } from '../utils/serviceReliability'
 
 // ── Constants ────────────────────────────────────────────────
 
 const WARN_THRESHOLD = 95.0 // < 95% → red
-const isEstimateNoData = (s) => s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -56,7 +56,7 @@ function UptimeBar({ service, sla, t }) {
   const MIN_DISPLAY = 95
   const range = 100 - MIN_DISPLAY
   const uptime = service.uptime30d ?? 0
-  const hasUptime = service.uptime30d != null && !isEstimateNoData(service)
+  const hasUptime = service.uptime30d != null && !isUnreliableUptime(service)
   const clampedPct = Math.max(MIN_DISPLAY, uptime)
   const widthPct = hasUptime ? Math.round(((clampedPct - MIN_DISPLAY) / range) * 100) : 0
   const slaPos = Math.round(((sla - MIN_DISPLAY) / range) * 100)
@@ -97,12 +97,12 @@ export default function Uptime() {
   const sla = settings.sla
   const services = (rawServices ?? []).filter((s) => settings.enabledServices.includes(s.id))
 
-  const hasReliableUptime = (s) => s.uptime30d != null && !isEstimateNoData(s)
+  const hasReliableUptime = (s) => s.uptime30d != null && !isUnreliableUptime(s)
   const sortedByUptime = useMemo(
     () => [...services]
       .sort((a, b) => {
-        const aUp = isEstimateNoData(a) ? null : a.uptime30d
-        const bUp = isEstimateNoData(b) ? null : b.uptime30d
+        const aUp = isUnreliableUptime(a) ? null : a.uptime30d
+        const bUp = isUnreliableUptime(b) ? null : b.uptime30d
         if (aUp == null && bUp == null) return 0
         if (aUp == null) return 1
         if (bUp == null) return -1

--- a/src/pages/__tests__/stale-source-ranking.test.js
+++ b/src/pages/__tests__/stale-source-ranking.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { hasReliableScoreData, isUnreliableUptime } from '../../utils/serviceReliability'
+
+// #591 — stale-source services (frozen incident feed, e.g. DeepSeek → Flashduty) must drop out of the
+// Score ranking + Uptime ranking: their empty 30-day window inflates the Score (full incidents +
+// recovery from MISSING data) and their uptime30d is frozen. The predicates below gate inclusion on
+// every ranking surface (Ranking.jsx, Uptime.jsx; api/is-down.ts carries an identical copy).
+
+const stale = { id: 'deepseek', uptimeSource: 'official', incidents: [{ id: 'x' }], incidentSourceStale: true }
+const estimateNoData = { id: 'bedrock', uptimeSource: 'estimate', incidents: [] }
+const normal = { id: 'claude', uptimeSource: 'official', incidents: [{ id: 'a' }] }
+// the key non-false-positive case: an incident-free service with a LIVE official feed (not stale) —
+// e.g. Groq, whose newest incident may be months old but whose feed works — must STAY ranked.
+const incidentFreeLive = { id: 'groq', uptimeSource: 'official', incidents: [] }
+
+describe('hasReliableScoreData (#591 — Ranking)', () => {
+  it('excludes a stale-source service', () => {
+    expect(hasReliableScoreData(stale)).toBe(false)
+  })
+  it('excludes estimate-uptime with no incidents (existing behaviour, unchanged)', () => {
+    expect(hasReliableScoreData(estimateNoData)).toBe(false)
+  })
+  it('keeps a normal service', () => {
+    expect(hasReliableScoreData(normal)).toBe(true)
+  })
+  it('keeps an incident-free service with a LIVE feed (no false-positive exclusion)', () => {
+    expect(hasReliableScoreData(incidentFreeLive)).toBe(true)
+  })
+})
+
+describe('isUnreliableUptime (#591 — Uptime)', () => {
+  it('flags a stale-source service unreliable (sorted out / N/A)', () => {
+    expect(isUnreliableUptime(stale)).toBe(true)
+  })
+  it('flags estimate-no-data unreliable (existing behaviour)', () => {
+    expect(isUnreliableUptime(estimateNoData)).toBe(true)
+  })
+  it('does NOT flag a normal service', () => {
+    expect(isUnreliableUptime(normal)).toBe(false)
+  })
+  it('does NOT flag an incident-free service with a live feed', () => {
+    expect(isUnreliableUptime(incidentFreeLive)).toBe(false)
+  })
+})

--- a/src/utils/serviceReliability.js
+++ b/src/utils/serviceReliability.js
@@ -1,0 +1,23 @@
+// Shared reliability predicates for a service's score/uptime data (#591). Centralized so every
+// surface (Ranking, Uptime, Overview, Sidebar, ServiceDetails; mirrored in api/is-down.ts) makes the
+// SAME include/exclude decision — the #591 bug was three surfaces drifting from the original copy.
+//
+// Two distinct "unreliable" cases:
+//   • estimate-no-data — `uptimeSource: 'estimate'` with no incidents (bedrock/azureopenai): no
+//     measured basis, so uptime/score are an industry-average assumption, not a real figure.
+//   • stale-source (#591) — the status page migrated to a server-side-unreachable platform, so the
+//     feed AIWatch reads is FROZEN (DeepSeek → Flashduty, #507). uptime30d + incidents read as
+//     current but aren't; an empty 30-day window inflates the Score (full incidents+recovery from
+//     MISSING data). Flagged per-service by the worker via ServiceStatus.incidentSourceStale.
+
+/** Estimate-uptime service with no incidents — no measured basis for uptime/score. */
+export const isEstimateNoData = (s) => s.uptimeSource === 'estimate' && (s.incidents ?? []).length === 0
+
+/** Uptime30d is not a reliable current figure — either estimate-no-data or a frozen stale source.
+ *  Use to exclude from uptime ranking/sort/averages and to blank uptime displays. */
+export const isUnreliableUptime = (s) => isEstimateNoData(s) || !!s.incidentSourceStale
+
+/** The AIWatch Score is trustworthy enough to RANK this service. Excludes estimate-no-data and
+ *  stale-source services (a frozen empty incident window scores full incidents+recovery from
+ *  missing data). Mirror of api/is-down.ts:hasReliableData. */
+export const hasReliableScoreData = (s) => !isEstimateNoData(s) && !s.incidentSourceStale

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -757,6 +757,16 @@ describe('buildMonthlyArchive', () => {
     expect(archive.services.claude.officialUptime).toBeNull()
   })
 
+  it('#591 threads incidentSourceStale into the archive (only when set)', async () => {
+    const archive = await buildMonthlyArchive(mockKV, 2026, 3, [
+      { id: 'deepseek', aiwatchScore: 88, scoreGrade: 'good' as const, incidentSourceStale: true },
+      { id: 'claude', aiwatchScore: 85, scoreGrade: 'excellent' as const },
+    ])
+    expect(archive.services.deepseek.incidentSourceStale).toBe(true)
+    // absent (not false) for non-stale services — the report generator treats absence as not-stale
+    expect(archive.services.claude.incidentSourceStale).toBeUndefined()
+  })
+
   it('#586 daily snapshot WINS over the build-time scoreData fallback', async () => {
     // History days carry officialUptime; the month-end (2026-03-02) value must be used over the
     // scoreData snapshot (which is the build-time fallback for months that lack daily snapshots).

--- a/worker/src/__tests__/stale-source-config.test.ts
+++ b/worker/src/__tests__/stale-source-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { SERVICES } from '../services'
+
+// #591 — the stale-source ranking exclusion keys off ServiceConfig.incidentSourceStale. This guards
+// against the flag being silently dropped (which would re-inflate the affected service's Score and
+// let its frozen feed rank again — DeepSeek was #4 with score 88 from an empty 30-day window).
+describe('stale-source config (#591)', () => {
+  it('deepseek is flagged incidentSourceStale (its Flashduty mirror is frozen, #507)', () => {
+    const deepseek = SERVICES.find((s) => s.id === 'deepseek')
+    expect(deepseek).toBeDefined()
+    expect(deepseek!.incidentSourceStale).toBe(true)
+  })
+
+  it('the flag is opt-in — no OTHER service is stale-flagged today', () => {
+    const flagged = SERVICES.filter((s) => s.incidentSourceStale).map((s) => s.id)
+    expect(flagged).toEqual(['deepseek'])
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1269,7 +1269,7 @@ async function handleAdminRebuildArchive(request: Request, env: Env, cors: Recor
       const probeSummaries = await readProbeSummaries(env.STATUS_CACHE, 'admin/rebuild-archive')
       scoreData = services.map((s) => {
         const r = scoreFor(s, probeSummaries)
-        return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null }
+        return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
       })
       for (const s of services) serviceNames[s.id] = s.name
     } catch (parseErr) {
@@ -1766,7 +1766,7 @@ export default {
               const probeSummaries = await readProbeSummaries(env.STATUS_CACHE, 'monthly-archive')
               scoreData = services.map((s) => {
                 const r = scoreFor(s, probeSummaries)
-                return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null }
+                return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
               })
               for (const s of services) serviceNames[s.id] = s.name
             } catch (parseErr) {

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -50,6 +50,10 @@ export interface MonthlyServiceData {
   // dashboard's 30-90d filter useful even on high-frequency services like Together AI).
   // Optional/null for archives written before this feature shipped — frontend must handle absence.
   incidentList?: MonthlyIncidentEntry[]
+  // #591 — the service's incident source was known-stale (frozen feed, e.g. DeepSeek → Flashduty)
+  // when this archive was built. The report generator excludes such services from the Score ranking
+  // (their empty incident window would inflate the Score). Absent when false / pre-#591 archives.
+  incidentSourceStale?: boolean
 }
 
 export interface MonthlyArchive {
@@ -629,6 +633,9 @@ export interface ArchiveScoreInput {
   // source is computeMonthlyOfficialUptime (the month-end daily snapshot), which is month-accurate
   // and rebuild-safe; this build-time value only applies to months with no daily snapshots.
   officialUptime?: number | null
+  // #591 — the service's incident source is known-stale (frozen feed). Threaded into the archive so
+  // the report generator can exclude it from the Score ranking, parity with the live dashboard.
+  incidentSourceStale?: boolean
 }
 
 /** Build monthly archive from daily KV data + accumulated incident data */
@@ -806,6 +813,7 @@ export async function buildMonthlyArchive(
       p95LatencyMs: latencyStats[id]?.p95 ?? null,
       latencySpikes: latencyStats[id]?.spikes ?? null,
       ...(incidentList ? { incidentList } : {}),
+      ...(scoreSvc?.incidentSourceStale ? { incidentSourceStale: true } : {}),
     }
   }
 

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -47,7 +47,10 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'xai', name: 'xAI (Grok)', provider: 'xAI', category: 'api', statusUrl: 'https://status.x.ai', apiUrl: null, rssFeedUrl: 'https://status.x.ai/feed.xml', incidentKeywords: ['api'], incidentExclude: ['[API Console]', 'Test+Incident'] },
   // status.deepseek.com blocks Cloudflare Workers IPs (SSL reset); deepseek.statuspage.io is the
   // Atlassian-hosted mirror that's accessible from Workers — same component IDs, same data (#498).
-  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://deepseek.statuspage.io/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'] },
+  // #591/#507 — that mirror FROZE at 2026-05-08 (DeepSeek migrated to Flashduty, unreachable
+  // server-side); it still returns 200 with stale data, so the feed reads as current but isn't.
+  // `incidentSourceStale` excludes it from all Score rankings until the feed is reachable again.
+  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://deepseek.statuspage.io/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'], incidentSourceStale: true },
   { id: 'openrouter', name: 'OpenRouter', provider: 'OpenRouter', category: 'api', statusUrl: 'https://status.openrouter.ai', apiUrl: null, onlineOrNotUrl: 'https://status.openrouter.ai', onlineOrNotComponent: 'Chat (/api/v1/chat/completions)' },
   // Voice & Speech AI
   { id: 'elevenlabs', name: 'ElevenLabs', provider: 'ElevenLabs', category: 'api', statusUrl: 'https://status.elevenlabs.io', apiUrl: 'https://status.elevenlabs.io/api/v2/summary.json', incidentIoBaseUrl: 'https://status.elevenlabs.io/incidents', incidentIoComponentId: '01JP2RQVGDHPEEDAFM5KV2MH9P', incidentExclude: ['webpage'] },
@@ -355,6 +358,9 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
     uptime30d: null,
     lastChecked: now,
     incidents: [],
+    // #591 — propagated from config to every return path (all spread `...base`), so a stale-source
+    // service is flagged regardless of which fetch branch produces its status.
+    ...(config.incidentSourceStale ? { incidentSourceStale: true } : {}),
   }
 
   try {
@@ -968,6 +974,9 @@ export async function fetchAllServices(kv?: KVNamespace, probeSnapshots?: ProbeS
       uptime30d: null,
       lastChecked: new Date().toISOString(),
       incidents: [],
+      // #591 — carry the stale flag even on a total fetch reject (fetchService's success paths set it
+      // via `base`; this fresh-object fallback must too, so a stale service stays ranking-excluded).
+      ...(SERVICES[i].incidentSourceStale ? { incidentSourceStale: true } : {}),
     }
   })
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -36,6 +36,13 @@ export interface ServiceStatus {
    *  while the service stays operational under the <30% threshold (#447). UI shows a
    *  "N affected" badge; absent when 0. */
   partialCount?: number
+  /** #591 — the service's incident source is known-stale (its status page migrated to a
+   *  platform AIWatch can't reach server-side, so the feed AIWatch reads is frozen — e.g.
+   *  DeepSeek → Flashduty, #507). The incident list/uptime read as current but aren't, which
+   *  inflates the Score (an empty 30-day incident window scores full incidents+recovery). All
+   *  ranking surfaces exclude these (like estimate-only services) so a frozen feed can't rank.
+   *  Declared per-service via ServiceConfig.incidentSourceStale; absent when false. */
+  incidentSourceStale?: boolean
 }
 
 export type DailyImpactLevel = 'minor' | 'major' | 'critical'
@@ -85,6 +92,11 @@ export interface ServiceConfig {
   // produce 10-20 alerts per affected model. Opt-in suppression dedups by normalized title
   // in a 60-minute window. See #283 and isFlapSuppressible() in alerts.ts.
   flapSuppression?: boolean
+  // #591 — mark a service whose status page migrated to a server-side-unreachable platform, so
+  // the feed AIWatch reads is FROZEN (e.g. DeepSeek → Flashduty, #507). Propagated to
+  // ServiceStatus.incidentSourceStale → all ranking surfaces exclude it (a frozen empty 30-day
+  // incident window would otherwise inflate the Score). REMOVE once the feed is reachable again.
+  incidentSourceStale?: boolean
 }
 
 export interface ProbeSummary {


### PR DESCRIPTION
## Problem (live)

DeepSeek's status feed is **frozen at 2026-05-08** (Statuspage→Flashduty migration; the mirror AIWatch reads still returns 200 with stale data — #507). Its 30-day incident window is now empty, which **inflates the AIWatch Score** (`incidents 25/25 + recovery 15/15` from *missing* data) — it ranked **#4 (88) live** on the dashboard, above GitHub Copilot.

Every ranking surface shared the predicate `uptimeSource==='estimate' && incidents.length===0`, which DeepSeek (official source + a non-empty frozen incident list) does **not** trip — so it slipped through everywhere.

## Approach

- **Signal**: a maintained `ServiceConfig.incidentSourceStale` flag (`deepseek=true`). Chosen over **age-based** detection (Groq has an old newest-incident but a live feed → false positive) and **fetch-failure** detection (the mirror returns 200). Propagated to `ServiceStatus` via the `base` object in `fetchService` (every return path spreads it; the reject fallback sets it too), flows through `/api/status` by spread, and is threaded into `scoreData → MonthlyServiceData` for the report generator (PR B).
- **Centralized** the predicates into `src/utils/serviceReliability.js` (`isEstimateNoData` / `isUnreliableUptime` / `hasReliableScoreData`) — the root cause was the predicate being copy-pasted and **drifting** across surfaces (round-1 review found 3 surfaces still showing the frozen uptime).

### Surfaces
- **Ranking** — `hasReliableScoreData` drops stale from the scored table (→ N/A bucket). N/A reason also deduped to one line + reworded to cover estimate-only **and** stale.
- **Uptime / Overview (category avg + card) / Sidebar** — `isUnreliableUptime` hides the frozen uptime + sorts it out.
- **ServiceDetails** — blanks uptime/incidents/MTTR/score cards + hides the status calendar & score breakdown for a stale service (**latency stays** — probe-measured).
- **is-down SSR** — excluded from the ranked set; header meta + SERP description omit the frozen uptime/score; renders an honest "source unreachable" note; shows **"Incident history unavailable"** instead of a false "No incidents in the last 30 days".

## Scope

Dashboard/edge **ranking + display** only. The **report generator** `buildScoreTable` exclusion is **PR B** (aiwatch-reports). `refs #591` — closes after PR B + the post-deploy verify (live #4 gone).

## Verification

- **Worker deploy required** (flag is config-driven). Verified locally: local worker emits `deepseek.incidentSourceStale=true`; Playwright confirmed DeepSeek drops from the dashboard Ranking scored table (→ N/A) and its detail cards blank; `vercel dev` (temp-pointed at the local worker, reverted before commit) confirmed `/is-deepseek-down` omits rank/uptime/score + shows the stale + "history unavailable" notes, while `/is-claude-down` still ranks.
- Tests: worker archive-threading + config guard; frontend predicate (stale excluded, estimate excluded, normal kept, **Groq-like incident-free-but-LIVE kept**); is-down html-template stale render. **src 368 · worker 1598 · html-template 55 · typecheck 0 · lint 0 errors.** The one e2e failure (`overview.spec.js:128`, ActionBanner Voice-tier mock) **reproduces on clean main** — pre-existing, unrelated.
- code-reviewer: converged **0 Critical / 0 Important** (3 rounds).

## Post-merge (remaining for #591)

- Worker deploy (after approval) → then verify the live dashboard no longer ranks DeepSeek at #4.
- **PR B** — aiwatch-reports `buildScoreTable` excludes stale + names it in the ranking-exclusion note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)