### PR TITLE
test(overview): make multi-tier-key test deterministic via route fixture

### DIFF
--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -126,29 +126,45 @@ test.describe('Overview page', () => {
   })
 
   test('action banner renders multi-tier groups in same category without duplicate React keys', async ({ browser }) => {
-    // Mock data has degraded services across multiple tiers within the api category
-    // (OpenAI Tier 1 LLM, xAI Tier 2 LLM, ElevenLabs Tier 4 Voice). Pre-fix the React key
-    // was `grp.category` which collided when ActionBanner produced multiple groups
-    // under the same category. We capture console errors during a fresh page load and
-    // assert no "same key" warning fires.
+    // Two degraded services in DIFFERENT fallback tiers but the SAME category (`api`) —
+    // OpenAI (Tier 1 LLM) + ElevenLabs (Tier 4 Voice) — make ActionBanner emit two grouped
+    // fallback rows ("LLM →" and "Voice →") both keyed under category `api`. Pre-fix the React
+    // key was `grp.category`, which collided across those two rows. Inject this scenario via a
+    // deterministic route fixture instead of relying on live/MOCK_SERVICES data: the live worker
+    // only intermittently has the right degraded mix (Score/incident drift), which made this test
+    // flaky. Then capture console errors on a fresh page load and assert no "same key" warning fires.
+    const mkDegraded = (id, name, provider) => ({
+      id, category: 'api', name, provider, status: 'degraded', latency: 150, uptime30d: 99.5,
+      calendarDays: 30,
+      incidents: [{ id: `${id}-inc`, title: `${name} elevated errors`, status: 'investigating',
+        impact: 'major', startedAt: new Date(Date.now() - 60_000).toISOString(), duration: null, timeline: [] }],
+    })
+    const multiTierMock = { json: {
+      services: [
+        mkDegraded('openai', 'OpenAI API', 'OpenAI'),         // Tier 1 LLM
+        mkDegraded('elevenlabs', 'ElevenLabs', 'ElevenLabs'), // Tier 4 Voice
+      ],
+      lastUpdated: new Date().toISOString(),
+    } }
     const ctx = await browser.newContext()
     const page = await ctx.newPage()
+    await page.route('**/api/status**', async (route) => { await route.fulfill(multiTierMock) })
+    await page.route('**/api/status/cached', async (route) => { await route.fulfill(multiTierMock) })
     const errors = []
     page.on('console', (msg) => {
       if (msg.type() === 'error') errors.push(msg.text())
     })
     await page.goto('/')
     await waitForDataLoad(page)
-    // Guard against silent regression if MOCK_SERVICES is changed to no longer trigger the
-    // multi-tier-same-category scenario: require both `LLM →` and `Voice →` groups in the
-    // fallback banner, which both live under category `api` and are precisely what produced
-    // the pre-fix `key='api'` collision. Two groups in *different* categories wouldn't trigger
-    // the bug, so a generic " · " separator count isn't strong enough.
+    // Require both `LLM →` and `Voice →` groups in the fallback banner — both live under category
+    // `api` and are precisely what produced the pre-fix `key='api'` collision. Two groups in
+    // *different* categories wouldn't trigger the bug, so a generic " · " separator count isn't
+    // strong enough. If the fixture or tier mapping changes so only one group renders, these fail.
     const banner = page.locator('main .rounded-lg').filter({ hasText: /Suggested fallback|대체 추천/ }).first()
     await expect(banner).toBeVisible({ timeout: 5000 })
     const bannerText = (await banner.textContent()) ?? ''
-    expect(bannerText, 'mock data no longer renders LLM-tier fallback group; bug path not exercised').toMatch(/LLM →/)
-    expect(bannerText, 'mock data no longer renders Voice-tier fallback group; bug path not exercised').toMatch(/Voice →/)
+    expect(bannerText, 'fixture no longer renders LLM-tier fallback group; bug path not exercised').toMatch(/LLM →/)
+    expect(bannerText, 'fixture no longer renders Voice-tier fallback group; bug path not exercised').toMatch(/Voice →/)
     const dupKeyError = errors.find((e) => /two children with the same key/i.test(e))
     expect(dupKeyError, `unexpected duplicate-key console error:\n${dupKeyError ?? ''}`).toBeUndefined()
     await ctx.close()


### PR DESCRIPTION
## Problem
`tests/overview.spec.js` → *'action banner renders multi-tier groups in same category without duplicate React keys'* was flaky on CI. It relied on whatever data the dev server returned (live worker **or** MOCK_SERVICES fallback) to contain degraded services across multiple fallback **tiers** within the `api` category. With live prod data (only Mistral degraded) just the **"LLM →"** group rendered, so the `toMatch(/Voice →/)` guard false-failed — the same live-data-drift flakiness as the tied-rank is-down test (fixed in #594).

This is the **only** test in the file that did *not* inject a fixture; its siblings already use `page.route(...).fulfill(mock)`.

## Fix
Inject a deterministic route fixture matching the established sibling pattern:
- `openai` (API_TIER 1 → "LLM") + `elevenlabs` (API_TIER 4 → "Voice"), both `category: 'api'`, forced **degraded**.
- `mergeWithMock` keeps the other MOCK_SERVICES operational, so the LLM group (claude/gemini) and the Voice group (assemblyai/deepgram) both draw candidates and render.
- Intercepts **both** `**/api/status**` and `**/api/status/cached`, so live drift can't change the scenario.

The purpose-guard is unchanged: still requires **both** `LLM →` and `Voice →` groups **and** asserts no `two children with the same key` console error — a regression to `key={grp.category}` still fails.

## Verification
- ✅ Target test 2× (deterministic) + full `overview.spec.js` (16 passed)
- ✅ PR review — 0 Critical / 0 Important / 0 Suggestion (reviewer confirmed the fixture exercises the real `key={\`${grp.category}:${grp.label}\`}` path in Overview.jsx)

Test-only change — no app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)