### PR TITLE
feat(status): per-component breakdown card on ServiceDetails + is-down (refs #604)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ scripts/
 worker/
   src/
     index.ts    # Worker entry: CORS, KV, routing, /api/alert, /badge, /api/v1, Cron scheduled handler
-    services.ts # Service configs + fetch orchestrator + status determination
+    services.ts # Service configs + fetch orchestrator + status determination (resolveSvcStatus worst-of badge; resolveSvcComponents = #604 per-component snapshot → ServiceStatus.components, curated statusComponentIds subset, ≥2-gated)
     types.ts    # Shared types (ServiceStatus, Incident, etc.)
     utils.ts    # Shared utilities (formatDuration, fetchWithTimeout, sanitize)
     score.ts    # AIWatch Score — composite reliability (Uptime 40 + Incidents 25 + Recovery 15 + Responsiveness 20 from probe p50/CV; 80→100 rescale + 5% penalty for probe-less services, insufficient-data penalty for <7d probe samples). Incidents component uses Atlassian-weighted affected days (#260/#261): null impact excluded, per-day max impact weight (critical/major=1.0, minor=0.3) — symmetric with uptime weighting. Grade thresholds tightened to absorb the upward score shift: excellent ≥90, good ≥75, fair ≥55, degrading ≥40, unstable <40. The score's Recovery component uses a 30-day **median** of resolved-incident durations (mean fallback for <3 incidents). NOTE the ServiceDetails "Recovery" metric **card** is a separate display (`src/utils/recovery.js`, #557): a **7-day median + worst** ("typical 15m · worst 29h34m") — same lower-middle median convention as the score, but a different window, so the two can legitimately differ. It replaced a 7-day mean that let one long outage be diluted away by many short component blips (Mistral)

--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -83,6 +83,7 @@ export default async function handler(req: Request) {
             latency: number | null; uptime30d: number | null; uptimeSource?: string
             lastChecked: string; incidents: unknown[]; aiwatchScore?: number | null
             scoreGrade?: string | null; scoreConfidence?: string; incidentSourceStale?: boolean
+            components?: Array<{ id: string; name: string; status: 'operational' | 'degraded' | 'down' }>
           }>
           aiAnalysis?: Record<string, { summary: string; estimatedRecovery: string; affectedScope: string[]; needsFallback?: boolean; analyzedAt: string; incidentId: string; resolvedAt?: string }>
         }

--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { buildMetaDescription, renderIncidents, renderFooter, renderRegionRecommendation, renderShareButtons, renderPage, type ServiceData } from '../html-template'
+import { buildMetaDescription, renderIncidents, renderFooter, renderRegionRecommendation, renderComponents, renderShareButtons, renderPage, type ServiceData } from '../html-template'
 import type { ServiceSEO } from '../seo-content'
 import { SLUG_TO_SERVICE, RELATED_SLUGS } from '../slug-map'
 import type { RegionStatusResult } from '../region-status'
@@ -618,6 +618,77 @@ describe('renderRegionRecommendation', () => {
       recommendedRegion: usWest,
     })
     const html = renderRegionRecommendation(rec, 'pinecone')
+    expect(html).not.toContain('<img src=x')
+    expect(html).toContain('&lt;img src=x')
+  })
+})
+
+// ── renderComponents (#604 per-component breakdown) ──────────────────
+//
+// Contract: returns '' when no curated components present; otherwise emits a
+// self-contained card with one row per component (dot + name + status label),
+// left-border colored by whether any component is non-operational. SSR mirror of
+// the dashboard ServiceDetails ComponentBreakdown. esc() guards the page-supplied
+// component name; statusColor/statusLabel are exhaustive over the normalized union.
+
+describe('renderComponents (#604)', () => {
+  it('returns empty string when service is null', () => {
+    expect(renderComponents(null)).toBe('')
+  })
+
+  it('returns empty string when components is absent', () => {
+    expect(renderComponents(mkService())).toBe('')
+  })
+
+  it('returns empty string when components is an empty array', () => {
+    expect(renderComponents(mkService({ components: [] }))).toBe('')
+  })
+
+  it('renders one row per component with its status label', () => {
+    const html = renderComponents(mkService({
+      components: [
+        { id: 'a', name: 'IDE', status: 'operational' },
+        { id: 'b', name: 'Cloud Agents', status: 'degraded' },
+        { id: 'c', name: 'Automations', status: 'down' },
+      ],
+    }))
+    expect(html).toContain('Component Status')
+    expect(html).toContain('IDE')
+    expect(html).toContain('Cloud Agents')
+    expect(html).toContain('Automations')
+    expect(html).toContain('Operational')
+    expect(html).toContain('Degraded Performance')
+    expect(html).toContain('Down')
+  })
+
+  it('uses the green accent border when all components are operational', () => {
+    const html = renderComponents(mkService({
+      components: [
+        { id: 'a', name: 'IDE', status: 'operational' },
+        { id: 'b', name: 'CLI', status: 'operational' },
+      ],
+    }))
+    expect(html).toContain('border-left:3px solid #3fb950')
+    expect(html).not.toContain('border-left:3px solid #e86235')
+  })
+
+  it('flips the accent border to amber when any component is non-operational', () => {
+    const html = renderComponents(mkService({
+      components: [
+        { id: 'a', name: 'IDE', status: 'operational' },
+        { id: 'b', name: 'CLI', status: 'down' },
+      ],
+    }))
+    expect(html).toContain('border-left:3px solid #e86235')
+  })
+
+  it('escapes a component name containing HTML metacharacters (no injection)', () => {
+    const html = renderComponents(mkService({
+      components: [
+        { id: 'a', name: '<img src=x onerror=alert(1)>', status: 'operational' },
+        { id: 'b', name: 'CLI', status: 'operational' },
+      ],
+    }))
     expect(html).not.toContain('<img src=x')
     expect(html).toContain('&lt;img src=x')
   })

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -40,6 +40,9 @@ export interface ServiceData {
   rankTied?: boolean
   totalRanked?: number
   incidentSourceStale?: boolean
+  /** #604 — per-component snapshot for multi-component services. Curated subset preserved
+   *  by the worker (statusComponentIds), present only when ≥2 components matched. */
+  components?: Array<{ id: string; name: string; status: 'operational' | 'degraded' | 'down' }>
 }
 
 interface Fallback {
@@ -287,6 +290,7 @@ ${renderStatusHeader(service, seo)}
 ${renderCTA(seo, service?.status ?? 'operational', slug, service?.id ?? slug)}
 ${renderAIInsight(aiInsight, service?.status, fallbacks)}
 ${renderRegionRecommendation(regionRec ?? null, slug)}
+${renderComponents(service)}
 ${renderIncidents(service)}
 ${renderDescription(seo, service)}
 ${renderFAQ(seo, fallbacks)}
@@ -453,6 +457,28 @@ function renderStatusHeader(service: ServiceData | null, seo: ServiceSEO): strin
 ${lastIncident ? `<p class="meta">Last incident: ${esc(formatDate(lastIncident.startedAt))} &mdash; ${esc(lastIncident.title)}${lastIncident.duration ? ` (${esc(lastIncident.duration)})` : ' (ongoing)'}</p>` : '<p class="meta">No recent incidents</p>'}
 ${service.rank ? `<p class="meta">${esc(seo.displayName)} is ranked <strong>#${service.rank}${service.rankTied ? ' (tied)' : ''}</strong> of ${service.totalRanked} AI services by <a href="https://ai-watch.dev/#ranking" onclick="typeof gtag==='function'&&gtag('event','click_ranking',{location:'is_down_page',source:'header'})">AIWatch reliability score</a> &middot; <a href="${REPORTS_INDEX_HREF}" onclick="typeof gtag==='function'&&gtag('event','click_reports',{location:'is_down_page',source:'header'})">${REPORTS_INDEX_LABEL} &rarr;</a></p>` : ''}
 ${service.incidentSourceStale ? `<p class="meta" style="color:var(--amber)">⚠️ ${esc(seo.displayName)}'s status page moved to a source AIWatch can't reach, so its incident feed is frozen — uptime, score, and ranking are omitted until the source is reachable again. Live status above is still measured directly.</p>` : ''}
+</div>`
+}
+
+// #604 — per-component breakdown for multi-component services (cerebras / cursor /
+// copilot / windsurf / langsmith / runway). Reads service.components, the curated
+// statusComponentIds subset the worker preserves (worst-of'd into the headline status).
+// Matches StatusGator / IsDown per-component exposure. Absent for single-component services.
+export function renderComponents(service: ServiceData | null): string {
+  const components = service?.components
+  if (!components || components.length === 0) return ''
+  const anyIssue = components.some((c) => c.status !== 'operational')
+  const rows = components.map((c) => {
+    const color = statusColor(c.status)
+    return `<div style="display:flex;align-items:center;gap:8px;padding:4px 0">
+<span style="width:7px;height:7px;border-radius:50%;background:${color};flex-shrink:0"></span>
+<span class="mono" style="font-size:13px;color:#c9d1d9">${esc(c.name)}</span>
+<span class="mono" style="font-size:11px;color:${color};margin-left:auto">${esc(statusLabel(c.status))}</span>
+</div>`
+  }).join('')
+  return `<div class="card" style="border-left:3px solid ${anyIssue ? '#e86235' : '#3fb950'}">
+<div class="mono" style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:#8b949e;margin-bottom:10px">Component Status</div>
+${rows}
 </div>`
 }
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -8,7 +8,7 @@ All served by the Cloudflare Worker (`aiwatch-worker`, domain `aiwatch-worker.p2
 
 | Endpoint | Notes |
 |---|---|
-| `GET /api/status` | Live parallel fetch of all 36 services, normalize, KV write, platform/probe cross-validation |
+| `GET /api/status` | Live parallel fetch of all 36 services, normalize, KV write, platform/probe cross-validation. Multi-component services (cerebras/cursor/runway/langsmith/copilot/windsurf) carry a `components: {id,name,status}[]` snapshot (#604, the curated `statusComponentIds` subset; absent otherwise) for the per-component breakdown |
 | `GET /api/status/cached` | KV-only (no live fetch), includes `probe24h` — for "Is X Down" SSR + initial load. **`?src=statusline-*`** returns a ~KB id/name/status-only projection via `buildStatuslinePayload` (`worker/src/statusline.ts`) — skips the ~2 MB probe/latency/AI reads. Statusline snippets (#400) poll this with the tag and target the Worker domain directly, **not** the Vercel-proxied `ai-watch.dev` path, so per-prompt polls don't burn Vercel Fast Data Transfer (#438) |
 | `GET /api/uptime?days=30` | Daily uptime counters |
 | `GET /api/probe/history?days=30` | Daily probe RTT summaries (90d max) |

--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -13,6 +13,14 @@ Per-service status is resolved in `worker/src/services.ts` with this priority:
    - If 70%+ of services on the same platform (Atlassian/incident.io/etc.) fail simultaneously → platform outage → override all to `operational`
    - Conservative: only overrides when evidence is strong (≥2 recent probes healthy, or quorum failure detected)
 
+## Per-component snapshot — `resolveSvcComponents` (#604)
+
+`resolveSvcStatus` collapses the `statusComponentIds` subset into one worst-of badge and **discards** the per-component statuses. `resolveSvcComponents(config, summaryData)` is the **display counterpart**: it preserves the same matched subset as `ServiceComponent[]` (`{ id, name, status }`, normalized, in configured order) on `ServiceStatus.components`, so the ServiceDetails + "Is X Down" surfaces can render a per-component breakdown card (parity with StatusGator / IsDown).
+
+- **Self-gates to ≥2 matched** — returns `[]` (caller omits the field) for single-`statusComponentId` services, no `components` array, or when status-page drift leaves <2 of the configured ids resolving. A one-row breakdown is redundant with the badge, so the rule lives in the resolver (one consumer = the `components` field).
+- **Curated, not all** — only the configured `statusComponentIds` are surfaced (Billing/Support excluded, same scope as the badge). Currently 6 services qualify: cerebras, cursor, runway, langsmith, copilot, windsurf. Shared status pages (status.openai.com = API+ChatGPT+Codex; status.claude.com = API+claude.ai+Code) are intentionally **not** expanded via "all page components" — that would leak sibling-service components; a per-service curated allowlist is tracked in **#606**.
+- **Plumbing**: the field rides on the raw `ServiceStatus` → `cacheWrite` (`services:latest`) → `/api/status` (`...svc`) and `/api/status/cached` (`...svc`). No projection strips it; the `?src=statusline-*` lite path omits it (statusline only needs id/name/status). The Edge is-down SSR reads it from `/api/status/cached`.
+
 ## Status page URL selection
 
 `apiUrl` (the machine-readable fetch endpoint) and `statusUrl` (the human-facing link) can differ. When selecting `apiUrl`, **verify it is reachable from Cloudflare Workers** — some providers host their status page on a custom domain that blocks Workers IPs while the canonical Atlassian/incident.io host remains accessible.

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -201,6 +201,8 @@ const en = {
   'svc.cal.ago.suffix': 'ago',
   'svc.cal.today': 'Today',
   'svc.status.link': 'Official Status',
+  'svc.components.title': 'Component Status',
+  'svc.components.sub': 'Per-component breakdown from the official status page',
   'svc.deepseek.probeNote': 'Status page (Flashduty) not accessible outside China — monitoring via API probe only since May 2026',
   'svc.rss': 'RSS',
   'svc.rss.copied': 'Copied ✓',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -201,6 +201,8 @@ const ko = {
   'svc.cal.ago.suffix': '전',
   'svc.cal.today': '오늘',
   'svc.status.link': '공식 Status',
+  'svc.components.title': '구성요소 상태',
+  'svc.components.sub': '공식 상태 페이지의 구성요소별 상태',
   'svc.deepseek.probeNote': '상태 페이지(Flashduty)가 중국 외 IP에서 접근 불가 — 2026년 5월부터 API probe만으로 모니터링',
   'svc.rss': 'RSS',
   'svc.rss.copied': '복사됨 ✓',

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -376,6 +376,49 @@ const INCIDENT_DOT_COLOR = {
   incident: 'bg-[var(--red)]',
 }
 
+// #604 — per-component snapshot status colors (operational/degraded/down)
+const COMPONENT_DOT_COLOR = {
+  operational: 'bg-[var(--green)]',
+  degraded: 'bg-[var(--amber)]',
+  down: 'bg-[var(--red)]',
+}
+const COMPONENT_TEXT_COLOR = {
+  operational: 'text-[var(--green)]',
+  degraded: 'text-[var(--amber)]',
+  down: 'text-[var(--red)]',
+}
+
+// #604 — per-component breakdown for multi-component services (cerebras / cursor /
+// copilot / windsurf / langsmith / runway). Reads service.components, the curated
+// statusComponentIds subset preserved by the worker (worst-of'd into the badge).
+function ComponentBreakdown({ service, t }) {
+  const components = service.components ?? []
+  if (components.length === 0) return null
+  const anyIssue = components.some((c) => c.status !== 'operational')
+  return (
+    <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
+      <div className="border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
+        <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
+          <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: anyIssue ? 'var(--amber)' : 'var(--green)' }} />
+          {t('svc.components.title')}
+          <span className="text-[var(--text2)] font-normal normal-case tracking-normal">— {t('svc.components.sub')}</span>
+        </div>
+      </div>
+      <div style={{ padding: '16px' }}>
+        <div className="flex flex-col" style={{ gap: '8px' }}>
+          {components.map((c) => (
+            <div key={c.id} className="flex items-center gap-2">
+              <span className={`rounded-full shrink-0 ${COMPONENT_DOT_COLOR[c.status] ?? COMPONENT_DOT_COLOR.operational}`} style={{ width: '6px', height: '6px' }} />
+              <span className="mono text-xs text-[var(--text1)]">{c.name}</span>
+              <span className={`mono text-[10px] ml-auto ${COMPONENT_TEXT_COLOR[c.status] ?? COMPONENT_TEXT_COLOR.operational}`}>{t(`status.${c.status}`)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function RegionalAvailability({ service, t }) {
   try {
     const state = regionStatusOf(service)
@@ -812,6 +855,11 @@ export default function ServiceDetails({ serviceId }) {
 
       {/* ── Regional Availability (only for services with defined regions) ── */}
       {SERVICE_REGIONS[service.id] && <RegionalAvailability service={service} t={t} />}
+
+      {/* ── Per-component breakdown (#604) — grouped with the Region card (same
+          per-dimension status pattern) in the drill-down zone, right before the
+          incident history block ── */}
+      <ComponentBreakdown service={service} t={t} />
 
       {/* ── Bottom: Incident History + Calendar (2-col on desktop) ── */}
       <div className="grid grid-cols-1 lg:grid-cols-2" style={{ gap: '10px' }}>

--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { normalizeStatus } from '../parsers/statuspage'
-import { filterIncidents, SERVICES, worstStatus, resolveSvcStatus } from '../services'
+import { filterIncidents, SERVICES, worstStatus, resolveSvcStatus, resolveSvcComponents } from '../services'
 import type { Incident, ServiceConfig } from '../types'
 import { type KVLike } from '../utils'
 
@@ -243,6 +243,83 @@ describe('worstStatus helper (#379)', () => {
   })
   it('handles single-element list', () => {
     expect(worstStatus(['degraded'])).toBe('degraded')
+  })
+})
+
+describe('resolveSvcComponents — per-component snapshot (#604)', () => {
+  const config: StatusConfig = {
+    statusComponentId: 'ide',
+    statusComponentIds: ['ide', 'cloud-agents', 'automations'],
+  }
+
+  it('returns the matched subset in configured order, normalized', () => {
+    const summary: SummaryData = {
+      status: { indicator: 'minor' },
+      components: [
+        { id: 'cloud-agents', name: 'Cloud Agents', status: 'partial_outage' }, // page order differs
+        { id: 'ide', name: 'IDE', status: 'operational' },
+        { id: 'automations', name: 'Automations', status: 'major_outage' },
+        { id: 'marketplace', name: 'Marketplace', status: 'operational' }, // untracked — excluded
+      ],
+    }
+    expect(resolveSvcComponents(config, summary)).toEqual([
+      { id: 'ide', name: 'IDE', status: 'operational' },
+      { id: 'cloud-agents', name: 'Cloud Agents', status: 'degraded' },
+      { id: 'automations', name: 'Automations', status: 'down' },
+    ])
+  })
+
+  it('omits ids that drifted out of the page but keeps the rest (still ≥2)', () => {
+    const summary: SummaryData = {
+      status: { indicator: 'minor' },
+      components: [
+        { id: 'ide', name: 'IDE', status: 'operational' },
+        { id: 'cloud-agents', name: 'Cloud Agents', status: 'partial_outage' },
+        // 'automations' missing
+      ],
+    }
+    expect(resolveSvcComponents(config, summary)).toEqual([
+      { id: 'ide', name: 'IDE', status: 'operational' },
+      { id: 'cloud-agents', name: 'Cloud Agents', status: 'degraded' },
+    ])
+  })
+
+  it('self-gates to [] when drift leaves only ONE matched id (a 1-row breakdown is redundant with the badge)', () => {
+    // 3 ids configured, but only 'ide' survives on the page → the ≥2 display gate suppresses the field.
+    const summary: SummaryData = {
+      status: { indicator: 'minor' },
+      components: [{ id: 'ide', name: 'IDE', status: 'operational' }],
+    }
+    expect(resolveSvcComponents(config, summary)).toEqual([])
+  })
+
+  it('returns [] for single-component services (no statusComponentIds) — redundant with the badge', () => {
+    const single: StatusConfig = { statusComponentId: 'api' }
+    const summary: SummaryData = {
+      status: { indicator: 'none' },
+      components: [{ id: 'api', name: 'API', status: 'operational' }],
+    }
+    expect(resolveSvcComponents(single, summary)).toEqual([])
+  })
+
+  it('returns [] when statusComponentIds is empty', () => {
+    const summary: SummaryData = {
+      status: { indicator: 'none' },
+      components: [{ id: 'ide', name: 'IDE', status: 'operational' }],
+    }
+    expect(resolveSvcComponents({ statusComponentIds: [] }, summary)).toEqual([])
+  })
+
+  it('returns [] when the page exposes no components array', () => {
+    expect(resolveSvcComponents(config, { status: { indicator: 'none' } })).toEqual([])
+  })
+
+  it('returns [] when none of the configured ids resolve (full drift)', () => {
+    const summary: SummaryData = {
+      status: { indicator: 'minor' },
+      components: [{ id: 'renamed-1', name: 'Renamed', status: 'operational' }],
+    }
+    expect(resolveSvcComponents(config, summary)).toEqual([])
   })
 })
 

--- a/worker/src/parsers/statuspage.ts
+++ b/worker/src/parsers/statuspage.ts
@@ -6,7 +6,10 @@ import { MAJOR_WEIGHT, MINOR_WEIGHT } from './impact-weights'
 
 export interface StatuspageResponse {
   status: { indicator: string; description: string }
-  components?: Array<{ name: string; status: string }>
+  // `id` is the Atlassian component UUID — read by resolveSvcStatus / resolveSvcComponents
+  // (#379, #604) for statusComponentIds matching. Present in every real summary.json
+  // component; declared here so those id-based lookups are type-sound.
+  components?: Array<{ id: string; name: string; status: string }>
   incidents?: Array<{
     id: string
     name: string

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -1,6 +1,6 @@
 // Service status fetching and parsing for all monitored AI services.
 
-import type { Incident, ServiceStatus, ServiceConfig, DailyImpactLevel } from './types'
+import type { Incident, ServiceStatus, ServiceComponent, ServiceConfig, DailyImpactLevel } from './types'
 export type { ServiceStatus } from './types'
 import { fetchWithTimeout, formatDuration, trackFetchFailure, resetFetchFailure, trackComponentMiss, resetComponentMiss, kvPut } from './utils'
 import { isProbeHealthy, type ProbeSnapshot } from './probe'
@@ -253,6 +253,36 @@ export function resolveSvcStatus(
     ? summaryData.components?.find((c) => c.name.startsWith(config.statusComponent!))
     : summaryData.components?.find((c) => c.id === config.statusComponentId)
   return comp ? normalizeStatus(comp.status) : overall
+}
+
+/**
+ * Resolve the curated per-component snapshot for the #604 breakdown — the *display*
+ * counterpart to the worst-of: `resolveSvcStatus` collapses the `statusComponentIds`
+ * subset into one badge; this preserves each matched component (same availability-relevant
+ * set) with its own normalized status, in the configured order.
+ *
+ * Self-gates to the display rule: returns the matched subset ONLY when **≥2** components
+ * resolve, else `[]`. A single row is redundant with the badge, so the ≥2 gate lives
+ * here (not at the caller) — there is exactly one consumer (the `components` field), so
+ * folding the rule in keeps it a single pure, fully-testable unit.
+ *
+ * Returns `[]` when: no `statusComponentIds` multi-component config, no page `components`,
+ * fewer than 2 of the configured ids resolve (incl. status-page drift that leaves 1), or
+ * none resolve. Single-`statusComponentId` services are never expanded.
+ */
+export function resolveSvcComponents(
+  config: StatusResolverConfig,
+  summaryData: StatusResolverSummary,
+): ServiceComponent[] {
+  if (!config.statusComponentIds || config.statusComponentIds.length === 0 || !summaryData.components) {
+    return []
+  }
+  const matched = config.statusComponentIds
+    .map((id) => summaryData.components!.find((c) => c.id === id))
+    .filter((c): c is NonNullable<typeof c> => c != null)
+    .map((c) => ({ id: c.id, name: c.name, status: normalizeStatus(c.status) }))
+  // ≥2 only — a one-row breakdown adds nothing the badge doesn't already say.
+  return matched.length >= 2 ? matched : []
 }
 
 export function filterIncidents(incidents: Incident[], config: ServiceConfig): Incident[] {
@@ -547,11 +577,16 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         await resetFetchFailure(kv, config.id)
       }
 
+      // #604 — preserve the curated per-component snapshot for the breakdown UI.
+      // resolveSvcComponents self-gates to ≥2 matched (a single component is redundant with the badge).
+      const components = resolveSvcComponents(config, summaryData)
+
       return {
         ...base,
         status: svcStatus,
         latency: config.category === 'api' ? latency : null,
         incidents: filtered,
+        ...(components.length > 0 ? { components } : {}),
         ...(Object.keys(augmentedImpact).length > 0 ? { dailyImpact: augmentedImpact } : {}),
         calendarDays: config.statusComponentId ? 30 : 14,
         ...(uptimeValue != null ? { uptime30d: uptimeValue, uptimeSource: uptimeSrc } : {}),

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -18,6 +18,15 @@ export interface Incident {
   timeline: TimelineEntry[]
 }
 
+/** A single status-page component preserved for the per-component breakdown (#604).
+ *  Only the availability-relevant subset configured via `statusComponentIds` is kept —
+ *  Billing/Support etc. are intentionally excluded to match the badge's curated scope. */
+export interface ServiceComponent {
+  id: string
+  name: string
+  status: 'operational' | 'degraded' | 'down'
+}
+
 export interface ServiceStatus {
   id: string
   name: string
@@ -28,6 +37,11 @@ export interface ServiceStatus {
   uptime30d: number | null
   lastChecked: string
   incidents: Incident[]
+  /** #604 — per-component snapshot for multi-component services (cerebras / cursor /
+   *  copilot / windsurf / langsmith / runway). The curated `statusComponentIds` subset,
+   *  worst-of'd into `status` above but retained here for the ServiceDetails / is-down
+   *  breakdown. Present only when ≥2 components matched; absent otherwise. */
+  components?: ServiceComponent[]
   dailyImpact?: Record<string, DailyImpactLevel>
   calendarDays?: number
   uptimeSource?: 'official' | 'platform_avg' | 'estimate'


### PR DESCRIPTION
## Summary
Surfaces a **per-component status breakdown** on the dashboard ServiceDetails and the "Is X Down" SSR pages — parity with StatusGator / IsDown. Implements the **snapshot** half of #604 (curated subset); historical accumulation stays in #605.

`resolveSvcStatus` collapses a service's `statusComponentIds` into one worst-of badge and discards the per-component statuses. New `resolveSvcComponents()` preserves that matched subset as `ServiceStatus.components` (`{id,name,status}[]`, normalized, configured order) for display.

**6 multi-component services qualify**: cerebras, cursor, runway, langsmith, copilot, windsurf. Self-gated to **≥2 matched** (a 1-row card is redundant with the badge).

## Design decisions
- **Curated, not all** — only the configured `statusComponentIds` (Billing/Support excluded, same scope as the badge). Shared status pages (`status.openai.com` = API+ChatGPT+Codex; `status.claude.com` = API+claude.ai+Code) are intentionally **not** expanded via "all components" — that would leak sibling-service components. Broader coverage (incl. easy single-owner statuspages cohere/groq/elevenlabs/replicate) tracked in **#606**.
- **Placement** — the card sits in the drill-down zone next to the Region card (its per-dimension-status twin), right before the Incident History block, on both surfaces.

## Changes
- **worker** — `resolveSvcComponents()` + `ServiceStatus.components` (`worker/src/services.ts`, `types.ts`). Flows through `/api/status` + `/api/status/cached` via the full-`svc` spread; no projection strips it (statusline lite path omits it by design).
- **statuspage.ts** — added `id` to `StatuspageResponse.components`, type-sounding the id-based resolver lookups (clears 6 pre-existing `services.ts` tsc errors, adds 0).
- **dashboard** — `ComponentBreakdown` card (design tokens only), i18n ko/en.
- **is-down** — `renderComponents()` (exported + unit-tested), `ServiceData.components` (union-typed).
- **docs** — status-determination.md, api-endpoints.md, CLAUDE.md.

## Tests / gates
- worker 1609 · is-down api 62 · src 391 · Playwright e2e 127 · typecheck (TS2304) clean · build OK · worker dry-run OK
- New: `resolveSvcComponents` (ordering/normalize/partial-drift/≥2 self-gate/empty paths) + `renderComponents` (empty contract / render / accent-color branch / `esc()` injection guard)

## Verification
- Local in-browser confirmed (dashboard + is-down) on real multi-component data; degraded/down colors eyeballed via a temp injection (reverted).
- **`refs #604` (not `closes`)** — the is-X-down real-data render is **deploy-gated** (worker not yet deployed). Close after `npm run deploy:worker` + prod check.

## PR review
2 rounds → **0 Critical / 0 Important** (Suggestions-only). Fixed: ≥2 gate folded into resolver + tested, `renderComponents` exported + tested, `StatuspageResponse.components` type-soundness, Edge mirrors narrowed to the status union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)