### PR TITLE
docs(readme): add component status breakdown to the feature list (refs #606)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -38,6 +38,7 @@
 - **24시간 지연시간 추세** — Chart.js 라인 차트 (5분 간격 probe 스냅샷)
 - **인시던트 이력** — 다양한 상태 페이지 형식의 타임라인 상세 정보
 - **공식 가동률** — Statuspage, incident.io, Better Stack에서 컴포넌트별 가동률
+- **구성요소 상태 분해** — 24개 멀티컴포넌트 서비스의 서비스별 상세 + Is X Down에 구성요소별(모델·API 표면 등) 실시간 상태 표시. 많으면 섹션/모델 그룹으로 접힘
 - **상태 캘린더** — 30일(Statuspage) 또는 14일(incident.io) 일별 상태 시각화
 - **Discord & Slack 알림** — 상태 변경/인시던트 Discord Webhook + Slack 내장 `/feed` RSS 앱(설정 0) + RSS 피드
 - **쿠키 동의** — GA4 Consent Mode v2 (동의/필수만)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 - **24h latency trend** — Chart.js line chart with 5-min probe snapshots
 - **Incident history** — Timeline with details from multiple status page formats
 - **Official uptime** — Per-component uptime from Statuspage, incident.io, Better Stack
+- **Component status breakdown** — Real-time per-component status (models, API surfaces, …) on ServiceDetails + Is X Down for 24 multi-component services, with collapsible section/model groups for long lists
 - **Status calendar** — 30-day (Statuspage) or 14-day (incident.io) daily status visualization
 - **Discord & Slack alerts** — Discord webhook on status changes/incidents + Slack via its native `/feed` RSS app (zero-config) + RSS feeds
 - **Cookie consent** — GA4 Consent Mode v2 with accept/essential-only


### PR DESCRIPTION
## Summary
Adds the **component status breakdown** feature (shipped across #609/#610/#611/#612) to the EN + KO README feature lists. It was missing — only "per-component uptime" was documented, not the new real-time per-component status card.

## Change
One line in `README.md` + `README.ko.md` (Features section), no competitor references.

Docs-only; no code, no tests affected.

refs #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)