### PR TITLE
feat(status): accumulate per-component daily uptime — #605 Phase 1 (refs #605)

### DIFF
--- a/docs/reference/adding-a-service.md
+++ b/docs/reference/adding-a-service.md
@@ -12,6 +12,13 @@ When adding a new monitored service, update ALL of the following:
    curl -sf --max-time 5 "{apiUrl}" -o /dev/null && echo "OK" || echo "BLOCKED — check .statuspage.io mirror"
    ```
    For Atlassian Statuspage services, if the custom domain is blocked, use `https://{slug}.statuspage.io/api/v2/summary.json` instead. Confirm `statusComponentId` resolves on the chosen endpoint. See `docs/reference/status-determination.md` § "Status page URL selection".
+
+   **Per-component breakdown (#606, optional but check it)** — if the status page exposes **≥2 availability-relevant components**, configure a display-only breakdown (the badge is unaffected; `resolveSvcStatus` never reads these). Pick the right mechanism — full rules in `docs/reference/status-determination.md` § "Per-component snapshot":
+   - **Curated allowlist** → `displayComponentIds: [ids]` (a few stable surfaces; e.g. elevenlabs, replicate, assemblyai).
+   - **Per-model / many churny components** → `displayAllComponents: true` + `componentDenylist: ['Docs','Website',…]` + `componentSurfaces: [names]` (surfaces stay individual; the rest fold into a collapsible "Models" group; e.g. cohere, groq).
+   - **Shared status page** (multiple AIWatch services on one page, e.g. status.openai.com) → per-service `displayComponentIds` matching the official groups, **disjoint across the sibling services** (add a LEAK-GUARD test); set `componentsUrl` (components.json) if summary.json omits some.
+   - **BetterStack page** → no config beyond `componentDenylist: ['Website']`; `parseBetterStackComponents` extracts the breakdown from `index.json` (grouped by section).
+   - Skip when the service maps to a single component (≥2 gate suppresses it) or its components are regions already on the Region card (configure `SERVICE_REGIONS` instead). Add a config-sanity test (count + badge-unchanged + disjointness) like the existing `#606` ones in `status-determination.test.ts`.
 2. `worker/src/probe.ts` — add `ProbeTarget` if API endpoint exists for RTT measurement
 3. `worker/src/fallback.ts` — update ALL of:
    - `EXCLUDE_FALLBACK` — remove if fallback-eligible

--- a/worker/src/__tests__/per-component-accumulation.test.ts
+++ b/worker/src/__tests__/per-component-accumulation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { accumulateComponentCounters } from '../index'
+
+// #605 — per-component daily uptime accumulation (rides the daily:{date} value).
+
+describe('accumulateComponentCounters (#605)', () => {
+  it('accumulates ok/total per component across cycles; ok only on operational', () => {
+    const entry: { ok: number; total: number; components?: Record<string, { ok: number; total: number; name: string }> } = { ok: 0, total: 0 }
+    // cycle 1: both operational
+    accumulateComponentCounters(entry, [
+      { id: 'api', name: 'API', status: 'operational' },
+      { id: 'm1', name: 'Model 1', status: 'operational' },
+    ])
+    // cycle 2: m1 degraded
+    accumulateComponentCounters(entry, [
+      { id: 'api', name: 'API', status: 'operational' },
+      { id: 'm1', name: 'Model 1', status: 'degraded' },
+    ])
+    expect(entry.components).toEqual({
+      api: { ok: 2, total: 2, name: 'API' },
+      m1: { ok: 1, total: 2, name: 'Model 1' }, // down 1 of 2 cycles
+    })
+  })
+
+  it('is a no-op when the service has no components', () => {
+    const entry: { ok: number; total: number; components?: Record<string, unknown> } = { ok: 5, total: 5 }
+    accumulateComponentCounters(entry, undefined)
+    accumulateComponentCounters(entry, [])
+    expect(entry.components).toBeUndefined()
+  })
+
+  it('keeps the latest display name when a component is renamed', () => {
+    const entry: { ok: number; total: number; components?: Record<string, { ok: number; total: number; name: string }> } = { ok: 0, total: 0 }
+    accumulateComponentCounters(entry, [{ id: 'x', name: 'Old Name', status: 'operational' }])
+    accumulateComponentCounters(entry, [{ id: 'x', name: 'New Name', status: 'operational' }])
+    expect(entry.components!.x).toEqual({ ok: 2, total: 2, name: 'New Name' })
+  })
+
+  it('a new component appearing mid-day starts its own counter (total tracks since first seen)', () => {
+    const entry: { ok: number; total: number; components?: Record<string, { ok: number; total: number; name: string }> } = { ok: 0, total: 0 }
+    accumulateComponentCounters(entry, [{ id: 'a', name: 'A', status: 'operational' }])
+    accumulateComponentCounters(entry, [
+      { id: 'a', name: 'A', status: 'operational' },
+      { id: 'b', name: 'B', status: 'down' },
+    ])
+    expect(entry.components).toEqual({
+      a: { ok: 2, total: 2, name: 'A' },
+      b: { ok: 0, total: 1, name: 'B' }, // appeared on cycle 2 only
+    })
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -86,7 +86,33 @@ function overRateLimit(map: Map<string, { start: number; count: number }>, ip: s
 }
 
 interface DailyCounters {
-  [serviceId: string]: { ok: number; total: number; officialUptime?: number | null }
+  [serviceId: string]: {
+    ok: number
+    total: number
+    officialUptime?: number | null
+    // #605 — per-component daily uptime accumulation. Same {ok,total} cadence as the service,
+    // keyed by component id (+ name for display). Populated from ServiceStatus.components (#604/#606).
+    // Rides the existing `daily:{date}` value (+0 KV writes); the monthly archive aggregates it.
+    components?: Record<string, { ok: number; total: number; name: string }>
+  }
+}
+
+/** #605 — accumulate per-component daily uptime into a service's counter entry (mutates `entry`).
+ *  Mirrors the per-service ok/total cadence; keyed by component id, with the latest display name.
+ *  No-op when the service has no breakdown. The monthly archive aggregates these into per-component
+ *  uptime% for the report (component-level reliability rankings). */
+export function accumulateComponentCounters(
+  entry: DailyCounters[string],
+  components: ReadonlyArray<{ id: string; name: string; status: string }> | undefined,
+): void {
+  if (!components || components.length === 0) return
+  const comps = (entry.components ??= {})
+  for (const c of components) {
+    const cc = (comps[c.id] ??= { ok: 0, total: 0, name: c.name })
+    cc.total++
+    if (c.status === 'operational') cc.ok++
+    cc.name = c.name // keep the latest display name (status pages rename components)
+  }
 }
 
 function todayUTC(): string {
@@ -119,6 +145,8 @@ async function cacheWrite(kv: KVNamespace, services: ServiceStatus[], discordUrl
     // "Official Uptime" display number, so it stays month-accurate and survives a later rebuild
     // (unlike a one-shot snapshot taken only at build time).
     counters[s.id].officialUptime = s.uptime30d ?? null
+    // #605 — accumulate per-component uptime (same cadence) for services with a breakdown.
+    accumulateComponentCounters(counters[s.id], s.components)
   })
 
   // Write cache + daily counters (2 writes per interval)

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -392,6 +392,10 @@ export function parseDurationMin(d: string): number {
 
 // ── Uptime / Latency computation ─────────────────────────────────────
 
+// #605 — the live daily:{date} value now also carries `components?: Record<compId,{ok,total,name}>`
+// (index.ts accumulateComponentCounters). This narrower local type is a compile-time view only —
+// JSON.parse preserves the field at runtime, so the #605 Phase 2 per-component monthly aggregator
+// can widen this type and read `components` without a data migration.
 type DailyCounters = Record<string, { ok: number; total: number; officialUptime?: number | null }>
 
 /** #586 — per-service "Official Uptime" for the month: the status-page rolling-30d value as of the


### PR DESCRIPTION
## Summary
**#605 Phase 1** — start accumulating per-component daily uptime, the foundation for per-component monthly **report content** (component-level reliability rankings). The live snapshot (#604/#606) doesn't feed the historical report, so the data must accumulate over time — landing now so the first month has data.

## Change
- `DailyCounters[svcId]` gains `components?: {compId:{ok,total,name}}`. New pure **`accumulateComponentCounters(entry, components)`** mirrors the per-service `ok/total` cadence (total++ each cycle, ok++ on operational, keeps latest name), called in `cacheWrite` with `ServiceStatus.components`. No-op for non-breakdown services.
- **Rides the existing `daily:{date}` value** (rewritten, not appended) → **+0 KV writes**; value grows ~5-8 KB (≪ 25 MB limit). `history:{date}` rollover copies it verbatim; nothing strips it.
- `monthly-archive.ts`: forward note that its local `DailyCounters` type is compile-time-only — Phase 2 widens it to read `components` (no data migration).

## Tests / gates
worker **1635** · typecheck (TS2304) clean · dry-run OK. Unit tests: accumulate-across-cycles / ok-only-on-operational / no-op / rename-keeps-latest / mid-day-add.

## Verification (UI-less backend)
No browser surface — per-component data is internal KV state until Phase 3 (report). Verified by the pure-function unit tests + the type-checked one-line wiring into the established `cacheWrite` daily-counter site.

## PR review
1 round → 0 Critical/Important.

## Follow-up (this issue stays open)
- **Phase 2** — per-component monthly aggregation in `monthly-archive.ts` (`MonthlyServiceData.components`).
- **Phase 3** — `/api/report` + the aiwatch-reports generator "Component reliability" table. **Time-gated: needs ~1 month of accumulated data.**

Also includes `docs/adding-a-service`: a "Per-component breakdown (#606)" sub-step for new services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)