### PR TITLE
feat(status): per-component monthly uptime in the archive — #605 Phase 2 (refs #605)

### DIFF
--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   computeMonthlyUptime,
+  computeMonthlyComponentUptime,
   computeMonthlyOfficialUptime,
   computeMonthlyLatency,
   computeMonthlyLatencyStats,
@@ -110,6 +111,59 @@ describe('computeMonthlyUptime', () => {
   it('returns 0 for total=0', () => {
     const dailyData = { '2026-03-01': { claude: { ok: 0, total: 0 } } }
     expect(computeMonthlyUptime(dailyData).claude).toBe(0)
+  })
+})
+
+// ── computeMonthlyComponentUptime (#605 Phase 2) ─────────────────────
+describe('computeMonthlyComponentUptime (#605)', () => {
+  it('aggregates per-component uptime across days, sorted least-reliable first', () => {
+    const daily = {
+      '2026-06-01': { openai: { ok: 288, total: 288, components: {
+        api: { ok: 288, total: 288, name: 'API' },
+        batch: { ok: 280, total: 288, name: 'Batch' },
+      } } },
+      '2026-06-02': { openai: { ok: 288, total: 288, components: {
+        api: { ok: 288, total: 288, name: 'API' },
+        batch: { ok: 288, total: 288, name: 'Batch' }, // batch recovered
+      } } },
+    }
+    const r = computeMonthlyComponentUptime(daily)
+    expect(r.openai).toEqual([
+      { id: 'batch', name: 'Batch', uptime: 98.61 }, // (280+288)/(288+288) → least reliable first
+      { id: 'api', name: 'API', uptime: 100 },
+    ])
+  })
+
+  it('omits services with no per-component data, and keeps the latest component name', () => {
+    const daily = {
+      '2026-06-01': {
+        claude: { ok: 288, total: 288 }, // no components → omitted
+        cohere: { ok: 288, total: 288, components: { m1: { ok: 288, total: 288, name: 'old-model' }, m2: { ok: 288, total: 288, name: 'Coral' } } },
+      },
+      '2026-06-02': { cohere: { ok: 288, total: 288, components: { m1: { ok: 288, total: 288, name: 'new-model' }, m2: { ok: 288, total: 288, name: 'Coral' } } } },
+    }
+    const r = computeMonthlyComponentUptime(daily)
+    expect(r.claude).toBeUndefined()
+    expect(r.cohere.find(c => c.id === 'm1')!.name).toBe('new-model') // latest name
+    expect(r.cohere).toHaveLength(2)
+  })
+
+  it('breaks equal-uptime ties by name (ascending), and drops zero-sample components', () => {
+    const daily = {
+      '2026-06-01': { svc: { ok: 288, total: 288, components: {
+        z: { ok: 288, total: 288, name: 'Zebra' },   // 100%
+        a: { ok: 288, total: 288, name: 'Apple' },    // 100% — ties with Zebra → name asc
+        n: { ok: 0, total: 0, name: 'NoSamples' },    // zero-sample → dropped
+      } } },
+    }
+    expect(computeMonthlyComponentUptime(daily).svc).toEqual([
+      { id: 'a', name: 'Apple', uptime: 100 },
+      { id: 'z', name: 'Zebra', uptime: 100 },
+    ])
+  })
+
+  it('returns {} for empty data', () => {
+    expect(computeMonthlyComponentUptime({})).toEqual({})
   })
 })
 

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -54,6 +54,11 @@ export interface MonthlyServiceData {
   // when this archive was built. The report generator excludes such services from the Score ranking
   // (their empty incident window would inflate the Score). Absent when false / pre-#591 archives.
   incidentSourceStale?: boolean
+  // #605 Phase 2 — per-component monthly uptime% (from the accumulated daily component counters),
+  // sorted least-reliable first. Present only for multi-component services with accumulated data;
+  // absent for single-component services and pre-#605 archives. Feeds the report's per-component
+  // reliability table / "weakest component this month" ranking (Phase 3).
+  components?: Array<{ id: string; name: string; uptime: number }>
 }
 
 export interface MonthlyArchive {
@@ -392,11 +397,14 @@ export function parseDurationMin(d: string): number {
 
 // ── Uptime / Latency computation ─────────────────────────────────────
 
-// #605 — the live daily:{date} value now also carries `components?: Record<compId,{ok,total,name}>`
-// (index.ts accumulateComponentCounters). This narrower local type is a compile-time view only —
-// JSON.parse preserves the field at runtime, so the #605 Phase 2 per-component monthly aggregator
-// can widen this type and read `components` without a data migration.
-type DailyCounters = Record<string, { ok: number; total: number; officialUptime?: number | null }>
+// #605 — the live daily:{date} value also carries per-component daily counters (index.ts
+// accumulateComponentCounters); Phase 2 reads them into per-component monthly uptime.
+type DailyCounters = Record<string, {
+  ok: number
+  total: number
+  officialUptime?: number | null
+  components?: Record<string, { ok: number; total: number; name: string }>
+}>
 
 /** #586 — per-service "Official Uptime" for the month: the status-page rolling-30d value as of the
  *  LATEST day in the window (≈ the month, since uptime30d trails 30 days). Reads the per-cycle daily
@@ -430,6 +438,39 @@ export function computeMonthlyUptime(
   const result: Record<string, number> = {}
   for (const [id, { ok, total }] of Object.entries(totals)) {
     result[id] = total > 0 ? Math.round((ok / total) * 10000) / 100 : 0
+  }
+  return result
+}
+
+/** #605 Phase 2 — per-component monthly uptime%, per service, from the accumulated daily
+ *  component counters. Sorted **least-reliable first** (the report's "which component was the
+ *  weakest link this month" angle). Services with no per-component data are omitted. */
+export function computeMonthlyComponentUptime(
+  dailyData: Record<string, DailyCounters>,
+): Record<string, Array<{ id: string; name: string; uptime: number }>> {
+  // svcId → compId → accumulated {ok,total,name}
+  const totals: Record<string, Record<string, { ok: number; total: number; name: string }>> = {}
+  for (const counters of Object.values(dailyData)) {
+    for (const [svcId, entry] of Object.entries(counters)) {
+      if (!entry.components) continue
+      const svc = (totals[svcId] ??= {})
+      for (const [compId, c] of Object.entries(entry.components)) {
+        const cc = (svc[compId] ??= { ok: 0, total: 0, name: c.name })
+        cc.ok += c.ok
+        cc.total += c.total
+        cc.name = c.name // latest display name
+      }
+    }
+  }
+  const result: Record<string, Array<{ id: string; name: string; uptime: number }>> = {}
+  for (const [svcId, comps] of Object.entries(totals)) {
+    const arr = Object.entries(comps)
+      // Drop zero-sample components (unlike computeMonthlyUptime's `total===0 → 0`): a component with
+      // no samples shouldn't appear as a misleading 0% in the "weakest component" table.
+      .filter(([, c]) => c.total > 0)
+      .map(([id, c]) => ({ id, name: c.name, uptime: Math.round((c.ok / c.total) * 10000) / 100 }))
+      .sort((a, b) => a.uptime - b.uptime || a.name.localeCompare(b.name)) // ties → name asc (stable)
+    if (arr.length > 0) result[svcId] = arr
   }
   return result
 }
@@ -761,6 +802,7 @@ export async function buildMonthlyArchive(
   }
 
   const uptimeMap = computeMonthlyUptime(dailyData)
+  const componentUptimeMap = computeMonthlyComponentUptime(dailyData) // #605 Phase 2 — per-component monthly uptime
   const officialUptimeMap = computeMonthlyOfficialUptime(dailyData) // #586 — month-end status-page value per service
   const latencyMap = computeMonthlyLatency(probeData)
   const latencyStats = computeMonthlyLatencyStats(probeData) // p95 + spikes (#17)
@@ -818,6 +860,7 @@ export async function buildMonthlyArchive(
       latencySpikes: latencyStats[id]?.spikes ?? null,
       ...(incidentList ? { incidentList } : {}),
       ...(scoreSvc?.incidentSourceStale ? { incidentSourceStale: true } : {}),
+      ...(componentUptimeMap[id] ? { components: componentUptimeMap[id] } : {}), // #605 Phase 2
     }
   }
 


### PR DESCRIPTION
## Summary
**#605 Phase 2** — aggregate the Phase 1 daily per-component counters (#614) into the **permanent monthly archive**, so the report (Phase 3) can render a per-component reliability table / "weakest component this month" ranking.

## Change (worker/src/monthly-archive.ts)
- **`computeMonthlyComponentUptime(dailyData)`** → per service, an array of `{id,name,uptime}` sorted **least-reliable first** (ties → name asc). Zero-sample components dropped; latest display name kept; services with no per-component data omitted.
- `MonthlyServiceData` gains `components?`; `buildMonthlyArchive` spreads it onto each entry **only when present** (single-component + pre-#605 archives omit it).
- Local `DailyCounters` type widened to read `components` (runtime data already present from Phase 1 — no migration). ~8 KB added per archive worst-case — bounded, 1 write/month.

## Tests / gates
worker **1638** (monthly-archive 132) · typecheck (TS2304) clean · dry-run OK. Unit tests: cross-day aggregation + least-reliable sort · omit-no-data + latest-name · equal-uptime tie-break by name + zero-sample drop · empty data.

## Verification (UI-less backend)
No browser surface — archive content is internal until Phase 3 (report). Verified by the pure-function unit tests + the type-checked conditional attach in `buildMonthlyArchive`. Past months / the pre-deploy current-month partial degrade gracefully to "only the days that had data" (omitted when none).

## PR review
1 round → 0 Critical/Important.

## Follow-up
- **Phase 3** — `/api/report` already serializes the archive (so `components` flows automatically); the **aiwatch-reports generator** renders a "Component reliability" table. **Time-gated: needs ~1 month of accumulated per-component data** (Phase 1 deployed 2026-06-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)