### PR TITLE
fix(fallback): exclude stale-source services from fallback recommendations (refs #616)

### DIFF
--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -188,8 +188,10 @@ export default async function handler(req: Request) {
           const sourceTier = tierFor(entry.id)
           fallbacks = allServices
             // #550 — exclude candidates with an unresolved incident even if status is still 'operational'.
+            // #616 — exclude stale-source services (#591): ranking-excluded → not a trusted fallback either.
             .filter(s => s.category === entry.category && s.id !== entry.id && s.status === 'operational'
               && !(s.incidents ?? []).some(i => (i as { status?: string }).status !== 'resolved')
+              && !s.incidentSourceStale
               && !EXCLUDE_FALLBACK.includes(s.id))
             .sort((a, b) => {
               const distA = Math.abs(tierFor(a.id) - sourceTier)

--- a/src/utils/__tests__/constants.test.js
+++ b/src/utils/__tests__/constants.test.js
@@ -187,6 +187,17 @@ describe('hasActiveIncident / getFallbacks active-incident exclusion (#550)', ()
     expect(ids).toContain('codex')
   })
 
+  it('#616 — excludes a stale-source candidate (incidentSourceStale, #591) even when operational with a high Score', () => {
+    // deepseek is excluded from Score ranking because its incident feed is stale (#591). Operational
+    // with an inflated Score and not in EXCLUDE_FALLBACK, so without the guard it would win the slot.
+    const source = { id: 'mistral', category: 'api', status: 'degraded', incidents: [] }
+    const deepseekStale = op('deepseek', 'api', 95, { incidentSourceStale: true })
+    const together = op('together', 'api', 89)
+    const ids = getFallbacks(source, [source, deepseekStale, together]).map(f => f.id)
+    expect(ids).not.toContain('deepseek') // stale source → not a trusted fallback
+    expect(ids).toContain('together')
+  })
+
   it('getGroupedFallbacks drops an operational-but-active-incident candidate', () => {
     const affected = [{ id: 'claudecode', category: 'agent', provider: 'Anthropic', status: 'degraded', incidents: [inc('investigating')] }]
     const pool = [

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -155,7 +155,8 @@ export function getFallbacks(service, allServices) {
   if (!service || !Array.isArray(allServices) || EXCLUDE_FALLBACK.includes(service.id)) return []
   const sourceTier = tierFor(service.id)
   return allServices
-    .filter(s => s.category === service.category && s.id !== service.id && s.status === 'operational' && !hasActiveIncident(s) && !EXCLUDE_FALLBACK.includes(s.id))
+    // #616 — exclude stale-source services (#591): ranking-excluded → not a trusted fallback either
+    .filter(s => s.category === service.category && s.id !== service.id && s.status === 'operational' && !hasActiveIncident(s) && !s.incidentSourceStale && !EXCLUDE_FALLBACK.includes(s.id))
     .sort((a, b) => {
       const distA = Math.abs(tierFor(a.id) - sourceTier)
       const distB = Math.abs(tierFor(b.id) - sourceTier)

--- a/worker/src/__tests__/fallback.test.ts
+++ b/worker/src/__tests__/fallback.test.ts
@@ -53,6 +53,20 @@ describe('getFallbacks', () => {
     expect(result.find(f => f.name === 'Together AI')).toBeDefined()     // only a resolved incident → eligible
   })
 
+  it('#616 — excludes a stale-source candidate (incidentSourceStale, #591) even when operational with a high Score', () => {
+    // deepseek is excluded from Score ranking because its incident feed is stale (#591). It is
+    // operational with an inflated Score and not in EXCLUDE_FALLBACK, so without the guard it would
+    // win the tier-2 slot. Ranking-excluded → must not be recommended as a trusted fallback either.
+    const services = [
+      { id: 'mistral', category: 'api', name: 'Mistral API', status: 'degraded', aiwatchScore: 76 },
+      { id: 'deepseek', category: 'api', name: 'DeepSeek API', status: 'operational', aiwatchScore: 95, incidentSourceStale: true },
+      { id: 'together', category: 'api', name: 'Together AI', status: 'operational', aiwatchScore: 89 },
+    ]
+    const result = getFallbacks('mistral', 'api', services)
+    expect(result.find(f => f.name === 'DeepSeek API')).toBeUndefined() // stale source → dropped
+    expect(result.find(f => f.name === 'Together AI')).toBeDefined()    // healthy → eligible
+  })
+
   it('#602/#601 step B — degraded Runway recommends its video sibling Luma OVER a higher-scored tier-3 infra service', () => {
     // openrouter (tier 3 Infra) has a higher Score than luma, so pre-step-B it won the Infra-tier slot
     // and Runway got recommended an LLM router. With the Video tier (5), luma (distance 0) outranks it.

--- a/worker/src/fallback.ts
+++ b/worker/src/fallback.ts
@@ -54,6 +54,10 @@ interface FallbackCandidate {
   status: string
   /** #550 — used to exclude candidates with an unresolved incident (operational-but-incident). */
   incidents?: Array<{ status: string }>
+  /** #616 — stale incident source (#591). Excluded from Score ranking, so it must also be excluded
+   *  as a fallback candidate: recommending a service we don't trust enough to rank contradicts the
+   *  same product surface. */
+  incidentSourceStale?: boolean
   aiwatchScore?: number | null
 }
 
@@ -71,7 +75,7 @@ export function getFallbacks(
   if (EXCLUDE_FALLBACK.includes(serviceId)) return []
   const sourceTier = tierFor(serviceId)
   return services
-    .filter(s => s.category === category && s.id !== serviceId && s.status === 'operational' && !hasActiveIncident(s) && !EXCLUDE_FALLBACK.includes(s.id))
+    .filter(s => s.category === category && s.id !== serviceId && s.status === 'operational' && !hasActiveIncident(s) && !s.incidentSourceStale && !EXCLUDE_FALLBACK.includes(s.id))
     .sort((a, b) => {
       // Prefer same or adjacent tier to the affected service
       const tierA = tierFor(a.id)


### PR DESCRIPTION
## Problem

DeepSeek is excluded from the **Score ranking** (#591) because its incident feed is frozen (status page migrated to a server-unreachable platform, #507) — an empty 30-day incident window inflates its raw `aiwatchScore` (~94, "excellent"). But the fallback recommendation filter consumed that same raw score **without** the `incidentSourceStale` guard the ranking surfaces already apply, so a ranking-excluded service still surfaced as a "trusted" alternative when another service had an incident.

Affected surfaces (4) — all route through `getFallbacks`:
- **Overview** ActionBanner + **AnalysisModal** (`src/utils/constants.js`)
- **Discord** new-incident alerts (`worker getFallbacks` → `buildFallbackText` / `buildGroupedFallbackText`)
- **Slack** `/feed` RSS (`rss.ts` `fallbackLine` → worker `getFallbacks`)
- **is-down** pages (`api/is-down.ts` inline filter)

## Root cause

`getFallbacks` candidate filter excluded `EXCLUDE_FALLBACK`, non-operational, and active-incident services — but not `incidentSourceStale`. DeepSeek is operational, not in `EXCLUDE_FALLBACK`, and carries an inflated score, so it passed.

## Fix

Add `&& !s.incidentSourceStale` to the candidate filter in all 3 `getFallbacks` mirrors (+ `FallbackCandidate` type in `fallback.ts`), mirroring the established #591 ranking exclusion. One worker filter covers **both** Discord and Slack (both delegate to `getFallbacks`).

## Test / verify

- `worker/src/__tests__/fallback.test.ts` — stale-source operational high-score candidate dropped; healthy peer kept.
- `src/utils/__tests__/constants.test.js` — same on the frontend mirror (the two mirrors drift independently, so both are pinned).
- Worker suite 1636 ✓ · frontend unit 403 ✓ · typecheck:worker 0 TS2304 ✓ · dry-run build ✓.
- **Local in-browser verified**: with live data (Mistral degraded, DeepSeek operational + `incidentSourceStale` + raw score 94), the Overview ActionBanner fallback list excludes DeepSeek and recommends a healthy peer (Together, 85) instead.

## Acceptance (refs #616)

- [x] `getFallbacks` excludes `incidentSourceStale` candidates in all 3 mirrors
- [x] Unit tests on both worker + frontend mirrors
- [x] Overview/AnalysisModal verified locally
- [ ] Discord / Slack / is-down — **deploy-gated** (worker deploy + Vercel deploy); Discord/Slack additionally surface only during a real incident → verify after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)