### PR TITLE
feat(worker): DeepSeek live status via browser-rendered Flashduty feed (refs #618)

### DIFF
--- a/.github/workflows/deepseek-feed.yml
+++ b/.github/workflows/deepseek-feed.yml
@@ -1,0 +1,43 @@
+name: DeepSeek status feed
+
+# #618 — DeepSeek's status page (status.deepseek.com, Flashduty) blocks non-browser TLS
+# fingerprints, so the Cloudflare Worker can't read it directly. This Action browser-renders the
+# page every 15 min, fetches the clean Flashduty JSON API from the browser context, and POSTs it to
+# the Worker (/api/internal/deepseek-feed → KV). fetchService('deepseek') then serves live incidents
+# and the Score re-includes DeepSeek (incidentSourceStale lifts while the feed is fresh; a 3h KV TTL
+# falls back to the frozen Atlassian mirror if this Action stops).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 min (GH cron is best-effort; the 3h KV TTL tolerates misses)
+  workflow_dispatch: {}       # manual trigger for first-run verification
+
+# A scheduled run + a manual dispatch (or an overlapping slow run) must not double-push.
+concurrency:
+  group: deepseek-feed
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  scrape:
+    name: Scrape + push Flashduty feed
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    # Official Playwright image ships Chromium + system deps preinstalled — no per-run browser
+    # download. Pin the tag to the @playwright/test version in package.json (^1.58.2).
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Playwright (npm pkg only — browsers are in the image)
+        run: npm install --no-save playwright@1.58.2
+      - name: Scrape DeepSeek feed + push to Worker
+        run: node scripts/scrape-deepseek-feed.mjs
+        env:
+          WORKER_URL: ${{ secrets.DEEPSEEK_FEED_WORKER_URL }}     # e.g. https://aiwatch-worker.p2c2kbf.workers.dev
+          DEEPSEEK_FEED_TOKEN: ${{ secrets.DEEPSEEK_FEED_TOKEN }} # must equal the Worker secret of the same name

--- a/scripts/scrape-deepseek-feed.mjs
+++ b/scripts/scrape-deepseek-feed.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// #618 — browser-render DeepSeek's Flashduty status feed and push it to the Worker.
+//
+// status.deepseek.com (Flashduty, #507) blocks non-browser TLS fingerprints — a plain fetch()/curl
+// is reset at the TLS layer regardless of IP (verified 2026-06-12: a real Chromium from the same IP
+// succeeds). So a Cloudflare Worker can't read it. This script (run by .github/workflows/
+// deepseek-feed.yml on a schedule) launches headless Chromium, fetches the clean Flashduty JSON API
+// FROM the browser context (browser fingerprint clears the wall), and POSTs the raw payload to
+// /api/internal/deepseek-feed, which caches it in KV for fetchService('deepseek') to normalize.
+//
+// Env:
+//   WORKER_URL           — Worker origin, e.g. https://aiwatch-worker.p2c2kbf.workers.dev
+//   DEEPSEEK_FEED_TOKEN  — Bearer token; must equal the Worker's DEEPSEEK_FEED_TOKEN secret
+import { chromium } from 'playwright'
+
+const PAGE_ID = '6410630422455' // status.deepseek.com Flashduty page id
+const STATUS_HOME = 'https://status.deepseek.com/'
+const API_BASE = `https://status.deepseek.com/api/status-page/${PAGE_ID}`
+
+const WORKER_URL = process.env.WORKER_URL
+const TOKEN = process.env.DEEPSEEK_FEED_TOKEN
+if (!WORKER_URL || !TOKEN) {
+  console.error('Missing WORKER_URL or DEEPSEEK_FEED_TOKEN env')
+  process.exit(2)
+}
+
+const HISTORY_DAYS = 90 // change/list window — wide enough for the Score's 30d incident history + margin
+const UPTIME_DAYS = 30 // summary/structure window — matches the 30-day uptime/impact the Score uses
+
+async function main() {
+  const browser = await chromium.launch()
+  let data
+  try {
+    const page = await browser.newPage()
+    // Establish a real browsing context on the host first (cookies / challenge cookies), then call
+    // the JSON API from inside the page so requests carry the browser TLS + HTTP fingerprint.
+    await page.goto(STATUS_HOME, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+    data = await page.evaluate(async ({ base, historyDays, uptimeDays }) => {
+      const now = Math.floor(Date.now() / 1000)
+      // Per-request 15s timeout so one hung endpoint fails fast instead of burning the job budget.
+      const j = (u) =>
+        fetch(u, { signal: AbortSignal.timeout(15_000) })
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null)
+      const [active, changeList, structure] = await Promise.all([
+        j(`${base}/summary/active`),
+        j(`${base}/change/list?start_at_seconds=${now - historyDays * 86400}&end_at_seconds=${now}`),
+        j(`${base}/summary/structure?start_at_from_seconds=${now - uptimeDays * 86400}&start_at_to_seconds=${now}`),
+      ])
+      return { active: active?.data ?? null, changeList: changeList?.data ?? null, structure: structure?.data ?? null }
+    }, { base: API_BASE, historyDays: HISTORY_DAYS, uptimeDays: UPTIME_DAYS })
+  } finally {
+    await browser.close()
+  }
+
+  if (!data.active && !data.changeList && !data.structure) {
+    // All three null → the bot wall changed or the API moved. Do NOT POST an empty payload (the
+    // Worker rejects it anyway); exit non-zero so the Action surfaces a failure to investigate.
+    console.error('All three Flashduty endpoints returned null — wall changed or API moved?')
+    process.exit(1)
+  }
+
+  const res = await fetch(`${WORKER_URL}/api/internal/deepseek-feed`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify(data),
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    console.error(`POST failed: ${res.status} ${text}`)
+    process.exit(1)
+  }
+  console.log(`Pushed DeepSeek feed: ${text}`)
+}
+
+main().catch((err) => {
+  console.error('scrape-deepseek-feed failed:', err)
+  process.exit(1)
+})

--- a/worker/src/__tests__/fixtures/deepseek-flashduty.json
+++ b/worker/src/__tests__/fixtures/deepseek-flashduty.json
@@ -1,0 +1,1234 @@
+{
+ "active": {
+  "page": {
+   "page_id": 6410630422455,
+   "name": "DeepSeek",
+   "url_name": "deepseek",
+   "type": "public",
+   "custom_domain": "status.deepseek.com",
+   "logo": "https://static.flashcat.cloud/statuspage/long-term/statuspage/image/5758820581287/6410630422455/logo_01KRD68AFGR1B4MXN1C7KMFDBM.png",
+   "dark_logo": "https://static.flashcat.cloud/statuspage/long-term/statuspage/image/5758820581287/6410630422455/logo_01KRD68K0AD6FZBCGZMPY0XK96.png",
+   "logo_url": "https://www.deepseek.com/",
+   "favicon": "https://static.flashcat.cloud/statuspage/long-term/statuspage/image/5758820581287/6410630422455/favicon_01KRD6DQEG6PHXDSA3J66PFMWV.png",
+   "date_view": "calendar",
+   "display_uptime_mode": "chart_and_percentage",
+   "components": [
+    {
+     "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+     "name": "API 服务 (API Service)",
+     "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+     "available_since_seconds": 1706745600,
+     "order_id": 1
+    },
+    {
+     "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+     "name": "网页对话服务 (Web Chat Service)",
+     "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+     "available_since_seconds": 1706745600,
+     "order_id": 2
+    }
+   ],
+   "sections": [],
+   "subscription": {
+    "email": true,
+    "im": false
+   },
+   "template_preference": "message"
+  },
+  "active_changes": []
+ },
+ "changeList": {
+  "items": [
+   {
+    "change_id": 6551550194287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "DeepSeek 网页 性能下降（DeepSeek Web Degraded Performance）",
+    "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1780991884,
+    "close_at_seconds": 1780994827,
+    "updates": [
+     {
+      "update_id": "01KTNP6ZE299P31AT21YR31YHV",
+      "at_seconds": 1780991884,
+      "status": "identified",
+      "description": "已定位原因，正在实施修复。\n\nThe cause has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "01KTNS0SC01G5FF20FT5A2JS3H",
+      "at_seconds": 1780994827,
+      "status": "resolved",
+      "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ],
+    "notify_subscribers": true
+   },
+   {
+    "change_id": 6499101276287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "API 性能下降（API Degraded Performance）",
+    "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1779967491,
+    "close_at_seconds": 1779968182,
+    "updates": [
+     {
+      "update_id": "01KSQ58ZQAH3ECX1CKZ1RZJN7X",
+      "at_seconds": 1779967491,
+      "status": "investigating",
+      "description": "正在排查问题，以定位原因。\n\nThe issue is being investigated to identify the cause.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "partial_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSQ5Y2MJX8QGF97RSAKBGZHP",
+      "at_seconds": 1779968182,
+      "status": "resolved",
+      "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ],
+    "notify_subscribers": true
+   },
+   {
+    "change_id": 6497432543287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）",
+    "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1779934899,
+    "close_at_seconds": 1779936653,
+    "updates": [
+     {
+      "update_id": "01KSP66B5CN5PRMT7MPR7H2VG9",
+      "at_seconds": 1779934899,
+      "status": "identified",
+      "description": "已定位原因，正在实施修复。\n\nThe cause has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "degraded"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSP6G7K0ED5A6D1ZW0N345Q1",
+      "at_seconds": 1779935223,
+      "status": "identified",
+      "description": "已定位原因，正在实施修复。\n\nThe cause has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "partial_outage"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "partial_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSP7BBJFF6GX7JNJW5GF6WTC",
+      "at_seconds": 1779936112,
+      "status": "monitoring",
+      "description": "已实施修复，正在监控结果。\n\nA fix has been implemented and the results are being monitored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSP7VWN6SNZS5D23ZPG8M92Z",
+      "at_seconds": 1779936653,
+      "status": "resolved",
+      "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ],
+    "notify_subscribers": true
+   },
+   {
+    "change_id": 6480608319287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "DeepSeek 网页端/API 不可用（DeepSeek WEB/API Unavailable）",
+    "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1779606301,
+    "close_at_seconds": 1779607386,
+    "updates": [
+     {
+      "update_id": "01KSCCTAHZ4TSDK5RCWCWQ40ZT",
+      "at_seconds": 1779606301,
+      "status": "investigating",
+      "description": "正在排查问题，以定位原因。\n\nThe issue is being investigated to identify the cause.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "full_outage"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSCDC2C9CJ9BA3XP0YYXF819",
+      "at_seconds": 1779606882,
+      "status": "identified",
+      "description": "已定位原因，正在实施修复。\n\nThe cause has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "partial_outage"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "partial_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "01KSCDM1H26DW7FNQSAERHM8BP",
+      "at_seconds": 1779607143,
+      "status": "monitoring",
+      "description": "已实施修复，正在监控结果。\n\nA fix has been implemented and the results are being monitored."
+     },
+     {
+      "update_id": "01KSCDVEK15MVYF8RMVN349YYJ",
+      "at_seconds": 1779607386,
+      "status": "resolved",
+      "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ],
+    "notify_subscribers": true
+   },
+   {
+    "change_id": 6467187538287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）",
+    "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1779344176,
+    "close_at_seconds": 1779345434,
+    "updates": [
+     {
+      "update_id": "01KS4JTXF1Z4D3KQ9WEPMAQ2AM",
+      "at_seconds": 1779344176,
+      "status": "identified",
+      "description": "已定位原因，正在实施修复。\n\nThe cause has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "degraded"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "01KS4M1A544D2Z3CCGNQ6CJQMG",
+      "at_seconds": 1779345434,
+      "status": "resolved",
+      "description": "本次问题已解决，服务已恢复。\n\nThe incident has been resolved and service has been restored.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ],
+    "notify_subscribers": true
+   },
+   {
+    "change_id": 6410630567287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API不可用（[Resolved]DeepSeek Web/API Service Not Available）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1778232728,
+    "close_at_seconds": 1778234748,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1778232728,
+      "status": "identified",
+      "description": "The issue has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1778234508,
+      "status": "monitoring",
+      "description": "A fix has been implemented and we are monitoring the results.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1778234748,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 76779374745287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1778051625,
+    "close_at_seconds": 1778052020,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1778051625,
+      "status": "identified",
+      "description": "The issue has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1778052020,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 147148118922287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     },
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1778039584,
+    "close_at_seconds": 1778040256,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1778039584,
+      "status": "identified",
+      "description": "The issue has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "partial_outage"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "partial_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1778040256,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       },
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 217516863100287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek API 异常（[Resolved]DeepSeek API Abnormal）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+      "name": "API 服务 (API Service)",
+      "description": "https://api.deepseek.com 的状态 (The status of https://api.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 1,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1776853398,
+    "close_at_seconds": 1776857192,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1776853398,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1776857192,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+        "component_name": "API 服务 (API Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 287885607278287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已解决】DeepSeek Web/APP 快速模式性能异常（[Resolved]DeepSeek Web/APP Instant Mode Performance Abnormal）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1776688800,
+    "close_at_seconds": 1776701307,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1776688800,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1776701307,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 358254351455287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/APP 服务异常（[Resolved]DeepSeek Web/APP Service Abnormal）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1775205401,
+    "close_at_seconds": 1775206218,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1775205401,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1775205495,
+      "status": "investigating",
+      "description": "We are continuing to investigate this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1775205598,
+      "status": "monitoring",
+      "description": "A fix has been implemented and we are monitoring the results.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1775206218,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 428623095633287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1774947759,
+    "close_at_seconds": 1774951554,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1774947760,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "partial_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774949734,
+      "status": "investigating",
+      "description": "We are continuing to investigate this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774951554,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 498991839811287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/APP 性能异常（[Resolved]DeepSeek Web/APP Service Performance Agnormal）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1774801214,
+    "close_at_seconds": 1774838022,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1774801214,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774802189,
+      "status": "investigating",
+      "description": "We are continuing to investigate this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774805059,
+      "status": "monitoring",
+      "description": "A fix has been implemented and we are monitoring the results.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774808176,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774833225,
+      "status": "monitoring",
+      "description": "A fix has been implemented and we are monitoring the results.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774838008,
+      "status": "monitoring",
+      "description": "We are continuing to monitor for any further issues.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774838022,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 569360583988287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/APP 服务异常（[Resolved]DeepSeek Web/APP Service Abnormal）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1774791352,
+    "close_at_seconds": 1774797797,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1774791352,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774794507,
+      "status": "identified",
+      "description": "The issue has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "full_outage"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774796932,
+      "status": "monitoring",
+      "description": "A fix has been implemented and we are monitoring the results.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1774797797,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "change_id": 639729328166287,
+    "page_id": 6410630422455,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/APP 性能异常（[Resolved]DeepSeek Web/APP Service Degraded Performance）",
+    "status": "resolved",
+    "affected_components": [
+     {
+      "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+      "name": "网页对话服务 (Web Chat Service)",
+      "description": "https://chat.deepseek.com 的状态 (The status of https://chat.deepseek.com)",
+      "available_since_seconds": 1706745600,
+      "order_id": 2,
+      "status": "operational"
+     }
+    ],
+    "start_at_seconds": 1773836812,
+    "close_at_seconds": 1773837427,
+    "updates": [
+     {
+      "update_id": "",
+      "at_seconds": 1773836812,
+      "status": "investigating",
+      "description": "We are currently investigating this issue.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1773836959,
+      "status": "identified",
+      "description": "The issue has been identified and a fix is being implemented.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "degraded"
+       }
+      ]
+     },
+     {
+      "update_id": "",
+      "at_seconds": 1773837427,
+      "status": "resolved",
+      "description": "This incident has been resolved.",
+      "component_changes": [
+       {
+        "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+        "component_name": "网页对话服务 (Web Chat Service)",
+        "status": "operational"
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ },
+ "structure": {
+  "section_impacts": [],
+  "section_uptimes": [],
+  "component_impacts": [
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6467187538287,
+    "start_at_seconds": 1779344176,
+    "end_at_seconds": 1779345434,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6467187538287,
+    "start_at_seconds": 1779344176,
+    "end_at_seconds": 1779345434,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6480608319287,
+    "start_at_seconds": 1779606301,
+    "end_at_seconds": 1779606882,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6480608319287,
+    "start_at_seconds": 1779606301,
+    "end_at_seconds": 1779606882,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6480608319287,
+    "start_at_seconds": 1779606882,
+    "end_at_seconds": 1779607386,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6480608319287,
+    "start_at_seconds": 1779606882,
+    "end_at_seconds": 1779607386,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6497432543287,
+    "start_at_seconds": 1779934899,
+    "end_at_seconds": 1779935223,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6497432543287,
+    "start_at_seconds": 1779934899,
+    "end_at_seconds": 1779935223,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6497432543287,
+    "start_at_seconds": 1779935223,
+    "end_at_seconds": 1779936112,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6497432543287,
+    "start_at_seconds": 1779935223,
+    "end_at_seconds": 1779936112,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6497432543287,
+    "start_at_seconds": 1779936112,
+    "end_at_seconds": 1779936653,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6499101276287,
+    "start_at_seconds": 1779967491,
+    "end_at_seconds": 1779968182,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6551550194287,
+    "start_at_seconds": 1780991884,
+    "end_at_seconds": 1780994827,
+    "status": "degraded"
+   }
+  ],
+  "component_uptimes": [
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "uptime": 99.89,
+    "available_since_seconds": 1706745600
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "uptime": 99.92,
+    "available_since_seconds": 1706745600
+   }
+  ],
+  "linked_changes": [
+   {
+    "id": 6467187538287,
+    "type": "incident",
+    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）"
+   },
+   {
+    "id": 6480608319287,
+    "type": "incident",
+    "title": "DeepSeek 网页端/API 不可用（DeepSeek WEB/API Unavailable）"
+   },
+   {
+    "id": 6497432543287,
+    "type": "incident",
+    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）"
+   },
+   {
+    "id": 6499101276287,
+    "type": "incident",
+    "title": "API 性能下降（API Degraded Performance）"
+   },
+   {
+    "id": 6551550194287,
+    "type": "incident",
+    "title": "DeepSeek 网页 性能下降（DeepSeek Web Degraded Performance）"
+   }
+  ]
+ }
+}

--- a/worker/src/__tests__/flashduty-parser.test.ts
+++ b/worker/src/__tests__/flashduty-parser.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { parseFlashdutyFeed, type FlashdutyFeed } from '../parsers/flashduty'
+import fixture from './fixtures/deepseek-flashduty.json'
+
+// #618 — Flashduty parser, exercised against a REAL captured DeepSeek payload (2026-06-12):
+// 2 components (API Service / Web Chat Service), 15 history incidents, 0 active, 13 impact windows,
+// per-component uptime 99.89 / 99.92.
+const feed = fixture as FlashdutyFeed
+
+describe('parseFlashdutyFeed (#618)', () => {
+  const parsed = parseFlashdutyFeed(feed)
+
+  it('maps the two page components to breakdown rows, all operational when no active incident', () => {
+    expect(parsed.components.map((c) => c.name)).toEqual([
+      'API 服务 (API Service)',
+      '网页对话服务 (Web Chat Service)',
+    ])
+    expect(parsed.components.every((c) => c.status === 'operational')).toBe(true)
+  })
+
+  it('overall status is operational when active_changes is empty', () => {
+    expect(parsed.status).toBe('operational')
+  })
+
+  it('parses every history incident with a flashduty: id and a sorted timeline', () => {
+    expect(parsed.incidents).toHaveLength(15)
+    const first = parsed.incidents[0]
+    expect(first.id).toMatch(/^flashduty:\d+$/)
+    // newest-first ordering
+    for (let i = 1; i < parsed.incidents.length; i++) {
+      expect(new Date(parsed.incidents[i - 1].startedAt).getTime())
+        .toBeGreaterThanOrEqual(new Date(parsed.incidents[i].startedAt).getTime())
+    }
+  })
+
+  it('maps a specific resolved incident end-to-end (6551550194287)', () => {
+    const inc = parsed.incidents.find((i) => i.id === 'flashduty:6551550194287')!
+    expect(inc).toBeDefined()
+    expect(inc.status).toBe('resolved')
+    expect(inc.resolvedAt).not.toBeNull()
+    expect(inc.duration).toBeTruthy()
+    expect(inc.componentNames).toContain('网页对话服务 (Web Chat Service)')
+    // timeline: identified → resolved, English text extracted from the bilingual description
+    expect(inc.timeline.map((t) => t.stage)).toEqual(['identified', 'resolved'])
+    expect(inc.timeline[0].text).toMatch(/identified/i)
+    expect(inc.timeline[0].text).not.toMatch(/[一-鿿]/) // Chinese half stripped
+  })
+
+  it('derives impact severity from component_changes (partial_outage → major)', () => {
+    // 6499101276287 = "API Degraded Performance" with a partial_outage component change.
+    const inc = parsed.incidents.find((i) => i.id === 'flashduty:6499101276287')!
+    expect(inc.impact).toBe('major')
+  })
+
+  it('uptime30d = worst (min) component uptime from structure', () => {
+    expect(parsed.uptime30d).toBeCloseTo(99.89, 2)
+  })
+
+  it('builds a dailyImpact map keyed by YYYY-MM-DD with valid levels', () => {
+    const days = Object.keys(parsed.dailyImpact)
+    expect(days.length).toBeGreaterThan(0)
+    expect(days.every((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))).toBe(true)
+    expect(Object.values(parsed.dailyImpact).every((v) => ['minor', 'major', 'critical'].includes(v))).toBe(true)
+  })
+
+  it('reflects an active incident in status + component rows', () => {
+    const withActive: FlashdutyFeed = {
+      ...feed,
+      active: {
+        page: feed.active?.page,
+        active_changes: [
+          {
+            change_id: 999,
+            title: 'API outage',
+            status: 'investigating',
+            start_at_seconds: 1781000000,
+            affected_components: [
+              { component_id: '01KR3NC9ETZYF436Z8YT1HM047', name: 'API 服务 (API Service)', status: 'full_outage' },
+            ],
+            updates: [
+              { at_seconds: 1781000000, status: 'investigating', description: 'Investigating.', component_changes: [{ component_id: '01KR3NC9ETZYF436Z8YT1HM047', status: 'full_outage' }] },
+            ],
+          },
+        ],
+      },
+    }
+    const p = parseFlashdutyFeed(withActive)
+    expect(p.status).toBe('down')
+    expect(p.components.find((c) => c.id === '01KR3NC9ETZYF436Z8YT1HM047')!.status).toBe('down')
+    expect(p.components.find((c) => c.id === '01KR3NC9ETESRRQ4GABE0TGW53')!.status).toBe('operational')
+    // active incident surfaces in the list as non-resolved
+    expect(p.incidents.find((i) => i.id === 'flashduty:999')!.status).toBe('investigating')
+  })
+
+  it('is defensive against an empty/partial payload', () => {
+    const empty = parseFlashdutyFeed({})
+    expect(empty.status).toBe('operational')
+    expect(empty.incidents).toEqual([])
+    expect(empty.uptime30d).toBeNull()
+    expect(empty.components).toEqual([])
+  })
+
+  describe('option A — scope to the API component only (#618)', () => {
+    const API_ID = '01KR3NC9ETZYF436Z8YT1HM047' // API Service (api.deepseek.com)
+    const WEBCHAT_ID = '01KR3NC9ETESRRQ4GABE0TGW53' // Web Chat (chat.deepseek.com) — excluded
+    const scoped = parseFlashdutyFeed(feed, { primaryComponentId: API_ID })
+
+    it('drops Web-Chat-only incidents (e.g. 6/9 6551550194287 affected only Web Chat)', () => {
+      expect(scoped.incidents.find((i) => i.id === 'flashduty:6551550194287')).toBeUndefined()
+      // an API-affecting incident stays
+      expect(scoped.incidents.find((i) => i.id === 'flashduty:6499101276287')).toBeDefined()
+      // strictly fewer than the unscoped 15
+      expect(scoped.incidents.length).toBeLessThan(15)
+      expect(scoped.incidents.length).toBeGreaterThan(0)
+    })
+
+    it('collapses components to just the API surface (so the ≥2 breakdown gate suppresses it)', () => {
+      expect(scoped.components.map((c) => c.id)).toEqual([API_ID])
+    })
+
+    it('uptime = the API component uptime (99.89), not the min-with-Web-Chat', () => {
+      expect(scoped.uptime30d).toBeCloseTo(99.89, 2)
+    })
+
+    it('a Web-Chat-only active incident does NOT flip the API badge', () => {
+      const webchatActive: FlashdutyFeed = {
+        ...feed,
+        active: {
+          page: feed.active?.page,
+          active_changes: [
+            {
+              change_id: 1001,
+              title: 'Web Chat outage',
+              status: 'investigating',
+              start_at_seconds: 1781000000,
+              affected_components: [{ component_id: WEBCHAT_ID, name: 'Web Chat', status: 'full_outage' }],
+              updates: [{ at_seconds: 1781000000, status: 'investigating', component_changes: [{ component_id: WEBCHAT_ID, status: 'full_outage' }] }],
+            },
+          ],
+        },
+      }
+      const p = parseFlashdutyFeed(webchatActive, { primaryComponentId: API_ID })
+      expect(p.status).toBe('operational') // API unaffected
+      expect(p.incidents.find((i) => i.id === 'flashduty:1001')).toBeUndefined()
+    })
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -17,6 +17,7 @@ import { corsHeaders } from './cors'
 import { buildStatuslinePayload, isStatuslineRequest } from './statusline'
 import { recordV1Traffic, queryV1Traffic } from './api-traffic'
 import { EDGE_FALLBACK_ALERT_TTL_S, EDGE_FALLBACK_ALERT_KEY_PREFIX } from './edge-fallback-alert-keys'
+import { DEEPSEEK_FEED_KV_KEY, DEEPSEEK_FEED_TTL_S, type FlashdutyFeed, type StoredFlashdutyFeed } from './parsers/flashduty'
 
 interface Env {
   ALLOWED_ORIGIN: string
@@ -40,6 +41,11 @@ interface Env {
   // `wrangler secret put EDGE_ALERT_TOKEN` and the same value as a Vercel env
   // var so both ends agree. Absent secret → endpoint always 401.
   EDGE_ALERT_TOKEN?: string
+  // #618: Bearer token for POST /api/internal/deepseek-feed — the GitHub Action scraper that
+  // browser-renders status.deepseek.com (bot-walled to a plain Worker fetch) authenticates with
+  // this. Set via `wrangler secret put DEEPSEEK_FEED_TOKEN` and the same value as a GH Action
+  // secret. Absent secret → endpoint always 401.
+  DEEPSEEK_FEED_TOKEN?: string
   AI?: Ai
   STATUS_CACHE: KVNamespace
   // #494: Workers Analytics Engine dataset for statusline traffic measurement.
@@ -1242,6 +1248,51 @@ export async function handleEdgeFallbackAlert(request: Request, env: Env, cors: 
   return json(200, { ok: true, dispatched })
 }
 
+// ── POST /api/internal/deepseek-feed ───────────────────────────
+// #618: status.deepseek.com (Flashduty) blocks non-browser TLS fingerprints, so a Worker fetch()
+// can't read DeepSeek's live incidents. A scheduled GitHub Action browser-renders the page, fetches
+// the Flashduty JSON API, and POSTs the raw { active, changeList, structure } payload here. We cache
+// it in KV (DEEPSEEK_FEED_KV_KEY, 3h TTL); fetchService('deepseek') reads + normalizes it (via
+// parseFlashdutyFeed) instead of the frozen Atlassian mirror, lifting incidentSourceStale while the
+// feed is fresh. Auth: Bearer DEEPSEEK_FEED_TOKEN. Body shape validated minimally; parsing happens
+// at read time so a malformed push can't corrupt the served status mid-write.
+interface DeepseekFeedRequest {
+  active?: unknown
+  changeList?: unknown
+  structure?: unknown
+}
+
+export async function handleDeepseekFeed(request: Request, env: Env, cors: Record<string, string>): Promise<Response> {
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { ...cors, 'Content-Type': 'application/json' } })
+
+  if (!env.DEEPSEEK_FEED_TOKEN) return json(401, { ok: false, error: 'unauthorized' })
+  const auth = request.headers.get('Authorization') ?? ''
+  if (!constantTimeEqual(auth, `Bearer ${env.DEEPSEEK_FEED_TOKEN}`)) return json(401, { ok: false, error: 'unauthorized' })
+
+  let body: DeepseekFeedRequest
+  try { body = await request.json() } catch { return json(400, { ok: false, error: 'invalid JSON body' }) }
+
+  // Require at least one of the three sections to be a non-null object — a totally empty push is a
+  // scraper bug, not a valid "all clear", and must NOT overwrite a good cached feed.
+  const sections = [body.active, body.changeList, body.structure]
+  if (!sections.some((s) => s !== null && typeof s === 'object')) {
+    return json(400, { ok: false, error: 'at least one of active/changeList/structure (object) required' })
+  }
+
+  const feed: FlashdutyFeed = {
+    active: (body.active ?? undefined) as FlashdutyFeed['active'],
+    changeList: (body.changeList ?? undefined) as FlashdutyFeed['changeList'],
+    structure: (body.structure ?? undefined) as FlashdutyFeed['structure'],
+  }
+  const stored: StoredFlashdutyFeed = { fetchedAt: new Date().toISOString(), feed }
+  await kvPut(env.STATUS_CACHE, DEEPSEEK_FEED_KV_KEY, JSON.stringify(stored), { expirationTtl: DEEPSEEK_FEED_TTL_S })
+
+  const incidentCount = feed.changeList?.items?.length ?? 0
+  const activeCount = feed.active?.active_changes?.length ?? 0
+  return json(200, { ok: true, stored: true, fetchedAt: stored.fetchedAt, incidents: incidentCount, active: activeCount })
+}
+
 // ── POST /api/admin/rebuild-archive ─────────────────────────────
 // Operator tool to regenerate a specific month's archive:monthly:{YYYY-MM} key.
 // Motivated by the discovery that earlier archive cron runs persisted score: null /
@@ -2208,6 +2259,12 @@ export default {
     // dedup ensures one notice per 5min per surface+slug.
     if (request.method === 'POST' && url.pathname === '/api/internal/edge-fallback') {
       return handleEdgeFallbackAlert(request, env, cors)
+    }
+
+    // POST /api/internal/deepseek-feed — GitHub Action scraper pushes the browser-rendered
+    // Flashduty feed for DeepSeek (#618), cached in KV for fetchService to normalize.
+    if (request.method === 'POST' && url.pathname === '/api/internal/deepseek-feed') {
+      return handleDeepseekFeed(request, env, cors)
     }
 
     // POST /api/admin/rebuild-archive — operator tool to regenerate a specific month's

--- a/worker/src/parsers/flashduty.ts
+++ b/worker/src/parsers/flashduty.ts
@@ -1,0 +1,274 @@
+// Flashduty status-page parser (#618). DeepSeek migrated its status page to Flashduty
+// (status.deepseek.com, #507), whose host blocks non-browser TLS fingerprints — a Cloudflare
+// Worker `fetch()` is reset at the TLS layer regardless of egress IP (verified 2026-06-12: a real
+// Chromium from the SAME IP succeeds where curl/fetch are reset). So the Worker cannot read it
+// directly; instead a scheduled GitHub Action renders the page in a real browser, fetches the
+// (clean JSON) Flashduty API, and POSTs the raw payload to /api/internal/deepseek-feed, which caches
+// it in KV. This module normalizes that raw payload into AIWatch's ServiceStatus shape.
+//
+// Flashduty data model (status.deepseek.com/api/status-page/{pageId}/...):
+//   summary/active      → { page:{ components[] }, active_changes[] }   (currently-open incidents)
+//   change/list         → { items[] }                                  (full incidents incl. timeline)
+//   summary/structure   → { component_impacts[], component_uptimes[] } (per-component outage windows + uptime%)
+import type { Incident, TimelineEntry, ServiceComponent, DailyImpactLevel } from '../types'
+import { formatDuration } from '../utils'
+
+// ── Raw Flashduty payload shapes (only the fields we consume) ──
+export interface FlashdutyComponent {
+  component_id: string
+  name: string
+  description?: string
+  order_id?: number
+}
+interface FlashdutyComponentChange {
+  component_id: string
+  component_name?: string
+  status: string
+}
+interface FlashdutyUpdate {
+  update_id?: string
+  at_seconds: number
+  status: string
+  description?: string
+  component_changes?: FlashdutyComponentChange[]
+}
+export interface FlashdutyChange {
+  change_id: number
+  type?: string
+  title: string
+  description?: string
+  status: string
+  affected_components?: Array<{ component_id: string; name: string; status: string }>
+  start_at_seconds: number
+  close_at_seconds?: number
+  updates?: FlashdutyUpdate[]
+}
+interface FlashdutyComponentImpact {
+  component_id: string
+  change_id: number
+  start_at_seconds: number
+  end_at_seconds: number
+  status: string
+}
+interface FlashdutyComponentUptime {
+  component_id: string
+  uptime: number
+}
+
+/** The payload the GitHub Action POSTs — the three Flashduty `data` objects, verbatim. */
+export interface FlashdutyFeed {
+  active?: { page?: { components?: FlashdutyComponent[] }; active_changes?: FlashdutyChange[] }
+  changeList?: { items?: FlashdutyChange[] }
+  structure?: { component_impacts?: FlashdutyComponentImpact[]; component_uptimes?: FlashdutyComponentUptime[] }
+}
+
+/** KV envelope: the raw feed + when the scraper captured it. */
+export interface StoredFlashdutyFeed {
+  fetchedAt: string
+  feed: FlashdutyFeed
+}
+
+// KV key the scraper (via /api/internal/deepseek-feed) writes and fetchService('deepseek') reads.
+export const DEEPSEEK_FEED_KV_KEY = 'deepseek:feed'
+// KV TTL. The scraper runs ~every 15 min; a 3h TTL tolerates ~12 consecutive missed runs before the
+// key expires and fetchService falls back to the frozen Atlassian mirror (with incidentSourceStale).
+export const DEEPSEEK_FEED_TTL_S = 3 * 60 * 60
+// Soft-staleness gate: a feed older than this still SERVES (badge/incidents stay live) but re-asserts
+// incidentSourceStale so the aging snapshot is excluded from Score ranking until a fresh push lands.
+// Graded degradation between "fresh → ranked" (≤1h) and "expired → frozen mirror" (>3h TTL).
+export const DEEPSEEK_FEED_SOFT_STALE_S = 60 * 60
+
+export interface ParsedFlashduty {
+  status: 'operational' | 'degraded' | 'down'
+  incidents: Incident[]
+  uptime30d: number | null
+  dailyImpact: Record<string, DailyImpactLevel>
+  components: ServiceComponent[]
+}
+
+// Flashduty component status → AIWatch badge status. partial_outage is a degradation (not a full
+// down); maintenance is treated as operational (planned, not an availability incident).
+const COMPONENT_STATUS: Record<string, 'operational' | 'degraded' | 'down'> = {
+  operational: 'operational',
+  degraded: 'degraded',
+  degraded_performance: 'degraded',
+  partial_outage: 'degraded',
+  maintenance: 'operational',
+  under_maintenance: 'operational',
+  full_outage: 'down',
+  major_outage: 'down',
+}
+function compStatus(s: string | undefined): 'operational' | 'degraded' | 'down' {
+  return COMPONENT_STATUS[(s ?? '').toLowerCase()] ?? 'operational'
+}
+
+// Flashduty component status → AIWatch DailyImpactLevel (for the Score's Atlassian-weighted affected
+// days, #260/#261). full_outage dominates (critical/red), partial_outage = major/orange,
+// degraded = minor. operational/maintenance contribute no impact.
+function impactLevelOf(s: string | undefined): DailyImpactLevel | null {
+  switch ((s ?? '').toLowerCase()) {
+    case 'full_outage':
+    case 'major_outage':
+      return 'critical'
+    case 'partial_outage':
+      return 'major'
+    case 'degraded':
+    case 'degraded_performance':
+      return 'minor'
+    default:
+      return null
+  }
+}
+
+const STAGE_ORDER: Record<DailyImpactLevel, number> = { minor: 1, major: 2, critical: 3 }
+
+// Flashduty incident status → AIWatch Incident.status. Unknown phases default to 'investigating'
+// (the safest "open" stage) so a renamed phase never silently reads as resolved.
+function mapStage(s: string | undefined): Incident['status'] {
+  switch ((s ?? '').toLowerCase()) {
+    case 'investigating':
+      return 'investigating'
+    case 'identified':
+      return 'identified'
+    case 'monitoring':
+      return 'monitoring'
+    case 'resolved':
+      return 'resolved'
+    default:
+      return 'investigating'
+  }
+}
+
+// Flashduty descriptions are bilingual ("中文\n\nEnglish"). Keep the English half when present
+// (after the blank-line separator) so AIWatch surfaces read in English; fall back to the whole
+// string. Trim to a single line for timeline display.
+function cleanText(desc: string | undefined): string | null {
+  if (!desc) return null
+  const parts = desc.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+  if (parts.length === 0) return null
+  const english = parts.find((p) => /[A-Za-z]/.test(p) && !/[一-鿿]/.test(p))
+  return (english ?? parts[parts.length - 1]).replace(/\s+/g, ' ').trim() || null
+}
+
+function toIncident(c: FlashdutyChange): Incident {
+  const updates = [...(c.updates ?? [])].sort((a, b) => a.at_seconds - b.at_seconds)
+  const timeline: TimelineEntry[] = updates.map((u) => ({
+    stage: mapStage(u.status),
+    text: cleanText(u.description),
+    at: new Date(u.at_seconds * 1000).toISOString(),
+  }))
+  // Worst component status seen across the incident → impact severity.
+  const statuses = [
+    ...updates.flatMap((u) => (u.component_changes ?? []).map((cc) => cc.status)),
+    ...(c.affected_components ?? []).map((a) => a.status),
+  ]
+  let impact: Incident['impact'] = null
+  for (const s of statuses) {
+    const lvl = impactLevelOf(s)
+    if (lvl && (impact === null || STAGE_ORDER[lvl] > STAGE_ORDER[impact])) impact = lvl
+  }
+  const status = mapStage(c.status)
+  const resolved = status === 'resolved'
+  const startMs = c.start_at_seconds * 1000
+  const endMs = c.close_at_seconds ? c.close_at_seconds * 1000 : null
+  return {
+    id: `flashduty:${c.change_id}`,
+    title: c.title,
+    status,
+    impact,
+    componentNames: (c.affected_components ?? []).map((a) => a.name),
+    startedAt: new Date(startMs).toISOString(),
+    resolvedAt: resolved && endMs ? new Date(endMs).toISOString() : null,
+    duration: resolved && endMs ? formatDuration(new Date(startMs), new Date(endMs)) : null,
+    timeline,
+  }
+}
+
+// Per-day worst impact across all component outage windows → the Score's dailyImpact map.
+function buildDailyImpact(impacts: FlashdutyComponentImpact[]): Record<string, DailyImpactLevel> {
+  const out: Record<string, DailyImpactLevel> = {}
+  for (const imp of impacts) {
+    const lvl = impactLevelOf(imp.status)
+    if (!lvl) continue
+    const start = new Date(imp.start_at_seconds * 1000)
+    const end = new Date((imp.end_at_seconds || imp.start_at_seconds) * 1000)
+    // Walk each UTC day the window touches.
+    for (let t = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()); t <= end.getTime(); t += 86_400_000) {
+      const day = new Date(t).toISOString().slice(0, 10)
+      if (!out[day] || STAGE_ORDER[lvl] > STAGE_ORDER[out[day]]) out[day] = lvl
+    }
+  }
+  return out
+}
+
+export interface ParseFlashdutyOptions {
+  // #618 option A — scope the badge/incidents/uptime/dailyImpact to a SINGLE Flashduty component
+  // (e.g. DeepSeek's API Service, excluding its Web Chat consumer-app surface — same api-vs-app split
+  // AIWatch applies to OpenAI API vs ChatGPT). When set: status/uptime/incidents/impacts derive only
+  // from this component, and `components` collapses to just it (so the ≥2-gated breakdown is
+  // suppressed). When absent, the whole feed is in-scope (all components, worst-of badge).
+  primaryComponentId?: string
+}
+
+/** Whether a change touched the given component (in its affected_components or any update). */
+function changeAffectsComponent(c: FlashdutyChange, compId: string): boolean {
+  if ((c.affected_components ?? []).some((a) => a.component_id === compId)) return true
+  return (c.updates ?? []).some((u) => (u.component_changes ?? []).some((cc) => cc.component_id === compId))
+}
+
+/**
+ * Normalize a raw Flashduty feed payload into AIWatch's ServiceStatus fields.
+ * Pure — no I/O. `incidentKeywords` is intentionally NOT applied; scoping (when needed) is by
+ * component id via `opts.primaryComponentId`, not keyword matching.
+ */
+export function parseFlashdutyFeed(feed: FlashdutyFeed, opts: ParseFlashdutyOptions = {}): ParsedFlashduty {
+  const primaryId = opts.primaryComponentId
+  const pageComponents = (feed.active?.page?.components ?? []).filter((pc) => !primaryId || pc.component_id === primaryId)
+  const activeChanges = (feed.active?.active_changes ?? []).filter((c) => mapStage(c.status) !== 'resolved')
+
+  // Current per-component status: worst non-resolved active impact on that component, else operational.
+  const liveStatusByComp = new Map<string, 'operational' | 'degraded' | 'down'>()
+  const rank = { operational: 0, degraded: 1, down: 2 } as const
+  for (const c of activeChanges) {
+    for (const a of c.affected_components ?? []) {
+      if (primaryId && a.component_id !== primaryId) continue
+      const s = compStatus(a.status)
+      const prev = liveStatusByComp.get(a.component_id) ?? 'operational'
+      if (rank[s] > rank[prev]) liveStatusByComp.set(a.component_id, s)
+    }
+  }
+
+  const components: ServiceComponent[] = pageComponents.map((pc) => ({
+    id: pc.component_id,
+    name: pc.name,
+    status: liveStatusByComp.get(pc.component_id) ?? 'operational',
+  }))
+
+  // Overall badge = worst (scoped) component status.
+  let status: 'operational' | 'degraded' | 'down' = 'operational'
+  for (const c of components) if (rank[c.status] > rank[status]) status = c.status
+
+  // History incidents (change/list) + any active ones not already in history, scoped to the primary
+  // component when set, newest first.
+  const historyItems = feed.changeList?.items ?? []
+  const seen = new Set(historyItems.map((i) => i.change_id))
+  const allChanges = [...historyItems, ...activeChanges.filter((c) => !seen.has(c.change_id))]
+    .filter((c) => !primaryId || changeAffectsComponent(c, primaryId))
+  const incidents = allChanges
+    .map(toIncident)
+    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
+
+  // Uptime: the primary component's uptime when scoped; otherwise the worst (min) across components —
+  // a multi-component service's availability is gated by its weakest surface.
+  const uptimes = (feed.structure?.component_uptimes ?? [])
+    .filter((u) => !primaryId || u.component_id === primaryId)
+    .map((u) => u.uptime)
+    .filter((n) => typeof n === 'number')
+  const uptime30d = uptimes.length > 0 ? Math.min(...uptimes) : null
+
+  const dailyImpact = buildDailyImpact(
+    (feed.structure?.component_impacts ?? []).filter((imp) => !primaryId || imp.component_id === primaryId),
+  )
+
+  return { status, incidents, uptime30d, dailyImpact, components }
+}

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -6,6 +6,7 @@ import { fetchWithTimeout, formatDuration, trackFetchFailure, resetFetchFailure,
 import { isProbeHealthy, type ProbeSnapshot } from './probe'
 import { platformStatusKey, type PlatformStatus } from './platform-monitor'
 import { type StatuspageResponse, normalizeStatus, parseIncidents, parseUptimeData } from './parsers/statuspage'
+import { parseFlashdutyFeed, DEEPSEEK_FEED_KV_KEY, DEEPSEEK_FEED_SOFT_STALE_S, type StoredFlashdutyFeed } from './parsers/flashduty'
 import { parseIncidentIoUptime, parseIncidentIoComponentImpacts, computeUptimeFromIncidents, enrichIncidentIoText } from './parsers/incident-io'
 import { type GCloudIncident, parseGCloudIncidents } from './parsers/gcloud'
 import {
@@ -53,12 +54,15 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'cerebras', name: 'Cerebras Inference', provider: 'Cerebras', category: 'api', statusUrl: 'https://status.cerebras.ai', apiUrl: 'https://status.cerebras.ai/api/v2/summary.json', statusComponentId: '83h1cchw4vs4', statusComponentIds: ['83h1cchw4vs4', '7xvps6c9lqwc', 'bhqw2gr7r710', 'hgfykfsb36gn', '8ygyx5vydlm2'] },
   { id: 'perplexity', name: 'Perplexity', provider: 'Perplexity AI', category: 'api', statusUrl: 'https://status.perplexity.com', apiUrl: null, instatusUrl: 'https://status.perplexity.com' },
   { id: 'xai', name: 'xAI (Grok)', provider: 'xAI', category: 'api', statusUrl: 'https://status.x.ai', apiUrl: null, rssFeedUrl: 'https://status.x.ai/feed.xml', incidentKeywords: ['api'], incidentExclude: ['[API Console]', 'Test+Incident'] },
-  // status.deepseek.com blocks Cloudflare Workers IPs (SSL reset); deepseek.statuspage.io is the
-  // Atlassian-hosted mirror that's accessible from Workers — same component IDs, same data (#498).
-  // #591/#507 — that mirror FROZE at 2026-05-08 (DeepSeek migrated to Flashduty, unreachable
-  // server-side); it still returns 200 with stale data, so the feed reads as current but isn't.
-  // `incidentSourceStale` excludes it from all Score rankings until the feed is reachable again.
-  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://deepseek.statuspage.io/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'], incidentSourceStale: true },
+  // status.deepseek.com (Flashduty, #507) blocks NON-BROWSER TLS fingerprints — a Worker fetch()
+  // is reset at the TLS layer regardless of egress IP (verified 2026-06-12: a real Chromium from
+  // the SAME IP succeeds where curl/fetch are reset, so it's a JA3/bot wall, NOT an IP block).
+  // #618 — a scheduled GitHub Action browser-renders the page and POSTs the Flashduty feed to
+  // /api/internal/deepseek-feed → KV. `flashdutyFeed` makes fetchService prefer that KV feed (fresh
+  // → supersedes the mirror, clears the stale flag). The deepseek.statuspage.io Atlassian mirror
+  // (#498) is the FALLBACK when the feed is missing/expired — it FROZE at 2026-05-08 (#591/#507),
+  // returning 200 with stale data, so `incidentSourceStale` keeps it out of Score rankings then.
+  { id: 'deepseek', name: 'DeepSeek API', provider: 'DeepSeek', category: 'api', statusUrl: 'https://status.deepseek.com', apiUrl: 'https://deepseek.statuspage.io/api/v2/summary.json', statusComponentId: 'j4n367d9mh3x', incidentKeywords: ['api'], incidentSourceStale: true, flashdutyFeed: true, flashdutyPrimaryComponentId: '01KR3NC9ETZYF436Z8YT1HM047' },
   { id: 'openrouter', name: 'OpenRouter', provider: 'OpenRouter', category: 'api', statusUrl: 'https://status.openrouter.ai', apiUrl: null, onlineOrNotUrl: 'https://status.openrouter.ai', onlineOrNotComponent: 'Chat (/api/v1/chat/completions)' },
   // Voice & Speech AI
   // displayComponentIds (#606): curated availability surfaces for the breakdown card —
@@ -478,6 +482,48 @@ interface PrefetchedData {
 // For services without `apiUrl`, status is based on HTTP reachability of the status page (200 = operational).
 // This may not reflect actual service outages if the status page itself remains up.
 
+// #618 — read the browser-rendered Flashduty feed (pushed to KV by the deepseek-feed Action) and
+// normalize it into a ServiceStatus. Returns null when the KV key is absent/expired/corrupt so the
+// caller falls through to the frozen-mirror apiUrl path (which keeps incidentSourceStale). On a
+// fresh feed the result intentionally DROPS the stale flag — the data is now live, not frozen.
+async function readFlashdutyStatus(kv: KVNamespace, config: ServiceConfig, base: ServiceStatus, now: string): Promise<ServiceStatus | null> {
+  let raw: string | null
+  try {
+    raw = await kv.get(DEEPSEEK_FEED_KV_KEY)
+  } catch (err) {
+    console.warn(`[fetchService] ${base.id} flashduty KV read failed:`, err instanceof Error ? err.message : err)
+    return null
+  }
+  if (!raw) return null
+  let parsed
+  let fetchedAt: string | undefined
+  try {
+    const stored = JSON.parse(raw) as StoredFlashdutyFeed
+    fetchedAt = stored.fetchedAt
+    parsed = parseFlashdutyFeed(stored.feed, { primaryComponentId: config.flashdutyPrimaryComponentId })
+  } catch (err) {
+    console.warn(`[fetchService] ${base.id} flashduty parse failed:`, err instanceof Error ? err.message : err)
+    return null
+  }
+  const result: ServiceStatus = {
+    ...base,
+    status: parsed.status,
+    lastChecked: now,
+    incidents: parsed.incidents,
+    ...(parsed.uptime30d != null ? { uptime30d: parsed.uptime30d, uptimeSource: 'official' as const } : {}),
+    ...(Object.keys(parsed.dailyImpact).length > 0 ? { dailyImpact: parsed.dailyImpact } : {}),
+    ...(parsed.components.length >= 2 ? { components: parsed.components } : {}),
+  }
+  // A FRESH feed (≤ soft-stale window) → no longer stale: strip the config's incidentSourceStale so
+  // ranking/fallback re-include DeepSeek with trustworthy data. An AGING feed (older than the soft
+  // window but not yet KV-expired) still serves its live badge/incidents but KEEPS incidentSourceStale
+  // so the stale snapshot can't inflate the Score ranking until a fresh scraper push lands.
+  const ageS = (Date.parse(now) - Date.parse(fetchedAt ?? '')) / 1000
+  const fresh = Number.isFinite(ageS) && ageS <= DEEPSEEK_FEED_SOFT_STALE_S
+  if (fresh) delete (result as { incidentSourceStale?: boolean }).incidentSourceStale
+  return result
+}
+
 async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, kv?: KVNamespace): Promise<ServiceStatus> {
   const now = new Date().toISOString()
   let parseErrors = 0 // Track internal parse/fetch failures — prevents resetFetchFailure from masking repeated errors
@@ -497,6 +543,14 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
   }
 
   try {
+    // #618 — DeepSeek: prefer the browser-rendered Flashduty feed cached in KV by the scraper Action.
+    // Fresh feed supersedes the frozen Atlassian mirror and clears incidentSourceStale; missing/
+    // expired feed falls through to the apiUrl path below (which keeps the stale flag from base).
+    if (config.flashdutyFeed && kv) {
+      const fed = await readFlashdutyStatus(kv, config, base, now)
+      if (fed) return fed
+    }
+
     if (config.apiUrl) {
       // Atlassian Statuspage API — use pre-fetched data when available, else fetch directly
       let summaryData: StatuspageResponse

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -147,6 +147,16 @@ export interface ServiceConfig {
   // ServiceStatus.incidentSourceStale → all ranking surfaces exclude it (a frozen empty 30-day
   // incident window would otherwise inflate the Score). REMOVE once the feed is reachable again.
   incidentSourceStale?: boolean
+  // #618 — the service's live status comes from a browser-rendered Flashduty feed pushed to KV by
+  // the deepseek-feed GitHub Action (status.deepseek.com is bot-walled to a plain Worker fetch).
+  // When set, fetchService reads DEEPSEEK_FEED_KV_KEY first; a FRESH feed supersedes apiUrl and
+  // clears incidentSourceStale, while a missing/expired feed falls through to apiUrl (the frozen
+  // Atlassian mirror) keeping incidentSourceStale. Pairs with incidentSourceStale (the fallback).
+  flashdutyFeed?: boolean
+  // #618 option A — scope the Flashduty feed to a single component id (the API surface), excluding
+  // sibling consumer-app components (e.g. DeepSeek's Web Chat) from the badge/incidents/uptime/score
+  // — the same api-vs-app split as OpenAI API (incidentExclude:['chatgpt']). Absent → whole feed.
+  flashdutyPrimaryComponentId?: string
 }
 
 export interface ProbeSummary {


### PR DESCRIPTION
## Problem

`status.deepseek.com` migrated to **Flashduty** (#507), which **blocks non-browser TLS fingerprints** — a Worker `fetch()` is reset at the TLS layer regardless of egress IP (verified: a real Chromium from the **same IP** succeeds where curl/fetch are reset → JA3/bot wall, **not** an IP block). DeepSeek was marked `incidentSourceStale` (#591) and read from the **frozen** Atlassian mirror (last updated 2026-05-08), so its incidents/uptime were stale and its Score inflated.

## Approach

A scheduled **GitHub Action** browser-renders the page, fetches the clean Flashduty JSON API from the browser context, and POSTs it to the Worker → KV → normalized by a tested parser.

```
GH Action (headless Chromium) → POST /api/internal/deepseek-feed → KV deepseek:feed
                                                                  ↓
                          fetchService('deepseek') → parseFlashdutyFeed → ServiceStatus
```

- **`parsers/flashduty.ts`** — pure parser, raw `{active, changeList, structure}` → ServiceStatus fields.
- **`/api/internal/deepseek-feed`** — Bearer `DEEPSEEK_FEED_TOKEN` auth, rejects empty pushes, KV 3h TTL.
- **Graded degradation**: fresh feed (≤1h) → live + ranked (`incidentSourceStale` cleared); aging (1–3h) → live but re-asserts `incidentSourceStale` (ranking-excluded); absent/expired (>3h) → falls back to the frozen mirror keeping the stale flag.
- **Option A scoping** — DeepSeek API is scoped to its **API Service** component (`flashdutyPrimaryComponentId`); the **Web Chat** consumer component is excluded from badge/incidents/score — same api-vs-app split as OpenAI API (excludes ChatGPT). The Web Chat surface becomes its own **"DeepSeek App"** service in **#619**.

## Test / verify

- `flashduty-parser.test.ts` (13 tests) vs **real captured** DeepSeek payload, incl. option-A scoping + active-incident + empty-payload defensiveness.
- Worker suite **1648 ✓** · `typecheck:worker` 0 TS2304 ✓ · dry-run build ✓ · scraper syntax ✓.
- PR review (code-reviewer): **0 Critical / 0 Important**; 2 robustness suggestions implemented (soft-staleness gate, scraper per-fetch timeout).
- **Local in-browser verified**: DeepSeek serves live from the feed — `incidentSourceStale` cleared, Score **86** (real data, was an inflated stale 94), API-scoped incidents, uptime 99.89 (official). Confirmed that Web-Chat-only incidents (e.g. 6/9) are correctly **excluded** from DeepSeek API and surface in #619 instead — DeepSeek API genuinely had no incidents in the 7d/14d display windows (accurate).

## Acceptance (refs #618 — deploy-gated)

- [x] Flashduty parser + option-A scoping, regression-tested
- [x] Ingestion endpoint (auth + validation) + KV feed + fetchService integration
- [x] Scraper script + scheduled Action (pinned Playwright 1.58.2)
- [x] `services.ts:56` comment corrected (bot/TLS wall, not IP block)
- [ ] **Post-merge**: set `DEEPSEEK_FEED_TOKEN` Worker secret + GH Action secrets (`DEEPSEEK_FEED_TOKEN`, `DEEPSEEK_FEED_WORKER_URL`); `npm run deploy:worker`; enable the Action; verify against a real DeepSeek incident

Follow-up: **#619** (add "DeepSeek App" consumer service, reuses this feed scoped to Web Chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)