### PR TITLE
feat: add DeepSeek App (consumer chat) as a separate app service (refs #619)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,9 @@ When adding a new monitored service, files across worker, frontend, docs, SEO me
 
 ## Architecture
 
-**AIWatch** is a React SPA that monitors 36 AI services in real time:
+**AIWatch** is a React SPA that monitors 37 AI services in real time:
 - **27 API services**: Claude, OpenAI, Gemini, Mistral, Cohere, Groq, Together, Fireworks, Cerebras, Perplexity, HuggingFace, Replicate, ElevenLabs, AssemblyAI, Deepgram, xAI, DeepSeek, OpenRouter, Bedrock, Azure OpenAI, Pinecone, Stability AI, Voyage AI, Modal, LangChain (LangSmith), Runway, Luma (Dream Machine)
-- **3 AI apps**: claude.ai, ChatGPT, Character.AI
+- **4 AI apps**: claude.ai, ChatGPT, Character.AI, DeepSeek App
 - **6 coding agents**: Claude Code, Codex, Cursor, GitHub Copilot, Windsurf, Junie
 
 ### Tech Stack
@@ -292,7 +292,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`; GA4 activates only 
 Per-service status is resolved in `worker/src/services.ts` with a layered priority chain (multi-component worst-of → component match → overall-indicator fallback → `incidentExclude` bypass → component-status filter → fetch-failure cross-validation). The full ordered rules and their #-issue rationale are in **[docs/reference/status-determination.md](docs/reference/status-determination.md)** — read it before changing status resolution.
 
 ### Status Data Flow
-Browser (60s polling) → Worker `/api/status` (parallel 36-service fetch, normalize, KV write, platform/probe cross-validation) → React state → pages. Cron (`*/5`) handles probing, incident detection + Discord alerts, AI analysis, daily/monthly aggregation, changelog/security/weekly briefing. The full annotated request + cron + Web Vitals flow diagram is in **[docs/reference/data-flow.md](docs/reference/data-flow.md)**.
+Browser (60s polling) → Worker `/api/status` (parallel 37-service fetch, normalize, KV write, platform/probe cross-validation) → React state → pages. Cron (`*/5`) handles probing, incident detection + Discord alerts, AI analysis, daily/monthly aggregation, changelog/security/weekly briefing. The full annotated request + cron + Web Vitals flow diagram is in **[docs/reference/data-flow.md](docs/reference/data-flow.md)**.
 
 ### SPA Navigation
 No React Router. Hash-based routing in `App.jsx` — `#claude` for service details, `#latency` for pages. `PageContext` shares current page state. Browser back/forward supported via `popstate` listener.

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 [English](README.md) | **한국어**
 
-**36개 AI 서비스**의 상태, 지연시간, 가동률, 인시던트를 실시간으로 모니터링하는 대시보드입니다.
+**37개 AI 서비스**의 상태, 지연시간, 가동률, 인시던트를 실시간으로 모니터링하는 대시보드입니다.
 
 **[대시보드](https://ai-watch.dev)** · **[랜딩 페이지](https://ai-watch.dev/intro)**
 
@@ -21,9 +21,9 @@
 | ![AIWatch 대시보드](docs/screenshot.png?v=3) | ![AIWatch 모바일](docs/screenshot-mobile.png?v=1) |
 
 **공유**
-[![X에 공유](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%2036%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81%20%28Claude%2C%20ChatGPT%2C%20Gemini%20%EC%99%B8%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
-[![Reddit에 공유](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%2036%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81)
-[![Hacker News에 공유](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2036%20AI%20services)
+[![X에 공유](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%2037%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81%20%28Claude%2C%20ChatGPT%2C%20Gemini%20%EC%99%B8%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+[![Reddit에 공유](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%2037%EA%B0%9C%20AI%20%EC%84%9C%EB%B9%84%EC%8A%A4%20%EC%8B%A4%EC%8B%9C%EA%B0%84%20%EC%9E%A5%EC%95%A0%20%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81)
+[![Hacker News에 공유](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2037%20AI%20services)
 [![LinkedIn에 공유](https://img.shields.io/badge/Share-LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
 
 ## 🛰️ 라이브 데모
@@ -32,7 +32,7 @@
 
 ## 주요 기능
 
-- **실시간 상태 모니터링** — 36개 AI 서비스의 정상 / 성능 저하 / 장애 상태
+- **실시간 상태 모니터링** — 37개 AI 서비스의 정상 / 성능 저하 / 장애 상태
 - **PWA 지원** — 홈 화면 추가, Service Worker 오프라인 캐시
 - **지연시간 측정** — 20개 probe 대상 서비스의 API 엔드포인트 직접 RTT 측정, 나머지는 상태 페이지 응답 시간
 - **24시간 지연시간 추세** — Chart.js 라인 차트 (5분 간격 probe 스냅샷)
@@ -83,7 +83,7 @@
 | AssemblyAI | AssemblyAI | Atlassian Statuspage |
 | Deepgram | Deepgram | Atlassian Statuspage |
 | xAI (Grok) | xAI | RSS 피드 |
-| DeepSeek API | DeepSeek | Atlassian Statuspage |
+| DeepSeek API | DeepSeek | Flashduty (브라우저 렌더 피드) |
 | OpenRouter | OpenRouter | OnlineOrNot (React Router SSR) |
 | Amazon Bedrock | AWS | AWS Health Dashboard |
 | Pinecone | Pinecone | Atlassian Statuspage |
@@ -95,13 +95,14 @@
 | Luma (Dream Machine) | Luma | Better Stack RSS + 가동률 API |
 | Azure OpenAI | Microsoft | Azure Status RSS |
 
-### AI 앱 (3개)
+### AI 앱 (4개)
 
 | 서비스 | 제공업체 |
 |--------|----------|
 | claude.ai | Anthropic |
 | ChatGPT | OpenAI |
 | Character.AI | Character AI |
+| DeepSeek App | DeepSeek |
 
 ### 코딩 에이전트 (6개)
 
@@ -132,7 +133,7 @@
 브라우저 (React SPA, 60초 폴링)
   ↓
 Cloudflare Worker
-  ├── GET /api/status    → 병렬 fetch (36개 서비스) → 정규화
+  ├── GET /api/status    → 병렬 fetch (37개 서비스) → 정규화
   ├── GET /api/uptime    → 일별 가동률 이력
   └── POST /api/alert   → Discord Webhook 프록시 (SSRF 보호)
   ↓
@@ -300,7 +301,7 @@ README, 문서, 블로그에 실시간 상태 배지를 임베드할 수 있습�
 
 ## Claude Code Statusline 통합
 
-Claude API, OpenAI, Gemini, GitHub Copilot 등 36개 AI 서비스의 장애 여부를 [Claude Code 스테이터스라인](https://docs.claude.com/en/docs/claude-code/statusline)에 직접 표시합니다. 추천 프리셋은 항상 표시되는 클릭 가능한 **AIWatch** 라벨을 유지합니다 — 모두 정상이면 `AIWatch 🟢`, 장애 시 `AIWatch 🔴 Claude API`, 라벨 cmd/ctrl+클릭 시 대시보드 열림. 정상일 때 공간을 비우고 싶으면 [프리셋 페이지](https://ai-watch.dev/#statusline)의 minimalist 프리셋을 쓰면 됩니다.
+Claude API, OpenAI, Gemini, GitHub Copilot 등 37개 AI 서비스의 장애 여부를 [Claude Code 스테이터스라인](https://docs.claude.com/en/docs/claude-code/statusline)에 직접 표시합니다. 추천 프리셋은 항상 표시되는 클릭 가능한 **AIWatch** 라벨을 유지합니다 — 모두 정상이면 `AIWatch 🟢`, 장애 시 `AIWatch 🔴 Claude API`, 라벨 cmd/ctrl+클릭 시 대시보드 열림. 정상일 때 공간을 비우고 싶으면 [프리셋 페이지](https://ai-watch.dev/#statusline)의 minimalist 프리셋을 쓰면 됩니다.
 
 가장 빠른 설정 — `~/.claude/settings.json`에 추가:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **English** | [한국어](README.ko.md)
 
-Real-time monitoring dashboard for **36 AI services** — track status, latency, uptime, and incidents across major AI providers.
+Real-time monitoring dashboard for **37 AI services** — track status, latency, uptime, and incidents across major AI providers.
 
 **[Dashboard](https://ai-watch.dev)** · **[Landing Page](https://ai-watch.dev/intro)**
 
@@ -22,9 +22,9 @@ Real-time monitoring dashboard for **36 AI services** — track status, latency,
 | ![AIWatch Dashboard](docs/screenshot.png?v=3) | ![AIWatch Mobile](docs/screenshot-mobile.png?v=1) |
 
 **Share**
-[![Share on X](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2036%20AI%20services%20%28Claude%2C%20ChatGPT%2C%20Gemini%2C%20and%20more%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
-[![Share on Reddit](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2036%20AI%20services)
-[![Share on Hacker News](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2036%20AI%20services)
+[![Share on X](https://img.shields.io/badge/Share-X-000000?logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2037%20AI%20services%20%28Claude%2C%20ChatGPT%2C%20Gemini%2C%20and%20more%29&url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
+[![Share on Reddit](https://img.shields.io/badge/Share-Reddit-FF4500?logo=reddit&logoColor=white)](https://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&title=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2037%20AI%20services)
+[![Share on Hacker News](https://img.shields.io/badge/Share-Hacker%20News-FF6600?logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch&t=AIWatch%20%E2%80%94%20Real-time%20monitoring%20for%2037%20AI%20services)
 [![Share on LinkedIn](https://img.shields.io/badge/Share-LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fbentleypark%2Faiwatch)
 
 ## 🛰️ Live Demo
@@ -33,7 +33,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 
 ## Features
 
-- **Real-time status** — Operational / Degraded / Down for 36 AI services
+- **Real-time status** — Operational / Degraded / Down for 37 AI services
 - **PWA support** — Add to home screen, offline cache with Service Worker
 - **Latency monitoring** — Direct API endpoint response time (RTT) for 20 probe-capable services, status page timing as fallback
 - **24h latency trend** — Chart.js line chart with 5-min probe snapshots
@@ -84,7 +84,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | AssemblyAI | AssemblyAI | Atlassian Statuspage |
 | Deepgram | Deepgram | Atlassian Statuspage |
 | xAI (Grok) | xAI | RSS feed |
-| DeepSeek API | DeepSeek | Atlassian Statuspage |
+| DeepSeek API | DeepSeek | Flashduty (browser-rendered feed) |
 | OpenRouter | OpenRouter | OnlineOrNot (React Router SSR) |
 | Amazon Bedrock | AWS | AWS Health Dashboard |
 | Pinecone | Pinecone | Atlassian Statuspage |
@@ -96,13 +96,14 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | Luma (Dream Machine) | Luma | Better Stack RSS + uptime API |
 | Azure OpenAI | Microsoft | Azure Status RSS |
 
-### AI Apps (3)
+### AI Apps (4)
 
 | Service | Provider |
 |---------|----------|
 | claude.ai | Anthropic |
 | ChatGPT | OpenAI |
 | Character.AI | Character AI |
+| DeepSeek App | DeepSeek |
 
 ### Coding Agents (6)
 
@@ -133,7 +134,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 Browser (React SPA, 60s polling)
   ↓
 Cloudflare Worker
-  ├── GET /api/status    → parallel fetch (36 services) → normalize
+  ├── GET /api/status    → parallel fetch (37 services) → normalize
   ├── GET /api/uptime    → daily uptime history
   └── POST /api/alert   → Discord webhook proxy (SSRF protected)
   ↓

--- a/api/intro/html-template.ts
+++ b/api/intro/html-template.ts
@@ -58,7 +58,7 @@ ${CONSENT_INIT_SCRIPT}
   "@type": "WebApplication",
   "name": "AIWatch",
   "url": "https://ai-watch.dev",
-  "description": "Real-time status monitoring for 36 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex. AI-powered incident analysis with fallback recommendations.",
+  "description": "Real-time status monitoring for 37 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex. AI-powered incident analysis with fallback recommendations.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Web",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -512,7 +512,7 @@ ${announcementHtml}
   <div class="hero-left">
     <div class="hero-badge"><span class="hero-badge-dot"></span><span data-i18n="hero.badge">LIVE MONITORING</span></div>
     <h1 data-i18n="hero.title"><em>AI 서비스</em> 장애를 즉시 파악하고,<br>갈아탈 대안까지 한 번에.</h1>
-    <p data-i18n="hero.sub">36개 AI 서비스 상태를 한 화면에서.<span class="hero-sub-line"> AIWatch가 신뢰도를 랭킹하고 장애를 분석해,</span> 멈추는 순간 대안을 즉시 추천합니다. 무료 · 오픈소스 · 무가입.</p>
+    <p data-i18n="hero.sub">37개 AI 서비스 상태를 한 화면에서.<span class="hero-sub-line"> AIWatch가 신뢰도를 랭킹하고 장애를 분석해,</span> 멈추는 순간 대안을 즉시 추천합니다. 무료 · 오픈소스 · 무가입.</p>
     <div class="hero-ctas">
       <a href="https://ai-watch.dev" class="btn-primary" data-i18n="hero.cta1" onclick="gtag('event','click_dashboard',{location:'landing_hero',source:'intro'})">대시보드 열기 →</a>
       <a href="https://github.com/bentleypark/aiwatch" target="_blank" rel="noopener noreferrer" class="btn-secondary" data-i18n="hero.cta2" onclick="gtag('event','click_github_header',{location:'landing_hero',source:'intro'})">GitHub에서 보기</a>
@@ -651,7 +651,7 @@ ${announcementHtml}
       <div class="mock-section-header">
         <div class="mock-section-title"><span class="green-slash">//</span> Services</div>
         <div class="mock-filter-tabs">
-          <span class="mock-filter-tab active">All 36</span>
+          <span class="mock-filter-tab active">All 37</span>
           <span class="mock-filter-tab">Operational 33</span>
           <span class="mock-filter-tab">Issues 1<span class="mock-filter-dot"></span></span>
         </div>
@@ -911,7 +911,7 @@ ${announcementHtml}
         <tr>
           <td data-i18n="compare.r2">장애 알림</td>
           <td class="no" data-i18n="compare.r2a">제공사마다 개별 구독</td>
-          <td class="yes" data-i18n="compare.r2b">36개를 한 곳에서 — Discord · Slack · RSS</td>
+          <td class="yes" data-i18n="compare.r2b">37개를 한 곳에서 — Discord · Slack · RSS</td>
         </tr>
         <tr>
           <td data-i18n="compare.r3">AIWatch Score</td>
@@ -1007,7 +1007,7 @@ ${announcementHtml}
   <p class="section-label">// monthly report</p>
   <h2 class="section-title" data-i18n="report.title">월간 AI 서비스 신뢰도 리포트</h2>
   <p class="section-sub" data-i18n="report.hook" style="color:var(--amber);font-size:15px;font-weight:500;margin-bottom:8px;">가장 안정적인 AI 서비스는? 답은 의외일 수 있습니다.</p>
-  <p class="section-sub" data-i18n="report.sub">매월 36개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.</p>
+  <p class="section-sub" data-i18n="report.sub">매월 37개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.</p>
   <div class="report-chart">
     <svg viewBox="0 0 320 356" xmlns="http://www.w3.org/2000/svg" style="width:100%;font-family:'JetBrains Mono',monospace;">
   <rect width="320" height="356" fill="#0d1117" rx="8"/>
@@ -1104,7 +1104,7 @@ const i18n = {
     'nav.features': '기능', 'nav.how': '동작 방식', 'nav.report': '월간 리포트', 'nav.cta': '장애 확인하기 →',
     'hero.badge': 'LIVE MONITORING',
     'hero.title': '<em>AI 서비스</em> 장애를 즉시 파악하고,<br>갈아탈 대안까지 한 번에.',
-    'hero.sub': '36개 AI 서비스 상태를 한 화면에서.<span class="hero-sub-line"> AIWatch가 신뢰도를 랭킹하고 장애를 분석해,</span> 멈추는 순간 대안을 즉시 추천합니다. 무료 · 오픈소스 · 무가입.',
+    'hero.sub': '37개 AI 서비스 상태를 한 화면에서.<span class="hero-sub-line"> AIWatch가 신뢰도를 랭킹하고 장애를 분석해,</span> 멈추는 순간 대안을 즉시 추천합니다. 무료 · 오픈소스 · 무가입.',
     'hero.cta1': '대시보드 열기 →', 'hero.trust': '로그인 없음 · 실시간 상태 · 완전 무료 오픈소스 (AGPL)', 'hero.cta2': 'GitHub에서 보기',
     'hero.pill1': 'AI 서비스', 'hero.pill2v': '실시간', 'hero.pill2': '알림', 'hero.pill3': '오픈소스',
     'flow.1.title': '장애 감지', 'flow.2.conn': 'AI 분석 시작', 'flow.2.bar': '패턴 분석 중', 'flow.3.conn': 'Discord · Slack · RSS 알림', 'flow.3.title': '알림 발송', 'flow.3.body': 'Discord · Slack · RSS 알림 발송', 'flow.4.conn': '대안 추천', 'flow.4.title': 'Fallback 추천',
@@ -1116,7 +1116,7 @@ const i18n = {
     'feat.3.title': 'Fallback 추천', 'feat.3.desc': '장애 중인 서비스의 대안을 같은 카테고리 Score 상위 순으로 즉시 제안합니다. 같은 제공사 서비스는 자동 제외됩니다.',
     'feat.4.title': '"Is X Down?" 전용 페이지', 'feat.4.desc': 'ai-watch.dev/is-claude-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.',
     'how.title': '이렇게 동작합니다', 'how.sub': '각 서비스의 공식 상태 페이지 데이터를 기반으로 동작합니다',
-    'compare.title': '공식 상태 페이지와 무엇이 다른가요?', 'compare.sub': '공식 페이지 데이터를 기반으로, 36개를 한 화면에서 통합합니다', 'compare.col1': '공식 상태 페이지', 'compare.r2': '장애 알림', 'compare.r2a': '제공사마다 개별 구독', 'compare.r2b': '36개를 한 곳에서 — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': '서비스별 개별 확인', 'compare.r3b': 'AIWatch Score — Uptime + 영향 일수 + 복구 + 응답성', 'compare.r4': '장애 분석', 'compare.r4b': 'AI가 원인 · 복구 시간 분석', 'compare.r5': '대안 추천', 'compare.r5b': 'Fallback 서비스 즉시 제안', 'compare.r6': '월간 리포트', 'compare.r6b': '매월 리포트 공개', 'compare.r7': '비용', 'compare.r7a': '무료', 'compare.r7b': '완전 무료 · 오픈소스',
+    'compare.title': '공식 상태 페이지와 무엇이 다른가요?', 'compare.sub': '공식 페이지 데이터를 기반으로, 37개를 한 화면에서 통합합니다', 'compare.col1': '공식 상태 페이지', 'compare.r2': '장애 알림', 'compare.r2a': '제공사마다 개별 구독', 'compare.r2b': '37개를 한 곳에서 — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': '서비스별 개별 확인', 'compare.r3b': 'AIWatch Score — Uptime + 영향 일수 + 복구 + 응답성', 'compare.r4': '장애 분석', 'compare.r4b': 'AI가 원인 · 복구 시간 분석', 'compare.r5': '대안 추천', 'compare.r5b': 'Fallback 서비스 즉시 제안', 'compare.r6': '월간 리포트', 'compare.r6b': '매월 리포트 공개', 'compare.r7': '비용', 'compare.r7a': '무료', 'compare.r7b': '완전 무료 · 오픈소스',
     'how.1.badge': '자동', 'how.2.badge': '장애 감지 시', 'how.3.badge': '실시간', 'how.4.badge': '매월',
     'how.1.title': '수집', 'how.1.desc': '공식 상태 페이지를 최대 5분 간격으로 자동 갱신',
     'how.2.title': '분석', 'how.2.desc': '하이브리드 AI(Gemma 4 + Claude Sonnet fallback)가 패턴 · 복구 시간 · 영향 범위 분석',
@@ -1125,26 +1125,26 @@ const i18n = {
     'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord · Slack · RSS 알림', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기', 'cta.rss': 'RSS로 구독',
     'alert.title': '장애 알림, 원하는 방식으로', 'alert.sub': '장애 발생 시 실시간 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
     'alert.rss.copied': '복사됨 ✓', 'alert.rss.prompt': 'RSS 피드 URL 복사:',
-    'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.hook': '가장 안정적인 AI 서비스는? 답은 의외일 수 있습니다.', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 36개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'report.chart.note': '* 하위 점수는 리포팅 방식 차이일 수 있으며, 실제 불안정성을 의미하지 않습니다',
+    'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.hook': '가장 안정적인 AI 서비스는? 답은 의외일 수 있습니다.', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 37개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'report.chart.note': '* 하위 점수는 리포팅 방식 차이일 수 있으며, 실제 불안정성을 의미하지 않습니다',
     'footer.report': '월간 리포트', 'footer.alert': '알림 설정'
   },
   en: {
     'nav.features': 'Features', 'nav.how': 'How it works', 'nav.report': 'Monthly Report', 'nav.cta': 'Check for Outages →',
     'hero.badge': 'LIVE MONITORING',
     'hero.title': 'Know when any <em>AI service</em> is down —<br>and what to switch to.',
-    'hero.sub': 'Real-time status for 36 AI services in one view.<span class="hero-sub-line"> AIWatch ranks reliability, analyzes incidents,</span> and recommends an instant fallback the moment something breaks. Free & open source — no signup.',
+    'hero.sub': 'Real-time status for 37 AI services in one view.<span class="hero-sub-line"> AIWatch ranks reliability, analyzes incidents,</span> and recommends an instant fallback the moment something breaks. Free & open source — no signup.',
     'hero.cta1': 'Open the dashboard →', 'hero.trust': 'No signup · Live status · Free & open source (AGPL)', 'hero.cta2': 'View on GitHub',
     'hero.pill1': 'AI Services', 'hero.pill2v': 'Real-time', 'hero.pill2': 'Alerts', 'hero.pill3': 'Open Source',
     'flow.1.title': 'Outage Detected', 'flow.2.conn': 'AI analysis started', 'flow.2.bar': 'Analyzing patterns', 'flow.3.conn': 'Discord · Slack · RSS alerts', 'flow.3.title': 'Alert Sent', 'flow.3.body': 'Discord · Slack · RSS alert sent', 'flow.4.conn': 'Alternatives suggested', 'flow.4.title': 'Fallback Suggested',
     'stats.services': 'Services monitored', 'stats.interval': 'Auto-collected', 'stats.free': 'Discord · Slack · RSS alerts included', 'stats.oss': 'Open source',
-    'demo.title': 'From outage detection to fallback — in one view', 'demo.sub': 'See which services are stable right now — and what to use instead when they\\\'re not', 'demo.more': '+ 31 more services...',
+    'demo.title': 'From outage detection to fallback — in one view', 'demo.sub': 'See which services are stable right now — and what to use instead when they\\\'re not', 'demo.more': '+ 32 more services...',
     'feat.title': 'Beyond status monitoring', 'feat.sub': 'An AI monitoring dashboard that helps you make decisions',
     'feat.1.title': 'AIWatch Score', 'feat.1.desc': 'A 0–100 reliability score combining Uptime (40) + Incident impact days (25) + Recovery time (15) + Responsiveness (20). Services without official data use industry averages with a penalty.',
     'feat.2.title': 'AI Incident Analysis', 'feat.2.desc': 'When an outage hits, AIWatch analyzes the pattern and tells you the estimated recovery time and impact scope. No more guessing.',
     'feat.3.title': 'Fallback Recommendations', 'feat.3.desc': 'Get instant alternative suggestions ranked by Score within the same category. Same-provider services are automatically excluded.',
     'feat.4.title': '"Is X Down?" Dedicated Pages', 'feat.4.desc': 'Pages like ai-watch.dev/is-claude-down show real-time status, AI analysis, and fallback recommendations — all in one place.',
     'how.title': 'How it works', 'how.sub': 'Powered by official status page data from each provider',
-    'compare.title': 'How is AIWatch different?', 'compare.sub': 'Built on official status data — aggregated across 36 services in one place', 'compare.col1': 'Official Status Page', 'compare.r2': 'Alerts', 'compare.r2a': 'Subscribe per provider, separately', 'compare.r2b': 'All 36 in one — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': 'Per-service, separate pages', 'compare.r3b': 'AIWatch Score — Uptime + Impact days + Recovery + Responsiveness', 'compare.r4': 'Incident analysis', 'compare.r4b': 'AI analyzes cause & recovery', 'compare.r5': 'Fallback', 'compare.r5b': 'Alternative services suggested', 'compare.r6': 'Monthly report', 'compare.r6b': 'Monthly report published', 'compare.r7': 'Cost', 'compare.r7a': 'Free', 'compare.r7b': 'Free & open source',
+    'compare.title': 'How is AIWatch different?', 'compare.sub': 'Built on official status data — aggregated across 37 services in one place', 'compare.col1': 'Official Status Page', 'compare.r2': 'Alerts', 'compare.r2a': 'Subscribe per provider, separately', 'compare.r2b': 'All 37 in one — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': 'Per-service, separate pages', 'compare.r3b': 'AIWatch Score — Uptime + Impact days + Recovery + Responsiveness', 'compare.r4': 'Incident analysis', 'compare.r4b': 'AI analyzes cause & recovery', 'compare.r5': 'Fallback', 'compare.r5b': 'Alternative services suggested', 'compare.r6': 'Monthly report', 'compare.r6b': 'Monthly report published', 'compare.r7': 'Cost', 'compare.r7a': 'Free', 'compare.r7b': 'Free & open source',
     'how.1.badge': 'Auto', 'how.2.badge': 'On detection', 'how.3.badge': 'Real-time', 'how.4.badge': 'Monthly',
     'how.1.title': 'Collect', 'how.1.desc': 'Official status pages auto-refreshed up to every 5 min',
     'how.2.title': 'Analyze', 'how.2.desc': 'Hybrid AI (Gemma 4 + Claude Sonnet fallback) analyzes pattern, recovery time & scope',
@@ -1153,7 +1153,7 @@ const i18n = {
     'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord · Slack · RSS alerts', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts', 'cta.rss': 'Subscribe via RSS',
     'alert.title': 'Get notified, your way', 'alert.sub': 'Real-time incident alerts with AI analysis and fallback recommendations. Free.',
     'alert.rss.copied': 'Copied ✓', 'alert.rss.prompt': 'Copy this RSS feed URL:',
-    'report.title': 'Monthly AI Reliability Report', 'report.hook': 'Which AI service is most reliable? The answer may surprise you.', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 36 services.', 'report.chart.note': '* Lower scores may reflect reporting granularity, not actual instability',
+    'report.title': 'Monthly AI Reliability Report', 'report.hook': 'Which AI service is most reliable? The answer may surprise you.', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 37 services.', 'report.chart.note': '* Lower scores may reflect reporting granularity, not actual instability',
     'footer.report': 'Monthly Report', 'footer.alert': 'Alert Settings'
   }
 };

--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -169,7 +169,7 @@ export default async function handler(req: Request) {
           claudecode: 11, codex: 11,
           cursor: 12, windsurf: 12,
           copilot: 13, junie: 13,
-          chatgpt: 21, claudeai: 21, characterai: 21,
+          chatgpt: 21, claudeai: 21, characterai: 21, deepseekapp: 21,
         }
         // Inline tierFor — same warn-once shape as worker/src/fallback.ts and src/utils/constants.js.
         // The Edge Function runs once per request so the warned set is functionally a one-shot per

--- a/api/is-down/seo-content.ts
+++ b/api/is-down/seo-content.ts
@@ -411,6 +411,20 @@ const SEO_CONTENT: Record<string, ServiceSEO> = {
       { q: 'How long do Character.AI outages usually last?', a: 'Character.AI outage durations vary by cause. Check the recent incidents section on this page for typical resolution times.' },
     ],
   },
+  // DeepSeek App (#619) — the consumer chat app (chat.deepseek.com + the "DeepSeek - AI Assistant"
+  // mobile app), distinct from the 'deepseek' (DeepSeek API) page for developers.
+  'deepseek-app': {
+    displayName: 'DeepSeek App',
+    description: 'DeepSeek App is DeepSeek\'s consumer AI assistant — the chat experience at chat.deepseek.com and the "DeepSeek - AI Assistant" mobile apps on iOS and Android. It is distinct from the DeepSeek API used by developers; AIWatch tracks the consumer Web Chat surface here and the API separately.',
+    insight: 'DeepSeek\'s consumer chat saw rapid, viral growth and experiences capacity-driven slowdowns more often than its developer API. AIWatch reads DeepSeek\'s official Flashduty status feed (via a browser-rendered fetch, since the page blocks plain server requests) and scopes this page to the Web Chat component — so a chat outage shows here even when the API stays healthy, and vice versa.',
+    whenDown: 'When the DeepSeek App is down, users cannot start or continue conversations on the web chat or mobile apps. The web and mobile clients share the same backend, so an outage typically affects all consumer access at once; the DeepSeek API may still be operational for developers.',
+    faqs: [
+      { q: 'Is the DeepSeek App down right now?', a: 'Check the live status indicator at the top of this page. AIWatch monitors DeepSeek\'s Web Chat service and shows real-time operational status from DeepSeek\'s official status feed.' },
+      { q: 'Is this the same as the DeepSeek API?', a: 'No. This page tracks the consumer chat app (chat.deepseek.com and the mobile apps). The developer API has its own page — AIWatch monitors the two surfaces separately because they can fail independently.' },
+      { q: 'Why is the DeepSeek App not loading?', a: 'The DeepSeek App may be experiencing high traffic, a backend incident, or maintenance. Check this page for current status and recent incident history.' },
+      { q: 'What are alternatives to the DeepSeek App?', a: 'When the DeepSeek App is down, ChatGPT, claude.ai, or Gemini are alternative AI chat apps. AIWatch shows which AI chat services are currently operational.' },
+    ],
+  },
   // Coding agents (#294) — "OpenAI Codex" on this page means the current coding
   // agent product (CLI, Codex Web, VS Code extension), not the deprecated 2023
   // Codex code-generation API.

--- a/api/is-down/slug-map.ts
+++ b/api/is-down/slug-map.ts
@@ -44,6 +44,11 @@ export const SLUG_TO_SERVICE: Record<string, { id: string; name: string; provide
   'luma':            { id: 'luma',       name: 'Luma (Dream Machine)', provider: 'Luma',     category: 'api' },
   // AI apps (#263)
   'character-ai':    { id: 'characterai', name: 'Character.AI',    provider: 'Character.AI', category: 'app' },
+  // DeepSeek App (#619) — DeepSeek's consumer chat app (chat.deepseek.com), distinct from the
+  // 'deepseek' (DeepSeek API) page. Slug 'deepseek-app' ≠ worker id 'deepseekapp'; the id≠slug
+  // mapping is mirrored in worker/src/rss.ts IS_DOWN_SLUG_OVERRIDE + src/utils/constants.js
+  // FEED_SLUG_OVERRIDE, pinned by feed-slug-sync.test.ts / feed-slug.test.js.
+  'deepseek-app':    { id: 'deepseekapp', name: 'DeepSeek App',    provider: 'DeepSeek',     category: 'app' },
   // Coding agents (#294) — OpenAI Codex is the current coding-agent product,
   // distinct from the deprecated 2023 Codex code-generation API.
   'codex':           { id: 'codex',       name: 'Codex',           provider: 'OpenAI',      category: 'agent' },
@@ -76,7 +81,7 @@ export const RELATED_SLUGS: Record<string, string[]> = {
   'cerebras':       ['groq', 'together', 'fireworks', 'mistral'],
   'perplexity':     ['openai', 'claude', 'gemini'],
   'xai':            ['openai', 'claude', 'gemini'],
-  'deepseek':       ['mistral', 'groq', 'openai', 'claude'],
+  'deepseek':       ['deepseek-app', 'mistral', 'groq', 'openai'],
   'openrouter':     ['openai', 'claude', 'mistral'],
   // Voice — same category
   'elevenlabs':     ['assemblyai', 'deepgram'],
@@ -94,6 +99,7 @@ export const RELATED_SLUGS: Record<string, string[]> = {
   'luma':           ['runway', 'replicate', 'stability'],
   // Apps
   'character-ai':   ['chatgpt', 'claude-ai', 'gemini'],
+  'deepseek-app':   ['deepseek', 'chatgpt', 'claude-ai', 'character-ai'],
 }
 
 // Reverse lookup: service ID → URL slug (for internal linking)

--- a/docs/aiwatch-landing.html
+++ b/docs/aiwatch-landing.html
@@ -30,7 +30,7 @@
   "@type": "WebApplication",
   "name": "AIWatch",
   "url": "https://ai-watch.dev",
-  "description": "Real-time status monitoring for 36 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex. AI-powered incident analysis with fallback recommendations.",
+  "description": "Real-time status monitoring for 37 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex. AI-powered incident analysis with fallback recommendations.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Web",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -630,7 +630,7 @@
       <div class="mock-section-header">
         <div class="mock-section-title"><span class="green-slash">//</span> Services</div>
         <div class="mock-filter-tabs">
-          <span class="mock-filter-tab active">All 36</span>
+          <span class="mock-filter-tab active">All 37</span>
           <span class="mock-filter-tab">Operational 33</span>
           <span class="mock-filter-tab">Issues 1<span class="mock-filter-dot"></span></span>
         </div>
@@ -1030,7 +1030,7 @@
   <div class="report-inner">
   <p class="section-label">// monthly report</p>
   <h2 class="section-title" data-i18n="report.title">월간 AI 서비스 신뢰도 리포트</h2>
-  <p class="section-sub" data-i18n="report.sub">매월 36개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.</p>
+  <p class="section-sub" data-i18n="report.sub">매월 37개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.</p>
   <div class="report-chart">
     <svg viewBox="0 0 560 190" xmlns="http://www.w3.org/2000/svg" style="width:100%;font-family:'JetBrains Mono',monospace;">
   <rect width="560" height="190" fill="#0d1117" rx="8"/>
@@ -1049,7 +1049,7 @@
   <text x="120" y="164" text-anchor="end" fill="#768390" font-size="11">OpenAI API</text>
   <rect x="128" y="150" width="258" height="16" rx="3" fill="#3b82f6"/>
   <text x="392" y="163" fill="#adbac7" font-size="11">86  Good</text>
-  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 36개 서비스 보기 → reports.ai-watch.dev</text>
+  <text x="200" y="186" text-anchor="middle" fill="#444" font-size="10">· · · 전체 37개 서비스 보기 → reports.ai-watch.dev</text>
 </svg>
   </div>
   <a href="https://reports.ai-watch.dev/" class="report-link" target="_blank" rel="noopener noreferrer" onclick="gtag('event','click_reports',{location:'landing_report',source:'intro'})">
@@ -1115,20 +1115,20 @@ const i18n = {
     'stats.services': '모니터링 서비스', 'stats.interval': '자동 수집', 'stats.free': 'Discord/Slack 알림 포함', 'stats.oss': '오픈소스',
     'demo.title': '장애 파악부터 대안 선택까지', 'demo.sub': '지금 어떤 서비스가 안정적인지, 장애 중이라면 대안은 무엇인지 한 화면에서 파악합니다', 'demo.more': '+ 31개 서비스 더 보기...',
     'feat.title': '단순 상태 표시를 넘어', 'feat.sub': '의사결정까지 도와주는 AI 모니터링 대시보드',
-    'feat.1.title': 'AIWatch Score', 'feat.1.desc': '36개 서비스의 인시던트 빈도, 복구 시간, 업타임을 종합한 0~100점 AIWatch Score입니다. 서비스마다 흩어진 공식 데이터를 통합해 한눈에 비교할 수 있게 합니다. 단, 공식 데이터가 부족한 일부 서비스는 업계 평균치를 반영합니다.',
+    'feat.1.title': 'AIWatch Score', 'feat.1.desc': '37개 서비스의 인시던트 빈도, 복구 시간, 업타임을 종합한 0~100점 AIWatch Score입니다. 서비스마다 흩어진 공식 데이터를 통합해 한눈에 비교할 수 있게 합니다. 단, 공식 데이터가 부족한 일부 서비스는 업계 평균치를 반영합니다.',
     'feat.2.title': 'AI 장애 분석', 'feat.2.desc': '장애 발생 시 Claude Sonnet이 패턴을 분석해 예상 복구 시간과 영향 범위를 알려줍니다. "언제쯤 복구될까?"에 빠르게 답합니다.',
     'feat.3.title': 'Fallback 추천', 'feat.3.desc': '장애 중인 서비스의 대안을 같은 카테고리 Score 상위 순으로 즉시 제안합니다. 같은 제공사 서비스는 자동 제외됩니다.',
     'feat.4.title': '"Is X Down?" 전용 페이지', 'feat.4.desc': 'ai-watch.dev/is-claude-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.',
     'how.title': '이렇게 동작합니다', 'how.sub': '각 서비스의 공식 상태 페이지 데이터를 기반으로 동작합니다',
-    'compare.title': '공식 상태 페이지와 무엇이 다른가요?', 'compare.sub': '공식 페이지 데이터를 기반으로, 36개를 한 화면에서 통합합니다', 'compare.col1': '공식 상태 페이지', 'compare.r2': '장애 알림', 'compare.r2a': '직접 확인 필요', 'compare.r2b': 'Discord · Slack 즉시 발송', 'compare.r3': 'AIWatch Score', 'compare.r3a': '서비스별 개별 확인', 'compare.r3b': 'AIWatch Score (0–100)', 'compare.r4': '장애 분석', 'compare.r4b': 'AI가 원인 · 복구 시간 분석', 'compare.r5': '대안 추천', 'compare.r5b': 'Fallback 서비스 즉시 제안', 'compare.r6': '월간 리포트', 'compare.r6b': '매월 리포트 공개', 'compare.r7': '비용', 'compare.r7a': '무료', 'compare.r7b': '완전 무료 · 오픈소스',
-    'how.1.title': '수집', 'how.1.desc': '36개 공식 상태 페이지를 자동으로 수집',
+    'compare.title': '공식 상태 페이지와 무엇이 다른가요?', 'compare.sub': '공식 페이지 데이터를 기반으로, 37개를 한 화면에서 통합합니다', 'compare.col1': '공식 상태 페이지', 'compare.r2': '장애 알림', 'compare.r2a': '직접 확인 필요', 'compare.r2b': 'Discord · Slack 즉시 발송', 'compare.r3': 'AIWatch Score', 'compare.r3a': '서비스별 개별 확인', 'compare.r3b': 'AIWatch Score (0–100)', 'compare.r4': '장애 분석', 'compare.r4b': 'AI가 원인 · 복구 시간 분석', 'compare.r5': '대안 추천', 'compare.r5b': 'Fallback 서비스 즉시 제안', 'compare.r6': '월간 리포트', 'compare.r6b': '매월 리포트 공개', 'compare.r7': '비용', 'compare.r7a': '무료', 'compare.r7b': '완전 무료 · 오픈소스',
+    'how.1.title': '수집', 'how.1.desc': '37개 공식 상태 페이지를 자동으로 수집',
     'how.2.title': '분석', 'how.2.desc': 'Claude Sonnet이 패턴 · 복구 시간 · 영향 범위 분석',
     'how.3.title': '알림', 'how.3.desc': 'Discord · Slack 즉시 발송 + Fallback 추천 포함',
     'how.4.title': '리포트', 'how.4.desc': '월간 업타임 추이 · 인시던트 통계 리포트 공개',
     'cta.title': '지금 바로 확인하세요', 'cta.sub': '완전 무료 · 설치 불필요 · Discord · Slack · RSS 알림', 'cta.btn1': '지금 장애 확인하기 →', 'cta.btn2': '알림 설정하기', 'cta.rss': 'RSS로 구독',
     'alert.title': '장애 알림, 원하는 방식으로', 'alert.sub': '장애 발생 즉시 알림 + AI 분석 + Fallback 추천까지 한 번에. 무료입니다.',
     'alert.rss.copied': '복사됨 ✓', 'alert.rss.prompt': 'RSS 피드 URL 복사:',
-    'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 36개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'ai.title': '장애가 나면 AI가 분석합니다', 'ai.sub': '단순 상태 표시에서 한 발 더 — 장애 패턴, 예상 복구 시간, 영향 범위를 Claude Sonnet이 즉시 분석합니다.',
+    'report.title': '월간 AI 서비스 신뢰도 리포트', 'report.link': '전체 리포트 보기 →', 'report.sub': '매월 37개 서비스의 AIWatch Score 순위, 인시던트 요약, 공식 업타임, 주요 장애 분석, 프로바이더 추천까지 한 리포트로 공개합니다.', 'ai.title': '장애가 나면 AI가 분석합니다', 'ai.sub': '단순 상태 표시에서 한 발 더 — 장애 패턴, 예상 복구 시간, 영향 범위를 Claude Sonnet이 즉시 분석합니다.',
     'footer.report': '월간 리포트', 'footer.alert': '알림 설정'
   },
   en: {
@@ -1140,14 +1140,14 @@ const i18n = {
     'hero.pill1': 'AI Services', 'hero.pill2v': 'Real-time', 'hero.pill2': 'Alerts', 'hero.pill3': 'Open Source',
     'flow.1.title': 'Outage Detected', 'flow.2.conn': 'AI analysis started', 'flow.2.bar': 'Analyzing patterns', 'flow.3.conn': 'Discord · Slack sent', 'flow.3.title': 'Alert Sent', 'flow.3.body': 'Discord · Slack alert delivered', 'flow.4.conn': 'Alternatives suggested', 'flow.4.title': 'Fallback Suggested',
     'stats.services': 'Services monitored', 'stats.interval': 'Auto-collected', 'stats.free': 'Discord/Slack alerts included', 'stats.oss': 'Open source',
-    'demo.title': 'From outage detection to fallback — in one view', 'demo.sub': 'See which services are stable right now — and what to use instead when they\'re not', 'demo.more': '+ 31 more services...',
+    'demo.title': 'From outage detection to fallback — in one view', 'demo.sub': 'See which services are stable right now — and what to use instead when they\'re not', 'demo.more': '+ 32 more services...',
     'feat.title': 'Beyond status monitoring', 'feat.sub': 'An AI monitoring dashboard that helps you make decisions',
     'feat.1.title': 'AIWatch Score', 'feat.1.desc': 'A 0–100 reliability score based on incident frequency and recovery time.',
     'feat.2.title': 'AI Incident Analysis', 'feat.2.desc': 'When an outage hits, Claude Sonnet analyzes the pattern and tells you the estimated recovery time and impact scope. No more guessing.',
     'feat.3.title': 'Fallback Recommendations', 'feat.3.desc': 'Get instant alternative suggestions ranked by Score within the same category. Same-provider services are automatically excluded.',
     'feat.4.title': '"Is X Down?" Dedicated Pages', 'feat.4.desc': 'Pages like ai-watch.dev/is-claude-down show real-time status, AI analysis, and fallback recommendations — all in one place.',
     'how.title': 'How it works', 'how.sub': 'Powered by official status page data from each provider',
-    'compare.title': 'How is AIWatch different?', 'compare.sub': 'Built on official status data — aggregated across 36 services in one place', 'compare.col1': 'Official Status Page', 'compare.r2': 'Alerts', 'compare.r2a': 'Manual check required', 'compare.r2b': 'Instant Discord · Slack', 'compare.r3': 'AIWatch Score', 'compare.r3a': 'Per-service, separate pages', 'compare.r3b': 'AIWatch Score (0–100)', 'compare.r4': 'Incident analysis', 'compare.r4b': 'AI analyzes cause & recovery', 'compare.r5': 'Fallback', 'compare.r5b': 'Alternative services suggested', 'compare.r6': 'Monthly report', 'compare.r6b': 'Monthly report published', 'compare.r7': 'Cost', 'compare.r7a': 'Free', 'compare.r7b': 'Free & open source',
+    'compare.title': 'How is AIWatch different?', 'compare.sub': 'Built on official status data — aggregated across 37 services in one place', 'compare.col1': 'Official Status Page', 'compare.r2': 'Alerts', 'compare.r2a': 'Manual check required', 'compare.r2b': 'Instant Discord · Slack', 'compare.r3': 'AIWatch Score', 'compare.r3a': 'Per-service, separate pages', 'compare.r3b': 'AIWatch Score (0–100)', 'compare.r4': 'Incident analysis', 'compare.r4b': 'AI analyzes cause & recovery', 'compare.r5': 'Fallback', 'compare.r5b': 'Alternative services suggested', 'compare.r6': 'Monthly report', 'compare.r6b': 'Monthly report published', 'compare.r7': 'Cost', 'compare.r7a': 'Free', 'compare.r7b': 'Free & open source',
     'how.1.title': 'Collect', 'how.1.desc': '36 official status pages collected automatically',
     'how.2.title': 'Analyze', 'how.2.desc': 'Claude Sonnet analyzes pattern, recovery time & scope',
     'how.3.title': 'Alert', 'how.3.desc': 'Discord · Slack instant alert + fallback recommendations',
@@ -1155,7 +1155,7 @@ const i18n = {
     'cta.title': 'Check it out now', 'cta.sub': 'Completely free · No installation · Discord · Slack · RSS alerts', 'cta.btn1': 'Check for Outages Now →', 'cta.btn2': 'Set Up Alerts', 'cta.rss': 'Subscribe via RSS',
     'alert.title': 'Get notified, your way', 'alert.sub': 'Instant incident alerts with AI analysis and fallback recommendations. Free.',
     'alert.rss.copied': 'Copied ✓', 'alert.rss.prompt': 'Copy this RSS feed URL:',
-    'report.title': 'Monthly AI Reliability Report', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 36 services.', 'ai.title': 'AI analyzes every incident', 'ai.sub': 'One step beyond status monitoring — Claude Sonnet instantly analyzes incident patterns, estimated recovery time, and impact scope.',
+    'report.title': 'Monthly AI Reliability Report', 'report.link': 'View All Reports →', 'report.sub': 'AIWatch Score rankings, incident summaries, official uptime, notable outage analysis, and provider recommendations — all in one monthly report for 37 services.', 'ai.title': 'AI analyzes every incident', 'ai.sub': 'One step beyond status monitoring — Claude Sonnet instantly analyzes incident patterns, estimated recovery time, and impact scope.',
     'footer.report': 'Monthly Report', 'footer.alert': 'Alert Settings'
   }
 };

--- a/docs/marketing-playbook.md
+++ b/docs/marketing-playbook.md
@@ -45,7 +45,7 @@ Show HN: Open-source AI status dashboard with AI-powered incident analysis
 ```
 Author here. Quick context since this went up during the Claude outage:
 
-AIWatch is an open-source status dashboard for 36 AI services (27 APIs + 3 apps
+AIWatch is an open-source status dashboard for 37 AI services (27 APIs + 4 apps
 + 6 coding agents). What makes it different from Downdetector / StatusGator:
 
 - AI-powered incident analysis — hybrid Gemma 4 26B (Cloudflare Workers AI

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -8,7 +8,7 @@ All served by the Cloudflare Worker (`aiwatch-worker`, domain `aiwatch-worker.p2
 
 | Endpoint | Notes |
 |---|---|
-| `GET /api/status` | Live parallel fetch of all 36 services, normalize, KV write, platform/probe cross-validation. Multi-component services carry a `components: {id,name,status,group?}[]` snapshot for the per-component breakdown — from `statusComponentIds` (#604: cerebras/cursor/runway/langsmith/copilot/windsurf), `displayComponentIds` (#606: elevenlabs/replicate), or dynamic `displayAllComponents` with a `group:'Models'` tag (#606: cohere/groq); absent otherwise |
+| `GET /api/status` | Live parallel fetch of all 37 services, normalize, KV write, platform/probe cross-validation. Multi-component services carry a `components: {id,name,status,group?}[]` snapshot for the per-component breakdown — from `statusComponentIds` (#604: cerebras/cursor/runway/langsmith/copilot/windsurf), `displayComponentIds` (#606: elevenlabs/replicate), or dynamic `displayAllComponents` with a `group:'Models'` tag (#606: cohere/groq); absent otherwise |
 | `GET /api/status/cached` | KV-only (no live fetch), includes `probe24h` — for "Is X Down" SSR + initial load. **`?src=statusline-*`** returns a ~KB id/name/status-only projection via `buildStatuslinePayload` (`worker/src/statusline.ts`) — skips the ~2 MB probe/latency/AI reads. Statusline snippets (#400) poll this with the tag and target the Worker domain directly, **not** the Vercel-proxied `ai-watch.dev` path, so per-prompt polls don't burn Vercel Fast Data Transfer (#438) |
 | `GET /api/uptime?days=30` | Daily uptime counters |
 | `GET /api/probe/history?days=30` | Daily probe RTT summaries (90d max) |

--- a/docs/reference/data-flow.md
+++ b/docs/reference/data-flow.md
@@ -3,7 +3,7 @@
 ```
 Browser (React SPA, 60s polling)
   → Cloudflare Worker (/api/status)
-    → parallel fetch (36 services)
+    → parallel fetch (37 services)
     → gemini dual-source (#310): gcloud Vertex feed + aistudio.google.com/status MakerSuite RPC — merged with vertex:/aistudio: ID prefixes
     → normalize to ServiceStatus[]
     → write to KV (cache + daily counters)

--- a/docs/reference/kv-schema.md
+++ b/docs/reference/kv-schema.md
@@ -4,7 +4,7 @@
 
 | Key Pattern | Value | TTL | Writes/Day | Purpose |
 |---|---|---|---|---|
-| `services:latest` | `{ services, cachedAt }` JSON | 5min | ~288 + a few | Real-time status cache (all 36 services). Written by the throttled `/api/status` `cacheWrite` (10-min) **and** by the cron on each status-change edge (#488, `cache-refresh.ts`) so OG/SEO previews (`/api/status/cached` readers) reflect an incident within one cron cycle — the edge writes are rare (incident start/recovery), negligible vs. the budget |
+| `services:latest` | `{ services, cachedAt }` JSON | 5min | ~288 + a few | Real-time status cache (all 37 services). Written by the throttled `/api/status` `cacheWrite` (10-min) **and** by the cron on each status-change edge (#488, `cache-refresh.ts`) so OG/SEO previews (`/api/status/cached` readers) reflect an incident within one cron cycle — the edge writes are rare (incident start/recovery), negligible vs. the budget |
 | `daily:{YYYY-MM-DD}` | `{ [svcId]: { ok, total } }` JSON | 2d | ~288 | Daily uptime counters |
 | `history:{YYYY-MM-DD}` | Same as daily | 90d | 1 | Archived yesterday's counters |
 | `latency:24h` | `{ snapshots: [{ t, data }] }` JSON | 25h | ~48 | 30-min latency snapshots (max 48) |

--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Real-time status monitoring for 36 AI services — Claude, ChatGPT, Gemini, Cursor, Codex and more. Check if AI services are down, track uptime and incidents." />
+    <meta name="description" content="Real-time status monitoring for 37 AI services — Claude, ChatGPT, Gemini, Cursor, Codex and more. Check if AI services are down, track uptime and incidents." />
     <title>AIWatch — AI 서비스 실시간 모니터링</title>
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ai-watch.dev/" />
-    <meta property="og:title" content="AIWatch — 36개 AI 서비스 실시간 모니터링" />
-    <meta property="og:description" content="Claude, ChatGPT, Gemini, Cursor, Codex 등 36개 AI 서비스 상태를 한눈에. 장애 발생 시 즉시 확인." />
+    <meta property="og:title" content="AIWatch — 37개 AI 서비스 실시간 모니터링" />
+    <meta property="og:description" content="Claude, ChatGPT, Gemini, Cursor, Codex 등 37개 AI 서비스 상태를 한눈에. 장애 발생 시 즉시 확인." />
     <meta property="og:image" content="https://ai-watch.dev/og-intro.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -23,8 +23,8 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://ai-watch.dev/" />
-    <meta name="twitter:title" content="AIWatch — 36개 AI 서비스 실시간 모니터링" />
-    <meta name="twitter:description" content="Claude, ChatGPT, Gemini, Cursor, Codex 등 36개 AI 서비스 상태를 한눈에. 장애 발생 시 즉시 확인." />
+    <meta name="twitter:title" content="AIWatch — 37개 AI 서비스 실시간 모니터링" />
+    <meta name="twitter:description" content="Claude, ChatGPT, Gemini, Cursor, Codex 등 37개 AI 서비스 상태를 한눈에. 장애 발생 시 즉시 확인." />
     <meta name="twitter:image" content="https://ai-watch.dev/og-intro.png" />
 
     <!-- Canonical & Additional -->
@@ -39,7 +39,7 @@
       "@type": "WebApplication",
       "name": "AIWatch",
       "url": "https://ai-watch.dev",
-      "description": "Real-time status monitoring for 36 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex",
+      "description": "Real-time status monitoring for 37 AI services including Claude, ChatGPT, Gemini, Cursor, and Codex",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Web"
     }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Main dashboard -->
   <url>
     <loc>https://ai-watch.dev/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,92 +11,93 @@
   <!-- Is X Down? SEO pages (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-chatgpt-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-gemini-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-github-copilot-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-cursor-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-claude-code-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/is-windsurf-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ai-watch.dev/is-claude-ai-down</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Phase B — additional Is-X-Down services (#263, expanded since) -->
-  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-langchain-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-runway-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-luma-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-06-11</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-mistral-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cohere-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-groq-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-together-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-fireworks-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-cerebras-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-perplexity-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-xai-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepseek-app-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-openrouter-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-elevenlabs-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-assemblyai-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-deepgram-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-huggingface-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-replicate-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-pinecone-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-stability-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-voyageai-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-modal-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-langchain-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-runway-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-luma-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-character-ai-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-codex-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://ai-watch.dev/is-junie-down</loc><lastmod>2026-06-12</lastmod><changefreq>hourly</changefreq><priority>0.8</priority></url>
 
   <!-- Landing page (Edge SSR) -->
   <url>
     <loc>https://ai-watch.dev/intro</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -104,25 +105,25 @@
   <!-- Monthly Reports (proxied via Edge Function to reports.ai-watch.dev, #264) -->
   <url>
     <loc>https://ai-watch.dev/reports/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-05/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-04/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-watch.dev/reports/2026-03/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/scripts/scrape-deepseek-feed.mjs
+++ b/scripts/scrape-deepseek-feed.mjs
@@ -25,7 +25,12 @@ if (!WORKER_URL || !TOKEN) {
 }
 
 const HISTORY_DAYS = 90 // change/list window — wide enough for the Score's 30d incident history + margin
-const UPTIME_DAYS = 30 // summary/structure window — matches the 30-day uptime/impact the Score uses
+// summary/structure window — 90 days to MATCH what the official DeepSeek status page displays (it
+// shows a 90-day uptime, e.g. Web Chat 99.48% / API 99.88%) and AIWatch's own convention: the
+// Atlassian parseUptimeData path iterates the full ~90-day uptimeData window, so "Official Uptime"
+// is effectively 90-day for every official-source service. A 30-day window here produced a higher,
+// inconsistent number (99.92%) that didn't match the source page (#619).
+const UPTIME_DAYS = 90
 
 async function main() {
   const browser = await chromium.launch()

--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -64,6 +64,13 @@ const MOCK_SERVICES = [
     history3m: null,
     incidents: [],
   },
+  {
+    id: 'deepseekapp', category: 'app', name: 'DeepSeek App', provider: 'DeepSeek', status: 'operational',
+    latency: null, uptime30d: 99.48,
+    history30d: hist([13, 18, 22]),
+    history3m: null,
+    incidents: [],
+  },
   // ── LLM API ──
   {
     id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational',

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -75,6 +75,7 @@ const STATUS_URL = {
   characterai: 'https://status.character.ai',
   claudeai:    'https://status.claude.com',
   chatgpt:     'https://status.openai.com',
+  deepseekapp: 'https://status.deepseek.com',
   claudecode:  'https://status.claude.com',
   copilot:     'https://githubstatus.com',
   cursor:      'https://status.cursor.com',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,7 +19,7 @@ export const API_SERVICE_IDS = [
 ]
 
 // AI web apps (no latency — web services, ordered before related API)
-export const APP_SERVICE_IDS = ['claudeai', 'chatgpt', 'characterai']
+export const APP_SERVICE_IDS = ['claudeai', 'chatgpt', 'characterai', 'deepseekapp']
 
 // Coding agents
 export const AGENT_SERVICE_IDS = ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie']
@@ -27,7 +27,7 @@ export const AGENT_SERVICE_IDS = ['claudecode', 'codex', 'cursor', 'copilot', 'w
 // Display order: app → LLM → voice → inference → agent
 export const SERVICE_AND_APP_IDS = [
   // app
-  'claudeai', 'chatgpt', 'characterai',
+  'claudeai', 'chatgpt', 'characterai', 'deepseekapp',
   // LLM API
   'claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq',
   'together', 'fireworks', 'cerebras', 'perplexity', 'xai', 'deepseek', 'openrouter',
@@ -43,7 +43,7 @@ export const ALL_SERVICE_IDS = [...SERVICE_AND_APP_IDS, ...AGENT_SERVICE_IDS]
 // Sidebar category filters — splits Worker's 'api' into LLM vs Voice/Inference
 export const SERVICE_CATEGORIES = {
   all:       { labelKey: 'filter.all',       ids: null }, // null = show all
-  apps:      { labelKey: 'filter.apps',      ids: ['claudeai', 'chatgpt', 'characterai'] },
+  apps:      { labelKey: 'filter.apps',      ids: ['claudeai', 'chatgpt', 'characterai', 'deepseekapp'] },
   llm:       { labelKey: 'filter.llm',       ids: ['claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq', 'together', 'fireworks', 'cerebras', 'perplexity', 'xai', 'deepseek', 'openrouter'] },
   inference: { labelKey: 'filter.inference', ids: ['elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone', 'stability', 'voyageai', 'modal', 'langsmith', 'runway', 'luma'] },
   agents:    { labelKey: 'filter.agents',    ids: ['claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie'] },
@@ -63,6 +63,7 @@ const FEED_SLUG_OVERRIDE = {
   claudeai:    'claude-ai',
   characterai: 'character-ai',
   langsmith:   'langchain',
+  deepseekapp: 'deepseek-app',
 }
 
 // Services with no /is-{slug}-down page and therefore no RSS feed — estimate-only
@@ -96,7 +97,7 @@ export const API_TIER = {
   claudecode: 11, codex: 11,
   cursor: 12, windsurf: 12,
   copilot: 13, junie: 13,
-  chatgpt: 21, claudeai: 21, characterai: 21,
+  chatgpt: 21, claudeai: 21, characterai: 21, deepseekapp: 21,
 }
 
 // Sync target for worker/src/fallback.ts TIER_LABEL. Pre-#403 this lived inline in Overview.jsx;

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     { "source": "/is-perplexity-down", "destination": "/api/is-down?slug=perplexity" },
     { "source": "/is-xai-down", "destination": "/api/is-down?slug=xai" },
     { "source": "/is-deepseek-down", "destination": "/api/is-down?slug=deepseek" },
+    { "source": "/is-deepseek-app-down", "destination": "/api/is-down?slug=deepseek-app" },
     { "source": "/is-openrouter-down", "destination": "/api/is-down?slug=openrouter" },
     { "source": "/is-elevenlabs-down", "destination": "/api/is-down?slug=elevenlabs" },
     { "source": "/is-assemblyai-down", "destination": "/api/is-down?slug=assemblyai" },

--- a/worker/src/__tests__/fixtures/deepseek-flashduty.json
+++ b/worker/src/__tests__/fixtures/deepseek-flashduty.json
@@ -1085,6 +1085,206 @@
   "section_uptimes": [],
   "component_impacts": [
    {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 639729328166287,
+    "start_at_seconds": 1773836812,
+    "end_at_seconds": 1773836959,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 639729328166287,
+    "start_at_seconds": 1773836959,
+    "end_at_seconds": 1773837427,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 569360583988287,
+    "start_at_seconds": 1774791352,
+    "end_at_seconds": 1774794507,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 569360583988287,
+    "start_at_seconds": 1774794507,
+    "end_at_seconds": 1774796932,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 569360583988287,
+    "start_at_seconds": 1774796932,
+    "end_at_seconds": 1774797797,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 498991839811287,
+    "start_at_seconds": 1774801214,
+    "end_at_seconds": 1774802189,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 498991839811287,
+    "start_at_seconds": 1774802189,
+    "end_at_seconds": 1774805059,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 498991839811287,
+    "start_at_seconds": 1774805059,
+    "end_at_seconds": 1774808176,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 498991839811287,
+    "start_at_seconds": 1774808176,
+    "end_at_seconds": 1774833225,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 498991839811287,
+    "start_at_seconds": 1774833225,
+    "end_at_seconds": 1774838008,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 428623095633287,
+    "start_at_seconds": 1774947760,
+    "end_at_seconds": 1774949734,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 428623095633287,
+    "start_at_seconds": 1774949734,
+    "end_at_seconds": 1774951554,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 358254351455287,
+    "start_at_seconds": 1775205401,
+    "end_at_seconds": 1775205495,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 358254351455287,
+    "start_at_seconds": 1775205495,
+    "end_at_seconds": 1775205598,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 358254351455287,
+    "start_at_seconds": 1775205598,
+    "end_at_seconds": 1775206218,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 287885607278287,
+    "start_at_seconds": 1776688800,
+    "end_at_seconds": 1776701307,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 217516863100287,
+    "start_at_seconds": 1776853398,
+    "end_at_seconds": 1776857192,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 147148118922287,
+    "start_at_seconds": 1778039584,
+    "end_at_seconds": 1778040256,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 147148118922287,
+    "start_at_seconds": 1778039584,
+    "end_at_seconds": 1778040256,
+    "status": "partial_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 76779374745287,
+    "start_at_seconds": 1778051625,
+    "end_at_seconds": 1778052020,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 76779374745287,
+    "start_at_seconds": 1778051625,
+    "end_at_seconds": 1778052020,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6410630567287,
+    "start_at_seconds": 1778232728,
+    "end_at_seconds": 1778234508,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6410630567287,
+    "start_at_seconds": 1778232728,
+    "end_at_seconds": 1778234508,
+    "status": "full_outage"
+   },
+   {
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "section_id": "",
+    "change_id": 6410630567287,
+    "start_at_seconds": 1778234508,
+    "end_at_seconds": 1778234748,
+    "status": "degraded"
+   },
+   {
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "section_id": "",
+    "change_id": 6410630567287,
+    "start_at_seconds": 1778234508,
+    "end_at_seconds": 1778234748,
+    "status": "degraded"
+   },
+   {
     "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
     "section_id": "",
     "change_id": 6467187538287,
@@ -1117,7 +1317,7 @@
     "status": "full_outage"
    },
    {
-    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
+    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
     "section_id": "",
     "change_id": 6480608319287,
     "start_at_seconds": 1779606882,
@@ -1125,7 +1325,7 @@
     "status": "partial_outage"
    },
    {
-    "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
+    "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
     "section_id": "",
     "change_id": 6480608319287,
     "start_at_seconds": 1779606882,
@@ -1193,17 +1393,42 @@
    {
     "component_id": "01KR3NC9ETZYF436Z8YT1HM047",
     "section_id": "",
-    "uptime": 99.89,
+    "uptime": 99.88,
     "available_since_seconds": 1706745600
    },
    {
     "component_id": "01KR3NC9ETESRRQ4GABE0TGW53",
     "section_id": "",
-    "uptime": 99.92,
+    "uptime": 99.48,
     "available_since_seconds": 1706745600
    }
   ],
   "linked_changes": [
+   {
+    "id": 569360583988287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/APP 服务异常（[Resolved]DeepSeek Web/APP Service Abnormal）"
+   },
+   {
+    "id": 498991839811287,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/APP 性能异常（[Resolved]DeepSeek Web/APP Service Performance Agnormal）"
+   },
+   {
+    "id": 428623095633287,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）"
+   },
+   {
+    "id": 287885607278287,
+    "type": "incident",
+    "title": "【已解决】DeepSeek Web/APP 快速模式性能异常（[Resolved]DeepSeek Web/APP Instant Mode Performance Abnormal）"
+   },
+   {
+    "id": 6410630567287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API不可用（[Resolved]DeepSeek Web/API Service Not Available）"
+   },
    {
     "id": 6467187538287,
     "type": "incident",
@@ -1215,19 +1440,44 @@
     "title": "DeepSeek 网页端/API 不可用（DeepSeek WEB/API Unavailable）"
    },
    {
-    "id": 6497432543287,
-    "type": "incident",
-    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）"
-   },
-   {
     "id": 6499101276287,
     "type": "incident",
     "title": "API 性能下降（API Degraded Performance）"
    },
    {
+    "id": 358254351455287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/APP 服务异常（[Resolved]DeepSeek Web/APP Service Abnormal）"
+   },
+   {
+    "id": 217516863100287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek API 异常（[Resolved]DeepSeek API Abnormal）"
+   },
+   {
+    "id": 147148118922287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）"
+   },
+   {
+    "id": 6497432543287,
+    "type": "incident",
+    "title": "DeepSeek 网页/API 性能下降（DeepSeek Web/API Degraded Performance）"
+   },
+   {
     "id": 6551550194287,
     "type": "incident",
     "title": "DeepSeek 网页 性能下降（DeepSeek Web Degraded Performance）"
+   },
+   {
+    "id": 639729328166287,
+    "type": "incident",
+    "title": "【已解决】DeepSeek 网页/APP 性能异常（[Resolved]DeepSeek Web/APP Service Degraded Performance）"
+   },
+   {
+    "id": 76779374745287,
+    "type": "incident",
+    "title": "【已恢复】DeepSeek 网页/API 性能异常（[Resolved]DeepSeek Web/API Service Degraded Performance）"
    }
   ]
  }

--- a/worker/src/__tests__/flashduty-parser.test.ts
+++ b/worker/src/__tests__/flashduty-parser.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { parseFlashdutyFeed, type FlashdutyFeed } from '../parsers/flashduty'
 import fixture from './fixtures/deepseek-flashduty.json'
 
-// #618 — Flashduty parser, exercised against a REAL captured DeepSeek payload (2026-06-12):
-// 2 components (API Service / Web Chat Service), 15 history incidents, 0 active, 13 impact windows,
-// per-component uptime 99.89 / 99.92.
+// #618 — Flashduty parser, exercised against a REAL captured DeepSeek payload (2026-06-12, 90-day
+// window to match the official status page's displayed uptime, #619): 2 components (API Service /
+// Web Chat Service), 15 history incidents, 0 active, 38 impact windows, per-component uptime
+// 99.88 (API) / 99.48 (Web Chat).
 const feed = fixture as FlashdutyFeed
 
 describe('parseFlashdutyFeed (#618)', () => {
@@ -53,7 +54,8 @@ describe('parseFlashdutyFeed (#618)', () => {
   })
 
   it('uptime30d = worst (min) component uptime from structure', () => {
-    expect(parsed.uptime30d).toBeCloseTo(99.89, 2)
+    // min(API 99.88, Web Chat 99.48) — the 90-day values shown on the official page (#619)
+    expect(parsed.uptime30d).toBeCloseTo(99.48, 2)
   })
 
   it('builds a dailyImpact map keyed by YYYY-MM-DD with valid levels', () => {
@@ -118,8 +120,8 @@ describe('parseFlashdutyFeed (#618)', () => {
       expect(scoped.components.map((c) => c.id)).toEqual([API_ID])
     })
 
-    it('uptime = the API component uptime (99.89), not the min-with-Web-Chat', () => {
-      expect(scoped.uptime30d).toBeCloseTo(99.89, 2)
+    it('uptime = the API component uptime (99.88), not the min-with-Web-Chat (99.48)', () => {
+      expect(scoped.uptime30d).toBeCloseTo(99.88, 2)
     })
 
     it('a Web-Chat-only active incident does NOT flip the API badge', () => {

--- a/worker/src/__tests__/stale-source-config.test.ts
+++ b/worker/src/__tests__/stale-source-config.test.ts
@@ -11,8 +11,17 @@ describe('stale-source config (#591)', () => {
     expect(deepseek!.incidentSourceStale).toBe(true)
   })
 
-  it('the flag is opt-in — no OTHER service is stale-flagged today', () => {
+  it('deepseekapp uses incidentSourceStale as its feed-absent fallback flag (#619)', () => {
+    // #619 — the DeepSeek consumer app is feed-only (no apiUrl). When the Flashduty feed is fresh,
+    // readFlashdutyStatus clears the flag; when absent it stays, so a feed outage can't rank an
+    // empty/unknown app. Both DeepSeek services therefore carry the config flag.
+    const app = SERVICES.find((s) => s.id === 'deepseekapp')
+    expect(app).toBeDefined()
+    expect(app!.incidentSourceStale).toBe(true)
+  })
+
+  it('the flag is opt-in — only the two DeepSeek (Flashduty) services are stale-flagged today', () => {
     const flagged = SERVICES.filter((s) => s.incidentSourceStale).map((s) => s.id)
-    expect(flagged).toEqual(['deepseek'])
+    expect(flagged).toEqual(['deepseek', 'deepseekapp'])
   })
 })

--- a/worker/src/fallback.ts
+++ b/worker/src/fallback.ts
@@ -27,7 +27,7 @@ export const API_TIER: Record<string, number> = {
   // fall-through, just without the warn-once noise. Entries exist only to suppress the
   // `tierFor` warn-once that would otherwise fire whenever chatgpt/claudeai surface as the
   // affected service in a fallback flow (Character.AI is in EXCLUDE_FALLBACK so it never does).
-  chatgpt: 21, claudeai: 21, characterai: 21,
+  chatgpt: 21, claudeai: 21, characterai: 21, deepseekapp: 21,
 }
 
 // #403 — surfaces the silent-fallback failure mode that produced #402 (Junie-as-#1) without

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -81,6 +81,7 @@ export const IS_DOWN_SLUG_OVERRIDE: Record<string, string> = {
   characterai: 'character-ai',
   copilot: 'github-copilot',
   langsmith: 'langchain',
+  deepseekapp: 'deepseek-app',
 }
 
 // Services with no /is-{slug}-down page — estimate-only, excluded per #263.

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -132,6 +132,12 @@ export const SERVICES: ServiceConfig[] = [
   // official grouping (not the API group, despite the names). Login here is the ChatGPT Login
   // (the APIs group has a separate API-Login id absent from summary.json).
   { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', statusUrl: 'https://status.openai.com', apiUrl: 'https://status.openai.com/api/v2/summary.json', incidentKeywords: ['chatgpt', 'conversation', 'login', 'pinned', 'file', 'download', 'upload', 'us-east-1', 'us-west-2', 'eu-central-1'], incidentIoBaseUrl: 'https://status.openai.com/incidents', incidentIoComponentId: '01JMXBNJXGV1T5GT2M9XA83XNG', incidentIoGroupId: '01K5H8S53SY1KMS4GQMNMZXTR1', displayComponentIds: ['01JNKS9D9S72PMP1938PVFFQN4', '01K8C008QVXHA6JX98PAS42VPD', '01JMXBNJXGV1T5GT2M9XA83XNG', '01K6TVGGGDCP0PPGCHXAG3AQX8', '01JSYVYQSWMJ9QG35XHP08BHA7', '01JMXBNJXGKKP51D4DEJ2HZJ8Q', '01JSFK5QX36ZRW0TW0ZV0ZYFXQ', '01JQ7EKW990MSPSWVXC7VPV2ZJ', '01JMXBNJXGGT5SR5DB9J7GYY48', '01JMXBNJXG1S2D9V65P1ZZTD94', '01JMXBNJXG1YMQPPCPCQX3MPA2', '01JSG1XMJ9RVJJQ0E85NVSJ2AZ'] },
+  // #619 — DeepSeek's consumer app (chat.deepseek.com, "DeepSeek App"). Same Flashduty feed as
+  // DeepSeek API (#618), scoped to the Web Chat component — the api-vs-app split mirror of
+  // OpenAI API↔ChatGPT. Feed-only (no apiUrl): when the scraper feed is fresh it supersedes +
+  // clears incidentSourceStale; when absent, fetchService returns an empty stale base (it does NOT
+  // fetch the bot-walled status.deepseek.com directly). incidentSourceStale is the feed-absent flag.
+  { id: 'deepseekapp', name: 'DeepSeek App', provider: 'DeepSeek', category: 'app', statusUrl: 'https://status.deepseek.com', apiUrl: null, incidentSourceStale: true, flashdutyFeed: true, flashdutyPrimaryComponentId: '01KR3NC9ETESRRQ4GABE0TGW53' },
   // Coding Agents
   // claudecode intentionally tracks only the Claude Code component for the badge.
   // Adding Claude API as a multi-component dependency would conflict with the
@@ -549,6 +555,10 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
     if (config.flashdutyFeed && kv) {
       const fed = await readFlashdutyStatus(kv, config, base, now)
       if (fed) return fed
+      // Feed-only service (no apiUrl fallback, e.g. DeepSeek App) and the feed is absent/expired:
+      // return an empty stale base rather than fetching the bot-walled statusUrl below (which would
+      // reset and falsely mark degraded). base carries incidentSourceStale from config.
+      if (!config.apiUrl) return base
     }
 
     if (config.apiUrl) {


### PR DESCRIPTION
## Summary

Adds **DeepSeek App** — DeepSeek's consumer chat (chat.deepseek.com) as a separate `app`-category service, the symmetric half of the #618 split (OpenAI API↔ChatGPT, Claude API↔claude.ai). Reuses the #618 Flashduty KV feed scoped to the Web Chat component — **zero new data source**.

| | id | category | tier | Flashduty component |
|---|---|---|---|---|
| existing | `deepseek` (DeepSeek API) | api/llm | 2 | API Service |
| **new** | `deepseekapp` (**DeepSeek App**) | **app** | 21 | Web Chat |

Official branding: "DeepSeek - AI Assistant" (app stores) / "DeepSeek App" (site) → AIWatch display name **DeepSeek App** (disambiguates from "DeepSeek API").

## Changes

- **worker/src/services.ts** — new config; `fetchService` feed-only guard: feed absent → empty stale base, never fetches the bot-walled `status.deepseek.com`.
- **Fallback tier 21** across all 3 API_TIER mirrors; fallback-eligible (not EXCLUDE_FALLBACK).
- **Is-X-Down**: `deepseek-app` slug (slug-map + RELATED + SEO content), `/is-deepseek-app-down` rewrite + sitemap; slug≠id override mirrored (feed-slug-sync pinned).
- **Frontend**: APP_SERVICE_IDS / SERVICE_AND_APP_IDS / SERVICE_CATEGORIES.apps, usePolling MOCK, ServiceDetails STATUS_URL.
- **Service count 36 → 37** (4 AI apps) across CLAUDE.md, README(.ko), index.html, intro template, docs.

### Uptime-window fix
The scraper fetched a **30-day** `summary/structure` (99.92% Web Chat), but the official DeepSeek page displays **90-day** uptime (99.48%), and AIWatch's `parseUptimeData` iterates the full ~90-day window — so "Official Uptime" is effectively 90-day repo-wide. Changed `UPTIME_DAYS` 30→90 so both DeepSeek services match the source (API **99.88** / Web Chat **99.48**); re-captured the fixture at 90-day, updated assertions.

### Shared incidents
A "Web/API" outage touching both components shares the same `flashduty:{change_id}` id across both services, so existing cross-surface grouping (Incidents page dedup→`affectedNames`, Analyze modal, RSS `dedupeSharedIncidents`) treats it as one — no new code.

## Test / verify

- Worker **1649** + src **402** + e2e **127** pass; `typecheck:worker` clean; dry-run + build OK.
- PR review: 1 Critical (api/is-down.ts API_TIER drift — a `git checkout` for a temp revert had dropped `deepseekapp:21`) + 1 Important (2 missed "36 services" EN strings in the live intro template) — **both fixed**, api-tier-sync now passes.
- **Local in-browser verified**: 37 services; DeepSeek App detail/ranking; the 6/9 Web-Chat incident now correctly shows under DeepSeek App (excluded from DeepSeek API); `/is-deepseek-app-down` Edge SSR; reports-site counts; uptime 99.88/99.48 matching the official page.

## Acceptance (refs #619 — deploy-gated)

- [x] DeepSeek App service across worker + frontend + is-down + SEO + docs (count 37)
- [x] Reuses #618 feed scoped to Web Chat; feed-only fallback guard
- [x] Uptime matches the official 90-day page
- [ ] **Post-merge**: `npm run deploy:worker`; verify against a real Web-Chat incident
- [ ] **Separate**: aiwatch-reports count bump (37 / 4 apps) — its own commit in that repo

Depends on #618 (merged, #620).

🤖 Generated with [Claude Code](https://claude.com/claude-code)