### PR TITLE
chore(deepseek-feed): scrape cadence */15 → */10 + document the feed pipeline (refs #618/#619)

### DIFF
--- a/.github/workflows/deepseek-feed.yml
+++ b/.github/workflows/deepseek-feed.yml
@@ -2,14 +2,14 @@ name: DeepSeek status feed
 
 # #618 — DeepSeek's status page (status.deepseek.com, Flashduty) blocks non-browser TLS
 # fingerprints, so the Cloudflare Worker can't read it directly. This Action browser-renders the
-# page every 15 min, fetches the clean Flashduty JSON API from the browser context, and POSTs it to
+# page every 10 min, fetches the clean Flashduty JSON API from the browser context, and POSTs it to
 # the Worker (/api/internal/deepseek-feed → KV). fetchService('deepseek') then serves live incidents
 # and the Score re-includes DeepSeek (incidentSourceStale lifts while the feed is fresh; a 3h KV TTL
 # falls back to the frozen Atlassian mirror if this Action stops).
 
 on:
   schedule:
-    - cron: '*/15 * * * *'   # every 15 min (GH cron is best-effort; the 3h KV TTL tolerates misses)
+    - cron: '*/10 * * * *'   # every 10 min (GH cron is best-effort + often delayed; the 3h KV TTL tolerates misses)
   workflow_dispatch: {}       # manual trigger for first-run verification
 
 # A scheduled run + a manual dispatch (or an overlapping slow run) must not double-push.

--- a/docs/reference/data-flow.md
+++ b/docs/reference/data-flow.md
@@ -39,3 +39,44 @@ Web Vitals Pipeline (per-request, 100% collection):
   Browser (web-vitals) → POST /api/vitals → Worker → KV merge (vitals:{date})
   Daily Summary cron reads vitals KV → Discord embed (p75 + grade)
 ```
+
+## DeepSeek Flashduty Feed Pipeline (#618 / #619)
+
+DeepSeek's status page migrated to Flashduty (`status.deepseek.com`, #507), which blocks
+**non-browser TLS fingerprints** — a Worker `fetch()` is reset at the TLS layer regardless of egress
+IP (a real Chromium from the same IP succeeds → JA3/bot wall, not an IP block). The Worker therefore
+cannot read it directly. A scheduled GitHub Action acts as a **browser-fingerprint proxy**:
+
+```
+[GitHub Action]  cron */10 min  (.github/workflows/deepseek-feed.yml — GH cron is best-effort + often delayed)
+  Playwright headless Chromium (official mcr.microsoft.com/playwright container, pinned)
+  → goto status.deepseek.com         ← real browser TLS/HTTP fingerprint clears the bot wall
+  → in-page fetch() of the clean Flashduty JSON API (scripts/scrape-deepseek-feed.mjs):
+       /api/status-page/{pageId}/summary/active            (active incidents + components)
+       /api/status-page/{pageId}/change/list   (90d window)  (full incidents incl. timelines)
+       /api/status-page/{pageId}/summary/structure (90d)     (per-component outage windows + uptime% — 90d to match the page)
+  → POST /api/internal/deepseek-feed  (Authorization: Bearer DEEPSEEK_FEED_TOKEN)
+                                  │
+                                  ▼
+[Worker]  handleDeepseekFeed → validate token + shape (reject empty) → KV `deepseek:feed` (3h TTL, ~18 missed-run tolerance)
+                                  ▲
+                                  │  read each */5 cron + each /api/status fan-out
+[Worker]  fetchService('deepseek' | 'deepseekapp')  (services.ts readFlashdutyStatus)
+  → parseFlashdutyFeed(feed, { primaryComponentId })   ← option A: scope to ONE component
+       deepseek    → API Service component   (api.deepseek.com)  → category api
+       deepseekapp → Web Chat Service component (chat.deepseek.com) → category app (DeepSeek App, #619)
+  → FRESH feed (≤1h)   → live data, incidentSourceStale cleared (ranked)
+  → AGING feed (1–3h)  → live badge/incidents but incidentSourceStale re-asserted (ranking-excluded)
+  → ABSENT/expired feed (>3h KV TTL):
+       deepseek    → fall back to the frozen Atlassian mirror (deepseek.statuspage.io) + incidentSourceStale
+       deepseekapp → empty stale base (feed-only, no apiUrl) — never fetches the bot-walled URL
+```
+
+Two timers interlock: the **Action (*/10)** refreshes the KV data source; the **Worker cron (*/5)**
+reads it + recomputes `services:latest`. So DeepSeek **status-page** incident detection lags ~10 min
+behind the 5-min-polled services — but DeepSeek **API RTT degradation** is still caught at */5 by the
+direct probe (`api.deepseek.com`, which bypasses the bot-walled status host). Shared incidents (a
+"Web/API" outage) carry the same `flashduty:{change_id}` id across both services, so the existing
+cross-surface grouping (Incidents page dedup→affectedNames, Analyze modal, RSS `dedupeSharedIncidents`)
+collapses them to one. Go-live ops: `DEEPSEEK_FEED_TOKEN` Worker secret + GH Action secrets
+(`DEEPSEEK_FEED_TOKEN`, `DEEPSEEK_FEED_WORKER_URL`).

--- a/worker/src/parsers/flashduty.ts
+++ b/worker/src/parsers/flashduty.ts
@@ -70,7 +70,7 @@ export interface StoredFlashdutyFeed {
 
 // KV key the scraper (via /api/internal/deepseek-feed) writes and fetchService('deepseek') reads.
 export const DEEPSEEK_FEED_KV_KEY = 'deepseek:feed'
-// KV TTL. The scraper runs ~every 15 min; a 3h TTL tolerates ~12 consecutive missed runs before the
+// KV TTL. The scraper runs ~every 10 min; a 3h TTL tolerates ~18 consecutive missed runs before the
 // key expires and fetchService falls back to the frozen Atlassian mirror (with incidentSourceStale).
 export const DEEPSEEK_FEED_TTL_S = 3 * 60 * 60
 // Soft-staleness gate: a feed older than this still SERVES (badge/incidents stay live) but re-asserts


### PR DESCRIPTION
Follow-up tuning + docs for the DeepSeek browser-rendered Flashduty feed (#618/#619).

## Why
At */15 the feed refreshed every ~15 min, so DeepSeek's **status-page** incident detection lagged the 5-min-polled services. Tighten to **`*/10`**. GitHub scheduled cron is best-effort (often delayed), so `*/5` wouldn't reliably deliver 5-min freshness — `*/10` is the realistic balance. (DeepSeek **API RTT degradation** is already caught at `*/5` by the direct `api.deepseek.com` probe, which bypasses the bot-walled status host.)

## Changes
- `.github/workflows/deepseek-feed.yml` — cron `*/15` → `*/10`.
- `worker/src/parsers/flashduty.ts` — TTL comment: 3h / 10min ≈ 18 missed-run tolerance.
- `docs/reference/data-flow.md` — new **DeepSeek Flashduty Feed Pipeline** section: browser-proxy Action, the two interlocking timers (Action */10 source refresh ↔ Worker cron */5 read), option-A per-component scoping, fresh/aging/absent feed degradation, the probe-bypasses-the-wall nuance, and shared-incident grouping.

## Verify
Config + docs only (no logic change). cron syntax valid; `typecheck:worker` clean; flashduty parser tests 13/13. Doc cross-checked against the implementation (90d windows, TTL math, scoping, secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)