### PR TITLE
fix(mistral): scope the API badge to API components, exclude Le Chat / non-API surfaces (refs #623)

### DIFF
--- a/worker/src/__tests__/filter-incidents.test.ts
+++ b/worker/src/__tests__/filter-incidents.test.ts
@@ -41,6 +41,27 @@ describe('filterIncidents', () => {
     expect(filterIncidents(incidents, config)).toHaveLength(0)
   })
 
+  it('#623 — Mistral: scopes to API, excludes Le Chat / non-API surfaces (Nuxt title carries the component)', () => {
+    // status.mistral.ai is Instatus/Nuxt — the parser appends the affected component to the title
+    // ("name · Component"). The mistral denylist drops the consumer/non-API surfaces while keeping
+    // every API component (denylist, so a real API incident is never dropped).
+    const mistral = mockConfig({ id: 'mistral', incidentExclude: ['le chat', 'le console', 'documentation', 'website'] })
+    const incidents = [
+      mockIncident({ id: 'a', title: 'Requests are experiencing degraded service · Chat Completions API' }),
+      mockIncident({ id: 'b', title: 'Requests are experiencing degraded service · AI Registry Prompts API' }),
+      mockIncident({ id: 'g', title: 'Elevated errors · Files API' }),   // broadens the no-collision net
+      mockIncident({ id: 'c', title: 'Slow responses · Le Chat' }),
+      mockIncident({ id: 'd', title: 'Login broken · Le Console' }),
+      mockIncident({ id: 'e', title: 'Docs outage · Documentation' }),
+      mockIncident({ id: 'f', title: 'Marketing page down · Mistral.ai Website' }),
+    ]
+    const kept = filterIncidents(incidents, mistral).map((i) => i.id)
+    expect(kept).toEqual(['a', 'b', 'g']) // only the API-component incidents survive
+    // a real API incident is never accidentally dropped (no API component name contains a denylist term)
+    expect(kept).not.toContain('c')
+    expect(kept).not.toContain('f')
+  })
+
   it('includes only matching incidentKeywords', () => {
     const incidents = [
       mockIncident({ id: '1', title: 'API latency spike' }),

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -39,7 +39,15 @@ export const SERVICES: ServiceConfig[] = [
     'https://status.aws.amazon.com/rss/bedrock-ap-northeast-1.rss',
   ] },
   { id: 'azureopenai', name: 'Azure OpenAI', provider: 'Microsoft', category: 'api', statusUrl: 'https://azure.status.microsoft/en-us/status', apiUrl: null, azureRssUrl: 'https://rssfeed.azure.status.microsoft/en-us/status/feed/', incidentKeywords: ['Azure OpenAI'] },
-  { id: 'mistral', name: 'Mistral API', provider: 'Mistral AI', category: 'api', statusUrl: 'https://status.mistral.ai', apiUrl: null, instatusUrl: 'https://status.mistral.ai/incidents/page/1' },
+  // #623 — status.mistral.ai (Instatus, Nuxt) lists API components ("Chat Completions API", …)
+  // alongside non-API surfaces (Le Chat consumer app, Le Console, Documentation, Website). The Nuxt
+  // parser appends the affected component to the incident title ("… · Le Chat"), so a denylist scopes
+  // the "Mistral API" badge/incidents/Score to the API only — the api-vs-app split (cf. OpenAI API
+  // excludes ChatGPT). Denylist (not an `['api']` allowlist) so a real API incident is never dropped.
+  // Known limitation: the Nuxt parser tags the title with only servicesArr[0] (first affected
+  // component) and doesn't populate componentNames, so a *combined* Le-Chat+API incident that lists
+  // Le Chat first would be dropped despite affecting the API. Low-probability; revisit if observed.
+  { id: 'mistral', name: 'Mistral API', provider: 'Mistral AI', category: 'api', statusUrl: 'https://status.mistral.ai', apiUrl: null, instatusUrl: 'https://status.mistral.ai/incidents/page/1', incidentExclude: ['le chat', 'le console', 'documentation', 'website'] },
   // displayAllComponents (#606): per-model statuspage — show every model/surface except Docs/Website
   // (dynamic, so new/retired models need no config edit). componentSurfaces stay as individual rows;
   // the rest fold into a collapsible "Models" group (matches the official Endpoints/Models split).


### PR DESCRIPTION
## Problem
`status.mistral.ai` (Instatus/Nuxt) lists API components alongside non-API surfaces — **Le Chat** (consumer app), Le Console, Documentation, Website. With no scoping, a Le Chat outage flipped the **"Mistral API"** badge and counted against its Score — the same api-vs-app leak #618/#619 fixed for DeepSeek and that OpenAI API (`incidentExclude:['chatgpt']`) already handles.

## Fix
The Nuxt parser appends the affected component to the incident title (`… · Le Chat`), so a title **denylist** scopes the badge/incidents/Score to the API. **Denylist, not an `['api']` allowlist** — the Instatus badge is derived from the post-filter incident list, so an allowlist false-negative would *hide a real API outage*; a denylist never drops a real API incident.

`mistral` → `incidentExclude: ['le chat', 'le console', 'documentation', 'website']`

## Verify
- New `filter-incidents` test: non-API surfaces dropped, API components (Chat Completions / AI Registry Prompts / Files API) kept; no-collision net.
- Worker suite 1655 + typecheck clean + dry-run.
- **Live artifact**: ran the real parser+filter against the live status.mistral.ai — all 14 current API-component incidents survive, no false-drop. (Exclusion is unit-tested deterministically; visible effect requires a live non-API incident.)
- Known limitation documented: the Nuxt parser tags only `servicesArr[0]`, so a combined Le-Chat+API incident listing Le Chat first would be dropped (low-probability).

## Scope (refs #623)
- [x] **Phase 1a** — Mistral (this PR)
- [ ] **Phase 1b** — Perplexity needs a `parseInstatusNextIncidents` enhancement (Next.js format doesn't tag the component) before the same denylist applies
- [ ] OpenRouter deferred; Le Chat → app split signal-gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)