### PR TITLE
fix(perplexity): capture Instatus Next.js components → scope the API badge, exclude Website (refs #623)

### DIFF
--- a/worker/src/__tests__/instatus.test.ts
+++ b/worker/src/__tests__/instatus.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mapInstatusImpact, parseInstatusIncidents } from '../parsers/instatus'
+import { filterIncidents } from '../services'
+import type { ServiceConfig } from '../types'
 
 describe('mapInstatusImpact (#556)', () => {
   it('maps Next.js component-status impact values', () => {
@@ -125,5 +127,47 @@ describe('parseInstatusIncidents — Next.js format impact mapping (#556, Perple
 
   it('maps MAJOROUTAGE → major', () => {
     expect(parseInstatusIncidents(nextHtml('MAJOROUTAGE'))[0].impact).toBe('major')
+  })
+})
+
+describe('parseInstatusIncidents — Next.js component capture (#623, Perplexity)', () => {
+  // Mirrors the real status.perplexity.com payload: a `components` array (id→name: Website, API,
+  // name has ONLY a `default` key) + notices that reference component ids and carry `name:{en,default}`.
+  function nextHtmlWithComponents() {
+    // Real Instatus ids are cuid-style (e.g. clyi6jhgg31469ihojbwbsmeeg) — use that shape so the test
+    // exercises the regex's id charset/length faithfully.
+    const WEB = 'clyi6jhgg31469ihojbwbsmeeg'
+    const API = 'clyiakn7i60113hvojwho6za6j'
+    const components =
+      '\\"components\\":[' +
+      `{\\"id\\":\\"${WEB}\\",\\"name\\":{\\"default\\":\\"Website\\"},\\"status\\":\\"OPERATIONAL\\"},` +
+      `{\\"id\\":\\"${API}\\",\\"name\\":{\\"default\\":\\"API\\"},\\"status\\":\\"OPERATIONAL\\"}]`
+    const n1 =
+      '\\"n1\\":{\\"id\\":\\"n1\\",\\"name\\":{\\"en\\":\\"Website and API incident\\",\\"default\\":\\"Website and API incident\\"},' +
+      '\\"impact\\":\\"DEGRADEDPERFORMANCE\\",\\"started\\":\\"2026-05-08T00:20:00.000Z\\",\\"resolved\\":\\"2026-05-08T04:19:00.000Z\\",' +
+      `\\"status\\":\\"RESOLVED\\",\\"components\\":[{\\"id\\":\\"${WEB}\\"},{\\"id\\":\\"${API}\\"}]}`
+    const n2 =
+      '\\"n2\\":{\\"id\\":\\"n2\\",\\"name\\":{\\"en\\":\\"Connector connectivity issues\\",\\"default\\":\\"Connector connectivity issues\\"},' +
+      '\\"impact\\":\\"PARTIALOUTAGE\\",\\"started\\":\\"2026-06-04T21:10:00.000Z\\",\\"resolved\\":\\"2026-06-05T01:40:00.000Z\\",' +
+      `\\"status\\":\\"RESOLVED\\",\\"components\\":[{\\"id\\":\\"${WEB}\\"}]}`
+    return `<script>self.__next_f.push([1,"x:${components}:notices\\":{${n1},${n2}},\\"metrics\\":{}"])</script>`
+  }
+
+  const perplexity = {
+    id: 'perplexity', name: 'Perplexity', provider: 'Perplexity AI', category: 'api',
+    statusUrl: 'https://status.perplexity.com', apiUrl: null, incidentKeywords: ['api'],
+  } as ServiceConfig
+
+  it('resolves each incident’s affected component ids → componentNames', () => {
+    const incidents = parseInstatusIncidents(nextHtmlWithComponents())
+    const byId = Object.fromEntries(incidents.map((i) => [i.id, i.componentNames]))
+    expect(byId['n1']).toEqual(['Website', 'API']) // Website + API
+    expect(byId['n2']).toEqual(['Website'])        // Website only
+  })
+
+  it('incidentKeywords:[api] keeps the Website+API incident, drops the Website-only one', () => {
+    const kept = filterIncidents(parseInstatusIncidents(nextHtmlWithComponents()), perplexity).map((i) => i.id)
+    expect(kept).toContain('n1')     // affects API → kept
+    expect(kept).not.toContain('n2') // Website-only → dropped
   })
 })

--- a/worker/src/parsers/instatus.ts
+++ b/worker/src/parsers/instatus.ts
@@ -30,6 +30,21 @@ export function mapInstatusImpact(raw: string | null | undefined): Incident['imp
   return 'minor'
 }
 
+// #623 — extract Instatus component definitions (id → display name) from the Next.js SSR payload so
+// each notice's `components: [{id}]` can be resolved to names (set on Incident.componentNames). That
+// lets a service like Perplexity scope its API badge with `incidentKeywords: ['api']` (matched
+// against componentNames): a Website-only incident is dropped, a Website+API incident kept.
+// Component entries serialize as `"id":"…","name":{"default":"Website"}` (name has ONLY a `default`
+// key); incident notices use `"name":{"en":…,"default":…}` (an `en` key first), so the
+// `"name":{"default":` anchor matches component definitions but not notice names.
+function buildInstatusComponentMap(html: string): Map<string, string> {
+  const map = new Map<string, string>()
+  const re = /\\"id\\":\\"([a-z0-9]+)\\",\\"name\\":\{\\"default\\":\\"([^\\"]+)\\"\}/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null) map.set(m[1], m[2])
+  return map
+}
+
 function parseInstatusNextIncidents(html: string): Incident[] {
   try {
     // Next.js SSR payload has escaped quotes: notices\":{\"id\":{...}}
@@ -41,7 +56,9 @@ function parseInstatusNextIncidents(html: string): Incident[] {
     const notices = JSON.parse(raw) as Record<string, {
       id: string; name: { default: string }; impact: string
       started: string; resolved: string | null; status: string
+      components?: Array<{ id: string }> // #623 — affected component ids (resolved → componentNames)
     }>
+    const componentNameById = buildInstatusComponentMap(html)
 
     const incidents: Incident[] = []
     for (const notice of Object.values(notices)) {
@@ -65,11 +82,25 @@ function parseInstatusNextIncidents(html: string): Incident[] {
         timeline.push({ stage: 'resolved' as const, text: 'Resolved', at: resolvedDate.toISOString() })
       }
 
+      // #623 — resolve affected component ids → names for component-aware filtering (e.g. Perplexity
+      // incidentKeywords:['api'] keeps a Website+API incident but drops a Website-only one).
+      const componentRefs = notice.components ?? []
+      const componentNames = componentRefs
+        .map((c) => componentNameById.get(c.id))
+        .filter((n): n is string => !!n)
+      // Resolution depends on the Instatus `"id":"…","name":{"default":…}` serialization (key order):
+      // if a notice references components but NONE resolve, the component map likely changed shape —
+      // log it so a future Instatus format change is diagnosable instead of silently scoping wrong.
+      if (componentRefs.length > 0 && componentNames.length === 0) {
+        console.debug(`[parseInstatusNext] notice ${notice.id} references ${componentRefs.length} component id(s) but none resolved — Instatus component serialization may have changed`)
+      }
+
       incidents.push({
         id: notice.id,
         title: notice.name.default,
         status: isResolved ? 'resolved' : 'investigating',
         impact: mapInstatusImpact(notice.impact), // #556 — was MAJOR/PARTIAL-only; DEGRADEDPERFORMANCE fell to null
+        componentNames: componentNames.length > 0 ? componentNames : undefined,
         startedAt: startDate.toISOString(),
         resolvedAt: (resolvedDate && !isNaN(resolvedDate.getTime())) ? resolvedDate.toISOString() : null,
         duration: (isResolved && resolvedDate && !isNaN(resolvedDate.getTime()))

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -52,7 +52,13 @@ export const SERVICES: ServiceConfig[] = [
   // service; statusComponentId (Developer Console) is the primary for uptime parsing / calendar /
   // component-miss alerting. Single-tenant page → no incidentKeywords needed.
   { id: 'cerebras', name: 'Cerebras Inference', provider: 'Cerebras', category: 'api', statusUrl: 'https://status.cerebras.ai', apiUrl: 'https://status.cerebras.ai/api/v2/summary.json', statusComponentId: '83h1cchw4vs4', statusComponentIds: ['83h1cchw4vs4', '7xvps6c9lqwc', 'bhqw2gr7r710', 'hgfykfsb36gn', '8ygyx5vydlm2'] },
-  { id: 'perplexity', name: 'Perplexity', provider: 'Perplexity AI', category: 'api', statusUrl: 'https://status.perplexity.com', apiUrl: null, instatusUrl: 'https://status.perplexity.com' },
+  // #623 — status.perplexity.com (Instatus, Next.js) has 2 components: "API" (Sonar) + "Website"
+  // (the consumer perplexity.ai). The Next.js parser now resolves each incident's affected components
+  // → componentNames (#623), so `incidentKeywords: ['api']` (matched against componentNames) scopes
+  // the badge/Score to the API: a Website-only incident is dropped, a Website+API incident kept (it
+  // affects the API). Allowlist is correct here — the API component is literally named "API", and
+  // unlike a title-denylist it keeps a multi-component "Website and API" incident.
+  { id: 'perplexity', name: 'Perplexity', provider: 'Perplexity AI', category: 'api', statusUrl: 'https://status.perplexity.com', apiUrl: null, instatusUrl: 'https://status.perplexity.com', incidentKeywords: ['api'] },
   { id: 'xai', name: 'xAI (Grok)', provider: 'xAI', category: 'api', statusUrl: 'https://status.x.ai', apiUrl: null, rssFeedUrl: 'https://status.x.ai/feed.xml', incidentKeywords: ['api'], incidentExclude: ['[API Console]', 'Test+Incident'] },
   // status.deepseek.com (Flashduty, #507) blocks NON-BROWSER TLS fingerprints — a Worker fetch()
   // is reset at the TLS layer regardless of egress IP (verified 2026-06-12: a real Chromium from


### PR DESCRIPTION
## Problem
`status.perplexity.com` is Instatus/**Next.js** with 2 components — **API** (Sonar) + **Website** (the consumer perplexity.ai). The Next.js parser didn't capture the affected component (unlike the Nuxt format used by Mistral), so a Website-only incident flipped the "Perplexity" API badge and hit its Score. A title-denylist can't fix it: a real **"Website and API"** incident affects the API and must be kept.

## Fix
Enhance `parseInstatusNextIncidents` to resolve each incident's affected component ids → `componentNames`, then scope with `incidentKeywords: ['api']` (matched against componentNames):
- Website-only incident ("Connector connectivity issues") → **dropped**
- Website+API incident ("Website and API incident") → **kept** (affects the API)

Allowlist (not the Mistral denylist) is correct here because of the multi-component case — the API component is literally named "API", and matching componentNames keeps the combined incident.

`buildInstatusComponentMap` extracts id→name from the SSR `components` array (the `"name":{"default":` anchor matches component defs, not notices whose name is `{en,default}`); debug-logs unresolved refs so a future Instatus key-order change is diagnosable rather than a silent mis-scope.

## Verify
- New parser/filter tests (real cuid-style ids): componentNames resolved (['Website','API'] / ['Website']); filter keeps Website+API, drops Website-only.
- Worker suite 1656 + typecheck clean + dry-run.
- **Live artifact**: ran the real status.perplexity.com through the worker — keeps the Website+API incident (componentNames ['Website','API']), drops the Connector/Website-only one.
- PR review: 0 Critical/Important (no ReDoS on 118KB, cuid ids match `[a-z0-9]+`, null-safe, instatus path doesn't re-add via includeUntaggedIncidents).

## Scope (refs #623)
- [x] Phase 1a — Mistral (#624)
- [x] **Phase 1b — Perplexity (this PR)** + the reusable Next.js component-capture
- [ ] Perplexity naming/split decision (rename "Perplexity API" vs track/split the consumer side) — separate
- [ ] OpenRouter deferred; Le Chat → app split signal-gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)