### PR TITLE
fix: drop stale DeepSeek 'API probe only' note — Flashduty feed is live again (refs #638)

### DIFF
--- a/api/is-down/seo-content.ts
+++ b/api/is-down/seo-content.ts
@@ -229,7 +229,7 @@ const SEO_CONTENT: Record<string, ServiceSEO> = {
   deepseek: {
     displayName: 'DeepSeek',
     description: 'DeepSeek API provides access to DeepSeek\'s frontier reasoning models (V3, R1) at significantly lower price points than Western providers. It is a Chinese AI lab whose models have gained rapid adoption since early 2026.',
-    insight: 'DeepSeek API can experience capacity-driven outages during demand spikes (model release events, viral moments). Geographic latency varies more than US-based providers given DeepSeek\'s primarily Asian infrastructure. Note: DeepSeek migrated their status page to Flashduty (a Chinese-hosted platform) in May 2026. That platform blocks non-Chinese IPs, so AIWatch monitors DeepSeek via direct API probe only — incident history may be incomplete after May 2026.',
+    insight: 'DeepSeek API can experience capacity-driven outages during demand spikes (model release events, viral moments). Geographic latency varies more than US-based providers given DeepSeek\'s primarily Asian infrastructure. Note: DeepSeek migrated their status page to Flashduty in May 2026. The platform blocks plain server requests, so AIWatch reads DeepSeek\'s official Flashduty status feed via a browser-rendered fetch — live incident coverage is current again, complemented by a direct API latency probe.',
     whenDown: 'When DeepSeek API is down, applications relying on its low-cost reasoning models will fail. Cost-sensitive deployments that switched from OpenAI/Claude to DeepSeek for affordability lose their primary backend.',
     faqs: [
       { q: 'Is DeepSeek API down right now?', a: 'Check the live status indicator at the top of this page. AIWatch monitors DeepSeek every 5 minutes and shows real-time operational status.' },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -204,7 +204,6 @@ const en = {
   'svc.components.title': 'Component Status',
   'svc.components.sub': 'Per-component breakdown from the official status page',
   'svc.components.groupCount': '{n} components',
-  'svc.deepseek.probeNote': 'Status page (Flashduty) not accessible outside China — monitoring via API probe only since May 2026',
   'svc.rss': 'RSS',
   'svc.rss.copied': 'Copied ✓',
   'svc.rss.title': 'Copy this service\'s incident RSS feed URL',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -204,7 +204,6 @@ const ko = {
   'svc.components.title': '구성요소 상태',
   'svc.components.sub': '공식 상태 페이지의 구성요소별 상태',
   'svc.components.groupCount': '구성요소 {n}개',
-  'svc.deepseek.probeNote': '상태 페이지(Flashduty)가 중국 외 IP에서 접근 불가 — 2026년 5월부터 API probe만으로 모니터링',
   'svc.rss': 'RSS',
   'svc.rss.copied': '복사됨 ✓',
   'svc.rss.title': '이 서비스 인시던트 RSS 피드 URL 복사',

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -791,11 +791,6 @@ export default function ServiceDetails({ serviceId }) {
             )}
             {feedUrl && <RssLink feedUrl={feedUrl} serviceId={service.id} t={t} />}
           </div>
-          {service.id === 'deepseek' && (
-            <div className="mono text-[10px] text-[var(--text2)]" style={{ marginTop: '6px' }}>
-              ⚠ {t('svc.deepseek.probeNote')}
-            </div>
-          )}
         </div>
         <div className="flex items-center gap-1.5">
           {!!recentlyRecovered[service.id] && <span className="mono text-[9px] rounded" style={{ color: 'var(--blue)', background: 'var(--blue-dim)', padding: '3px 8px' }}>{t('overview.recovered')}</span>}


### PR DESCRIPTION
## Problem
The DeepSeek **API** detail page permanently showed:
> ⚠ Status page (Flashduty) not accessible outside China — monitoring via API probe only since May 2026

Stale — the note was hard-gated on `service.id === 'deepseek'` so it **always** rendered, but since #618/#620 (browser-rendered Flashduty feed) + #629/#630 (reliable worker-cron dispatch) DeepSeek is monitored from its live Flashduty feed again.

## Change
- **`ServiceDetails.jsx`** — remove the footer note block.
- **`ko.js` + `en.js`** — remove the now-unused `svc.deepseek.probeNote` key (only consumer was the block above; a stale feed is already handled by the #591 stale-source blanking, so a permanent warning is unwarranted).
- **`seo-content.ts`** — correct the is-deepseek-down `insight` from "monitors via direct API probe only — incident history may be incomplete after May 2026" to the live-feed reality (matching the deepseekapp insight tone).

## Verify
- **In-browser (user-confirmed)**: DeepSeek API detail page no longer shows the note; KO/EN intact; Official Status + RSS links remain.
- build OK · `test:src` 403 · `test:worker` 1681 · **E2E 127 pass** · PR review 0 Critical/0 Important · no dangling `probeNote` reference · ko/en key parity preserved.
- is-deepseek-down insight (Edge SSR) verifiable on the Vercel Preview / post-deploy → `refs #638`, close after preview check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)