### PR TITLE
ux: drop subjective "no fallback" message + suppress fallback when a region switch exists (refs #641)

### DIFF
--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -239,6 +239,13 @@ export default async function handler(req: Request) {
       }
     }
 
+    // #641 — when a region switch is offered (the cheaper same-provider fix for a region-specific
+    // outage), suppress the cross-service fallback so the page doesn't push a redundant full provider
+    // switch alongside it. Condition mirrors renderRegionRecommendation + the ActionBanner.
+    if (regionRec && regionRec.hasRegionSpecific && !regionRec.allDown && regionRec.recommendedRegion) {
+      fallbacks = []
+    }
+
     const html = renderPage(slug, serviceData as Parameters<typeof renderPage>[1], seo, fallbacks, aiInsight, regionRec)
 
     // #378: when the upstream Worker fetch failed and we're rendering the

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -350,12 +350,12 @@ function renderAIInsight(insight?: { summary: string; estimatedRecovery: string;
   const resolvedBadge = isResolved
     ? '<span class="mono" style="font-size:10px;color:#3fb950;background:rgba(63,185,80,0.15);padding:2px 8px;border-radius:4px">Resolved</span>'
     : ''
-  const fallbackHtml = insight.needsFallback && !isResolved && fallbacks
+  // #641 — only render the Alternatives block when we actually have a recommendation; we don't
+  // assert "No operational alternatives" (a subjective claim from our own incomplete coverage).
+  const fallbackHtml = insight.needsFallback && !isResolved && fallbacks && fallbacks.length > 0
     ? `<div style="margin-top:8px;padding:8px 10px;background:#0d1117;border-radius:6px;border-left:3px solid #d29922">
 <span class="mono" style="font-size:11px;color:#c9d1d9;font-weight:600">🔄 Alternatives</span>
-${fallbacks.length > 0
-    ? fallbacks.map(f => `<div class="mono" style="font-size:11px;color:#c9d1d9;margin-top:3px">• ${esc(f.name)}${f.score != null ? ` (Score: ${f.score})` : ''}</div>`).join('')
-    : '<div class="mono" style="font-size:11px;color:#8b949e;margin-top:3px">No operational alternatives currently available</div>'}
+${fallbacks.map(f => `<div class="mono" style="font-size:11px;color:#c9d1d9;margin-top:3px">• ${esc(f.name)}${f.score != null ? ` (Score: ${f.score})` : ''}</div>`).join('')}
 </div>`
     : ''
   return `<div class="card" style="border-left:3px solid ${isResolved ? '#3fb950' : '#7C3AED'};margin:16px 0${isResolved && !isRecentlyRecovered ? ';opacity:0.75' : ''}">

--- a/src/components/AnalysisModal.jsx
+++ b/src/components/AnalysisModal.jsx
@@ -196,24 +196,20 @@ export default function AnalysisModal({ aiAnalysis, services, onClose }) {
                   )
                 })}
 
-                {/* Contextual fallback recommendation — per category for the service group */}
-                {showFallback && (
+                {/* Contextual fallback recommendation — per category for the service group.
+                    #641 — only render when we actually have a recommendation; no
+                    "No operational alternatives" claim (subjective, may be inaccurate). */}
+                {showFallback && fallbackGroups.length > 0 && (
                   <div className="mono text-[10px]" style={{ marginTop: '10px', padding: '8px 10px', background: 'var(--bg1)', borderRadius: '6px', borderLeft: '3px solid var(--amber)' }}>
                     <span style={{ color: 'var(--text1)', fontWeight: 600 }}>🔄 {lang === 'ko' ? '대안 서비스' : 'Alternatives'}</span>
-                    {fallbackGroups.length > 0 ? (
-                      <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
-                        {fallbackGroups.map(grp => (
-                          <span key={`${grp.category}:${grp.label}`} style={{ color: 'var(--text1)' }}>
-                            <span style={{ color: 'var(--text2)' }}>{grp.label} → </span>
-                            {grp.items.map(f => `${f.name}${f.aiwatchScore != null ? ` (${f.aiwatchScore})` : ''}`).join(', ')}
-                          </span>
-                        ))}
-                      </div>
-                    ) : (
-                      <div style={{ marginTop: '4px', color: 'var(--text2)' }}>
-                        {lang === 'ko' ? '현재 운영 중인 대안 서비스가 없습니다' : 'No operational alternatives currently available'}
-                      </div>
-                    )}
+                    <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                      {fallbackGroups.map(grp => (
+                        <span key={`${grp.category}:${grp.label}`} style={{ color: 'var(--text1)' }}>
+                          <span style={{ color: 'var(--text2)' }}>{grp.label} → </span>
+                          {grp.items.map(f => `${f.name}${f.aiwatchScore != null ? ` (${f.aiwatchScore})` : ''}`).join(', ')}
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -67,7 +67,6 @@ const en = {
   'overview.banner.affected': '{n} services affected',
   'overview.banner.fallback': 'Suggested fallback:',
   'overview.banner.regionSwitch': 'Switch region:',
-  'overview.banner.noFallback': 'No direct fallback available · Retry or caching recommended',
   'overview.banner.viewIssues': 'View Issues tab for details',
   'overview.banner.viewIncidents': 'View incident details',
   'overview.banner.downCount': 'Down ({n}):',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -67,7 +67,6 @@ const ko = {
   'overview.banner.affected': '{n}개 서비스 장애',
   'overview.banner.fallback': '대체 추천:',
   'overview.banner.regionSwitch': '리전 전환:',
-  'overview.banner.noFallback': '대체 서비스 없음 · 재시도 또는 캐싱 권장',
   'overview.banner.viewIssues': 'Issues 탭에서 확인',
   'overview.banner.viewIncidents': '인시던트 상세 확인',
   'overview.banner.downCount': '중단 ({n}):',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -9,7 +9,7 @@ import { usePolling } from '../hooks/usePolling'
 import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { isUnreliableUptime } from '../utils/serviceReliability'
-import { SCORE_BG_CLASS, SERVICE_CATEGORIES, getGroupedFallbacks, ALL_SERVICES_FEED_URL } from '../utils/constants'
+import { SCORE_BG_CLASS, SERVICE_CATEGORIES, getGroupedFallbacksExcludingRegionSwitchable, ALL_SERVICES_FEED_URL } from '../utils/constants'
 import RssCopyIcon from '../components/RssCopyIcon'
 import { regionStatusOf } from '../utils/regionStatus'
 import { buildCalendarFromIncidents } from '../utils/calendar'
@@ -404,13 +404,6 @@ function ActionBanner({ services, setPage, t }) {
     </span>
   ))
 
-  // Per-category fallback groups (with API-tier subdivision), shared with the
-  // AnalysisModal via getGroupedFallbacks so both surfaces show identical
-  // per-category alternatives for a multi-service incident (#445). The helper
-  // excludes non-operational + same-provider candidates and uses tierFor/
-  // tierLabelFor (warn-once on missing API_TIER rows) under the hood.
-  const categoryGroups = getGroupedFallbacks(affected, services)
-
   // Region-switch recommendations (refs #422 Phase 1). For each affected service
   // whose status page reports per-region incidents AND has at least one healthy
   // region, surface "Pinecone → AWS US West" alongside the cross-service fallback.
@@ -433,6 +426,12 @@ function ActionBanner({ services, setPage, t }) {
       docsUrl: rs.docsUrl,
     })
   }
+
+  // Per-category fallback groups (#445), EXCLUDING services that already have a region-switch
+  // recommendation (#641 — a region-specific outage is solved by the cheaper same-provider region
+  // switch shown above, so a cross-provider fallback alongside it is redundant noise). Per-service:
+  // an affected service without a region switch keeps its cross-service fallback. Helper is unit-tested.
+  const categoryGroups = getGroupedFallbacksExcludingRegionSwitchable(affected, services)
 
   return (
     <div className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg" style={{ padding: '10px 14px', lineHeight: 1.5, borderLeft: `3px solid ${borderColor}` }}>
@@ -530,11 +529,10 @@ function ActionBanner({ services, setPage, t }) {
             </span>
           ))}
         </div>
-      ) : affected.length > 0 ? (
-        <div className="mono text-[11px] text-[var(--text2)]" style={{ marginTop: '4px' }}>
-          {t('overview.banner.noFallback')}
-        </div>
       ) : null}
+      {/* #641 — when there's no fallback recommendation we render nothing here (no
+          "No direct fallback available" claim — that's a subjective statement from our
+          own incomplete coverage). Region-switch above stays; it's a real alternative. */}
     </div>
   )
 }

--- a/src/utils/__tests__/constants.test.js
+++ b/src/utils/__tests__/constants.test.js
@@ -3,7 +3,7 @@
 // because the worker can't import frontend code at runtime.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, shouldShowFallback, hasActiveIncident } from '../constants'
+import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, getGroupedFallbacksExcludingRegionSwitchable, hasRegionSwitch, shouldShowFallback, hasActiveIncident } from '../constants'
 
 describe('tierFor (#403 frontend warn-once helper)', () => {
   let warnSpy
@@ -253,5 +253,48 @@ describe('shouldShowFallback (#454 status-based modal gate)', () => {
   it('returns false for empty or invalid input', () => {
     expect(shouldShowFallback([], false)).toBe(false)
     expect(shouldShowFallback(null, false)).toBe(false)
+  })
+})
+
+describe('region-switch fallback suppression (#641)', () => {
+  const regionInc = { id: 'oai-r', title: 'errors', status: 'investigating', componentNames: ['us-east-1'] }
+
+  describe('hasRegionSwitch', () => {
+    it('is true for a region-specific outage on a region-aware service', () => {
+      expect(hasRegionSwitch({ id: 'openai', incidents: [regionInc] })).toBe(true)
+    })
+    it('is false for a non-region-aware service (no SERVICE_REGIONS entry)', () => {
+      expect(hasRegionSwitch({ id: 'mistral', incidents: [{ id: 'm', title: 'errors', status: 'investigating' }] })).toBe(false)
+    })
+    it('is false when there is no ongoing incident (openai is not always-show)', () => {
+      expect(hasRegionSwitch({ id: 'openai', incidents: [] })).toBe(false)
+    })
+    it('stays true when a global incident coexists (web predicate intentionally omits hasGlobalIncident)', () => {
+      // Documents the intentional asymmetry vs the Worker's buildRegionHint (which additionally
+      // guards hasGlobalIncident). The web surfaces render the region link + suppress the fallback
+      // here; the Worker keeps the fallback. Pinning so the decision doesn't silently drift.
+      const globalInc = { id: 'oai-g', title: 'Major outage', status: 'investigating' }
+      expect(hasRegionSwitch({ id: 'openai', incidents: [regionInc, globalInc] })).toBe(true)
+    })
+  })
+
+  describe('getGroupedFallbacksExcludingRegionSwitchable', () => {
+    const op = (id, category, provider, aiwatchScore) => ({ id, category, provider, aiwatchScore, status: 'operational', incidents: [] })
+
+    it('excludes a region-switchable service but KEEPS a non-region service\'s fallback (per-service)', () => {
+      const openai = { id: 'openai', category: 'api', provider: 'OpenAI', status: 'degraded', incidents: [regionInc] }
+      const cursor = { id: 'cursor', category: 'agent', provider: 'Cursor', status: 'degraded', incidents: [] }
+      const services = [openai, cursor, op('claude', 'api', 'Anthropic', 95), op('codex', 'agent', 'OpenAI', 88), op('windsurf', 'agent', 'Windsurf', 85)]
+
+      const cats = getGroupedFallbacksExcludingRegionSwitchable([openai, cursor], services).map(g => g.category)
+      expect(cats).toContain('agent')     // cursor (no region map) keeps its fallback
+      expect(cats).not.toContain('api')   // openai (region-switchable) excluded → no api group
+      // Contrast: without the exclusion the api group WOULD appear (proves it's the suppression, not absence)
+      expect(getGroupedFallbacks([openai, cursor], services).map(g => g.category)).toContain('api')
+    })
+
+    it('returns [] for a non-array input', () => {
+      expect(getGroupedFallbacksExcludingRegionSwitchable(null, [])).toEqual([])
+    })
   })
 })

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,5 @@
+import { regionStatusOf } from './regionStatus'
+
 export const VALID_THEMES = ['dark', 'light', 'system']
 
 export const THEME_STORAGE_KEY = 'aiwatch-theme'
@@ -221,6 +223,30 @@ export function getGroupedFallbacks(affected, allServices) {
     groups.push({ category: svc.category, label, items: candidates.slice(0, perGroup) })
   }
   return groups
+}
+
+/**
+ * #641 — whether a service already has an actionable region-switch recommendation. Mirrors the
+ * ActionBanner `regionRecs` filter + the is-down `renderRegionRecommendation` render condition.
+ * NOTE: the web predicate intentionally OMITS `hasGlobalIncident` (a coexisting global outage) —
+ * matching how the region link itself is rendered on the web surfaces. The Worker's `buildRegionHint`
+ * additionally guards `hasGlobalIncident`, so Discord is marginally stricter; that asymmetry is
+ * pre-existing in the region-link logic and inherited here, not introduced by #641.
+ */
+export function hasRegionSwitch(service) {
+  const rs = regionStatusOf(service)
+  return !!(rs && rs.hasRegionSpecific && !rs.allDown && rs.recommendedRegion)
+}
+
+/**
+ * #641 — per-service variant of getGroupedFallbacks that EXCLUDES services which already have a
+ * region-switch recommendation: a region-specific outage is solved by the cheaper same-provider
+ * region switch, so a cross-provider fallback alongside it is redundant noise. Per-service — an
+ * affected service WITHOUT a region switch keeps its cross-service fallback.
+ */
+export function getGroupedFallbacksExcludingRegionSwitchable(affected, allServices) {
+  if (!Array.isArray(affected)) return []
+  return getGroupedFallbacks(affected.filter(s => !hasRegionSwitch(s)), allServices)
 }
 
 /**

--- a/worker/src/__tests__/alerts.test.ts
+++ b/worker/src/__tests__/alerts.test.ts
@@ -282,6 +282,30 @@ describe('region-switch hint (#422)', () => {
     expect(buildRegionHint(pinecone)).toBe('📍 Try region: AWS EU West')
   })
 
+  it('#641 suppresses the cross-service fallback when a region switch IS offered', () => {
+    // OpenAI is region-aware (SERVICE_REGIONS) AND fallback-eligible (not EXCLUDE_FALLBACK). A
+    // region-specific outage is solved by the cheaper same-provider region switch, so the
+    // cross-service fallback (Claude) must be suppressed to avoid redundant noise.
+    const openai = mockService({ id: 'openai', name: 'OpenAI API', status: 'degraded', incidents: [
+      { id: 'oai-r', title: 'Elevated errors', status: 'investigating', startedAt: recentDate, impact: 'major', componentNames: ['us-east-1'] },
+    ] })
+    const claude = mockService({ id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', aiwatchScore: 95 })
+    const alert = buildIncidentAlerts([openai, claude], alertedMap(), NOW).find(a => a.key === 'alerted:new:oai-r')
+    expect(alert.regionText).toBe('📍 Try region: US West (us-west-2)')
+    expect(alert.fallbackText).toBe('') // suppressed despite Claude being an operational same-tier fallback
+  })
+
+  it('#641 still shows the cross-service fallback for a GLOBAL (non-region) incident', () => {
+    // No region switch applies → the cross-service fallback is the only actionable alternative.
+    const openai = mockService({ id: 'openai', name: 'OpenAI API', status: 'down', incidents: [
+      { id: 'oai-g', title: 'Major outage', status: 'investigating', startedAt: recentDate, impact: 'critical' },
+    ] })
+    const claude = mockService({ id: 'claude', name: 'Claude API', provider: 'Anthropic', status: 'operational', aiwatchScore: 95 })
+    const alert = buildIncidentAlerts([openai, claude], alertedMap(), NOW).find(a => a.key === 'alerted:new:oai-g')
+    expect(alert.regionText).toBeUndefined()        // global → no region hint
+    expect(alert.fallbackText).toContain('Claude API') // fallback shown
+  })
+
   it('mergeTogetherAlerts preserves regionText from the first merged alert', () => {
     // Together has no region map so this is undefined in practice, but the merge path
     // is generic — pin that a set regionText survives the merge. (#422 Severity-6)

--- a/worker/src/__tests__/fallback.test.ts
+++ b/worker/src/__tests__/fallback.test.ts
@@ -178,9 +178,8 @@ describe('buildFallbackText', () => {
     expect(text).toBe('👉 Suggested fallback: Claude API')
   })
 
-  it('returns no-fallback message when empty', () => {
-    const text = buildFallbackText([])
-    expect(text).toBe('⚠️ No operational fallback available. Consider retry logic or caching.')
+  it('returns an empty string when there are no fallbacks (#641 — no subjective "no fallback" claim)', () => {
+    expect(buildFallbackText([])).toBe('')
   })
 })
 
@@ -220,9 +219,8 @@ describe('buildGroupedFallbackText', () => {
     expect(text).not.toContain('Character.AI:')
   })
 
-  it('returns no-fallback message when all excluded', () => {
-    const text = buildGroupedFallbackText(['replicate', 'huggingface'], services)
-    expect(text).toContain('No operational fallback')
+  it('returns an empty string when all services are excluded (#641 — no "no fallback" claim)', () => {
+    expect(buildGroupedFallbackText(['replicate', 'huggingface'], services)).toBe('')
   })
 
   it('returns single tier group when only one affected', () => {

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -231,7 +231,11 @@ export function buildIncidentAlerts(
 
   for (const [incId, { names, ids, inc, category, firstSvc }] of newIncidents) {
     const displayName = names.length > 1 ? `${firstSvc.provider} (${names.join(', ')})` : names[0]
-    const fallbackText = firstSvc.status !== 'operational'
+    const regionText = buildRegionHint(firstSvc)
+    // #641 — suppress the cross-service fallback when a region switch is offered: a region-specific
+    // outage is solved by the cheaper same-provider region switch, so a full provider switch
+    // alongside it is redundant noise. (buildRegionHint returns undefined when no switch applies.)
+    const fallbackText = (firstSvc.status !== 'operational' && !regionText)
       ? buildFallbackText(getFallbacks(firstSvc.id, category, services))
       : ''
     alerts.push({
@@ -239,7 +243,7 @@ export function buildIncidentAlerts(
       title: `🔴 ${displayName} — New Incident`,
       description: sanitize(inc.title),
       fallbackText,
-      regionText: buildRegionHint(firstSvc),
+      regionText,
       color: 0xED4245,
       url: `https://ai-watch.dev/#${ids[0]}`,
       svcIds: ids, // #545 — the not-yet-alerted subset (all affected on first fire, only the joiner after)

--- a/worker/src/fallback.ts
+++ b/worker/src/fallback.ts
@@ -91,7 +91,10 @@ export function getFallbacks(
 }
 
 export function buildFallbackText(fallbacks: Array<{ name: string; score: number | null }>): string {
-  if (fallbacks.length === 0) return '⚠️ No operational fallback available. Consider retry logic or caching.'
+  // #641 — no recommendation → emit nothing (the Discord embed omits an empty fallbackText). We
+  // don't assert "no fallback available": that's a subjective claim from our own (incomplete)
+  // coverage and may be inaccurate — "we have no recommendation" ≠ "no alternative exists".
+  if (fallbacks.length === 0) return ''
   const list = fallbacks.map((f, i) => {
     const label = f.score != null ? `${f.name} (Score ${f.score})` : f.name
     return label
@@ -162,6 +165,6 @@ export function buildGroupedFallbackText(
     }).join(' · ')
     lines.push(`${label}: ${list}`)
   }
-  if (lines.length === 0) return '⚠️ No operational fallback available. Consider retry logic or caching.'
+  if (lines.length === 0) return '' // #641 — no recommendation → emit nothing (see buildFallbackText)
   return `👉 Suggested fallback:\n${lines.join('\n')}`
 }


### PR DESCRIPTION
## Why
1. The **"no fallback available · retry/caching · no operational alternatives"** message is a *subjective claim from our own incomplete coverage* — we may simply not track an alternative that exists, so asserting "none available" can be inaccurate. It also reads as applying to unrelated services in the same banner (a degraded estimate-only Bedrock triggers it next to monitoring/recovering services).
2. When a service already has a **region-switch** recommendation, a cross-service fallback alongside it is redundant noise — a region-specific outage is solved by the cheaper same-provider region switch.

## What
**Drop the negative message** (render nothing when no recommendation) across all 4 surfaces:
- `fallback.ts` `buildFallbackText`/`buildGroupedFallbackText` → `''` (Discord embed already omits empty).
- Overview banner drops the `noFallback` branch · AnalysisModal gates the Alternatives block on `fallbackGroups.length > 0` · is-down renders only when `fallbacks.length > 0`.
- removed unused `overview.banner.noFallback` locale keys.

**Region-switch suppression** (per-service) on the 3 surfaces that render a region link (banner / is-down / Discord; the modal has no region line so it keeps its fallback):
- `alerts.ts`: `fallbackText` suppressed when `buildRegionHint` returns a hint.
- `is-down.ts`: `fallbacks = []` when the region rec is switchable.
- Overview: new exported `getGroupedFallbacksExcludingRegionSwitchable()` + `hasRegionSwitch()` (unit-testable). The web predicate intentionally omits `hasGlobalIncident` (matching the region-link render condition); the Worker's `buildRegionHint` is marginally stricter — documented.

## Verify
- **In-browser (user-confirmed)**: banner shows no "No direct fallback" line (live Bedrock degraded); region-suppression confirmed via an openai-region mock fixture (region switch shown, cross-service fallback to Claude suppressed); region card `ALWAYS_SHOW_REGIONS` policy kept as-is (option A).
- worker **1683** · src **409** · **E2E 127** · typecheck / dry-run / build / lint clean.
- PR review (code / tests) → **0 Critical / 0 Important** (extracted `hasRegionSwitch`/`getGroupedFallbacksExcludingRegionSwitchable` + mixed-case proof with a contrast assertion; the `hasGlobalIncident` asymmetry pinned by a test).

## Deploy
- **Worker change** (`alerts.ts`/`fallback.ts`) → `npm run deploy:worker` after merge; frontend + Edge auto-deploy on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)