### PR TITLE
feat(overview): per-category service sections + on-screen category control (#646)

### DIFF
--- a/docs/reference/ga4-events.md
+++ b/docs/reference/ga4-events.md
@@ -20,7 +20,7 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `view_incident` | `incident_id` | Incidents page | Incident detail open |
 | `fallback_click` | `from_service`, `to_service`, `location` | ActionBanner, Is X Down | Fallback recommendation click |
 | `change_filter` | `filter` | Overview (filter tabs) | Status filter change |
-| `category_filter` | `category` | Sidebar (category) | Category filter change |
+| `category_filter` | `category`, `location` | Sidebar (category) · Overview (category tabs) | Category filter change. `location` ∈ `sidebar` (omitted on the legacy sidebar call) / `overview` — the Overview surfaces the same category control as on-screen tabs (#646) |
 | `navigate_page` | `page` | Sidebar (nav) | Page navigation |
 | `click_refresh` | — | Topbar | Manual refresh |
 | `click_github_header` | — | Topbar | GitHub link click |

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -223,6 +223,43 @@ function FilterTabs({ filter, setFilter, total, issueCount, downCount, t }) {
   )
 }
 
+// Service categories rendered as Overview sections (mirrors the sidebar taxonomy, #646).
+// 'all' is the meta-bucket (no section of its own); the four below partition every service.
+const SECTION_KEYS = ['apps', 'llm', 'inference', 'agents']
+const CATEGORY_TAB_KEYS = ['all', ...SECTION_KEYS]
+
+// Category selector on the Overview itself (#646) — mirrors the sidebar's category filter so the
+// active category is both visible AND changeable from the main screen, including on mobile where the
+// sidebar is hidden behind the hamburger. Drives the same shared `categoryFilter` (usePage).
+function CategoryTabs({ categoryFilter, setCategoryFilter, t }) {
+  return (
+    <div className="flex flex-wrap" style={{ gap: '4px' }} role="tablist" aria-label={t('nav.services')}>
+      {CATEGORY_TAB_KEYS.map((key) => {
+        const active = categoryFilter === key
+        return (
+          <button
+            key={key}
+            role="tab"
+            aria-selected={active}
+            onClick={() => { setCategoryFilter(key); trackEvent('category_filter', { category: key, location: 'overview' }) }}
+            className="mono text-[10px] rounded transition-all cursor-pointer"
+            style={{
+              padding: '4px 10px',
+              letterSpacing: '0.03em',
+              whiteSpace: 'nowrap',
+              background: active ? 'var(--bg4)' : 'var(--bg2)',
+              color: active ? 'var(--text0)' : 'var(--text2)',
+              border: active ? '1px solid var(--border-hi)' : '1px solid var(--border)',
+            }}
+          >
+            {t(SERVICE_CATEGORIES[key].labelKey)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 // Grouped flap incidents (same title, same day) — compact expandable row (#496)
 function GroupIncidentItem({ group, lang, t }) {
   const [expanded, setExpanded] = useState(false)
@@ -580,21 +617,34 @@ export default function Overview() {
     ? (uptimeServices.reduce((sum, s) => sum + s.uptime30d, 0) / uptimeServices.length).toFixed(1)
     : '—'
 
-  const apiAndWebServices = catServices.filter((s) => s.category !== 'agent')
-  const agentServices = catServices.filter((s) => s.category === 'agent')
-
   const statusPriority = { down: 0, degraded: 1, operational: 2 }
   const issueSort = (a, b) => (statusPriority[a.status] - statusPriority[b.status]) || ((a.aiwatchScore ?? 0) - (b.aiwatchScore ?? 0))
+  const applyStatusFilter = (list) =>
+    filter === 'operational' ? list.filter((s) => s.status === 'operational')
+    : filter === 'issues'    ? [...list.filter((s) => s.status !== 'operational')].sort(issueSort)
+    : list
 
-  const filteredServices =
-    filter === 'operational' ? apiAndWebServices.filter((s) => s.status === 'operational')
-    : filter === 'issues'    ? [...apiAndWebServices.filter((s) => s.status !== 'operational')].sort(issueSort)
-    : apiAndWebServices
-
-  const filteredAgents =
-    filter === 'operational' ? agentServices.filter((s) => s.status === 'operational')
-    : filter === 'issues'    ? [...agentServices.filter((s) => s.status !== 'operational')].sort(issueSort)
-    : agentServices
+  // Build per-category sections mirroring the sidebar taxonomy (#646), replacing the old
+  // Services-blob + Coding-Agents-only split. In 'all' mode render all four sections in order; when a
+  // specific category is active, catServices is already scoped to it → render just that one section.
+  const sectionKeys = categoryFilter === 'all' ? SECTION_KEYS : SECTION_KEYS.filter((k) => k === categoryFilter)
+  const matched = new Set()
+  const sections = sectionKeys.map((key) => {
+    const ids = SERVICE_CATEGORIES[key].ids
+    const members = catServices.filter((s) => ids.includes(s.id))
+    members.forEach((s) => matched.add(s.id))
+    return { key, labelKey: SERVICE_CATEGORIES[key].labelKey, services: applyStatusFilter(members) }
+  })
+  // Defensive catch-all (only reachable in 'all' mode — in single-category mode catServices is itself
+  // scoped to that category's ids): a known/enabled service that no category claims (e.g. a new service
+  // added to ALL_SERVICE_IDS but not yet to SERVICE_CATEGORIES) would otherwise silently vanish —
+  // surface it under "Services". The partition invariant is pinned by constants.test.js.
+  const leftover = catServices.filter((s) => !matched.has(s.id))
+  if (leftover.length) sections.push({ key: 'other', labelKey: 'nav.services', services: applyStatusFilter(leftover) })
+  // #553: the empty state spans ALL rendered sections. issueCount and totalShown are both derived from
+  // the category-scoped catServices, so they stay consistent — an issue in any rendered section keeps
+  // "No Issues" from showing.
+  const totalShown = sections.reduce((n, sec) => n + sec.services.length, 0)
 
   const sevenDaysAgo = Date.now() - 7 * 86_400_000
   // Dedup by incident ID (Anthropic bulk-links one incident to claude.ai + Claude API + Claude Code)
@@ -721,58 +771,43 @@ export default function Overview() {
         <StatCard index={3} value={avgUptime === '—' ? '—' : `${avgUptime}%`}  sub={t('overview.stats.uptime.sub')}  labelKey="overview.stats.uptime"       colorClass="text-[var(--blue)]"  t={t} />
       </div>
 
-      {/* ── Section Header + Filter ── */}
-      <div className="flex items-center justify-between">
-        <h2 className="mono text-[10px] text-[var(--text2)] uppercase flex items-center gap-2" style={{ letterSpacing: '0.1em' }}>
-          <span className="text-[var(--green)] font-semibold">//</span>
-          {t('nav.services')}
-        </h2>
+      {/* ── Services controls (#646) ──
+          No standalone "// Services" group title: the category tab row already labels this area, and a
+          group title stacked above the per-category section headers (// AI Apps, // LLM APIs, …) was
+          redundant. Layout: category row above status row on mobile (items-start so the status filter
+          shrinks to its content width instead of stretching full-width); centered single row on desktop. */}
+      <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between">
+        <CategoryTabs categoryFilter={categoryFilter} setCategoryFilter={setCategoryFilter} t={t} />
         <FilterTabs filter={filter} setFilter={setFilter} total={catServices.length} issueCount={issueCount} downCount={downCount} t={t} />
       </div>
 
-      {/* ── Service Grid ── */}
-      {/* #553: the empty state must consider agents too — issueCount counts all categories, but
-          filteredServices excludes agents, so an agent-only issue otherwise shows "No Issues"
-          here while the Coding Agents section below renders the degraded agent. */}
-      {filter === 'issues' && filteredServices.length === 0 && filteredAgents.length === 0 ? (
+      {/* ── Per-category service sections (#646) ──
+          Each category (AI Apps / LLM APIs / Voice & Inference / Coding Agents) is a peer section
+          with its own header — no Coding-Agents-only special case. Empty sections are not rendered;
+          the shared "No Issues" empty state shows only when NO section has a match (#553). */}
+      {filter === 'issues' && totalShown === 0 ? (
         <EmptyState type="good" />
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style={{ gap: '8px' }}>
-          {filteredServices.map((svc, i) => (
-            <ServiceCard
-              key={svc.id}
-              service={svc}
-              index={i}
-              t={t}
-              isRecovered={!!recentlyRecovered[svc.id]}
-              onClick={() => { trackEvent('select_service', { service_id: svc.id }); setPage({ name: 'service', serviceId: svc.id }) }}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* ── Coding Agents ── */}
-      {filteredAgents.length > 0 && (
-        <>
-          <div className="flex items-center justify-between" style={{ marginTop: '16px' }}>
+        sections.filter((sec) => sec.services.length > 0).map((sec) => (
+          <section key={sec.key} className="flex flex-col" style={{ gap: '8px' }}>
             <h2 className="mono text-[10px] text-[var(--text2)] uppercase flex items-center gap-2" style={{ letterSpacing: '0.1em' }}>
               <span className="text-[var(--green)] font-semibold">//</span>
-              {t('nav.agents')}
+              {t(sec.labelKey)}
             </h2>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style={{ gap: '8px' }}>
-            {filteredAgents.map((svc, i) => (
-              <ServiceCard
-                key={svc.id}
-                service={svc}
-                index={i}
-                t={t}
-                isRecovered={!!recentlyRecovered[svc.id]}
-                onClick={() => { trackEvent('select_service', { service_id: svc.id }); setPage({ name: 'service', serviceId: svc.id }) }}
-              />
-            ))}
-          </div>
-        </>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style={{ gap: '8px' }}>
+              {sec.services.map((svc, i) => (
+                <ServiceCard
+                  key={svc.id}
+                  service={svc}
+                  index={i}
+                  t={t}
+                  isRecovered={!!recentlyRecovered[svc.id]}
+                  onClick={() => { trackEvent('select_service', { service_id: svc.id }); setPage({ name: 'service', serviceId: svc.id }) }}
+                />
+              ))}
+            </div>
+          </section>
+        ))
       )}
 
       {/* ── Bottom Panels ── */}

--- a/src/utils/__tests__/constants.test.js
+++ b/src/utils/__tests__/constants.test.js
@@ -3,7 +3,29 @@
 // because the worker can't import frontend code at runtime.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, getGroupedFallbacksExcludingRegionSwitchable, hasRegionSwitch, shouldShowFallback, hasActiveIncident } from '../constants'
+import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, getGroupedFallbacksExcludingRegionSwitchable, hasRegionSwitch, shouldShowFallback, hasActiveIncident, SERVICE_CATEGORIES, ALL_SERVICE_IDS } from '../constants'
+
+// #646 — the Overview renders one section per SERVICE_CATEGORIES bucket (apps/llm/inference/agents).
+// Its render has a defensive "other" catch-all for any service no bucket claims, but that path should
+// stay empty: the four buckets must PARTITION ALL_SERVICE_IDS exactly. This pins the real failure mode
+// (a new service added to ALL_SERVICE_IDS but forgotten in SERVICE_CATEGORIES → it falls into "other")
+// at the source, so it surfaces in unit tests rather than as a stray "Services" section in the UI.
+describe('SERVICE_CATEGORIES partitions ALL_SERVICE_IDS (#646 Overview sections)', () => {
+  const SECTION_KEYS = ['apps', 'llm', 'inference', 'agents']
+  const sectionIds = SECTION_KEYS.flatMap((k) => SERVICE_CATEGORIES[k].ids)
+
+  it("'all' is the meta-bucket with no id list", () => {
+    expect(SERVICE_CATEGORIES.all.ids).toBeNull()
+  })
+
+  it('the four section buckets are disjoint (no service in two categories)', () => {
+    expect(sectionIds.length).toBe(new Set(sectionIds).size)
+  })
+
+  it('the four section buckets cover every service in ALL_SERVICE_IDS (no leftover, no extra)', () => {
+    expect([...sectionIds].sort()).toEqual([...ALL_SERVICE_IDS].sort())
+  })
+})
 
 describe('tierFor (#403 frontend warn-once helper)', () => {
   let warnSpy

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -57,6 +57,61 @@ test.describe('Overview page', () => {
     await expect(page.locator('main button').filter({ hasText: 'Claude API' })).toBeVisible()
   })
 
+  test('category tabs filter the grid into per-category sections (#646)', async ({ page }) => {
+    // The Overview surfaces the sidebar's category taxonomy as an on-screen control + per-category
+    // section headers (so the active category is visible/changeable here, incl. on mobile).
+    const tablist = page.getByRole('tablist', { name: /Services|서비스/ })
+    await expect(tablist).toBeVisible()
+    // All five category tabs present (locale-agnostic).
+    for (const name of [/^All$|^전체$/, /AI Apps|AI 앱/, /LLM/, /Voice & Inference|음성/, /Coding Agents|코딩 에이전트/]) {
+      await expect(tablist.getByRole('tab', { name }).first()).toBeVisible()
+    }
+
+    // Default 'all' → multiple category section headings render (the structure #646 adds).
+    await expect(page.getByRole('heading', { name: /LLM/ })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Coding Agents|코딩 에이전트/ })).toBeVisible()
+
+    // Select the LLM tab → only the LLM section renders; the AI Apps section heading disappears
+    // (catServices is scoped to LLM, so the apps section is not built at all).
+    await tablist.getByRole('tab', { name: /LLM/ }).click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('main button').filter({ hasText: 'Claude API' }).first()).toBeVisible()
+    await expect(page.getByRole('heading', { name: /AI Apps|AI 앱/ })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: /Coding Agents|코딩 에이전트/ })).toHaveCount(0)
+  })
+
+  test('status filter composes within a category and resets when the category changes (#646)', async ({ page }) => {
+    // MOCK_SERVICES is merged in, so override the services this test reasons about to known statuses.
+    const op = (id, name, category = 'api') => ({ id, category, name, provider: 'x', status: 'operational', latency: 150, uptime30d: 99.9, calendarDays: 30, incidents: [] })
+    const degraded = (id, name, category = 'api') => ({ ...op(id, name, category), status: 'degraded',
+      incidents: [{ id: `${id}-i`, title: 'Issue', status: 'investigating', impact: 'minor', startedAt: new Date(Date.now() - 60_000).toISOString(), timeline: [] }] })
+    const mockData = { json: { services: [
+      degraded('openai', 'OpenAI API'),               // LLM, degraded
+      op('claude', 'Claude API'),                     // LLM, operational
+      degraded('claudecode', 'Claude Code', 'agent'), // agent, degraded
+      op('cursor', 'Cursor', 'agent'),                // agent, operational
+    ], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mockData))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mockData))
+    await page.goto('/')
+    await page.locator('main button').first().waitFor({ state: 'visible', timeout: 20000 })
+
+    const tablist = page.getByRole('tablist', { name: /Services|서비스/ })
+    // LLM category + Issues status → only the degraded LLM service shows; the operational LLM is hidden.
+    await tablist.getByRole('tab', { name: /LLM/ }).click()
+    await page.locator('main').getByRole('button', { name: /Issues/ }).click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('main button').filter({ hasText: 'OpenAI API' }).first()).toBeVisible()
+    await expect(page.locator('main button').filter({ hasText: 'Claude API' })).toHaveCount(0)
+
+    // Switching category resets the status filter to All (useEffect on categoryFilter) → the operational
+    // agent (Cursor) is visible, which it would NOT be if the Issues filter had persisted.
+    await tablist.getByRole('tab', { name: /Coding Agents|코딩 에이전트/ }).click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('main button').filter({ hasText: 'Cursor' }).first()).toBeVisible()
+    await expect(page.locator('main button').filter({ hasText: 'Claude Code' }).first()).toBeVisible()
+  })
+
   test('Analyze button shows Coming Soon or Beta based on analysis data', async ({ page }) => {
     // Analyze button should exist in topbar (desktop)
     const analyzeBtn = page.locator('header button, header [aria-disabled]').filter({ hasText: /Analyze/ })
@@ -419,10 +474,12 @@ test.describe('#553 Issues filter — agent-only issue', () => {
     // Select Issues → the agent section must render and the "No Issues" empty state must NOT appear.
     await page.locator('main').getByRole('button', { name: /Issues/ }).click()
 
-    // Positive: assert the *Coding Agents section heading* (renders only when filteredAgents.length > 0),
-    // NOT bare getByText('Claude Code') — the agent name also appears in the Recent Incidents panel below,
-    // which renders regardless of the filter or the fix, so a name-only check would pass even when buggy.
-    await expect(page.locator('main').getByText(/Coding Agents|코딩 에이전트/)).toBeVisible()
+    // Positive: assert the *Coding Agents section heading* (renders only when the agents section has a
+    // matching service), NOT bare getByText('Claude Code') — the agent name also appears in the Recent
+    // Incidents panel below, which renders regardless of the filter or the fix, so a name-only check
+    // would pass even when buggy. Scoped to role=heading because #646 added a CategoryTabs "Coding
+    // Agents" *tab* with the same label — getByText would now match both (strict-mode violation).
+    await expect(page.locator('main').getByRole('heading', { name: /Coding Agents|코딩 에이전트/ })).toBeVisible()
 
     // Negative (load-bearing — this is what fails when the fix is reverted): no "No Issues" empty state.
     // EmptyState type="good" is shared by the issues-grid AND the Recent Incidents panel, but the fixture's


### PR DESCRIPTION
Closes #646.

## Problem
The dashboard's 5-category taxonomy (`SERVICE_CATEGORIES`: all/apps/llm/inference/agents) was a **sidebar-only** control. On the **Overview** it silently filtered the content with no on-screen indicator or control, and the grid hard-split into just **"Services" (everything non-agent) + a Coding-Agents-only section** — so Coding Agents got peer treatment the other categories didn't, and on **mobile** (sidebar hidden behind the hamburger) there was no way to see or change the category at all.

## Change
- **Per-category sections** mirroring the sidebar taxonomy — `// AI Apps`, `// LLM APIs`, `// Voice & Inference`, `// Coding Agents` — each a peer section (no Coding-Agents-only special case). In `all` mode all four render in order; selecting a category renders just that one.
- **`CategoryTabs` on the Overview** (role=tablist) drives the same shared `categoryFilter` (usePage), so the active category is visible AND changeable here — the only category control on mobile.
- Header row **stacks on mobile** (`items-start` so the status filter shrinks to its content width instead of stretching full-width — wasted space flagged in review) and is a centered single row on desktop.
- No standalone `// Services` group title (the tab row already labels the area; per-section headers label each grid). Status filter (All/Operational/Issues) composes within each section; the `totalShown`-based empty state spans all sections (preserves the #553 agent-only-issue path).
- Defensive `other` catch-all surfaces any enabled service not yet in `SERVICE_CATEGORIES` under "Services" (kept empty by a partition invariant unit test).

## #646 acceptance
- [x] One labeled section per category — no Coding-Agents-only special case
- [x] Active category visible on the Overview (tabs + section headers)
- [x] Category changeable from the Overview on **mobile** (CategoryTabs; verified in-browser at ≤768px)
- [x] Status filter composes within sections; empty states incl. #553 hold (e2e)
- [x] Section-header i18n — **reused** existing `filter.*` labels (KO+EN); no new keys needed
- [x] Design-draft diff: intentional divergence from `AIWatch_화면디자인_초안_v2.html` (the draft's Services-blob + Coding-Agents-only layout was the source of the inconsistency this issue fixes)

## Testing
- `npm run build` ✓ · `npm run test:src` (vitest, incl. 3 new partition tests) ✓ · full Playwright e2e **129 passed** ✓
- New e2e: tab→section filtering; status-filter-within-category + reset-on-category-change. `#553` assertion scoped to `role=heading` (the new tab shares the "Coding Agents" label — `getByText` would now strict-mode-fail).
- Local in-browser verification by the operator (desktop + mobile, incl. the mobile status-filter width fix and the `// Services` title decision).

## Notes
- `category_filter` GA4 event gains a `location` param (`sidebar`/`overview`) — `docs/reference/ga4-events.md` updated.
- No worker change; no CLAUDE.md change (Overview section structure isn't described there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)