### PR TITLE
chore(ops): gate sitemap lastmod bump to deploy/CI only (#648)

### DIFF
--- a/scripts/bump-sitemap-lastmod.mjs
+++ b/scripts/bump-sitemap-lastmod.mjs
@@ -1,39 +1,70 @@
 #!/usr/bin/env node
-// #337: bump <lastmod> in public/sitemap.xml to today's UTC date.
-// Runs as `prebuild` on every Vercel deploy so Googlebot sees fresh re-crawl
-// priority signals. Without this, `lastmod` silently drifts (we saw 4-32 day
-// staleness in production on 2026-04-24).
+// #337: bump <lastmod> in public/sitemap.xml to today's UTC date so Googlebot sees fresh re-crawl
+// priority signals. Without this, `lastmod` silently drifts (we saw 4-32 day staleness in production
+// on 2026-04-24).
 //
-// Node-based rather than sed so the same script works on BSD (macOS local)
-// and GNU (Vercel Linux) without flag quirks.
+// #648: gated to DEPLOY/CI builds only. The `prebuild` npm hook fires on EVERY `npm run build`,
+// including local dev builds — which rewrote the working tree on every build and forced a manual
+// `git checkout public/sitemap.xml` before each commit (recurring review-step friction + a risk of
+// committing date-only churn). Google reads the *served* sitemap, which Vercel rebuilds (and bumps)
+// on every deploy: `prebuild` rewrites the source `public/sitemap.xml`, and Vite copies that
+// freshly-bumped file into the served `dist/sitemap.xml`. The committed file is only a base — so
+// skipping the bump locally does not stale the SEO signal. Vercel sets VERCEL=1 during its build.
+//
+// Node-based rather than sed so the same script works on BSD (macOS local) and GNU (Vercel Linux)
+// without flag quirks.
 
 import fs from 'node:fs'
 import path from 'node:path'
 
-const SITEMAP_PATH = path.resolve(process.cwd(), 'public/sitemap.xml')
-const today = new Date().toISOString().slice(0, 10)
+const LASTMOD_RE = /<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g
 
-if (!fs.existsSync(SITEMAP_PATH)) {
-  console.error(`[bump-sitemap] ${SITEMAP_PATH} not found — skipping (not a fatal build error)`)
-  process.exit(0)
+// Only bump on a real deploy/CI build — not on local `npm run build` (#648).
+export function shouldBump(env = process.env) {
+  return Boolean(env.VERCEL || env.CI)
 }
 
-const before = fs.readFileSync(SITEMAP_PATH, 'utf8')
-// Strict YYYY-MM-DD match — won't touch any other timestamps elsewhere in the file.
-const matches = before.match(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g) ?? []
-if (matches.length === 0) {
-  // Genuine schema drift — no YYYY-MM-DD <lastmod> entries at all. Warn so a
-  // future contributor who changes the sitemap format (e.g. to ISO datetime)
-  // updates this script too instead of silently deploying with stale signals.
-  console.error(`[bump-sitemap] WARNING: no <lastmod>YYYY-MM-DD</lastmod> entries in ${SITEMAP_PATH} — schema may have changed, update this script`)
-  process.exit(0)  // non-fatal so builds don't break on a docs edit
+// Pure transform: replace every YYYY-MM-DD <lastmod> with `today`. Returns the new content + the
+// match count + whether anything changed (count 0 = schema drift; changed false = already today).
+// The strict YYYY-MM-DD match won't touch any other timestamps elsewhere in the file.
+export function bumpLastmod(content, today) {
+  const matches = content.match(LASTMOD_RE) ?? []
+  const next = content.replace(LASTMOD_RE, `<lastmod>${today}</lastmod>`)
+  return { content: next, count: matches.length, changed: next !== content }
 }
 
-const after = before.replace(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g, `<lastmod>${today}</lastmod>`)
-if (after === before) {
-  console.log(`[bump-sitemap] ${matches.length} entries already at ${today} — no change`)
-  process.exit(0)
+function main() {
+  if (!shouldBump()) {
+    console.log('[bump-sitemap] local build (no VERCEL/CI env) — skipping lastmod bump (deploy-only, #648)')
+    return
+  }
+
+  const sitemapPath = path.resolve(process.cwd(), 'public/sitemap.xml')
+  if (!fs.existsSync(sitemapPath)) {
+    console.error(`[bump-sitemap] ${sitemapPath} not found — skipping (not a fatal build error)`)
+    return
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+  const before = fs.readFileSync(sitemapPath, 'utf8')
+  const { content: after, count, changed } = bumpLastmod(before, today)
+
+  if (count === 0) {
+    // Genuine schema drift — no YYYY-MM-DD <lastmod> entries at all. Warn so a future contributor who
+    // changes the sitemap format (e.g. to ISO datetime) updates this script too instead of silently
+    // deploying with stale signals.
+    console.error(`[bump-sitemap] WARNING: no <lastmod>YYYY-MM-DD</lastmod> entries in ${sitemapPath} — schema may have changed, update this script`)
+    return
+  }
+  if (!changed) {
+    console.log(`[bump-sitemap] ${count} entries already at ${today} — no change`)
+    return
+  }
+
+  fs.writeFileSync(sitemapPath, after)
+  console.log(`[bump-sitemap] updated ${count} <lastmod> entries → ${today}`)
 }
 
-fs.writeFileSync(SITEMAP_PATH, after)
-console.log(`[bump-sitemap] updated ${matches.length} <lastmod> entries → ${today}`)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/bump-sitemap-lastmod.test.mjs
+++ b/scripts/bump-sitemap-lastmod.test.mjs
@@ -1,0 +1,54 @@
+// #648 — unit tests for the sitemap lastmod bump gate + transform. Run with `npm run test:scripts`
+// (= `node --test scripts/*.test.mjs`). Uses node:test (no vitest) since this is a build/CI script,
+// not src/worker code.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { shouldBump, bumpLastmod } from './bump-sitemap-lastmod.mjs'
+
+test('shouldBump — false for a local build (no VERCEL/CI env)', () => {
+  assert.equal(shouldBump({}), false)
+  assert.equal(shouldBump({ NODE_ENV: 'production' }), false) // production != deploy platform
+})
+
+test('shouldBump — true on Vercel or CI', () => {
+  assert.equal(shouldBump({ VERCEL: '1' }), true)
+  assert.equal(shouldBump({ CI: 'true' }), true)
+  assert.equal(shouldBump({ VERCEL: '1', CI: 'true' }), true)
+})
+
+test('bumpLastmod — rewrites every YYYY-MM-DD <lastmod> to today', () => {
+  const before = '<url><loc>/a</loc><lastmod>2026-06-12</lastmod></url>\n<url><loc>/b</loc><lastmod>2026-05-01</lastmod></url>'
+  const { content, count, changed } = bumpLastmod(before, '2026-06-14')
+  assert.equal(count, 2)
+  assert.equal(changed, true)
+  assert.equal((content.match(/<lastmod>2026-06-14<\/lastmod>/g) ?? []).length, 2)
+  assert.ok(!content.includes('2026-06-12') && !content.includes('2026-05-01'))
+})
+
+test('bumpLastmod — changed=false when every entry already equals today', () => {
+  const before = '<lastmod>2026-06-14</lastmod>'
+  const { count, changed } = bumpLastmod(before, '2026-06-14')
+  assert.equal(count, 1)
+  assert.equal(changed, false)
+})
+
+test('bumpLastmod — count=0 on schema drift (no YYYY-MM-DD lastmod)', () => {
+  const before = '<lastmod>2026-06-14T00:00:00Z</lastmod>' // ISO datetime, not the YYYY-MM-DD shape
+  const { count, changed } = bumpLastmod(before, '2026-06-14')
+  assert.equal(count, 0)
+  assert.equal(changed, false)
+})
+
+test('bumpLastmod — does not touch non-lastmod timestamps', () => {
+  const before = '<lastmod>2026-06-12</lastmod><other>2026-06-12</other>'
+  const { content } = bumpLastmod(before, '2026-06-14')
+  assert.ok(content.includes('<other>2026-06-12</other>')) // untouched
+  assert.ok(content.includes('<lastmod>2026-06-14</lastmod>'))
+})
+
+test('importing the module runs no side effects (main is guarded)', () => {
+  // Reaching here with both pure fns imported proves the import did not invoke main() (which reads/
+  // writes public/sitemap.xml) — main only fires behind the import.meta.url === argv[1] guard.
+  assert.equal(typeof shouldBump, 'function')
+  assert.equal(typeof bumpLastmod, 'function')
+})


### PR DESCRIPTION
Closes #648.

## Problem
`scripts/bump-sitemap-lastmod.mjs` runs as the npm **`prebuild`** hook, so it rewrote `public/sitemap.xml` `<lastmod>` on **every** `npm run build` — including local builds. During the per-issue workflow (build gate, preview, re-test after review fixes) the sitemap got re-dirtied repeatedly and had to be manually `git checkout`-reverted before each commit. Recurring friction + a latent risk of committing date-only churn. The script's own header already stated the intent was *"every Vercel deploy"* (#337) — but the hook fires locally too.

## Fix
Gate the bump behind `shouldBump(env) = VERCEL || CI` — local builds skip it; deploy/CI builds still bump.

**Deploy-time freshness preserved**: Vercel sets `VERCEL=1`, `prebuild` rewrites the source `public/sitemap.xml`, and Vite copies that bumped file into the served `dist/sitemap.xml` (what Googlebot reads). The committed file is only a base, so skipping locally cannot stale the SEO signal.

Refactored into pure, testable exports (`shouldBump` + `bumpLastmod`) behind the `import.meta` main guard, mirroring `scripts/verify-reminders.mjs`.

## #648 acceptance
- [x] Local `npm run build` does NOT modify `public/sitemap.xml` (verified: clean after build)
- [x] `VERCEL=1` (or `CI`) still bumps every `<lastmod>` to today's UTC date (verified: 41 entries bumped)
- [x] Unit test (`npm run test:scripts`) covers the gate + the lastmod transform
- [x] #337 deploy-path freshness preserved

## Testing
- `npm run test:scripts` → **16 passed** (7 new: gate skip-local / run-on-Vercel·CI, rewrite-all, already-today, schema-drift, non-lastmod-untouched, no-import-side-effects)
- Manual artifact check (UI-less build script): local build leaves the tree clean; `VERCEL=1 node scripts/bump-sitemap-lastmod.mjs` bumps 41 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)