### PR TITLE
fix(calendar): paint ongoing incidents through today + translated status labels (refs #662)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -133,7 +133,7 @@ function ServiceCard({ service, index, onClick, t, isRecovered, isProbed }) {
             {!isUnreliable && scoreStr && <>{' · '}{scoreStr}</>}
           </span>
         </div>
-        <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact)} compact />
+        <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact, 30, service.status)} compact />
       </div>
 
       {/* ── Desktop full layout ── */}
@@ -182,7 +182,7 @@ function ServiceCard({ service, index, onClick, t, isRecovered, isProbed }) {
           </div>
         )}
 
-        <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact)} />
+        <HistoryBars history30d={buildCalendarFromIncidents(service.incidents, service.dailyImpact, 30, service.status)} />
       </div>
     </button>
   )

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -569,8 +569,11 @@ function RegionalAvailability({ service, t }) {
 
 const CALENDAR_OPACITY = { operational: 0.7, degraded: 0.8, down: 0.9 }
 
-function CalendarCell({ status, date }) {
+function CalendarCell({ status, date, t }) {
   const [hovered, setHovered] = useState(false)
+  // #662 — show the translated status label ("Degraded"/"Partial Outage"/…), not the raw internal
+  // key (degraded_perf/…). Matches the legend (all four statuses have ko/en labels).
+  const label = t ? t(`status.${status}`) : status
   const bgCls = CALENDAR_CLASS[status] ?? 'bg-[var(--bg3)]'
   const opacity = CALENDAR_OPACITY[status] ?? 1
 
@@ -589,7 +592,7 @@ function CalendarCell({ status, date }) {
         style={{ width: '18px', height: '18px', borderRadius: '2px', opacity: hovered ? opacity * 0.8 : opacity }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        aria-label={`${date}: ${status}`}
+        aria-label={`${date}: ${label}`}
       />
       {hovered && (
         <div className="fixed z-50 bg-[var(--bg4)] border border-[var(--border)] rounded px-2 py-1
@@ -605,7 +608,7 @@ function CalendarCell({ status, date }) {
                  }
                }
              }}>
-          {date} — {status}
+          {date} — {label}
         </div>
       )}
     </div>
@@ -758,7 +761,7 @@ export default function ServiceDetails({ serviceId }) {
   const incidentsBlanked = !!service.incidentSourceStale
   const calendarDays = service.calendarDays ?? 14
 
-  const calendarData = buildCalendarFromIncidents(service.incidents, service.dailyImpact, calendarDays)
+  const calendarData = buildCalendarFromIncidents(service.incidents, service.dailyImpact, calendarDays, service.status)
 
   return (
     <div className="flex flex-col" style={{ gap: '20px' }}>
@@ -982,7 +985,7 @@ export default function ServiceDetails({ serviceId }) {
           <div style={{ padding: '16px' }}>
             <div className="flex flex-wrap" style={{ gap: '2px' }}>
               {calendarData.map((status, i) => (
-                <CalendarCell key={i} status={status} date={calendarDate(i, lang, calendarDays)} />
+                <CalendarCell key={i} status={status} date={calendarDate(i, lang, calendarDays)} t={t} />
               ))}
             </div>
             <div className="flex justify-between mono text-[9px] text-[var(--text2)]" style={{ marginTop: '6px' }}>

--- a/src/utils/__tests__/calendar.test.js
+++ b/src/utils/__tests__/calendar.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { buildCalendarFromIncidents } from '../calendar'
+
+// Anchor incident dates to LOCAL noon so day-key math is stable regardless of the test runner's
+// timezone (the calendar buckets by local date; noon never crosses a date boundary on a ±14h offset).
+const atLocalNoon = (daysAgo) => {
+  const d = new Date()
+  d.setHours(12, 0, 0, 0)
+  d.setDate(d.getDate() - daysAgo)
+  return d
+}
+const iso = (daysAgo) => atLocalNoon(daysAgo).toISOString()
+
+afterEach(() => vi.useRealTimers())
+
+describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', () => {
+  it('RSS / no-dailyImpact: spans an ongoing incident startedAt→today (degraded service)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'investigating', impact: 'major', startedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'degraded')
+    expect(cal[13]).toBe('degraded') // today
+    expect(cal[12]).toBe('degraded') // today-1
+    expect(cal[11]).toBe('degraded') // today-2 (start)
+    expect(cal[10]).toBe('operational') // today-3 (before start)
+  })
+
+  it('RSS / null impact (Bedrock-shaped) spans as degraded_perf', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'investigating', impact: null, startedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'degraded')
+    expect(cal[13]).toBe('degraded_perf')
+    expect(cal[11]).toBe('degraded_perf')
+    expect(cal[10]).toBe('operational')
+  })
+
+  it('dailyImpact (statuspage): fills ONLY today for an ongoing incident, defers past days to official', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    // Official record: one finalized past-day bucket; the ongoing incident itself started 2 days ago.
+    const dailyImpact = { '2026-06-10': 'major' } // → degraded at its index
+    const incidents = [{ status: 'investigating', impact: 'critical', startedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'down')
+    expect(cal[29]).toBe('down') // today — live ongoing status
+    expect(cal[28]).toBe('operational') // today-1 (intermediate) NOT overridden
+    expect(cal[27]).toBe('operational') // today-2 (start day) NOT overridden — deferred to official
+    expect(cal[24]).toBe('degraded') // 2026-06-10 official bucket preserved
+  })
+
+  it('dailyImpact: Phase 3 does not escalate a finalized past bucket (worst-of touches today only)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const dailyImpact = { '2026-06-13': 'major' } // degraded, finalized
+    const incidents = [{ status: 'investigating', impact: 'critical', startedAt: iso(2) }] // critical=down
+    const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'down')
+    expect(cal[27]).toBe('degraded') // 06-13 stays the official 'degraded', NOT upgraded to 'down'
+    expect(cal[29]).toBe('down') // today reflects the live critical
+  })
+
+  it('OPERATIONAL service with an open minor incident is NOT painted (claude-shaped, no noise)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const dailyImpact = { '2026-06-10': 'major' }
+    const incidents = [{ status: 'investigating', impact: 'minor', startedAt: iso(1) }]
+    const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'operational')
+    expect(cal[29]).toBe('operational') // today NOT filled — service is operational
+    expect(cal[24]).toBe('degraded') // official past bucket still shown
+  })
+
+  it('RSS: clamps a pre-window ongoing incident to the window start (fills every cell)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'investigating', impact: 'major', startedAt: iso(40) }] // before the 14d window
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
+    expect(cal[0]).toBe('degraded') // oldest cell filled (clamped to windowStart, no out-of-bounds)
+    expect(cal[13]).toBe('degraded') // today
+  })
+
+  it('RSS: multiple overlapping ongoing incidents merge worst-of', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [
+      { status: 'investigating', impact: 'minor', startedAt: iso(4) }, // older, yellow
+      { status: 'investigating', impact: 'critical', startedAt: iso(1) }, // newer, red
+    ]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
+    expect(cal[9]).toBe('degraded_perf') // today-4: only the minor incident
+    expect(cal[12]).toBe('down') // today-1: critical overlaps → worst-of red
+    expect(cal[13]).toBe('down') // today
+  })
+
+  it('skips a malformed startedAt without throwing', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'investigating', impact: 'major', startedAt: 'not-a-date' }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
+    expect(cal.every((s) => s === 'operational')).toBe(true)
+  })
+
+  it('does not forward-fill a RESOLVED incident (only its start day)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(3), resolvedAt: iso(3) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[10]).toBe('degraded') // start day (today-3), painted by Phase 2
+    expect(cal[11]).toBe('operational') // not spanned forward
+    expect(cal[13]).toBe('operational') // today untouched (resolved)
+  })
+})

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -15,12 +15,20 @@ function escalate(dayStatus, key, status) {
   }
 }
 
+// Map an incident impact to a calendar cell status (single source of truth for Phase 2 + Phase 3).
+// critical → down (red), major → degraded (orange), minor/null/unknown → degraded_perf (yellow).
+function impactToCellStatus(impact) {
+  if (impact === 'critical') return 'down'
+  if (impact === 'major') return 'degraded'
+  return 'degraded_perf'
+}
+
 // Convert Date to local YYYY-MM-DD string
 function toLocalDateKey(d) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
-export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30) {
+export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30, currentStatus = undefined) {
   const today = new Date()
   const dayStatus = {}
 
@@ -44,18 +52,40 @@ export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30) {
     ;(incidents ?? []).forEach((inc) => {
       if (!inc.startedAt) return
       const key = toLocalDateKey(new Date(inc.startedAt))
-      if (inc.status !== 'resolved') {
-        // Ongoing incidents: use impact level instead of always 'down'
-        if (inc.impact === 'critical') escalate(dayStatus, key, 'down')
-        else if (inc.impact === 'major') escalate(dayStatus, key, 'degraded')
-        else escalate(dayStatus, key, 'degraded_perf')
-      } else if (inc.impact === 'critical') {
-        escalate(dayStatus, key, 'down')
-      } else if (inc.impact === 'major') {
-        escalate(dayStatus, key, 'degraded')
+      // Same impact→status map for ongoing and resolved (minor/null/unknown → degraded_perf yellow).
+      escalate(dayStatus, key, impactToCellStatus(inc.impact))
+    })
+  }
+
+  // Phase 3 (#662): extend ONGOING incidents forward to "today" — source-aware, so the official
+  // record stays authoritative for finalized past days.
+  //   • services WITH an official daily record (dailyImpact: statuspage / incident.io / betterstack /
+  //     aistudio / flashduty-DeepSeek): official buckets own past days; fill ONLY today's (local) cell
+  //     from the live ongoing status — today's official bucket isn't finalized yet, so this
+  //     contradicts nothing. Without this an active incident leaves today green.
+  //   • services with NO daily record (no dailyImpact — RSS-only, e.g. Bedrock/Azure): nothing to
+  //     contradict → span startedAt→today (clamped to the window), the only multi-day signal.
+  // GATED on the live badge: only when the service is actually non-operational. A service can stay
+  // `operational` with an open informational/minor incident (e.g. claude); painting the calendar for
+  // those is noise (mirrors the old worker-augment `svcStatus !== 'operational'` guard, #662).
+  if (currentStatus && currentStatus !== 'operational') {
+    const todayKey = toLocalDateKey(today)
+    const windowStart = new Date(today.getTime() - (days - 1) * 86_400_000)
+    ;(incidents ?? []).forEach((inc) => {
+      if (inc.status === 'resolved' || !inc.startedAt) return
+      const start = new Date(inc.startedAt)
+      if (isNaN(start.getTime())) return // skip a malformed startedAt explicitly (don't rely on key ordering)
+      const status = impactToCellStatus(inc.impact)
+      if (dailyImpact) {
+        escalate(dayStatus, todayKey, status) // today only — defer past days to the official record
       } else {
-        // minor, null, or unknown impact — show as degraded_perf (yellow)
-        escalate(dayStatus, key, 'degraded_perf')
+        const from = start < windowStart ? windowStart : start
+        // step day-by-day (noon-anchored, DST-safe) from start → today, inclusive
+        for (let cur = new Date(from.getFullYear(), from.getMonth(), from.getDate(), 12);
+             toLocalDateKey(cur) <= todayKey;
+             cur.setDate(cur.getDate() + 1)) {
+          escalate(dayStatus, toLocalDateKey(cur), status)
+        }
       }
     })
   }

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -754,21 +754,13 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
           console.warn(`[fetchService] ${config.id} displayComponentIds missing (breakdown drift): ${missing.join(', ')}`)
         }
       }
-      // Augment dailyImpact with ongoing incidents (source data only includes resolved).
-      // Only when the service itself is non-operational, to avoid marking the calendar
-      // for unrelated incidents that survived the filters but don't affect this component.
-      const augmentedImpact = dailyImpact ? { ...dailyImpact } : {}
-      if (svcStatus !== 'operational') {
-        for (const inc of filtered) {
-          if (inc.status !== 'resolved') {
-            const day = inc.startedAt.split('T')[0]
-            if (day && !augmentedImpact[day]) {
-              augmentedImpact[day] = inc.impact === 'major' || inc.impact === 'critical' ? 'critical'
-                : inc.impact === 'minor' ? 'minor' : 'major'
-            }
-          }
-        }
-      }
+      // #662 — dailyImpact is kept as a PURE official record (no ongoing-incident augmentation here).
+      // The removed augment keyed an ongoing incident by its UTC `startedAt` day, so Phase 1's
+      // noon-UTC→local remap could land the cell on a different local day than the incident's true
+      // local start; it also only ever painted the single start day (never extended to "today") and
+      // used a coarser severity map (major→critical/red). That forward-fill now lives in the frontend
+      // calendar (Phase 3, source-aware), which keys the incident directly in local time so "today" is
+      // unambiguous. (dailyImpact is consumed only by buildCalendarFromIncidents.)
 
       // Successful fetch — reset or track based on parse errors
       if (parseErrors > 0) {
@@ -788,7 +780,7 @@ async function fetchService(config: ServiceConfig, prefetched?: PrefetchedData, 
         latency: config.category === 'api' ? latency : null,
         incidents: filtered,
         ...(components.length > 0 ? { components } : {}),
-        ...(Object.keys(augmentedImpact).length > 0 ? { dailyImpact: augmentedImpact } : {}),
+        ...(dailyImpact && Object.keys(dailyImpact).length > 0 ? { dailyImpact } : {}),
         calendarDays: config.statusComponentId ? 30 : 14,
         ...(uptimeValue != null ? { uptime30d: uptimeValue, uptimeSource: uptimeSrc } : {}),
       }


### PR DESCRIPTION
## Summary
The Status Calendar painted an ongoing incident **only on its `startedAt` day**, so today's cell stayed empty/green while the service was actively impacted:
- **Character.AI** (statuspage): incident showed on 6/14 (official bucket), today 6/15 empty.
- **Amazon Bedrock** (RSS): ongoing incident showed 6/13 only; 6/14·6/15 green.

## Fix — source-aware forward-fill (Phase 3), official record stays authoritative
`src/utils/calendar.js` adds a Phase 3 that extends **ongoing** incidents forward to today:
- **Services with an official daily record** (`dailyImpact`: statuspage / incident.io / betterstack / aistudio / flashduty): fill **only today's local cell** (today's official bucket isn't finalized yet — past days defer to the official buckets, so we never diverge from the source).
- **No daily record** (RSS-only: Bedrock/Azure): span `startedAt → today` (clamped to the window) — the only multi-day signal available.
- **Gated on the live badge** (`currentStatus !== 'operational'`, new 4th param) so an operational service with an open *minor* incident isn't painted (mirrors the removed worker guard). Verified live: claude/claude.ai/Claude Code (operational + open minor) are not painted.

`worker/src/services.ts`: removed the augment that injected an ongoing incident's **UTC** `startedAt` into `dailyImpact` (it diverged from the calendar's local-date buckets, only painted the start day, and used a coarser severity map). `dailyImpact` is now a pure official record; the forward-fill lives in the frontend where "today" is unambiguous in local time. (`dailyImpact` is consumed only by `buildCalendarFromIncidents`.)

`src/pages/ServiceDetails.jsx`: the calendar cell tooltip + aria-label now render the **translated status label** (`t('status.*')` → "Degraded" / "Partial Outage" / …) instead of the raw internal key (`degraded_perf`). Matches the legend.

## Window-label decision (#654)
Per #654 the calendar uses generic status labels; this PR doesn't change that. The deeper status **key/label taxonomy** confusion (`degraded_perf`→"Degraded" vs `degraded`→"Partial Outage", shared with the 3-state badge wire contract) is tracked separately in **#663** — out of scope here.

## Verification
- **In-browser**: Bedrock 6/13–6/15 filled (yellow "Degraded", null impact); claude operational not painted; tooltips show friendly labels — user-confirmed.
- 9 new calendar unit tests (span, today-only, official-bucket preserved/not-escalated, operational-skip, pre-window clamp, multi-incident worst-of, malformed date, resolved).
- worker 1703 · src 446 · e2e 131 · typecheck 0 · dry-run OK.
- PR review (pr-review-toolkit): 2 rounds → 0 Critical / 0 Important.

## Deploy
Worker change (removed augment) — needs `npm run deploy:worker` after merge. `refs #662` (close after merge + deploy verify on prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
