### PR TITLE
fix(hooks): step35-verify-gate matches absolute Edit paths so verified UI commits pass (refs #664)

### DIFF
--- a/.claude/hooks/step35-verify-gate.mjs
+++ b/.claude/hooks/step35-verify-gate.mjs
@@ -63,7 +63,12 @@ function audit(decision, note = '') {
 export function isUiEdgePath(p) {
   if (!p) return false
   if (/(?:^|\/)__tests__\/|\.test\.|\.spec\./.test(p)) return false
-  return /^src\//.test(p) || /^api\/(?:is-down|intro)\//.test(p)
+  // Match a `src/` or `api/(is-down|intro)/` segment at any path boundary so this works for BOTH the
+  // git-relative paths from the staged diff (`src/x`) AND the Edit/Write tool's absolute `file_path`
+  // (`/repo/src/x`) — anchoring `^src/` broke the edit-event correlation in lastUiEditIndex (#664,
+  // every UI commit fail-closed). Exclude the worker's own `worker/src/` (not frontend UI).
+  if (/(?:^|\/)worker\/src\//.test(p)) return false
+  return /(?:^|\/)src\//.test(p) || /(?:^|\/)api\/(?:is-down|intro)\//.test(p)
 }
 
 // Genuine in-browser verification confirmation (KO + EN). DELIBERATELY NARROW — bare "확인"

--- a/scripts/step35-verify-gate.test.mjs
+++ b/scripts/step35-verify-gate.test.mjs
@@ -28,11 +28,23 @@ test('isUiEdgePath — dashboard + Edge SSR are UI; worker/docs/tests are not', 
   assert.equal(isUiEdgePath('tests/overview.spec.js'), false)
 })
 
+test('isUiEdgePath — absolute paths (Edit tool supplies absolute file_path, #664)', () => {
+  // The Edit/Write tools require an absolute file_path — the gate must classify these too, else
+  // lastUiEditIndex never finds a UI edit and every UI commit fail-closes.
+  assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/src/pages/ServiceDetails.jsx'), true)
+  assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/api/is-down/html-template.ts'), true)
+  assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/worker/src/services.ts'), false) // absolute worker/src excluded
+  assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/src/utils/__tests__/calendar.test.js'), false) // absolute test excluded
+})
+
 test('lastUiEditIndex — picks the last UI/Edge edit (Edit + Bash write); -1 when none', () => {
   assert.equal(lastUiEditIndex([userText('hi'), edit('src/a.jsx'), userText('ok')]), 1)
   assert.equal(lastUiEditIndex([edit('src/a.jsx'), edit('worker/src/b.ts'), edit('src/c.jsx')]), 2) // worker edit doesn't reset
   assert.equal(lastUiEditIndex([bashWrite('cat > src/x.js <<EOF\n...')]), 0)
   assert.equal(lastUiEditIndex([edit('worker/src/b.ts'), edit('docs/x.md')]), -1) // no UI edit
+  // #664 — absolute file_path (what the Edit tool actually supplies) must be found, not -1
+  assert.equal(lastUiEditIndex([userText('hi'), edit('/Users/x/aiwatch/src/pages/Overview.jsx')]), 1)
+  assert.equal(lastUiEditIndex([edit('/Users/x/aiwatch/worker/src/b.ts')]), -1) // absolute worker edit isn't UI
 })
 
 test('hasUserTurnAfter — detects both string-content (real prompts) and array-text human turns', () => {

--- a/scripts/step35-verify-gate.test.mjs
+++ b/scripts/step35-verify-gate.test.mjs
@@ -35,6 +35,8 @@ test('isUiEdgePath — absolute paths (Edit tool supplies absolute file_path, #6
   assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/api/is-down/html-template.ts'), true)
   assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/worker/src/services.ts'), false) // absolute worker/src excluded
   assert.equal(isUiEdgePath('/Users/x/dev/aiwatch/src/utils/__tests__/calendar.test.js'), false) // absolute test excluded
+  // worker/src/ guard runs before the api/src match → a worker path nesting api/is-down stays non-UI (ordering pin)
+  assert.equal(isUiEdgePath('worker/src/parsers/api/is-down/x.ts'), false)
 })
 
 test('lastUiEditIndex — picks the last UI/Edge edit (Edit + Bash write); -1 when none', () => {
@@ -76,6 +78,19 @@ test('decideCommit — DENIES a UI commit with no post-edit user confirmation (t
 test('decideCommit — ALLOWS once a genuine user confirmation follows the last UI edit', () => {
   const e = [edit('src/pages/Overview.jsx'), userText('확인했고 잘 나옴, 커밋해')]
   assert.deepEqual(decideCommit(['src/pages/Overview.jsx'], e), { deny: false, reason: 'confirmed' })
+})
+
+test('decideCommit — #664 end-to-end: relative staged + ABSOLUTE edit + confirm → ALLOWS (the exact bug)', () => {
+  // The real invocation mixes formats: stagedUiEdge is git-relative; the edit event's file_path is
+  // absolute (Edit tool). Before #664 the absolute edit was invisible → fail-closed despite a valid
+  // confirmation. This pins that a verified UI commit now PASSES, not just that isUiEdgePath is true.
+  const e = [edit('/Users/x/aiwatch/src/pages/Overview.jsx'), userText('브라우저 확인 OK, 커밋해')]
+  assert.deepEqual(decideCommit(['src/pages/Overview.jsx'], e), { deny: false, reason: 'confirmed' })
+})
+
+test('decideCommit — #664: absolute UI edit with NO confirmation still DENIES (gate not weakened)', () => {
+  const e = [edit('/Users/x/aiwatch/src/pages/Overview.jsx'), toolResult()]
+  assert.equal(decideCommit(['src/pages/Overview.jsx'], e).deny, true)
 })
 
 test('decideCommit — a post-edit test/doc edit does NOT re-trigger the gate (confirmation still valid)', () => {


### PR DESCRIPTION
## Problem
The #657 hard gate denied **every** UI/Edge commit regardless of in-browser verification — forcing the `검증 생략하고 커밋` override each time. The intended "verified UI commit passes" path was broken (discovered while shipping #662).

## Root cause
`isUiEdgePath(p)` anchored the match to the string start:
```js
return /^src\//.test(p) || /^api\/(?:is-down|intro)\//.test(p)
```
- The staged-diff check feeds git **relative** paths (`src/x`) → `^src/` matches ✓.
- `lastUiEditIndex()` feeds the Edit/Write tool's `file_path`, which is **always absolute** (`/repo/src/x`) → `^src/` does NOT match ✗.

So `lastUiEditIndex` returned `-1` for every commit → `decideCommit` hit the `editIdx === -1` → `{ deny: true, reason: 'no-edit-event' }` (fail-closed) **before** the `CONFIRM_RE` check ran. A valid confirmation couldn't lift it; only the override could.

## Fix
Match a `src/` or `api/(is-down|intro)/` segment at any path boundary (relative + absolute), still excluding the worker's own `worker/src/`:
```js
if (/(?:^|\/)worker\/src\//.test(p)) return false
return /(?:^|\/)src\//.test(p) || /(?:^|\/)api\/(?:is-down|intro)\//.test(p)
```

## Tests
- New `isUiEdgePath` cases: absolute frontend → true, absolute `api/is-down` → true, absolute `worker/src/` → false, absolute `__tests__` → false.
- New `lastUiEditIndex` case: an absolute `file_path` edit is found (not -1); an absolute `worker/src/` edit is not UI.
- `npm run test:scripts` → 39 pass.

## Note
This restores the intended #657 behavior (verified UI commits pass; only genuinely-unverified ones need the override). Verified end-to-end: with this fix in the working tree, the #662 UI commit passed on a real in-browser confirmation (no override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
