### PR TITLE
refactor(calendar): impact-aligned cell-status keys + cal.status.* labels (refs #663)

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -30,9 +30,13 @@ const en = {
 
   // Status
   'status.operational': 'Operational',
-  'status.degraded_perf': 'Degraded',
   'status.degraded': 'Partial Outage',
   'status.down': 'Major Outage',
+  // #663 — calendar's own impact-aligned status labels (decoupled from the 3-state badge status.* above)
+  'cal.status.operational': 'Operational',
+  'cal.status.minor': 'Degraded',
+  'cal.status.major': 'Partial Outage',
+  'cal.status.critical': 'Major Outage',
   'status.partial.suffix': ' affected',
   'status.partial.tooltip': 'Some components are reporting issues on the provider status page; overall service availability is still nominal.',
 

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -30,9 +30,13 @@ const ko = {
 
   // Status
   'status.operational': '정상',
-  'status.degraded_perf': '성능 저하',
   'status.degraded': '부분 장애',
   'status.down': '주요 장애',
+  // #663 — 캘린더 전용 impact 정렬 상태 라벨 (위 3-state 배지 status.*와 분리)
+  'cal.status.operational': '정상',
+  'cal.status.minor': '성능 저하',
+  'cal.status.major': '부분 장애',
+  'cal.status.critical': '주요 장애',
   'status.partial.suffix': '개 영향',
   'status.partial.tooltip': '제공사 상태 페이지에서 일부 구성요소에 이슈가 보고됐습니다. 서비스 전체 가용성은 정상 범위입니다.',
 

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -24,11 +24,12 @@ import EmptyState from '../components/EmptyState'
 
 // Border-left now applied via inline style in ServiceCard
 
+// Calendar cell status → bar color (#663 impact-aligned keys, matches CALENDAR_CLASS in ServiceDetails)
 const HISTORY_CLASS = {
-  operational:    'bg-[var(--green)]',
-  degraded_perf:  'bg-[var(--yellow)]',
-  degraded:       'bg-[var(--amber)]',
-  down:           'bg-[var(--red)]',
+  operational:  'bg-[var(--green)]',
+  minor:        'bg-[var(--yellow)]',
+  major:        'bg-[var(--amber)]',
+  critical:     'bg-[var(--red)]',
 }
 
 const INC_BAR_CLASS = {

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -87,12 +87,12 @@ const STATUS_URL = {
 // Services that cannot provide incident data (no API, bot-protected, etc.)
 const NO_INCIDENT_SUPPORT = new Set([])
 
-// 30-day calendar status → Tailwind color class
+// Calendar cell status → Tailwind color class (#663 impact-aligned keys, frontend-internal)
 const CALENDAR_CLASS = {
-  operational:    'bg-[var(--green)]',
-  degraded_perf:  'bg-[var(--yellow)]',
-  degraded:       'bg-[var(--amber)]',
-  down:           'bg-[var(--red)]',
+  operational:  'bg-[var(--green)]',
+  minor:        'bg-[var(--yellow)]',
+  major:        'bg-[var(--amber)]',
+  critical:     'bg-[var(--red)]',
 }
 
 // Compute calendar date label for index i (0 = oldest, last = today)
@@ -567,13 +567,14 @@ function RegionalAvailability({ service, t }) {
 }
 
 
-const CALENDAR_OPACITY = { operational: 0.7, degraded: 0.8, down: 0.9 }
+const CALENDAR_OPACITY = { operational: 0.7, major: 0.8, critical: 0.9 } // minor → default 1 (was degraded_perf)
 
 function CalendarCell({ status, date, t }) {
   const [hovered, setHovered] = useState(false)
-  // #662 — show the translated status label ("Degraded"/"Partial Outage"/…), not the raw internal
-  // key (degraded_perf/…). Matches the legend (all four statuses have ko/en labels).
-  const label = t ? t(`status.${status}`) : status
+  // #662/#663 — show the translated label ("Degraded"/"Partial Outage"/…), not the raw internal cell
+  // key (minor/major/critical). cal.status.* is the calendar's own namespace, decoupled from the
+  // 3-state badge `status.*`. Matches the legend (all four keys have ko/en labels).
+  const label = t ? t(`cal.status.${status}`) : status
   const bgCls = CALENDAR_CLASS[status] ?? 'bg-[var(--bg3)]'
   const opacity = CALENDAR_OPACITY[status] ?? 1
 
@@ -974,10 +975,10 @@ export default function ServiceDetails({ serviceId }) {
               {t('svc.cal.legend')}
             </div>
             <div className="flex gap-3">
-              {['operational', 'degraded_perf', 'degraded', 'down'].map((s) => (
+              {['operational', 'minor', 'major', 'critical'].map((s) => (
                 <div key={s} className="flex items-center gap-1">
                   <span className={`rounded-sm ${CALENDAR_CLASS[s]}`} style={{ width: '8px', height: '8px' }} />
-                  <span className="text-[9px] mono text-[var(--text2)]">{t(`status.${s}`)}</span>
+                  <span className="text-[9px] mono text-[var(--text2)]">{t(`cal.status.${s}`)}</span>
                 </div>
               ))}
             </div>

--- a/src/utils/__tests__/calendar.test.js
+++ b/src/utils/__tests__/calendar.test.js
@@ -13,45 +13,47 @@ const iso = (daysAgo) => atLocalNoon(daysAgo).toISOString()
 
 afterEach(() => vi.useRealTimers())
 
+// NOTE (#663): cell keys are impact-aligned — 'minor' (yellow) / 'major' (orange) / 'critical' (red).
+// The 4th arg is the live wire `service.status` (operational|degraded|down) — NOT a cell key.
 describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', () => {
   it('RSS / no-dailyImpact: spans an ongoing incident startedAt→today (degraded service)', () => {
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
     const incidents = [{ status: 'investigating', impact: 'major', startedAt: iso(2) }]
     const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'degraded')
-    expect(cal[13]).toBe('degraded') // today
-    expect(cal[12]).toBe('degraded') // today-1
-    expect(cal[11]).toBe('degraded') // today-2 (start)
+    expect(cal[13]).toBe('major') // today
+    expect(cal[12]).toBe('major') // today-1
+    expect(cal[11]).toBe('major') // today-2 (start)
     expect(cal[10]).toBe('operational') // today-3 (before start)
   })
 
-  it('RSS / null impact (Bedrock-shaped) spans as degraded_perf', () => {
+  it('RSS / null impact (Bedrock-shaped) spans as minor (yellow)', () => {
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
     const incidents = [{ status: 'investigating', impact: null, startedAt: iso(2) }]
     const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'degraded')
-    expect(cal[13]).toBe('degraded_perf')
-    expect(cal[11]).toBe('degraded_perf')
+    expect(cal[13]).toBe('minor')
+    expect(cal[11]).toBe('minor')
     expect(cal[10]).toBe('operational')
   })
 
   it('dailyImpact (statuspage): fills ONLY today for an ongoing incident, defers past days to official', () => {
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
     // Official record: one finalized past-day bucket; the ongoing incident itself started 2 days ago.
-    const dailyImpact = { '2026-06-10': 'major' } // → degraded at its index
+    const dailyImpact = { '2026-06-10': 'major' } // impact value → 'major' cell at its index
     const incidents = [{ status: 'investigating', impact: 'critical', startedAt: iso(2) }]
     const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'down')
-    expect(cal[29]).toBe('down') // today — live ongoing status
+    expect(cal[29]).toBe('critical') // today — live ongoing status
     expect(cal[28]).toBe('operational') // today-1 (intermediate) NOT overridden
     expect(cal[27]).toBe('operational') // today-2 (start day) NOT overridden — deferred to official
-    expect(cal[24]).toBe('degraded') // 2026-06-10 official bucket preserved
+    expect(cal[24]).toBe('major') // 2026-06-10 official bucket preserved
   })
 
   it('dailyImpact: Phase 3 does not escalate a finalized past bucket (worst-of touches today only)', () => {
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
-    const dailyImpact = { '2026-06-13': 'major' } // degraded, finalized
-    const incidents = [{ status: 'investigating', impact: 'critical', startedAt: iso(2) }] // critical=down
+    const dailyImpact = { '2026-06-13': 'major' } // major, finalized
+    const incidents = [{ status: 'investigating', impact: 'critical', startedAt: iso(2) }] // critical
     const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'down')
-    expect(cal[27]).toBe('degraded') // 06-13 stays the official 'degraded', NOT upgraded to 'down'
-    expect(cal[29]).toBe('down') // today reflects the live critical
+    expect(cal[27]).toBe('major') // 06-13 stays the official 'major', NOT upgraded to 'critical'
+    expect(cal[29]).toBe('critical') // today reflects the live critical
   })
 
   it('OPERATIONAL service with an open minor incident is NOT painted (claude-shaped, no noise)', () => {
@@ -60,15 +62,15 @@ describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', (
     const incidents = [{ status: 'investigating', impact: 'minor', startedAt: iso(1) }]
     const cal = buildCalendarFromIncidents(incidents, dailyImpact, 30, 'operational')
     expect(cal[29]).toBe('operational') // today NOT filled — service is operational
-    expect(cal[24]).toBe('degraded') // official past bucket still shown
+    expect(cal[24]).toBe('major') // official past bucket still shown
   })
 
   it('RSS: clamps a pre-window ongoing incident to the window start (fills every cell)', () => {
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
     const incidents = [{ status: 'investigating', impact: 'major', startedAt: iso(40) }] // before the 14d window
     const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
-    expect(cal[0]).toBe('degraded') // oldest cell filled (clamped to windowStart, no out-of-bounds)
-    expect(cal[13]).toBe('degraded') // today
+    expect(cal[0]).toBe('major') // oldest cell filled (clamped to windowStart, no out-of-bounds)
+    expect(cal[13]).toBe('major') // today
   })
 
   it('RSS: multiple overlapping ongoing incidents merge worst-of', () => {
@@ -78,9 +80,9 @@ describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', (
       { status: 'investigating', impact: 'critical', startedAt: iso(1) }, // newer, red
     ]
     const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
-    expect(cal[9]).toBe('degraded_perf') // today-4: only the minor incident
-    expect(cal[12]).toBe('down') // today-1: critical overlaps → worst-of red
-    expect(cal[13]).toBe('down') // today
+    expect(cal[9]).toBe('minor') // today-4: only the minor incident
+    expect(cal[12]).toBe('critical') // today-1: critical overlaps → worst-of red
+    expect(cal[13]).toBe('critical') // today
   })
 
   it('skips a malformed startedAt without throwing', () => {
@@ -94,8 +96,32 @@ describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', (
     vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
     const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(3), resolvedAt: iso(3) }]
     const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
-    expect(cal[10]).toBe('degraded') // start day (today-3), painted by Phase 2
+    expect(cal[10]).toBe('major') // start day (today-3), painted by Phase 2
     expect(cal[11]).toBe('operational') // not spanned forward
     expect(cal[13]).toBe('operational') // today untouched (resolved)
+  })
+
+  it('an unknown (non-null) impact falls back to minor (#663 documented contract)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const incidents = [{ status: 'investigating', impact: 'something_else', startedAt: iso(1) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
+    expect(cal[13]).toBe('minor') // unknown → minor (yellow)
+  })
+
+  it('a dailyImpact minor bucket lands as a minor cell (Phase 1 via impactToCellStatus)', () => {
+    vi.setSystemTime(new Date('2026-06-15T09:00:00Z'))
+    const cal = buildCalendarFromIncidents([], { '2026-06-12': 'minor' }, 30, 'operational')
+    expect(cal[26]).toBe('minor') // 2026-06-12 = today-3 → index 26 (30-day window)
+  })
+})
+
+describe('calendar cell keys ↔ cal.status.* i18n coverage (#663 decoupling pin)', () => {
+  it('every calendar cell key has a cal.status.* label in both en and ko', async () => {
+    const { default: en } = await import('../../locales/en')
+    const { default: ko } = await import('../../locales/ko')
+    for (const key of ['operational', 'minor', 'major', 'critical']) {
+      expect(en[`cal.status.${key}`], `en missing cal.status.${key}`).toBeTruthy()
+      expect(ko[`cal.status.${key}`], `ko missing cal.status.${key}`).toBeTruthy()
+    }
   })
 })

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -1,13 +1,17 @@
 // Build status calendar from service data
 // Uses local dates to match how official status pages display dates to users.
-// Returns array of N statuses (default 30, incident.io services use 14):
-//   'down'               — red: full/major outage
-//   'degraded'           — orange: partial outage
-//   'degraded_perf'      — yellow: degraded performance (minor impact)
-//   'operational'        — green: no incidents
-// Index 0 = oldest, last index = today
+// Returns array of N cell statuses (default 30, incident.io services use 14). The cell keys are
+// IMPACT-ALIGNED and frontend-internal (NOT the wire `service.status`) — #663 renamed them from the
+// old degraded_perf/degraded/down so the key name matches the incident impact and the severity order
+// is self-evident, decoupling the calendar from the 3-state badge that shares the `status.*` i18n:
+//   'critical'    — red:    critical impact (major/full outage)
+//   'major'       — orange: major impact (partial outage)
+//   'minor'       — yellow: minor / null / unknown impact (degraded)
+//   'operational' — green:  no incidents
+// User-facing labels are unchanged (Major Outage / Partial Outage / Degraded / Operational) via the
+// `cal.status.*` i18n keys. Index 0 = oldest, last index = today.
 
-const STATUS_RANK = { operational: 0, degraded_perf: 1, degraded: 2, down: 3 }
+const STATUS_RANK = { operational: 0, minor: 1, major: 2, critical: 3 }
 
 function escalate(dayStatus, key, status) {
   if ((STATUS_RANK[status] ?? 0) > (STATUS_RANK[dayStatus[key]] ?? 0)) {
@@ -15,12 +19,12 @@ function escalate(dayStatus, key, status) {
   }
 }
 
-// Map an incident impact to a calendar cell status (single source of truth for Phase 2 + Phase 3).
-// critical → down (red), major → degraded (orange), minor/null/unknown → degraded_perf (yellow).
+// Map an incident impact to a calendar cell status (single source of truth for Phase 1/2/3). The cell
+// keys now equal the impact name (critical/major), with minor/null/unknown → 'minor' (yellow).
 function impactToCellStatus(impact) {
-  if (impact === 'critical') return 'down'
-  if (impact === 'major') return 'degraded'
-  return 'degraded_perf'
+  if (impact === 'critical') return 'critical'
+  if (impact === 'major') return 'major'
+  return 'minor'
 }
 
 // Convert Date to local YYYY-MM-DD string
@@ -32,15 +36,17 @@ export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30, cu
   const today = new Date()
   const dayStatus = {}
 
-  // Phase 1: Apply dailyImpact (keys are UTC dates from Worker — remap to local)
+  // Phase 1: Apply dailyImpact (keys are UTC dates from Worker — remap to local). dailyImpact values
+  // are impact names (critical/major/minor), which now equal the cell keys — so map via the shared
+  // impactToCellStatus (skips any unknown impact by returning 'minor', but dailyImpact only emits the
+  // three known levels).
   if (dailyImpact) {
-    const impactToStatus = { critical: 'down', major: 'degraded', minor: 'degraded_perf' }
+    const KNOWN_IMPACT = new Set(['critical', 'major', 'minor'])
     for (const [utcDay, impact] of Object.entries(dailyImpact)) {
-      const status = impactToStatus[impact]
-      if (!status) continue
+      if (!KNOWN_IMPACT.has(impact)) continue
       // UTC date key → local date key (may shift ±1 day depending on timezone)
       const localKey = toLocalDateKey(new Date(utcDay + 'T12:00:00Z'))
-      escalate(dayStatus, localKey, status)
+      escalate(dayStatus, localKey, impactToCellStatus(impact))
     }
   }
 
@@ -52,7 +58,7 @@ export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30, cu
     ;(incidents ?? []).forEach((inc) => {
       if (!inc.startedAt) return
       const key = toLocalDateKey(new Date(inc.startedAt))
-      // Same impact→status map for ongoing and resolved (minor/null/unknown → degraded_perf yellow).
+      // Same impact→cell map for ongoing and resolved (minor/null/unknown → 'minor' yellow).
       escalate(dayStatus, key, impactToCellStatus(inc.impact))
     })
   }


### PR DESCRIPTION
## Summary
The Status Calendar's cell-status keys had a confusing **key↔label inversion** and shared the `status.*` i18n namespace with the 3-state badge:
- key `degraded_perf` → label "Degraded", key `degraded` → label "Partial Outage" (key name ≠ severity)
- `status.degraded`/`status.down` were used by BOTH the badge (wire `service.status`) AND the calendar

This refactor makes the calendar cell keys **impact-aligned and frontend-internal**, with their own label namespace — no wire/UX change.

## Change (frontend-only, non-breaking)
| old cell key | → new key | label (unchanged) | impact |
|---|---|---|---|
| `degraded_perf` | `minor` | Degraded | minor / null |
| `degraded` | `major` | Partial Outage | major |
| `down` | `critical` | Major Outage | critical |
| `operational` | `operational` | Operational | none |

- **`src/utils/calendar.js`** — `STATUS_RANK`, `impactToCellStatus`, and Phase 1's `dailyImpact` mapping now use `minor/major/critical` (impact names = cell keys; Phase 1 `KNOWN_IMPACT` set routes through the shared `impactToCellStatus`). Phase 1/2/3 share one impact→cell map.
- **`src/pages/ServiceDetails.jsx` / `Overview.jsx`** — `CALENDAR_CLASS` / `CALENDAR_OPACITY` / `HISTORY_CLASS` / legend / `CalendarCell` label → the new keys + the `cal.status.*` namespace.
- **`src/locales/{en,ko}.js`** — added `cal.status.*` (label text identical), removed the now-orphaned `status.degraded_perf` (the calendar was its only consumer; badge/component use the 3-state `status.operational/degraded/down`).

## Deliberately untouched
- The **wire `service.status`** (`operational`/`degraded`/`down`) consumed by `StatusPill` + per-component status — unchanged (no `/api/status` contract change).
- The **region taxonomy** (`svc.region.type.*`, `regionStatus.js`) — a separate namespace; its `degraded_perf` is unrelated to the calendar.
- Worker / `dailyImpact` values (`minor|major|critical`) — unchanged.

## Verification
- **In-browser**: no visible change (labels + colors identical; Bedrock calendar + legend + tooltips render correctly, KO/EN labels intact) — user-confirmed.
- 12 calendar unit tests (cell-key expectations + unknown-impact→minor + dailyImpact minor bucket + a `cal.status.*` en/ko coverage pin to catch future decoupling drift).
- src 449 · e2e 131 · build OK.
- PR review (pr-review-toolkit, 3 agents): converged at 0 Critical / 0 Important.

`refs #663` (close after merge + Vercel deploy verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
