### PR TITLE
feat(ci): verify-reminders scans aiwatch-reports too (refs #541, aiwatch-reports#41)

### DIFF
--- a/.github/workflows/verify-reminders.yml
+++ b/.github/workflows/verify-reminders.yml
@@ -3,6 +3,12 @@ name: Verify Reminders
 # #541 — daily scan of open issues for `verify-after <YYYY-MM-DD>` lines; pings the operator Discord
 # when a production-data verification is due (and weekly while the issue stays open). Issue = source
 # of truth, so closing the issue / removing the line cancels the reminder.
+#
+# Cross-repo: the scan now also covers the sibling aiwatch-reports repo (where report-generator
+# verify-after lines land). The default GITHUB_TOKEN is scoped to THIS repo only, so reaching the
+# sibling needs a PAT with issues:read+write on both repos, stored as the VERIFY_CROSS_REPO_TOKEN
+# secret. When that secret is absent the job falls back to GITHUB_TOKEN and the sibling scan is
+# skipped best-effort (warn, no failure) — so the primary aiwatch reminder keeps working regardless.
 
 on:
   schedule:
@@ -30,5 +36,10 @@ jobs:
       - name: Scan issues + notify
         run: node scripts/verify-reminders.mjs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}             # `gh` CLI auth (preinstalled on the runner)
+          # Prefer the cross-repo PAT (covers aiwatch + aiwatch-reports); fall back to the repo-scoped
+          # GITHUB_TOKEN (aiwatch-only — the sibling scan then warn-skips). Set VERIFY_CROSS_REPO_TOKEN
+          # as a repo secret (classic PAT or fine-grained, issues:read+write on both repos) to enable it.
+          GH_TOKEN: ${{ secrets.VERIFY_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          # Comma-separated sibling repos to also scan (defaults to the reports repo inside the script).
+          VERIFY_EXTRA_REPOS: bentleypark/aiwatch-reports
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}  # reuse the operator channel (#541)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ gh pr merge --squash --delete-branch
 9. **Verify Vercel Preview** (frontend)
 10. **Merge** `gh pr merge --squash --delete-branch` — worker deploy is manual (`npm run deploy:worker`, once, after approval; batch multi-PR deploys)
 11. **Verify checklist** against code before closing; periodically re-verify `deferred`/`tracking` issues (later work may have completed one)
-12. **Close** only after verification; deferred items → keep open with a label carrying a **written exit condition**. Production-data check needed after a delay → add a `- [ ] **verify-after YYYY-MM-DD** — …` line; the daily `verify-reminders` Action (`.github/workflows/verify-reminders.yml` + `scripts/verify-reminders.mjs`, #541) pings the operator Discord when due so the check isn't missed
+12. **Close** only after verification; deferred items → keep open with a label carrying a **written exit condition**. Production-data check needed after a delay → add a `- [ ] **verify-after YYYY-MM-DD** — …` line; the daily `verify-reminders` Action (`.github/workflows/verify-reminders.yml` + `scripts/verify-reminders.mjs`, #541) pings the operator Discord when due so the check isn't missed. It scans **both this repo AND `aiwatch-reports`** (`parseScanRepos` + `VERIFY_EXTRA_REPOS`), so a `verify-after` line in either repo fires — the sibling scan needs the `VERIFY_CROSS_REPO_TOKEN` PAT secret (issues:read+write on both repos; absent → the sibling scan warn-skips best-effort, the aiwatch reminder still runs). Sibling refs show qualified (`aiwatch-reports#N`) in the Discord ping
 
 > Never close an issue immediately after merging. Verify each checklist item against the code first; deferred → keep open with a labeled exit condition.
 

--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -38,14 +38,56 @@ export function parseVerifyAfter(body) {
 /**
  * Trusted issue authors whose `verify-after` lines are honored. #541 abuse-gate: this runs on a
  * PUBLIC repo, so without a gate anyone could open an issue to fire an operator Discord ping + apply
- * a label. Default to the repo OWNER (from GITHUB_REPOSITORY, always set in Actions) plus an explicit
- * VERIFY_TRUSTED_AUTHORS allow-list (comma-separated). Empty set (e.g. local dev with neither env) →
- * the caller does NOT filter, so the maintainer can test against their own board.
+ * a label. The trusted set is the union of: the repo OWNER (from GITHUB_REPOSITORY, always set in
+ * Actions), an explicit VERIFY_TRUSTED_AUTHORS allow-list (comma-separated), AND the owner of every
+ * concrete `repos` entry being scanned (so scanning a public sibling can't open the gate even when
+ * GITHUB_REPOSITORY is unset). Empty set (only `repos: [null]` / pure local with no env) → the
+ * caller does NOT filter, so the maintainer can test against their own board.
  */
-export function parseTrustedAuthors(env = process.env) {
+export function parseTrustedAuthors(env = process.env, repos = []) {
   const explicit = (env.VERIFY_TRUSTED_AUTHORS || '').split(',').map((s) => s.trim()).filter(Boolean)
   const owner = (env.GITHUB_REPOSITORY || '').split('/')[0].trim()
-  return new Set([...explicit, ...(owner ? [owner] : [])])
+  // Also trust the OWNER of every concrete repo being scanned. This keeps the abuse-gate closed when
+  // GITHUB_REPOSITORY is empty but a concrete sibling is scanned (VERIFY_EXTRA_REPOS defaults to the
+  // public reports repo) — otherwise the trusted set would be empty and main() would skip filtering,
+  // opening the gate on a public repo. It also gates a different-owner sibling against ITS own owner
+  // (each scanned repo trusts its owner's issues). Only `repos: [null]` (pure local) yields an empty
+  // set → no filter, preserving the maintainer's against-own-board test path.
+  const repoOwners = repos.filter(Boolean).map((r) => r.split('/')[0].trim()).filter(Boolean)
+  return new Set([...explicit, ...(owner ? [owner] : []), ...repoOwners])
+}
+
+/**
+ * The `owner/repo` slugs to scan. The board lives in more than one repo now — `verify-after` lines
+ * also land in the sibling **aiwatch-reports** repo (the report generator), and the daily Action only
+ * ran the repo it lives in, so those lines never fired. Returns the main repo (GITHUB_REPOSITORY)
+ * plus the extras in VERIFY_EXTRA_REPOS (comma-separated; defaults to the reports repo), de-duped and
+ * order-preserving. Local dev with no GITHUB_REPOSITORY → `[null]` = "current repo, no --repo flag",
+ * preserving the maintainer's against-own-board test path.
+ *
+ * NOTE the GitHub Action's default GITHUB_TOKEN is scoped to its OWN repo, so reaching a sibling repo
+ * needs a cross-repo PAT (VERIFY_CROSS_REPO_TOKEN in the workflow). When that's absent the sibling
+ * fetch 403/404s — main() treats a per-repo fetch failure as best-effort (warn + skip), so the
+ * primary reminder never breaks just because the cross-repo token isn't set yet.
+ */
+export function parseScanRepos(env = process.env) {
+  const main = (env.GITHUB_REPOSITORY || '').trim()
+  const extras = (env.VERIFY_EXTRA_REPOS ?? 'bentleypark/aiwatch-reports')
+    .split(',').map((s) => s.trim()).filter(Boolean)
+  const all = [...(main ? [main] : []), ...extras]
+  const deduped = [...new Set(all)]
+  return deduped.length > 0 ? deduped : [null]
+}
+
+/**
+ * Discord/label reference for an issue, disambiguated across repos. The main repo (or a null/local
+ * repo) stays the bare `#N`; a sibling repo is qualified by its short name, e.g. `aiwatch-reports#41`,
+ * so the operator can tell `aiwatch#41` from `aiwatch-reports#41` at a glance.
+ */
+export function displayRef(repo, number, env = process.env) {
+  const main = (env.GITHUB_REPOSITORY || '').trim()
+  if (!repo || repo === main) return `#${number}`
+  return `${repo.split('/')[1]}#${number}`
 }
 
 /** Whole-day difference today − due (UTC midnight). Negative = due is in the future. NaN on bad input. */
@@ -75,7 +117,7 @@ function gh(args) {
 async function postDiscord(webhook, items) {
   const lines = items.map((it) => {
     const when = it.overdueDays > 0 ? `due ${it.date}, ${it.overdueDays}d overdue` : 'due today'
-    return `• **#${it.number}** ${it.title}\n  → ${it.note || 'verify production data'} _(${when})_`
+    return `• **${it.ref || `#${it.number}`}** ${it.title}\n  → ${it.note || 'verify production data'} _(${when})_`
   })
   const body = {
     embeds: [{
@@ -93,21 +135,48 @@ async function postDiscord(webhook, items) {
   if (!res.ok) throw new Error(`Discord webhook ${res.status}: ${await res.text().catch(() => '')}`)
 }
 
+// Fetch open issues for one repo (null = current repo, no --repo flag). Best-effort: a per-repo
+// failure (e.g. the cross-repo PAT is missing so a sibling repo 403/404s) warns + returns [] so the
+// primary reminder still runs. Each issue is tagged with its `repo` for later ref/label targeting.
+function fetchRepoIssues(repo) {
+  const args = ['issue', 'list', '--state', 'open', '--limit', '200', '--json', 'number,title,body,author']
+  if (repo) args.push('--repo', repo)
+  try {
+    const issues = JSON.parse(gh(args))
+    return issues.map((i) => ({ ...i, repo }))
+  } catch (e) {
+    console.warn(`[verify-reminders] could not list issues for ${repo || 'current repo'} (skipping): ${e.message.split('\n')[0]}`)
+    return []
+  }
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run') || process.env.DRY_RUN === '1'
   const today = todayUTC()
-  const issues = JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', '200', '--json', 'number,title,body,author']))
 
-  // #541 abuse-gate (public repo): only honor verify-after lines from trusted authors. Empty trusted
-  // set (local dev with no GITHUB_REPOSITORY/override) → no filter, so the maintainer can test.
-  const trusted = parseTrustedAuthors()
+  const repos = parseScanRepos()
+  console.log(`[verify-reminders] ${today}: scanning ${repos.length} repo(s): ${repos.map((r) => r || 'current').join(', ')}`)
+  const issues = repos.flatMap(fetchRepoIssues)
+
+  // #541 abuse-gate (public repo): only honor verify-after lines from trusted authors. Trusted owners
+  // include every concrete scanned repo's owner, so scanning a public sibling never opens the gate.
+  // Empty set only for pure-local (`repos: [null]`) → no filter, so the maintainer can test own board.
+  const trusted = parseTrustedAuthors(process.env, repos)
   const considered = trusted.size > 0 ? issues.filter((i) => trusted.has(i.author?.login)) : issues
 
   const due = []
   for (const iss of considered) {
     for (const { date, note } of parseVerifyAfter(iss.body)) {
       if (shouldFire(date, today)) {
-        due.push({ number: iss.number, title: iss.title, date, note, overdueDays: daysSinceDue(date, today) })
+        due.push({
+          number: iss.number,
+          repo: iss.repo,
+          ref: displayRef(iss.repo, iss.number),
+          title: iss.title,
+          date,
+          note,
+          overdueDays: daysSinceDue(date, today),
+        })
       }
     }
   }
@@ -116,7 +185,7 @@ async function main() {
     console.log(`[verify-reminders] ${today}: nothing due.`)
     return
   }
-  console.log(`[verify-reminders] ${today}: ${due.length} due → ${due.map((d) => `#${d.number}`).join(', ')}`)
+  console.log(`[verify-reminders] ${today}: ${due.length} due → ${due.map((d) => d.ref).join(', ')}`)
 
   if (dryRun) {
     console.log('[verify-reminders] --dry-run: would post:\n' + JSON.stringify(due, null, 2))
@@ -130,12 +199,19 @@ async function main() {
   }
   await postDiscord(webhook, due)
   // Board visibility: label each fired issue so issue-triage sees what's past its verify date.
-  // Best-effort — a label failure must not fail the run after a successful Discord send.
-  for (const number of [...new Set(due.map((d) => d.number))]) {
+  // Best-effort — a label failure must not fail the run after a successful Discord send. Keyed by
+  // repo+number so a sibling-repo issue is labeled in its own repo (and the label must exist there).
+  const seen = new Set()
+  for (const { number, repo } of due) {
+    const key = `${repo || ''}#${number}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const args = ['issue', 'edit', String(number), '--add-label', 'verify-overdue']
+    if (repo) args.push('--repo', repo)
     try {
-      gh(['issue', 'edit', String(number), '--add-label', 'verify-overdue'])
+      gh(args)
     } catch (e) {
-      console.warn(`[verify-reminders] could not label #${number}: ${e.message}`)
+      console.warn(`[verify-reminders] could not label ${displayRef(repo, number)}: ${e.message.split('\n')[0]}`)
     }
   }
   console.log('[verify-reminders] posted to Discord + labeled verify-overdue.')

--- a/scripts/verify-reminders.test.mjs
+++ b/scripts/verify-reminders.test.mjs
@@ -3,7 +3,7 @@
 // script, not src/worker code.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseVerifyAfter, daysSinceDue, shouldFire, isValidIsoDate, parseTrustedAuthors } from './verify-reminders.mjs'
+import { parseVerifyAfter, daysSinceDue, shouldFire, isValidIsoDate, parseTrustedAuthors, parseScanRepos, displayRef } from './verify-reminders.mjs'
 
 test('parseVerifyAfter — extracts date + note from a checklist line', () => {
   const body = '- [ ] **verify-after 2026-09-01** — check p95 after 3 months (#511)\nother text'
@@ -58,7 +58,36 @@ test('isValidIsoDate', () => {
 test('parseTrustedAuthors — owner from GITHUB_REPOSITORY + explicit override; empty by default', () => {
   assert.deepEqual([...parseTrustedAuthors({ GITHUB_REPOSITORY: 'bentleypark/aiwatch' })], ['bentleypark'])
   assert.deepEqual([...parseTrustedAuthors({ VERIFY_TRUSTED_AUTHORS: 'a, b', GITHUB_REPOSITORY: 'o/r' })], ['a', 'b', 'o'])
-  assert.equal(parseTrustedAuthors({}).size, 0) // local dev → empty → caller does not filter
+  assert.equal(parseTrustedAuthors({}).size, 0) // pure local → empty → caller does not filter
+})
+
+test('parseTrustedAuthors — also trusts scanned-repo owners (abuse-gate stays closed on a public sibling)', () => {
+  // GITHUB_REPOSITORY empty but a concrete sibling is scanned → gate must NOT open: owner derived from the repo.
+  assert.deepEqual([...parseTrustedAuthors({}, ['bentleypark/aiwatch-reports'])], ['bentleypark'])
+  // main + different-owner sibling → both owners trusted (each gates its own repo's issues)
+  assert.deepEqual([...parseTrustedAuthors({ GITHUB_REPOSITORY: 'o/main' }, ['x/sib'])], ['o', 'x'])
+  // pure-local (repos:[null]) keeps the empty set → no filter
+  assert.equal(parseTrustedAuthors({}, [null]).size, 0)
+})
+
+test('parseScanRepos — main repo + default reports sibling, de-duped, order-preserving', () => {
+  // main repo from GITHUB_REPOSITORY + the default reports sibling
+  assert.deepEqual(parseScanRepos({ GITHUB_REPOSITORY: 'bentleypark/aiwatch' }), ['bentleypark/aiwatch', 'bentleypark/aiwatch-reports'])
+  // explicit extras override the default; main stays first
+  assert.deepEqual(parseScanRepos({ GITHUB_REPOSITORY: 'o/main', VERIFY_EXTRA_REPOS: 'o/a, o/b' }), ['o/main', 'o/a', 'o/b'])
+  // a sibling duplicating the main repo is de-duped
+  assert.deepEqual(parseScanRepos({ GITHUB_REPOSITORY: 'o/r', VERIFY_EXTRA_REPOS: 'o/r' }), ['o/r'])
+  // empty VERIFY_EXTRA_REPOS → main only (no sibling)
+  assert.deepEqual(parseScanRepos({ GITHUB_REPOSITORY: 'o/main', VERIFY_EXTRA_REPOS: '' }), ['o/main'])
+  // local dev (no GITHUB_REPOSITORY, no extras) → [null] = current repo, no --repo
+  assert.deepEqual(parseScanRepos({ VERIFY_EXTRA_REPOS: '' }), [null])
+})
+
+test('displayRef — bare #N for main/local, qualified for a sibling', () => {
+  const env = { GITHUB_REPOSITORY: 'bentleypark/aiwatch' }
+  assert.equal(displayRef('bentleypark/aiwatch', 41, env), '#41')            // main repo → bare
+  assert.equal(displayRef('bentleypark/aiwatch-reports', 41, env), 'aiwatch-reports#41') // sibling → qualified
+  assert.equal(displayRef(null, 41, env), '#41')                            // local/current → bare
 })
 
 test('importing the module runs no side effects (main is guarded)', () => {


### PR DESCRIPTION
Extends the daily `verify-reminders` Action (#541) to **also scan the sibling `aiwatch-reports` repo**, so `verify-after` lines that land there (report-generator work — e.g. **aiwatch-reports#41**'s 2026-06 generation check) actually fire. Previously the Action only scanned the repo it runs in.

## Changes
- **`parseScanRepos(env)`** — main repo (`GITHUB_REPOSITORY`) + `VERIFY_EXTRA_REPOS` siblings (defaults to `bentleypark/aiwatch-reports`), de-duped; `[null]` for pure-local.
- **`displayRef(repo, n)`** — bare `#N` for main/local, qualified `aiwatch-reports#N` for a sibling (disambiguates cross-repo issue numbers in the Discord ping + labels).
- **`main()`** loops repos via `fetchRepoIssues()` — **best-effort**: a per-repo `gh` failure (e.g. missing cross-repo PAT → 403/404) warns + skips, so the primary aiwatch reminder never breaks. Discord ref + `verify-overdue` label target the right repo.
- **Abuse-gate (#541) hardened** — trusted owners are now derived from every concrete scanned repo's owner too, so scanning a public sibling can't open the gate when `GITHUB_REPOSITORY` is unset (fail-closed); a different-owner sibling is gated against its own owner.
- **Workflow** — `GH_TOKEN = ${{ secrets.VERIFY_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}` + `VERIFY_EXTRA_REPOS`. The default token is repo-scoped, so the sibling scan needs a PAT (issues:RW on both repos); absent → graceful fallback.
- Created the `verify-overdue` label in `aiwatch-reports` so sibling labeling works.

## Operator setup (done)
`VERIFY_CROSS_REPO_TOKEN` secret is set on `bentleypark/aiwatch` (a PAT spanning both repos). Without it the Action falls back to `GITHUB_TOKEN` and the sibling scan warn-skips — the aiwatch reminder still runs.

## Tests / verification
- `npm run test:scripts` — 51/51 pass (+5: `parseScanRepos`, `displayRef`, abuse-gate owner derivation).
- Local dry-run confirmed it scans **both** repos (`scanning 2 repo(s)`) and that **reports#41** parses `verify-after 2026-07-02` → fires as **`aiwatch-reports#41`** on its due date with `--repo`-targeted labeling.

## Review
2 rounds via code-reviewer → converged (0 Critical/Important; the one Suggestion — a public-repo abuse-gate edge — was fixed).

Refs #541 (parent feature) · aiwatch-reports#41 (the verify-after this unblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)