### PR TITLE
fix(probe): correct exclusion reasons + add 4 reachable probe targets (#678)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ worker/
     monthly-archive.ts # Monthly reliability archive (uptime, score, incidents, latency per service, permanent KV). Also aggregates detection:lead:monthly (#369) + probe-degradation:monthly (#511, RTT degradation total/noStatus via summarizeDegradation) into MonthlyArchive, exposed by /api/report
     monthly-narrative.ts # AI retrospective narrative (Notable Incidents + Observations draft) baked into the archive — hybrid Gemma→Sonnet, #426
     vitals.ts   # Web Vitals aggregation (ingest, KV flush, p75 computation, Discord formatting)
-    probe.ts    # Health check probing — direct RTT measurement (20 API services)
+    probe.ts    # Health check probing — direct RTT measurement (24 API services)
     probe-archival.ts # Daily probe RTT archival + 7-day summary (p50, p95, cvCombined)
     platform-monitor.ts # Status page platform health monitoring (metastatuspage.com for Atlassian)
     detection.ts # Detection Lead entry parsing + incident-aware reset logic

--- a/README.ko.md
+++ b/README.ko.md
@@ -34,7 +34,7 @@
 
 - **실시간 상태 모니터링** — 37개 AI 서비스의 정상 / 성능 저하 / 장애 상태
 - **PWA 지원** — 홈 화면 추가, Service Worker 오프라인 캐시
-- **지연시간 측정** — 20개 probe 대상 서비스의 API 엔드포인트 직접 RTT 측정, 나머지는 상태 페이지 응답 시간
+- **지연시간 측정** — 24개 probe 대상 서비스의 API 엔드포인트 직접 RTT 측정, 나머지는 상태 페이지 응답 시간
 - **24시간 지연시간 추세** — Chart.js 라인 차트 (5분 간격 probe 스냅샷)
 - **인시던트 이력** — 다양한 상태 페이지 형식의 타임라인 상세 정보
 - **공식 가동률** — Statuspage, incident.io, Better Stack에서 컴포넌트별 가동률
@@ -52,7 +52,7 @@
 - **스마트 알림** — degraded/down 상태 Discord 알림 (anti-flapping + 인시던트 억제 + 복구 지속 시간)
 - **오프라인 UI** — API 연결 불가 시 안내 화면 (프로덕션 전용)
 - **Is X Down SEO 페이지** — 34개 서비스 (Bedrock/Azure OpenAI 제외한 모든 모니터링 대상), 동적 OG 이미지(PNG), 공유 버튼, AIWatch 순위 (대시보드와 동일한 동률 표기), 대체 서비스 추천
-- **헬스체크 프로빙** — API 엔드포인트 직접 RTT 측정 (20개 API 서비스) + 연속 스파이크 조기 장애 감지 및 RTT 저하 추적
+- **헬스체크 프로빙** — API 엔드포인트 직접 RTT 측정 (24개 API 서비스) + 연속 스파이크 조기 장애 감지 및 RTT 저하 추적
 - **페이지별 스켈레톤** — 각 페이지 레이아웃에 맞는 로딩 placeholder
 - **AI 분석 (Beta)** — 장애 발생 시 하이브리드 AI 자동 분석 (Gemma 4 primary + Sonnet fallback): 원인 추정, 예상 복구 시간, 영향 범위, 대체 서비스 추천. 인시던트 Discord 알림에 통합(단일 embed), Topbar Analyze 모달, Is X Down AI Insight 카드
 - **랜딩 페이지** — 랜딩 페이지(`/intro`), 대시보드 프리뷰 mock, KO/EN 이중 언어, Flow 애니메이션, `?banner=` 캠페인 슬롯(선택), GA4 트래킹
@@ -152,7 +152,7 @@ Cloudflare KV
   ├── daily:YYYY-MM-DD     (가동률 카운터, TTL 2일)
   ├── history:YYYY-MM-DD   (아카이브 카운터, TTL 90일)
   ├── latency:24h          (30분 스냅샷, 최대 48개, TTL 25시간)
-  ├── probe:24h            (헬스체크 프로브, 최대 2016개, TTL 7일, 20개 API 서비스)
+  ├── probe:24h            (헬스체크 프로브, 최대 2016개, TTL 7일, 24개 API 서비스)
   ├── ai:analysis:{svcId}:{incId}  (AI 인시던트별 분석, TTL 1시간, 활성 시 갱신)
   ├── ai:reanalysis-skip:* (재분석 실패 쿨다운, TTL 30분)
   ├── ai:usage:{date}      (일별 AI 사용량 카운터, TTL 2일)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 
 - **Real-time status** — Operational / Degraded / Down for 37 AI services
 - **PWA support** — Add to home screen, offline cache with Service Worker
-- **Latency monitoring** — Direct API endpoint response time (RTT) for 20 probe-capable services, status page timing as fallback
+- **Latency monitoring** — Direct API endpoint response time (RTT) for 24 probe-capable services, status page timing as fallback
 - **24h latency trend** — Chart.js line chart with 5-min probe snapshots
 - **Incident history** — Timeline with details from multiple status page formats
 - **Official uptime** — Per-component uptime from Statuspage, incident.io, Better Stack
@@ -53,7 +53,7 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 - **Smart alerts** — Discord alerts for degraded/down status with anti-flapping, incident suppression, and recovery duration
 - **Offline UI** — Graceful error state when API is unreachable (production only)
 - **Is X Down SEO pages** — 34 services (all monitored services except Bedrock / Azure OpenAI) with dynamic OG images (PNG), share buttons, AIWatch rank (matches dashboard with tied-rank display), and fallback recommendations
-- **Health check probing** — Direct RTT measurement to API endpoints (20 API services) with early outage detection via consecutive spike alerts and RTT degradation tracking
+- **Health check probing** — Direct RTT measurement to API endpoints (24 API services) with early outage detection via consecutive spike alerts and RTT degradation tracking
 - **Page-specific skeletons** — Loading placeholders matched to each page layout
 - **AI Analysis (Beta)** — Hybrid AI auto-analysis on incidents (Gemma 4 primary + Sonnet fallback): cause estimation, recovery time, affected scope, contextual fallback recommendations. Merged into incident Discord alert (single embed), Topbar Analyze modal, Is X Down AI Insight card
 - **Landing page** — Landing page (`/intro`) with dashboard preview mock, KO/EN i18n, flow animation, optional `?banner=` campaign slot, and GA4 tracking
@@ -153,7 +153,7 @@ Cloudflare KV
   ├── daily:YYYY-MM-DD     (uptime counters, TTL 2d)
   ├── history:YYYY-MM-DD   (archived counters, TTL 90d)
   ├── latency:24h          (30-min snapshots, max 48, TTL 25h)
-  ├── probe:24h            (health check probes, max 2016, TTL 7d, 20 API services)
+  ├── probe:24h            (health check probes, max 2016, TTL 7d, 24 API services)
   ├── ai:analysis:{svcId}:{incId}  (AI per-incident analysis, TTL 1h, refreshed while active)
   ├── ai:reanalysis-skip:* (re-analysis failure cooldown, TTL 30min)
   ├── ai:usage:{date}      (daily AI usage counter, TTL 2d)

--- a/api/methodology/__tests__/html-template.test.ts
+++ b/api/methodology/__tests__/html-template.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { renderMethodologyPage } from '../html-template'
+import { PROBE_TARGETS } from '../../../worker/src/probe' // #678 — lockstep source of truth
 
 // #673 — the public /methodology page. Renders once (no per-request data), so these assertions
 // guard: it renders without throwing, carries all 7 section anchors + the SEO head, is bilingual,
@@ -114,13 +115,23 @@ describe('renderMethodologyPage', () => {
     expect(html).not.toContain('class="hero-outer"')
   })
 
-  it('lists the full non-probed set (20 probed of 27 API → 7 excluded) in §4/§5', () => {
-    // PROBE_TARGETS has 20 services; the other 7 API services must be named accurately
-    // (the old copy listed only 3-4, mismatching §4 vs §5).
-    for (const svc of ['Bedrock', 'Azure OpenAI', 'Pinecone', 'Modal', 'LangSmith', 'Runway', 'Luma']) {
+  it('keeps the probe count + non-probed set in LOCKSTEP with PROBE_TARGETS (#678)', () => {
+    // The methodology copy hardcodes the probe count + the non-probed list. Derive the expected
+    // count from the source of truth (worker/src/probe.PROBE_TARGETS) so a change to probe.ts that
+    // forgets to update this page fails HERE — otherwise the two layers drift independently (the
+    // exact regression #678 guards against).
+    const n = PROBE_TARGETS.length // 24
+    expect(html).toContain(`${n} AI service`)  // EN (matches "24 AI services")
+    expect(html).toContain(`${n}개 AI 서비스`)   // KO
+    // the 3 remaining non-probed API services must be named...
+    for (const svc of ['Bedrock', 'Azure OpenAI', 'Modal']) {
       expect(html, `non-probed list should name ${svc}`).toContain(svc)
     }
-    expect(html).toContain('20 AI service') // EN probe count
+    // ...and the now-probed ones must NOT appear in the doc (Runway/Pinecone/LangSmith appear
+    // nowhere else; Luma is also a Platform-uptime example so it's intentionally not asserted here).
+    for (const svc of ['Runway', 'Pinecone', 'LangSmith']) {
+      expect(html, `${svc} is now probed — must not be listed as non-probed`).not.toContain(svc)
+    }
   })
 
   it('keeps the honest detection framing — MTTD + RTT, explicitly disclaiming "faster than official" (#464)', () => {

--- a/api/methodology/html-template.ts
+++ b/api/methodology/html-template.ts
@@ -281,7 +281,7 @@ ${CONSENT_INIT_SCRIPT}
     <li><strong>Flashduty</strong> <span data-i18n="s1.src.flashduty">— DeepSeek 상태 피드 정규화 (status.deepseek.com)</span></li>
     <li><strong>AWS Health Dashboard</strong> <span data-i18n="s1.src.awshealth">— Amazon Bedrock — 공개 이벤트 JSON API(인시던트 start/end), 가동률 API 없음</span></li>
     <li><strong>RSS incident feeds</strong> <span data-i18n="s1.src.rss">— Azure Status(Azure OpenAI) · xAI(status.x.ai) — 가동률 API 없이 인시던트 RSS만 수집</span></li>
-    <li><strong>Direct RTT probes</strong> <span data-i18n="s1.src.probe">— 20개 AI 서비스의 API 엔드포인트 직접 측정</span></li>
+    <li><strong>Direct RTT probes</strong> <span data-i18n="s1.src.probe">— 24개 AI 서비스의 API 엔드포인트 직접 측정</span></li>
   </ul>
   <h3 data-i18n="s1.secTitle">보안 이슈 모니터링</h3>
   <p data-i18n="s1.secDesc">상태·신뢰도 측정과는 별개로, AI 스택에 영향을 주는 보안 이슈도 함께 추적해 <strong>월간 리포트</strong>에 집계합니다. 이 데이터는 AIWatch Score나 인시던트 집계에는 반영되지 않습니다.</p>
@@ -363,11 +363,11 @@ ${CONSENT_INIT_SCRIPT}
 <section class="section" id="latency">
   <p class="section-label">// 04</p>
   <h2 data-i18n="s5.title">레이턴시 (Probe RTT)</h2>
-  <p class="lead" data-i18n="s5.lead">20개 AI 서비스의 API 엔드포인트를 Cloudflare Workers 엣지에서 5분 간격으로 직접 측정합니다. p50 / p75 / p95 분위수를 산출합니다.</p>
+  <p class="lead" data-i18n="s5.lead">24개 AI 서비스의 API 엔드포인트를 Cloudflare Workers 엣지에서 5분 간격으로 직접 측정합니다. p50 / p75 / p95 분위수를 산출합니다.</p>
   <div class="limits">
     <div class="limits-label">⚠ <span data-i18n="s5.limit.label">핵심 한계 — 네트워크 RTT ≠ 추론 레이턴시</span></div>
     <p data-i18n="s5.limit.body">Probe RTT는 <strong>네트워크 왕복 시간</strong>을 측정합니다. 모델의 추론(토큰 생성) 레이턴시가 아닙니다. "이 서비스가 얼마나 빨리 토큰을 만드나"가 아니라 "엔드포인트가 네트워크 계층에서 얼마나 빨리 응답하나"를 나타냅니다.</p>
-    <p data-i18n="s5.limit.probe"><strong>Probe 미적용:</strong> 레이턴시 랭킹은 직접 probe하는 20개 AI 서비스만 대상입니다 — 앱·코딩 에이전트, 그리고 probe하지 않는 나머지 7개 AI 서비스는 제외됩니다.</p>
+    <p data-i18n="s5.limit.probe"><strong>Probe 미적용:</strong> 레이턴시 랭킹은 직접 probe하는 24개 AI 서비스만 대상입니다 — 앱·코딩 에이전트, 그리고 probe하지 않는 나머지 3개 AI 서비스는 제외됩니다.</p>
   </div>
 </section>
 
@@ -464,10 +464,10 @@ ${CONSENT_INIT_SCRIPT}
   <!-- Responsiveness sub -->
   <div class="subscore">
     <h3 data-i18n="s4.resp.title">Responsiveness Score (0~20)</h3>
-    <p data-i18n="s4.resp.desc">5분 간격 health-check probe로 실제 API 엔드포인트의 응답 속도와 안정성을 측정합니다(20개 AI 서비스). 응답 속도와 일관성을 함께 반영합니다.</p>
+    <p data-i18n="s4.resp.desc">5분 간격 health-check probe로 실제 API 엔드포인트의 응답 속도와 안정성을 측정합니다(24개 AI 서비스). 응답 속도와 일관성을 함께 반영합니다.</p>
     <div class="formula"><span class="fl-sub" data-i18n="s4.resp.speed">Speed (0~10) — p50 RTT 지수 감쇠</span><br>10 × exp(−max(p50, 50ms) / 400ms)</div>
     <div class="formula"><span class="fl-sub" data-i18n="s4.resp.stability">Stability (0~10) — 결합 변동계수 지수 감쇠</span><br>10 × exp(−CV_combined / 0.5)</div>
-    <p data-i18n="s4.resp.na1">앱과 코딩 에이전트는 측정할 API 엔드포인트가 없어 probe 대상이 아니며, probe 세트(20개)에 들지 않은 나머지 7개 AI 서비스(Bedrock · Azure OpenAI · Pinecone · Modal · LangSmith · Runway · Luma)도 probe하지 않습니다.</p>
+    <p data-i18n="s4.resp.na1">앱과 코딩 에이전트는 측정할 API 엔드포인트가 없어 probe 대상이 아니며, probe 세트(24개)에 들지 않은 나머지 3개 AI 서비스(Bedrock · Azure OpenAI · Modal)도 probe하지 않습니다.</p>
     <p data-i18n="s4.resp.na2">이 경우 80점 만점을 100점으로 환산하고, 응답성 신호가 없으므로 5% 페널티를 적용합니다.</p>
     <div class="formula">Score = (Uptime + Incidents + Recovery) × 0.9 → ×(100/80)<br><span class="fl-sub" data-i18n="s4.resp.naFormula">probe-less: base 80 → 100 환산 + 5% 신뢰도 페널티</span></div>
     <p class="note" data-i18n="s4.resp.insufficient">새로 추가된 probe 대상 서비스는 7일치 데이터가 쌓이기 전까지 5% 페널티를 적용합니다.</p>
@@ -548,7 +548,7 @@ const i18n = {
     's1.lead': 'AIWatch는 LLM API 15개, 코딩 에이전트 6개, 음성 3개, 추론·인프라 7개, 영상 2개, AI 앱 4개 — 총 37개 AI 서비스를 최대 5분 간격으로 폴링합니다. 모든 시각은 UTC 기준입니다.',
     's1.sourcesTitle': '데이터 출처',
     's1.sourcesDesc': '상태·인시던트·uptime 데이터는 각 서비스의 공식 상태 페이지에서 수집됩니다. 제공사가 공개한 데이터가 1차 출처이며, 없는 값을 자체 추정으로 채우지 않습니다 — 공식 uptime이 없는 경우의 처리는 아래 <a href="#uptime">Uptime 섹션</a>에서 다룹니다.',
-    's1.src.atlassian': '— 다수의 주요 제공사', 's1.src.incidentio': '— 컴포넌트 단위 인시던트 + 영향도', 's1.src.gcloud': '— Gemini API (Google Cloud 상태 + AI Studio 컴포넌트 인시던트 병합)', 's1.src.others': '— 그 외 상태 페이지 플랫폼 (인시던트 RSS + 가동률 JSON)', 's1.src.flashduty': '— DeepSeek 상태 피드 정규화 (status.deepseek.com)', 's1.src.awshealth': '— Amazon Bedrock — 공개 이벤트 JSON API(인시던트 start/end), 가동률 API 없음', 's1.src.rss': '— Azure Status(Azure OpenAI) · xAI(status.x.ai) — 가동률 API 없이 인시던트 RSS만 수집', 's1.src.probe': '— 20개 AI 서비스의 API 엔드포인트 직접 측정',
+    's1.src.atlassian': '— 다수의 주요 제공사', 's1.src.incidentio': '— 컴포넌트 단위 인시던트 + 영향도', 's1.src.gcloud': '— Gemini API (Google Cloud 상태 + AI Studio 컴포넌트 인시던트 병합)', 's1.src.others': '— 그 외 상태 페이지 플랫폼 (인시던트 RSS + 가동률 JSON)', 's1.src.flashduty': '— DeepSeek 상태 피드 정규화 (status.deepseek.com)', 's1.src.awshealth': '— Amazon Bedrock — 공개 이벤트 JSON API(인시던트 start/end), 가동률 API 없음', 's1.src.rss': '— Azure Status(Azure OpenAI) · xAI(status.x.ai) — 가동률 API 없이 인시던트 RSS만 수집', 's1.src.probe': '— 24개 AI 서비스의 API 엔드포인트 직접 측정',
     's1.secTitle': '보안 이슈 모니터링',
     's1.secDesc': '상태·신뢰도 측정과는 별개로, AI 스택에 영향을 주는 보안 이슈도 함께 추적해 <strong>월간 리포트</strong>에 집계합니다. 이 데이터는 AIWatch Score나 인시던트 집계에는 반영되지 않습니다.',
     's1.sec.osv': '— SDK 취약점 (PyPI · npm 24개 추적 패키지), GitHub Advisories로 상세 보강', 's1.sec.hn': '— AI 서비스 관련 보안 뉴스 (Algolia 검색 API)',
@@ -584,10 +584,10 @@ const i18n = {
     's4.rec.title': 'Recovery Score (0~15)',
     's4.rec.note': 'MTTR은 해결된 인시던트 지속 시간의 30일 중앙값입니다(3건 미만이면 평균으로 폴백).',
     's4.resp.title': 'Responsiveness Score (0~20)',
-    's4.resp.desc': '5분 간격 health-check probe로 실제 API 엔드포인트의 응답 속도와 안정성을 측정합니다(20개 AI 서비스). 응답 속도와 일관성을 함께 반영합니다.',
+    's4.resp.desc': '5분 간격 health-check probe로 실제 API 엔드포인트의 응답 속도와 안정성을 측정합니다(24개 AI 서비스). 응답 속도와 일관성을 함께 반영합니다.',
     's4.resp.speed': 'Speed (0~10) — p50 RTT 지수 감쇠',
     's4.resp.stability': 'Stability (0~10) — 결합 변동계수 지수 감쇠',
-    's4.resp.na1': '앱과 코딩 에이전트는 측정할 API 엔드포인트가 없어 probe 대상이 아니며, probe 세트(20개)에 들지 않은 나머지 7개 AI 서비스(Bedrock · Azure OpenAI · Pinecone · Modal · LangSmith · Runway · Luma)도 probe하지 않습니다.',
+    's4.resp.na1': '앱과 코딩 에이전트는 측정할 API 엔드포인트가 없어 probe 대상이 아니며, probe 세트(24개)에 들지 않은 나머지 3개 AI 서비스(Bedrock · Azure OpenAI · Modal)도 probe하지 않습니다.',
     's4.resp.na2': '이 경우 80점 만점을 100점으로 환산하고, 응답성 신호가 없으므로 5% 페널티를 적용합니다.',
     's4.resp.naFormula': 'probe-less: base 80 → 100 환산 + 5% 신뢰도 페널티',
     's4.resp.insufficient': '새로 추가된 probe 대상 서비스는 7일치 데이터가 쌓이기 전까지 5% 페널티를 적용합니다.',
@@ -595,10 +595,10 @@ const i18n = {
     's4.noUptime.desc': '일부 서비스(Gemini, xAI 등)는 공식 uptime 수치가 없습니다. 이 경우 업계 평균(99.5%, 40점 척도에서 36점)을 가정하고 10% 페널티를 적용합니다.',
     's4.grades.title': '등급 기준',
     's5.title': '레이턴시 (Probe RTT)',
-    's5.lead': '20개 AI 서비스의 API 엔드포인트를 Cloudflare Workers 엣지에서 5분 간격으로 직접 측정합니다. p50 / p75 / p95 분위수를 산출합니다.',
+    's5.lead': '24개 AI 서비스의 API 엔드포인트를 Cloudflare Workers 엣지에서 5분 간격으로 직접 측정합니다. p50 / p75 / p95 분위수를 산출합니다.',
     's5.limit.label': '핵심 한계 — 네트워크 RTT ≠ 추론 레이턴시',
     's5.limit.body': 'Probe RTT는 <strong>네트워크 왕복 시간</strong>을 측정합니다. 모델의 추론(토큰 생성) 레이턴시가 아닙니다. "이 서비스가 얼마나 빨리 토큰을 만드나"가 아니라 "엔드포인트가 네트워크 계층에서 얼마나 빨리 응답하나"를 나타냅니다.',
-    's5.limit.probe': '<strong>Probe 미적용:</strong> 레이턴시 랭킹은 직접 probe하는 20개 AI 서비스만 대상입니다 — 앱·코딩 에이전트, 그리고 probe하지 않는 나머지 7개 AI 서비스는 제외됩니다.',
+    's5.limit.probe': '<strong>Probe 미적용:</strong> 레이턴시 랭킹은 직접 probe하는 24개 AI 서비스만 대상입니다 — 앱·코딩 에이전트, 그리고 probe하지 않는 나머지 3개 AI 서비스는 제외됩니다.',
     's6.title': '인시던트 · MTTR · 탐지',
     's6.counting.title': '인시던트 집계',
     's6.counting.body': '인시던트 수는 서비스별 영향 컴포넌트를 모두 반영합니다. 제공사마다 인시던트를 세분화하는 정도가 다릅니다 — Anthropic은 모델별(Opus/Sonnet/Haiku)로 따로 보고해, 서비스 단위로 묶어 보고하는 곳보다 건수가 부풀려집니다. 따라서 건수가 많다고 신뢰도가 낮은 것은 아니며, 제공사끼리 비교할 때는 이 세분화 차이를 감안해야 합니다.',
@@ -630,7 +630,7 @@ const i18n = {
     's1.lead': 'AIWatch polls 37 AI services — 15 LLM APIs, 6 coding agents, 3 voice, 7 inference & infra, 2 video, and 4 AI apps — up to every 5 minutes. All timestamps are in UTC.',
     's1.sourcesTitle': 'Data sources',
     's1.sourcesDesc': 'Status, incident, and uptime data are all collected from each service\\'s official status page. The provider\\'s published data is the primary source, and we never fill a missing value with our own estimate — how a missing official uptime is handled is covered in the <a href="#uptime">Uptime section</a> below.',
-    's1.src.atlassian': '— many major providers', 's1.src.incidentio': '— per-component incidents + impact', 's1.src.gcloud': '— Gemini API (Google Cloud status + AI Studio component incidents, merged)', 's1.src.others': '— additional status-page platforms (incident RSS + uptime JSON)', 's1.src.flashduty': '— normalized DeepSeek status feed (status.deepseek.com)', 's1.src.awshealth': '— Amazon Bedrock — public events JSON API (incident start/end), no uptime API', 's1.src.rss': '— Azure Status (Azure OpenAI) · xAI (status.x.ai) — incident RSS only, no uptime API', 's1.src.probe': '— direct measurement of 20 AI services\\' API endpoints',
+    's1.src.atlassian': '— many major providers', 's1.src.incidentio': '— per-component incidents + impact', 's1.src.gcloud': '— Gemini API (Google Cloud status + AI Studio component incidents, merged)', 's1.src.others': '— additional status-page platforms (incident RSS + uptime JSON)', 's1.src.flashduty': '— normalized DeepSeek status feed (status.deepseek.com)', 's1.src.awshealth': '— Amazon Bedrock — public events JSON API (incident start/end), no uptime API', 's1.src.rss': '— Azure Status (Azure OpenAI) · xAI (status.x.ai) — incident RSS only, no uptime API', 's1.src.probe': '— direct measurement of 24 AI services\\' API endpoints',
     's1.secTitle': 'Security-issue monitoring',
     's1.secDesc': 'On a track separate from status & reliability, we also track security issues affecting the AI stack, aggregated into the <strong>monthly report</strong>. This data does not feed the AIWatch Score or incident counts.',
     's1.sec.osv': '— SDK vulnerabilities (24 tracked PyPI · npm packages), enriched via GitHub Advisories', 's1.sec.hn': '— security news about AI services (Algolia search API)',
@@ -666,10 +666,10 @@ const i18n = {
     's4.rec.title': 'Recovery Score (0–15)',
     's4.rec.note': 'MTTR is the 30-day median of resolved-incident durations (mean fallback for fewer than 3 incidents).',
     's4.resp.title': 'Responsiveness Score (0–20)',
-    's4.resp.desc': 'Measures actual API endpoint speed and stability via 5-minute health-check probes (20 AI services). Combines response speed and consistency.',
+    's4.resp.desc': 'Measures actual API endpoint speed and stability via 5-minute health-check probes (24 AI services). Combines response speed and consistency.',
     's4.resp.speed': 'Speed (0–10) — exp decay on p50 RTT',
     's4.resp.stability': 'Stability (0–10) — exp decay on combined coefficient of variation',
-    's4.resp.na1': 'Apps and coding agents have no API endpoint to measure; and 7 other AI services outside the 20-service probe set (Bedrock, Azure OpenAI, Pinecone, Modal, LangSmith, Runway, Luma) are not probed either.',
+    's4.resp.na1': 'Apps and coding agents have no API endpoint to measure; and 3 other AI services outside the 24-service probe set (Bedrock, Azure OpenAI, Modal) are not probed either.',
     's4.resp.na2': 'Their score is rescaled from the 80-point base to 100, with a 5% penalty applied to reflect the missing responsiveness signal.',
     's4.resp.naFormula': 'probe-less: rescale base 80 → 100 + 5% confidence penalty',
     's4.resp.insufficient': 'Newly added probed services receive a 5% penalty until 7 days of probe data accumulate.',
@@ -677,10 +677,10 @@ const i18n = {
     's4.noUptime.desc': 'Some services (Gemini, xAI, etc.) do not publish official uptime. In that case an industry average (99.5%, which is 36 on the 40-point scale) is assumed with a 10% penalty applied.',
     's4.grades.title': 'Grade thresholds',
     's5.title': 'Latency (Probe RTT)',
-    's5.lead': 'We measure the API endpoints of 20 AI services directly from the Cloudflare Workers edge every 5 minutes, producing p50 / p75 / p95 percentiles.',
+    's5.lead': 'We measure the API endpoints of 24 AI services directly from the Cloudflare Workers edge every 5 minutes, producing p50 / p75 / p95 percentiles.',
     's5.limit.label': 'Key limit — network RTT ≠ inference latency',
     's5.limit.body': 'Probe RTT measures <strong>network round-trip time</strong>, NOT a model\\'s inference (token-generation) latency. It reflects how fast the endpoint responds at the network layer, not how fast the service generates tokens.',
-    's5.limit.probe': '<strong>No probe:</strong> The latency ranking covers only the 20 directly-probed AI services — apps, coding agents, and 7 other non-probed AI services are excluded.',
+    's5.limit.probe': '<strong>No probe:</strong> The latency ranking covers only the 24 directly-probed AI services — apps, coding agents, and 3 other non-probed AI services are excluded.',
     's6.title': 'Incidents · MTTR · Detection',
     's6.counting.title': 'Incident counting',
     's6.counting.body': 'Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model (Opus/Sonnet/Haiku counted separately), inflating its totals versus service-level reporters. A higher count does not mean lower reliability; adjust for granularity before comparing across providers.',

--- a/docs/reference/data-flow.md
+++ b/docs/reference/data-flow.md
@@ -12,8 +12,8 @@ Browser (React SPA, 60s polling)
     → platform quorum detection: 70%+ same-platform fetch failures → platform outage → hold operational for all affected services
     → probe cross-validation: individual probe RTT normal → hold operational (prevents false positives during status page failures)
   → React state (usePolling hook via PollingContext)
-    → overlay probe RTT onto service.latency (20 probe services)
-    → non-probe services (bedrock, azureopenai, pinecone) keep status page latency
+    → overlay probe RTT onto service.latency (24 probe services)
+    → non-probe services (bedrock, azureopenai, modal) keep status page latency
   → all pages read from context
 
 Cron Trigger (*/5 min)

--- a/docs/reference/kv-schema.md
+++ b/docs/reference/kv-schema.md
@@ -8,7 +8,7 @@
 | `daily:{YYYY-MM-DD}` | `{ [svcId]: { ok, total } }` JSON | 2d | ~288 | Daily uptime counters |
 | `history:{YYYY-MM-DD}` | Same as daily | 90d | 1 | Archived yesterday's counters |
 | `latency:24h` | `{ snapshots: [{ t, data }] }` JSON | 25h | ~48 | 30-min latency snapshots (max 48) |
-| `probe:24h` | `{ snapshots: [{ t, data }] }` JSON | 7d | ~288 | 5-min health check probe results (max 2016, 20 API services) |
+| `probe:24h` | `{ snapshots: [{ t, data }] }` JSON | 7d | ~288 | 5-min health check probe results (max 2016, 24 API services) |
 | `probe:daily:{YYYY-MM-DD}` | `{ [svcId]: { p50, p75, p95, min, max, count, spikes } }` JSON | 90d | 1 | Daily probe RTT summary for monthly reports |
 | `probe:summaries` | `[svcId, ProbeSummary][]` JSON | 80min | ~48 | Cron-cached 7-day probe summaries (p50, p95, cvCombined, validDays); refreshed every 30min via in-memory slot guard, TTL covers up to 2 missed 30-min refresh cycles |
 | `alerted:new:{incId}` | `JSON.stringify(svcIds)` (e.g. `["codex","chatgpt"]`); legacy `"1"` auto-migrated | 7d | ~5 | Incident alert dedup — now the **per-service roster** already alerted for the incident (#545). A service that JOINS a multi-service incident after the first alert fired (e.g. ChatGPT joining a Codex incident after OpenAI renamed the title) is alerted only if NOT in this set, then merged in. Read via `parseAlertedRoster` (legacy `"1"` → seed with the currently-matching service, no re-alert storm on deploy). The cron's dedup loop bypasses the key-exists skip for `alerted:new:` (per-service dedup already happened in `buildIncidentAlerts`); a failed roster write is logged loudly since it would re-fire the alert next cycle |

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -153,7 +153,7 @@ function ServiceCard({ service, index, onClick, t, isRecovered, isProbed }) {
         <div className="grid grid-cols-3" style={{ gap: '6px', marginBottom: '10px', textAlign: 'center' }}>
           <div>
             <div className={`mono text-[13px] font-medium ${latencyColor}`}>{service.latency != null ? `${service.latency}ms` : '—'}</div>
-            {/* #658 — probed services (20 API services) show direct API RTT; label must say so, not
+            {/* #658 — probed services (24 API services, #678) show direct API RTT; label must say so, not
                 "status page" (matches ServiceDetails svc.latency vs svc.latency.statusPage). */}
             <div className="mono text-[9px] text-[var(--text2)]" style={{ letterSpacing: '0.04em' }}>{t(isProbed ? 'overview.card.latency.api' : 'overview.card.latency')}</div>
           </div>

--- a/worker/src/__tests__/probe.test.ts
+++ b/worker/src/__tests__/probe.test.ts
@@ -71,10 +71,11 @@ describe('PROBE_TARGETS', () => {
     'claude', 'openai', 'gemini', 'mistral', 'cohere', 'groq', 'together',
     'fireworks', 'cerebras', 'perplexity', 'huggingface', 'replicate', 'elevenlabs', 'xai', 'deepseek',
     'openrouter', 'stability', 'assemblyai', 'deepgram', 'voyageai',
+    'pinecone', 'langsmith', 'runway', 'luma', // #678 — added (stable representative API path)
   ]
 
-  it('has all 20 API service probe targets', () => {
-    expect(PROBE_TARGETS).toHaveLength(20)
+  it('has all 24 API service probe targets', () => {
+    expect(PROBE_TARGETS).toHaveLength(24)
     const ids = PROBE_TARGETS.map((t) => t.id)
     for (const expected of EXPECTED_IDS) {
       expect(ids).toContain(expected)

--- a/worker/src/probe.ts
+++ b/worker/src/probe.ts
@@ -27,7 +27,17 @@ export const PROBE_TARGETS: ProbeTarget[] = [
   { id: 'assemblyai', url: 'https://api.assemblyai.com/v2/transcript' },
   { id: 'deepgram', url: 'https://api.deepgram.com/v1/models' },
   { id: 'voyageai', url: 'https://api.voyageai.com/v1/embeddings' },
-  // Not feasible: bedrock (no public endpoint), azureopenai (tenant-specific), pinecone (index-specific), modal (no public API), langsmith (API requires auth), runway (API requires auth), luma (API requires auth)
+  // #678 — added after a live cross-check showed these have a stable, representative API path that
+  // returns a fast status without auth (the probe measures RTT and treats ANY HTTP response as
+  // "server alive", so the old "requires auth" exclusions were invalid):
+  { id: 'pinecone', url: 'https://api.pinecone.io/indexes' },                       // control-plane, 401
+  { id: 'langsmith', url: 'https://api.smith.langchain.com/info' },                 // public /info, 200
+  { id: 'runway', url: 'https://api.runwayml.com/v1/tasks' },                       // 401
+  { id: 'luma', url: 'https://api.lumalabs.ai/dream-machine/v1/generations' },      // 403
+  // Not probed (#678): bedrock (region-specific runtime endpoint, estimate-only — incident-derived
+  // reliability is enough), azureopenai (tenant-specific {resource}.openai.azure.com — no generic
+  // endpoint), modal (api.modal.com returns a catch-all 200 on every path — not a representative
+  // API-path RTT)
 ]
 
 /** Compute 5-minute aligned slot string from a Date */

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -124,14 +124,15 @@ export const SERVICES: ServiceConfig[] = [
   // Atlassian Statuspage (page s9lfdrzmhryw) → statuspage.ts covers it, no new parser. Multi-component
   // worst-of (#379): badge tracks the three availability surfaces (Public API + App + Backend); Billing +
   // Support are excluded so non-availability blips don't flip the badge. Single-tenant page → no
-  // incidentKeywords. Probe-less (API requires auth). is-down slug == id ('runway'), so no slug override.
+  // incidentKeywords. Probed since #678 (api.runwayml.com/v1/tasks → 401, auth not needed for RTT).
+  // is-down slug == id ('runway'), so no slug override.
   // Lumped under `inference` for now (avoid a single-member video category until Luma/Pika are added).
   { id: 'runway', name: 'Runway', provider: 'Runway', category: 'api', statusUrl: 'https://status.runwayml.com', apiUrl: 'https://status.runwayml.com/api/v2/summary.json', statusComponentId: 'w3jcq3dwljp4', statusComponentIds: ['w3jcq3dwljp4', '2fr8tksxj5ns', 'hl94rh0mg6xt'] },
   // Luma / Dream Machine (#602, #601 Phase 1) — generative-video AI (Dream Machine, Ray, UNI-1), added
   // as a Runway sibling. Better Stack status page (status.lumalabs.ai) → betterstack.ts parser via
   // rssFeedUrl (incidents) + betterStackUrl /index.json (status + uptime). flapSuppression: true — the
   // page auto-emits "X went down/recovered/degraded" model blips (#283/#597). Video-native, so no
-  // component scoping needed. is-down slug == id ('luma'). Probe-less (API auth-gated).
+  // component scoping needed. is-down slug == id ('luma'). Probed since #678 (dream-machine/v1/generations → 403).
   { id: 'luma', name: 'Luma (Dream Machine)', provider: 'Luma', category: 'api', statusUrl: 'https://status.lumalabs.ai', apiUrl: null, rssFeedUrl: 'https://status.lumalabs.ai/feed', betterStackUrl: 'https://status.lumalabs.ai', flapSuppression: true, componentDenylist: ['Website'] },
   // AI Apps
   { id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app', statusUrl: 'https://status.claude.com', apiUrl: 'https://status.claude.com/api/v2/summary.json', incidentKeywords: ['claude.ai', 'across surfaces', 'claude desktop'], statusComponent: 'claude.ai', statusComponentId: 'rwppv331jlwc' },


### PR DESCRIPTION
> **Stacked on #682** (`feat/673-methodology-page`) because the lockstep touches the `/methodology` page, which only exists on that branch. Base is `feat/673` so this diff shows ONLY the probe changes. After #682 merges, retarget to `main` (rebase).

## Summary
A live cross-check showed `worker/src/probe.ts` excluded 7 API services with **inaccurate reasons** ("requires auth" / "no public API") — the probe measures RTT and treats ANY HTTP response (401/403/404) as "server alive", so those exclusions were invalid. Add the 4 reachable ones with a stable representative API path; keep the 3 genuinely un-probeable with corrected reasons.

**PROBE_TARGETS 20 → 24:**
- pinecone — `api.pinecone.io/indexes` (401, control-plane)
- langsmith — `api.smith.langchain.com/info` (200, public health)
- runway — `api.runwayml.com/v1/tasks` (401)
- luma — `api.lumalabs.ai/dream-machine/v1/generations` (403)

**Kept excluded (corrected reasons):** bedrock (region-specific runtime, estimate-only), azureopenai (tenant-specific subdomain), modal (`api.modal.com` is a **catch-all 200** on every path — not a representative API-path RTT).

## Lockstep (the "20 probed / 7 not probed" + 7-name list was hardcoded in ~12 places)
- `probe.ts` + `probe.test.ts` (count 20→24 + ids); `services.ts` runway/luma "Probe-less" comments corrected
- `/methodology` §1/§4/§5 (ko+en+inline) → **24 / 3** (Bedrock·Azure OpenAI·Modal). The methodology test now **imports `PROBE_TARGETS` and DERIVES** the expected count — so a future probe.ts change that forgets the page **fails the test** (the cross-layer lockstep guard this issue is about)
- `CLAUDE.md`, `README(.ko)`, `kv-schema.md`, `data-flow.md`, `Overview.jsx` comment

## Score side-effect (intended)
The 4 services now get probe-based Responsiveness instead of the no-probe rescale+penalty; `score.ts`'s `<7d`-sample insufficient-data penalty covers the transition week.

## Verification
- **In-browser** (local-mode worker cron, **no prod KV impact**): the 4 appear in the Latency ranking + show "direct API RTT" on Overview. (`probeServiceIds` is derived from the probe data, so no frontend list to update.)
- `test:src` 483 · `test:worker` 1703 · `typecheck:worker` 0 · `wrangler --dry-run` · `npm run build`
- ⚠️ Ranking "Resp. (p50)" needs 7-day accumulated probe data → only populates on prod after a few days (not the live snapshot)

Closes #678
refs #673 (methodology lockstep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)