### PR TITLE
fix(calendar): span resolved multi-day incidents for no-dailyImpact services (#691)

### DIFF
--- a/src/utils/__tests__/calendar.test.js
+++ b/src/utils/__tests__/calendar.test.js
@@ -115,6 +115,123 @@ describe('buildCalendarFromIncidents — Phase 3 ongoing forward-fill (#662)', (
   })
 })
 
+describe('buildCalendarFromIncidents — Phase 2 resolved multi-day span for no-dailyImpact (#691)', () => {
+  it('spans a RESOLVED multi-day incident startedAt→resolvedAt (Bedrock-shaped, service now operational)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    // 3-day outage that resolved: started today-5, resolved today-3. Service recovered → operational.
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(5), resolvedAt: iso(3) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[8]).toBe('major') // today-5 (start)
+    expect(cal[9]).toBe('major') // today-4 (middle — previously left green)
+    expect(cal[10]).toBe('major') // today-3 (resolved day)
+    expect(cal[7]).toBe('operational') // today-6 (before start)
+    expect(cal[11]).toBe('operational') // today-2 (after resolve)
+    expect(cal[13]).toBe('operational') // today
+  })
+
+  it('clamps a RESOLVED incident that started before the window to the window start', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: 'critical', startedAt: iso(20), resolvedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[0]).toBe('critical') // oldest cell (clamped start, no out-of-bounds)
+    expect(cal[11]).toBe('critical') // today-2 (resolved day)
+    expect(cal[12]).toBe('operational') // today-1 (after resolve)
+  })
+
+  it('dailyImpact service: a RESOLVED incident still paints ONLY its start day (official record owns the span)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const dailyImpact = { '2026-06-13': 'minor' } // official record present
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(5), resolvedAt: iso(3) }]
+    const cal = buildCalendarFromIncidents(incidents, dailyImpact, 14, 'operational')
+    expect(cal[8]).toBe('major') // today-5 start day supplemented
+    expect(cal[9]).toBe('operational') // middle NOT spanned — deferred to the official daily record
+    expect(cal[10]).toBe('operational') // resolved day NOT spanned
+  })
+
+  it('no-dailyImpact: an ONGOING incident is unaffected by the Phase 2 span (still start-day only here)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    // ongoing (no resolvedAt) on an operational service → Phase 3 gate is off, so only the start day paints
+    const incidents = [{ status: 'investigating', impact: 'major', startedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[11]).toBe('major') // start day
+    expect(cal[12]).toBe('operational') // not spanned (Phase 3 gated on non-operational)
+    expect(cal[13]).toBe('operational') // today
+  })
+
+  it('guards a malformed resolvedAt — falls back to painting the start day only', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(4), resolvedAt: 'not-a-date' }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[9]).toBe('major') // start day (today-4)
+    expect(cal[10]).toBe('operational') // no span from a bad resolvedAt
+  })
+
+  it('clamps a FUTURE resolvedAt to today (never paints beyond the window)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    // resolvedAt 2 days in the FUTURE (clock skew / bad feed) → span must cap at today
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(2), resolvedAt: iso(-2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[11]).toBe('major') // start day (today-2)
+    expect(cal[13]).toBe('major') // today — clamped end
+    expect(() => buildCalendarFromIncidents(incidents, undefined, 14, 'operational')).not.toThrow()
+  })
+
+  it('paints the start day only for an INVERTED range (resolvedAt < startedAt), never nothing', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: 'critical', startedAt: iso(3), resolvedAt: iso(5) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[10]).toBe('critical') // start day (today-3) still painted
+    expect(cal[8]).toBe('operational') // does NOT paint backwards toward the inverted "end"
+  })
+
+  it('single-day RESOLVED span (startedAt === resolvedAt) paints exactly one cell', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: 'major', startedAt: iso(3), resolvedAt: iso(3) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[9]).toBe('operational') // day before
+    expect(cal[10]).toBe('major') // the single span day (loop runs exactly once)
+    expect(cal[11]).toBe('operational') // day after
+  })
+
+  it('null-impact RESOLVED multi-day span paints minor (Bedrock-shaped null impact)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [{ status: 'resolved', impact: null, startedAt: iso(4), resolvedAt: iso(2) }]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[9]).toBe('minor') // start
+    expect(cal[10]).toBe('minor') // middle
+    expect(cal[11]).toBe('minor') // resolved day
+  })
+
+  it('overlapping RESOLVED spans merge worst-of (minor span ∪ critical span)', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    const incidents = [
+      { status: 'resolved', impact: 'minor', startedAt: iso(6), resolvedAt: iso(2) }, // 5-day minor
+      { status: 'resolved', impact: 'critical', startedAt: iso(4), resolvedAt: iso(3) }, // 2-day critical (overlaps)
+    ]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'operational')
+    expect(cal[7]).toBe('minor') // today-6: minor only
+    expect(cal[9]).toBe('critical') // today-4: overlap → worst-of red
+    expect(cal[10]).toBe('critical') // today-3: overlap → red
+    expect(cal[11]).toBe('minor') // today-2: minor tail only
+  })
+
+  it('composes Phase 2 resolved span + Phase 3 ongoing fill on the same no-dailyImpact service', () => {
+    vi.setSystemTime(new Date('2026-06-18T09:00:00Z'))
+    // A past resolved multi-day outage AND a currently-ongoing one, service live status = down.
+    const incidents = [
+      { status: 'resolved', impact: 'major', startedAt: iso(8), resolvedAt: iso(6) }, // past, spanned by Phase 2
+      { status: 'investigating', impact: 'critical', startedAt: iso(1) }, // ongoing, filled by Phase 3
+    ]
+    const cal = buildCalendarFromIncidents(incidents, undefined, 14, 'down')
+    expect(cal[5]).toBe('major') // today-8 (resolved start)
+    expect(cal[6]).toBe('major') // today-7 (resolved middle — Phase 2 span)
+    expect(cal[7]).toBe('major') // today-6 (resolved end)
+    expect(cal[8]).toBe('operational') // today-5 (gap between the two incidents)
+    expect(cal[12]).toBe('critical') // today-1 (ongoing start — Phase 3)
+    expect(cal[13]).toBe('critical') // today (ongoing → forward-filled)
+  })
+})
+
 describe('calendar cell keys ↔ cal.status.* i18n coverage (#663 decoupling pin)', () => {
   it('every calendar cell key has a cal.status.* label in both en and ko', async () => {
     const { default: en } = await import('../../locales/en')

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -55,11 +55,38 @@ export function buildCalendarFromIncidents(incidents, dailyImpact, days = 30, cu
   // adding incidents would introduce noise from unrelated components.
   // incident.io (14-day) and others: supplement Phase 1 with keyword-filtered incidents.
   if (!(dailyImpact && days === 30)) {
+    const windowStart = new Date(today.getTime() - (days - 1) * 86_400_000)
     ;(incidents ?? []).forEach((inc) => {
       if (!inc.startedAt) return
-      const key = toLocalDateKey(new Date(inc.startedAt))
-      // Same impact→cell map for ongoing and resolved (minor/null/unknown → 'minor' yellow).
-      escalate(dayStatus, key, impactToCellStatus(inc.impact))
+      const start = new Date(inc.startedAt)
+      if (isNaN(start.getTime())) return
+      const status = impactToCellStatus(inc.impact) // same map for ongoing/resolved (minor/null → yellow)
+      // dailyImpact services (incident.io 14-day): the official per-day record (Phase 1) owns the
+      // days — supplement only the START day to avoid spanning noise across unrelated components.
+      // Ongoing incidents likewise paint only the start day here (Phase 3 extends them to today).
+      // no-dailyImpact services (RSS/JSON-only: Bedrock/Azure) with a RESOLVED incident have no
+      // per-day record, so the incident must span its OWN days startedAt→resolvedAt (window-clamped),
+      // else a multi-day outage shows only its start day (#691 — surfaced by #677's real durations).
+      if (dailyImpact || !inc.resolvedAt) {
+        escalate(dayStatus, toLocalDateKey(start), status)
+        return
+      }
+      const end = new Date(inc.resolvedAt)
+      // A malformed OR inverted (resolvedAt < startedAt) range can't be spanned — paint the start
+      // day only, never nothing (an inverted range would make the loop run zero times otherwise).
+      if (isNaN(end.getTime()) || end.getTime() < start.getTime()) {
+        escalate(dayStatus, toLocalDateKey(start), status)
+        return
+      }
+      const from = start < windowStart ? windowStart : start
+      const endClamped = end.getTime() > today.getTime() ? today : end // guard a future resolvedAt
+      const endKey = toLocalDateKey(endClamped)
+      // step day-by-day (noon-anchored, DST-safe) from start → resolved, inclusive
+      for (let cur = new Date(from.getFullYear(), from.getMonth(), from.getDate(), 12);
+           toLocalDateKey(cur) <= endKey;
+           cur.setDate(cur.getDate() + 1)) {
+        escalate(dayStatus, toLocalDateKey(cur), status)
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
The ServiceDetails **Status Calendar** painted only the **start day** of a RESOLVED multi-day incident on a service with **no `dailyImpact`** (RSS/JSON-only: Bedrock, Azure OpenAI). The Bedrock "Fable 5 and Mythos 5 Access" outage (6/13 01:26Z → 6/15 18:13Z = **6/13–6/16 KST**, 64h47m) showed only 6/13.

## Root cause (`src/utils/calendar.js` `buildCalendarFromIncidents`)
For a no-`dailyImpact` service:
- **Phase 1** (per-day official record) — skipped (none).
- **Phase 2** — painted only `inc.startedAt` (one day).
- **Phase 3** (forward-fill) — `return`s for `status === 'resolved'` AND is gated on `currentStatus !== 'operational'` (the service is now operational).

→ A resolved multi-day incident's middle/end days fell through every phase.

**Surfaced by #677**: pre-#677 Bedrock incidents were a 1m single point (`startedAt === resolvedAt`), so one cell was correct; the AWS Health JSON API now yields real multi-day durations, exposing the gap.

## Fix
Phase 2's **no-`dailyImpact`** branch now spans a resolved incident's own days `startedAt → resolvedAt` (window-clamped, noon-anchored DST-safe step), with guards: future `resolvedAt` clamps to today; inverted (`resolvedAt < startedAt`) / malformed dates fall back to the start day only (never zero cells).
- `dailyImpact` services keep `startedAt`-only — Phase 1's official daily record owns those cells (no spanning noise).
- Ongoing incidents unchanged (Phase 3 still extends them to today).
- Badge/Score untouched — purely the calendar cell painting.

Azure OpenAI benefits too (same no-`dailyImpact` path).

## Tests (`src/utils/__tests__/calendar.test.js`, +11 cases)
multi-day span · window clamp · future-`resolvedAt` clamp · inverted-range guard · malformed-`resolvedAt` guard · single-day span (loop runs exactly once) · null-impact span · overlapping resolved worst-of merge · dailyImpact-service-not-spanned · ongoing-unaffected · Phase 2 resolved ∪ Phase 3 ongoing composition.

## Verification
- PR review (code + test analyzers): converged 0 Critical/Important
- `npm run test:src` → **493 pass** · `npm run build` clean · `npm test` (Playwright e2e) → **131 pass**
- **In-browser verified** (local worker live AWS Health data): Bedrock calendar now shows **6/13–6/16** contiguous (major); dailyImpact services (OpenAI/Claude) unchanged

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)