### PR TITLE
feat(is-down): lift outage notify conversion — UTM-tag tweet links + Slack-primary CTA (#696)

### DIFF
--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -867,20 +867,35 @@ describe('RSS feed surfacing on /is-*-down (#430)', () => {
     }
   })
 
-  it('renders the PRIMARY "Notify me via RSS" button that copies the feed URL (#547)', () => {
+  it('renders the PRIMARY Slack-feed button (#696 — zero-config action is primary)', () => {
     const html = renderPage('claude', mkService(), mkSeo(), [])
-    // #547: RSS is the primary (btn-primary) CTA — the only channel that converted on the
-    // outage day. Lock the exact primary markup + label.
+    // #696: Slack /feed (paste a command into any channel) is the lowest-friction ACTION for the
+    // dev/team audience, so it owns btn-primary. Lock the exact primary markup + label.
     expect(html).toContain(
-      '<button type="button" class="btn btn-primary" data-rss="https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copyRss(this)">🔔 Notify me via RSS</button>',
+      '<button type="button" class="btn btn-primary" data-slack="/feed subscribe https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copySlackFeed(this)">💬 Get alerts in Slack</button>',
+    )
+    expect(html).toContain('function copySlackFeed(b)')
+    expect(html).toContain("gtag('event','copy_slack_feed',{location:'is_down_page',service_id:b.dataset.svc})")
+    // prompt() fallback for insecure-context / writeText-rejection paths
+    expect(html).toContain("prompt('Copy Slack command:',c)")
+  })
+
+  it('renders the SECONDARY RSS button + the action-explicit helper line (#696)', () => {
+    const html = renderPage('claude', mkService(), mkSeo(), [])
+    // RSS is demoted to a secondary (.btn, not .btn-primary) and relabeled away from jargon —
+    // "Copy alert link (RSS)" + a helper line spelling out where to paste it (the #696 fix for the
+    // 9-sessions→0-conversions leak: "Notify me via RSS" copied a URL panic visitors couldn't use).
+    expect(html).toContain(
+      '<button type="button" class="btn" data-rss="https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copyRss(this)">🔗 Copy alert link (RSS)</button>',
     )
     expect(html).toContain('function copyRss(b)')
     expect(html).toContain('navigator.clipboard.writeText(u)')
-    // prompt() fallback for insecure-context / writeText-rejection paths (label text unchanged)
     expect(html).toContain("prompt('Copy RSS URL:',u)")
+    // helper line makes each action's destination explicit
+    expect(html).toMatch(/<p class="cta-help">.*Slack.*paste the command.*RSS.*paste the link/)
   })
 
-  it('demotes the Discord double-opt-in to a de-emphasized secondary text link (#547)', () => {
+  it('demotes the Discord double-opt-in to a de-emphasized secondary text link (#547/#696)', () => {
     const html = renderPage('claude', mkService(), mkSeo(), [])
     // The heavy Discord per-user push keeps the #546 deep-link (scrolls to the Alerts section)
     // but is no longer a btn-primary; it is a .cta-alt text link tagged status_banner_secondary
@@ -890,19 +905,8 @@ describe('RSS feed surfacing on /is-*-down (#430)', () => {
     // No "email" channel exists yet — the link must not advertise one.
     expect(html).toContain('Prefer Discord push alerts?')
     expect(html).not.toContain('email push')
-    // The Discord path must NOT be a btn-primary anchor anymore (RSS owns btn-primary).
+    // The Discord path must NOT be a btn-primary anchor (the Slack button owns btn-primary, #696).
     expect(html).not.toMatch(/<a[^>]*class="btn btn-primary"/)
-  })
-
-  it('renders a "Copy Slack command" button with the per-service /feed subscribe command (#467)', () => {
-    const html = renderPage('claude', mkService(), mkSeo(), [])
-    expect(html).toContain(
-      '<button type="button" class="btn" data-slack="/feed subscribe https://ai-watch.dev/feed/claude" data-svc="claude" onclick="copySlackFeed(this)">Copy Slack command</button>',
-    )
-    expect(html).toContain('function copySlackFeed(b)')
-    expect(html).toContain("gtag('event','copy_slack_feed',{location:'is_down_page',service_id:b.dataset.svc})")
-    // prompt() fallback for insecure-context / writeText-rejection paths
-    expect(html).toContain("prompt('Copy Slack command:',c)")
   })
 
   it('keys data-svc on the service ID, not the page slug, so copy_rss matches other per-service events', () => {

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -266,6 +266,7 @@ button.btn{cursor:pointer;font-family:inherit;line-height:inherit}
 .cta{background:#0d1117;border:1px solid rgba(255,255,255,0.07);border-radius:8px;padding:16px 20px;text-align:center;margin:16px 0}
 .cta-title{font-size:14px;font-weight:600;margin-bottom:10px}
 .cta-buttons{display:flex;gap:8px;justify-content:center;flex-wrap:wrap}
+.cta-help{font-size:11.5px;margin-top:8px;color:#8b949e;line-height:1.5}
 .cta-alt{font-size:12px;margin-top:10px;color:#8b949e}
 .cta-alt a{color:#8b949e;text-decoration:underline}
 .cta-alt a:hover{color:#c9d1d9}
@@ -552,24 +553,27 @@ function renderCTA(seo: ServiceSEO, status: string, slug: string, svcId: string)
     ? `${seo.displayName} is down right now.`
     : `${seo.displayName} is having issues right now.`
   const message = isDown
-    ? `${stateLead} Get notified when it recovers.`
-    : `Get notified when ${seo.displayName} goes down`
-  // #547: the outage-day funnel leaked — 3 clicks on the Discord double-opt-in CTA,
-  // 0 webhook_register; the only channel that converted was the zero-config RSS copy
-  // (copy_rss 3×). So lead with the lowest-friction channel: RSS is the PRIMARY button,
-  // Slack /feed the secondary, and the heavy Discord per-user push (double opt-in) is demoted
-  // to a de-emphasized text link so it no longer out-competes the converting channel for the
-  // click. (copy_rss remains the success proxy; we compare its rate vs the 3→0 baseline.)
-  // data-rss uses the page slug (feed URL is /feed/{slug}); data-svc uses the service ID
-  // so copy_rss keys on the same id as fallback_click / click_service_detail (id and slug
-  // diverge for claude-code, github-copilot, etc.).
+    ? `${stateLead} Stop refreshing — we'll ping you when it's back.`
+    : `Get notified the next time ${seo.displayName} goes down.`
+  // #547/#696: the outage-day funnel leaked — 9 is-down sessions on the 6/11 Claude outage → 0
+  // copy_rss / 0 click_cta_alerts. "Notify me via RSS" reads as power-user jargon (it copies a feed
+  // URL the panic visitor can't use without an RSS reader). So #696 reframes around the lowest-friction
+  // ACTION for this audience: Slack /feed (zero-config — paste a command into any channel) is the
+  // PRIMARY button, the RSS link is secondary (explicitly "paste into Slack/Teams/any reader"), and
+  // the heavy Discord per-user push (double opt-in) stays a de-emphasized text link. A one-line helper
+  // makes each action's destination explicit. Success proxies: copy_slack_feed (primary) + copy_rss
+  // (secondary), compared vs the 3→0 baseline on the next larger-n outage.
+  // data-rss/data-slack use the page slug (feed URL is /feed/{slug}); data-svc uses the service ID
+  // so the events key on the same id as fallback_click / click_service_detail (id and slug diverge
+  // for claude-code, github-copilot, etc.).
   return `<div class="cta">
 <p class="cta-title">${esc(message)}</p>
 <div class="cta-buttons">
-<button type="button" class="btn btn-primary" data-rss="https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copyRss(this)">🔔 Notify me via RSS</button>
 <!-- Slack subscribes via its native /feed RSS app (#467) — paste into any channel, zero webhook setup. -->
-<button type="button" class="btn" data-slack="/feed subscribe https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copySlackFeed(this)">Copy Slack command</button>
+<button type="button" class="btn btn-primary" data-slack="/feed subscribe https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copySlackFeed(this)">💬 Get alerts in Slack</button>
+<button type="button" class="btn" data-rss="https://ai-watch.dev/feed/${esc(slug)}" data-svc="${esc(svcId)}" onclick="copyRss(this)">🔗 Copy alert link (RSS)</button>
 </div>
+<p class="cta-help">💬 Slack: paste the command into any channel — done. &middot; 🔗 RSS: paste the link into Slack, Teams, or any reader.</p>
 <p class="cta-alt"><a href="https://ai-watch.dev/#settings?focus=alerts" onclick="typeof gtag==='function'&&gtag('event','click_cta_alerts',{location:'is_down_page',source:'status_banner_secondary'})">Prefer Discord push alerts? Set up here &rarr;</a></p>
 </div>
 <script>
@@ -580,8 +584,8 @@ function copyRss(b){
   else{prompt('Copy RSS URL:',u)}
 }
 function copySlackFeed(b){
-  var c=b.dataset.slack;
-  function done(){b.textContent='Copied!';setTimeout(function(){b.textContent='Copy Slack command'},2000);typeof gtag==='function'&&gtag('event','copy_slack_feed',{location:'is_down_page',service_id:b.dataset.svc})}
+  var c=b.dataset.slack, orig=b.textContent;
+  function done(){b.textContent='Copied! Paste into any Slack channel';setTimeout(function(){b.textContent=orig},2200);typeof gtag==='function'&&gtag('event','copy_slack_feed',{location:'is_down_page',service_id:b.dataset.svc})}
   if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(c).then(done).catch(function(){prompt('Copy Slack command:',c)})}
   else{prompt('Copy Slack command:',c)}
 }

--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -80,10 +80,11 @@ test.describe('Is X Down? SSR pages', () => {
       test(`has CTA alert banner`, async ({ page: p }) => {
         await p.goto(`/is-${page.slug}-down`, { waitUntil: 'domcontentloaded' })
         await expect(p.locator('.cta')).toBeVisible()
-        // #547: the PRIMARY CTA is now the zero-friction RSS copy button (the only channel that
-        // converted on the outage day); the Discord double-opt-in is demoted to a
+        // #696: the PRIMARY CTA is the zero-config Slack /feed button (lowest-friction action for the
+        // dev/team audience); RSS is the secondary button; the Discord double-opt-in stays a
         // de-emphasized secondary text link (.cta-alt) that still carries the focus=alerts href.
-        await expect(p.locator('.cta button.btn-primary[data-rss]')).toBeVisible()
+        await expect(p.locator('.cta button.btn-primary[data-slack]')).toBeVisible()
+        await expect(p.locator('.cta button[data-rss]')).toBeVisible()
         await expect(p.locator('.cta a.btn-primary')).toHaveCount(0)
         await expect(p.locator('.cta .cta-alt a')).toHaveAttribute('href', 'https://ai-watch.dev/#settings?focus=alerts')
       })
@@ -344,13 +345,18 @@ test.describe('Is X Down? SSR pages', () => {
       if (aiIdx >= 0) expect(aiIdx).toBeGreaterThan(ctaIdx)
     })
 
-    test('primary CTA is the RSS copy button; Discord demoted to secondary link (#547)', async ({ page }) => {
+    test('primary CTA is the Slack-feed button; RSS secondary; Discord demoted to a text link (#547/#696)', async ({ page }) => {
       await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
-      // Primary = zero-friction RSS button → fires copy_rss (success proxy) via copyRss().
-      const primary = page.locator('.cta button.btn-primary[data-rss]')
+      // #696 Primary = zero-config Slack /feed button → fires copy_slack_feed (success proxy).
+      const primary = page.locator('.cta button.btn-primary[data-slack]')
       await expect(primary).toBeVisible()
-      expect(await primary.getAttribute('onclick')).toContain('copyRss(this)')
-      // Heavy Discord path is now a de-emphasized text link, tagged source=status_banner_secondary
+      expect(await primary.getAttribute('onclick')).toContain('copySlackFeed(this)')
+      // RSS is the secondary button now (.btn, not .btn-primary) → still fires copy_rss.
+      const rss = page.locator('.cta button[data-rss]')
+      await expect(rss).toBeVisible()
+      expect(await rss.getAttribute('onclick')).toContain('copyRss(this)')
+      expect(await rss.getAttribute('class')).not.toContain('btn-primary')
+      // Heavy Discord path is a de-emphasized text link, tagged source=status_banner_secondary
       // so the funnel comparison can tell post-reorder clicks apart from the old primary placement.
       const onclick = await page.locator('.cta .cta-alt a').getAttribute('onclick')
       expect(onclick).toContain("'click_cta_alerts'")
@@ -363,17 +369,16 @@ test.describe('Is X Down? SSR pages', () => {
       // fall back to any is-down page — we check the copy's shape, not the status.
       await page.goto('/is-chatgpt-down', { waitUntil: 'domcontentloaded' })
       const ctaText = await page.locator('.cta').textContent()
-      // Accept either down-state copy (#546: "<svc> is down/having issues right now.
-      // Get notified when it recovers.") or operational copy ("Get notified when X
-      // goes down") — both are acceptable; we check shape, not the live status.
-      const isDownCopy = /is (down|having issues) right now\.\s*Get notified when it recovers/i.test(ctaText || '')
-      const isOperationalCopy = /Get notified when .* goes down/i.test(ctaText || '')
+      // Accept either down-state copy (#696: "<svc> is down/having issues right now.
+      // Stop refreshing — we'll ping you when it's back.") or operational copy
+      // ("Get notified the next time X goes down.") — check shape, not live status.
+      const isDownCopy = /is (down|having issues) right now\.\s*Stop refreshing/i.test(ctaText || '')
+      const isOperationalCopy = /Get notified the next time .* goes down/i.test(ctaText || '')
       expect(isDownCopy || isOperationalCopy).toBe(true)
 
-      // #547: the primary button is now the zero-friction RSS notify button (both states);
-      // the title copy (#546 benefit framing) is unchanged above.
+      // #696: the primary button is the zero-config Slack-feed button (both states).
       const btnText = (await page.locator('.cta button.btn-primary').textContent()) || ''
-      expect(btnText).toMatch(/Notify me via RSS/i)
+      expect(btnText).toMatch(/Get alerts in Slack/i)
     })
   })
 })

--- a/worker/src/__tests__/tweet-draft.test.ts
+++ b/worker/src/__tests__/tweet-draft.test.ts
@@ -41,20 +41,29 @@ describe('buildTweetDraft', () => {
     })
     const draft = buildTweetDraft(alert(), [svc])
     expect(draft).not.toBeNull()
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: API returning 500s. Live status → https://ai-watch.dev/is-claude-down?e=down')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: API returning 500s. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
     expect(draft!.intentUrl).toBe(X_INTENT + encodeURIComponent(draft!.text))
+  })
+
+  it('#696 — tags the is-down link with the X UTM campaign (for GA4 attribution), after the ?e= hint', () => {
+    const svc = mockService({ status: 'down' })
+    const draft = buildTweetDraft(alert({ key: 'alerted:down:claude', title: '🔴 Claude API — Service Down' }), [svc])
+    // utm rides as &-params AFTER ?e=, so the canonical is-down path is unchanged and ?e= still toggles
+    expect(draft!.text).toContain('?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
+    // the encoded intent URL carries it too (so the X click lands tagged even with a stripped referrer)
+    expect(draft!.intentUrl).toContain(encodeURIComponent('utm_source=x'))
   })
 
   it('falls back to status phrasing for a status-only down alert (no incident)', () => {
     const svc = mockService({ id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'down' })
     const draft = buildTweetDraft(alert({ key: 'alerted:down:openai', title: '🔴 OpenAI API — Service Down' }), [svc])
-    expect(draft!.text).toBe('🔴 OpenAI API is reporting an outage. Live status → https://ai-watch.dev/is-openai-down?e=down')
+    expect(draft!.text).toBe('🔴 OpenAI API is reporting an outage. Live status → https://ai-watch.dev/is-openai-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('uses "degraded performance" for a degraded status alert', () => {
     const svc = mockService({ id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app', status: 'degraded' })
     const draft = buildTweetDraft(alert({ key: 'alerted:degraded:chatgpt', title: '🟠 ChatGPT — Partially Degraded' }), [svc])
-    expect(draft!.text).toBe('🔴 ChatGPT is reporting degraded performance. Live status → https://ai-watch.dev/is-chatgpt-down?e=degraded')
+    expect(draft!.text).toBe('🔴 ChatGPT is reporting degraded performance. Live status → https://ai-watch.dev/is-chatgpt-down?e=degraded&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('maps minor incident impact to "degraded performance"', () => {
@@ -63,7 +72,7 @@ describe('buildTweetDraft', () => {
       incidents: [{ id: 'inc1', title: 'Slow responses', status: 'investigating', startedAt: new Date().toISOString(), impact: 'minor' } as any],
     })
     const draft = buildTweetDraft(alert(), [svc])
-    expect(draft!.text).toBe('🔴 Claude API is reporting degraded performance: Slow responses. Live status → https://ai-watch.dev/is-claude-down?e=degraded')
+    expect(draft!.text).toBe('🔴 Claude API is reporting degraded performance: Slow responses. Live status → https://ai-watch.dev/is-claude-down?e=degraded&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('builds a recovery draft with duration parsed from the resolved title (claude.ai slug)', () => {
@@ -72,19 +81,19 @@ describe('buildTweetDraft', () => {
       incidents: [{ id: 'incX', title: 'Resolved', status: 'resolved', startedAt: new Date().toISOString(), duration: '1h 20m', impact: 'major' } as any],
     })
     const draft = buildTweetDraft(alert({ key: 'alerted:res:incX', title: '🟢 claude.ai — Incident Resolved (1h 20m)' }), [svc])
-    expect(draft!.text).toBe('🟢 claude ai recovered after 1h 20m. Live status → https://ai-watch.dev/is-claude-ai-down?e=resolved')
+    expect(draft!.text).toBe('🟢 claude ai recovered after 1h 20m. Live status → https://ai-watch.dev/is-claude-ai-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('builds a recovery draft from a service-recovered status alert', () => {
     const svc = mockService({ status: 'operational' })
     const draft = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered (45m)' }), [svc])
-    expect(draft!.text).toBe('🟢 Claude API recovered after 45m. Live status → https://ai-watch.dev/is-claude-down?e=resolved')
+    expect(draft!.text).toBe('🟢 Claude API recovered after 45m. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('omits duration when the recovery title has none', () => {
     const svc = mockService({ status: 'operational' })
     const draft = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered' }), [svc])
-    expect(draft!.text).toBe('🟢 Claude API has recovered. Live status → https://ai-watch.dev/is-claude-down?e=resolved')
+    expect(draft!.text).toBe('🟢 Claude API has recovered. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('resolves the claudecode → claude-code slug and maps critical impact to "a major outage"', () => {
@@ -93,7 +102,7 @@ describe('buildTweetDraft', () => {
       incidents: [{ id: 'inc1', title: 'CLI down', status: 'investigating', startedAt: new Date().toISOString(), impact: 'critical' } as any],
     })
     const draft = buildTweetDraft(alert(), [svc])
-    expect(draft!.text).toBe('🔴 Claude Code is reporting a major outage: CLI down. Live status → https://ai-watch.dev/is-claude-code-down?e=down')
+    expect(draft!.text).toBe('🔴 Claude Code is reporting a major outage: CLI down. Live status → https://ai-watch.dev/is-claude-code-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('skips a non-target sibling and resolves the in-scope service in a shared-incident group', () => {
@@ -103,7 +112,7 @@ describe('buildTweetDraft', () => {
     const gemini = mockService({ id: 'gemini', name: 'Gemini API', provider: 'Google', status: 'down', incidents: [inc] })
     const claude = mockService({ status: 'down', incidents: [inc] })
     const draft = buildTweetDraft(alert(), [gemini, claude])
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Shared multi-provider outage. Live status → https://ai-watch.dev/is-claude-down?e=down')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Shared multi-provider outage. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('consults _mergedKeys when resolving the covered service', () => {
@@ -113,7 +122,7 @@ describe('buildTweetDraft', () => {
       incidents: [{ id: 'incA', title: 'Merged incident', status: 'investigating', startedAt: new Date().toISOString(), impact: 'major' } as any],
     })
     const draft = buildTweetDraft(alert({ key: 'alerted:new:incA', _mergedKeys: ['alerted:new:incA', 'alerted:new:incB'] }), [svc])
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Merged incident. Live status → https://ai-watch.dev/is-claude-down?e=down')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Merged incident. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('returns null for a non-target service', () => {
@@ -194,7 +203,7 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
   it('builds recovery drafts per surface for a resolved multi-surface incident', () => {
     const drafts = buildTweetDrafts(alert({ key: 'alerted:res:opus47', title: '🟢 Claude API — Incident Resolved (34m)' }), anthropic)
     expect(drafts).toHaveLength(3)
-    expect(drafts[0].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-down?e=resolved')
+    expect(drafts[0].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
     expect(drafts[1].text).toContain('🟢 claude ai recovered after 34m') // #539: brand defused
   })
 
@@ -360,11 +369,11 @@ describe('buildTweetForService brand defuse + status hint (#539)', () => {
   it('appends ?e=resolved on recovery and ?e=<status> on outage (distinct URLs)', () => {
     const recSvc = mockService({ status: 'operational' })
     const rec = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered (45m)' }), [recSvc])!
-    expect(rec.text).toContain('is-claude-down?e=resolved')
+    expect(rec.text).toContain('is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
 
     const downSvc = mockService({ status: 'down', incidents: [{ id: 'inc1', title: 'down', status: 'investigating', startedAt: new Date().toISOString(), impact: 'major' } as any] })
     const down = buildTweetDraft(alert(), [downSvc])!
-    expect(down.text).toContain('is-claude-down?e=down')
+    expect(down.text).toContain('is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
     // the two transitions yield different URLs → fresh unfurl
     expect(rec.text).not.toBe(down.text)
   })

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -481,6 +481,13 @@ export const TWEET_DRAFT_SERVICES: Record<string, string> = {
 const TWEET_MAX = 270
 const X_INTENT_BASE = 'https://twitter.com/intent/tweet?text='
 
+// #696 — UTM campaign on the is-down link the operator tweets. X mobile-app clicks strip the HTTP
+// referrer, so without this they bucket as GA4 (direct)/(none) and X-driven outage inflow is
+// invisible (the #547 funnel couldn't separate organic from X). The is-down Edge ignores unknown
+// query params and keeps a clean rel=canonical, so the canonical URL is NOT polluted. Appended AFTER
+// appendStatusHint (which always adds ?e=…), so the separator is always '&'.
+const X_UTM = 'utm_source=x&utm_medium=social&utm_campaign=outage'
+
 /** Single-line, tweet-safe text: drop backticks (would break the Discord blockquote preview AND
  *  read oddly on X) and collapse all whitespace/newlines to single spaces. */
 function cleanForTweet(s: string): string {
@@ -532,7 +539,7 @@ function buildTweetForService(
   // service status has flipped off 'operational', so clamp that edge to 'active' (never emit
   // ?e=operational on an outage share). The only requirement is outage URL ≠ recovery URL.
   const hint = isRecovery ? 'resolved' : svc.status === 'operational' ? 'active' : svc.status
-  const url = appendStatusHint(`https://ai-watch.dev/is-${TWEET_DRAFT_SERVICES[svc.id]}-down`, hint)
+  const url = `${appendStatusHint(`https://ai-watch.dev/is-${TWEET_DRAFT_SERVICES[svc.id]}-down`, hint)}&${X_UTM}`
 
   let text: string
   if (isRecovery) {


### PR DESCRIPTION
Combines the (a) attribution + (b) copy work for the #547 conversion leak (issue #696).

## Why
On the 2026-06-11 Claude **major** outage, **9 sessions landed on `/is-claude-down`** yet produced **`copy_rss 0` / `click_cta_alerts 0`** — the RSS-primary reorder (#567) did not convert the panic visitor. Separately, **91% of inflow bucketed `(direct)/(none)`** (X-app clicks strip the referrer; the is-down links carried no UTM), so X-driven traffic was invisible.

## (a) UTM attribution — `worker/src/alerts.ts`
`buildTweetForService` appends `utm_source=x&utm_medium=social&utm_campaign=outage` to the is-down URL it embeds in each operator tweet draft (after `appendStatusHint`'s `?e=…`, so the separator is always `&`). X-app clicks now land tagged regardless of referrer stripping. The is-down Edge ignores unknown query params and keeps a clean `rel=canonical`, so the canonical URL is not polluted.

## (b) CTA copy rework — `api/is-down/html-template.ts`
"Notify me via RSS" read as power-user jargon (it copies a feed URL a panic visitor can't use without an RSS reader). Reframed around the lowest-friction **action** for the dev/team audience:
- **Primary** (`btn-primary`): **💬 Get alerts in Slack** — Slack `/feed` is zero-config (paste a command into any channel) → `copy_slack_feed`
- **Secondary**: **🔗 Copy alert link (RSS)** → `copy_rss`
- **Helper line** spelling out each destination (Slack channel / Slack·Teams·any reader)
- New outage title: **"Stop refreshing — we'll ping you when it's back."** (`isDown` covers `down` + `degraded`)
- Discord double-opt-in stays the de-emphasized tertiary text link (`status_banner_secondary`)

Events unchanged (`copy_slack_feed` primary proxy, `copy_rss` secondary) so the next larger-n outage stays comparable to the 3→0 baseline.

**Scope note:** the dashboard ActionBanner is RSS-only/low-friction (no Discord double-opt-in) — not the measured leak surface — so it's left unchanged.

## Tests
- `tweet-draft.test.ts` — 13 URL assertions updated + a dedicated #696 UTM test (text URL + `%26`-encoded intent URL).
- `is-down/html-template.test.ts` — Slack-primary markup, RSS-secondary, helper line, Discord-not-btn-primary.
- `is-down.spec.js` (e2e) — primary/secondary + new copy.
- `test:worker` **1730** · `test:src` **483** · `typecheck:worker` clean · `build` · e2e **is-down 136 + SPA 131** pass.

## Verification
- PR review: converged 0 Critical/Important.
- **In-browser verified** (vercel dev, live data): `/is-claude-down` (operational) shows "Get notified the next time…"; `/is-chatgpt-down` (degraded, active incident) shows "ChatGPT is having issues right now. Stop refreshing — we'll ping you when it's back." + the Slack-primary CTA. UTM verified via unit test (operator Discord tweet-draft link).

## Deploy
**Worker deploy required after merge** (`buildTweetForService` change). Frontend/Edge auto-deploys via Vercel.

## Re-measure (refs #547/#428)
After deploy, the next larger-n outage re-runs the funnel vs the 3→0 baseline with clean X-vs-organic attribution. #547/#428 stay open at verify-after 2026-07-15.

refs #547 #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)