### PR TITLE
fix(deepgram): surface 'Voice Agent API: Downstream Providers' in the breakdown (#692)

### DIFF
--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -501,7 +501,7 @@ describe('displayComponentIds config sanity (#606)', () => {
 
   // #606 — single-owner statuspages: a curated displayComponentIds breakdown + the existing
   // single statusComponentId badge (so the badge is unchanged; statusComponentIds plural absent).
-  const SINGLE_OWNER_COUNT: Record<string, number> = { assemblyai: 6, deepgram: 8, characterai: 5, junie: 2, voyageai: 2, pinecone: 6 }
+  const SINGLE_OWNER_COUNT: Record<string, number> = { assemblyai: 6, deepgram: 9, characterai: 5, junie: 2, voyageai: 2, pinecone: 6 }
 
   it('single-owner services carry the curated displayComponentIds count, keep their badge statusComponentId, and have no worst-of statusComponentIds', () => {
     for (const [id, count] of Object.entries(SINGLE_OWNER_COUNT)) {

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -99,8 +99,12 @@ export const SERVICES: ServiceConfig[] = [
   // displayComponentIds (#606): curated user-facing API surfaces for assemblyai + deepgram
   // (excludes internal infra / Website / Billing / Docs, and the badge's umbrella statusComponentId
   // — the card shows the per-surface children). Display-only — badge stays on statusComponentId.
+  // #692 — deepgram includes BOTH '...Voice Agent API' (r2z04fcdhhzb) AND its sibling 'Voice Agent
+  // API: Downstream Providers' (7n3stjcbj4bx, a third-party dependency e.g. Gemini), kept adjacent.
+  // Deepgram degrades only the Downstream component during a provider outage, so omitting it hid a
+  // real degradation behind an operational base row — surfacing it makes the breakdown honest.
   { id: 'assemblyai', name: 'AssemblyAI', provider: 'AssemblyAI', category: 'api', statusUrl: 'https://status.assemblyai.com', apiUrl: 'https://status.assemblyai.com/api/v2/summary.json', statusComponentId: '50txf4qfk2kv', displayComponentIds: ['kygwc83t1rfg', '20vm7q71wjcn', 'trxjzz9bwdmc', 'psxcg5mfhznq', 'rfh9swc12f9h', '12wrfd55ml3r'] },
-  { id: 'deepgram', name: 'Deepgram', provider: 'Deepgram', category: 'api', statusUrl: 'https://status.deepgram.com', apiUrl: 'https://status.deepgram.com/api/v2/summary.json', statusComponentId: 'cv8l6gg3cb9d', displayComponentIds: ['m49xkwqkc4kh', 's6v5z4lsl658', '6854s60zwxgw', 'r2z04fcdhhzb', 'jgfq9ffjsfqk', 'vm1x1v101qtn', 'cvbdk3fslx9v', 't80v4qz2jdsf'] },
+  { id: 'deepgram', name: 'Deepgram', provider: 'Deepgram', category: 'api', statusUrl: 'https://status.deepgram.com', apiUrl: 'https://status.deepgram.com/api/v2/summary.json', statusComponentId: 'cv8l6gg3cb9d', displayComponentIds: ['m49xkwqkc4kh', 's6v5z4lsl658', '6854s60zwxgw', 'r2z04fcdhhzb', '7n3stjcbj4bx', 'jgfq9ffjsfqk', 'vm1x1v101qtn', 'cvbdk3fslx9v', 't80v4qz2jdsf'] },
   // Inference / Infrastructure
   { id: 'huggingface', name: 'Hugging Face', provider: 'Hugging Face', category: 'api', statusUrl: 'https://status.huggingface.co', apiUrl: null, rssFeedUrl: 'https://status.huggingface.co/feed', betterStackUrl: 'https://status.huggingface.co', flapSuppression: true, componentDenylist: ['Website'] },
   // displayComponentIds (#606): curated API/product surfaces — HTTP API, Streaming API, Registry,


### PR DESCRIPTION
## Summary
Deepgram's component breakdown showed **"Voice Agent API" as operational** during the active **"Elevated errors when using Google Gemini models with Voice Agent"** incident — a visible contradiction.

## Root cause
Deepgram's status page has two near-identically-named components:
| ID | Name | Status |
|---|---|---|
| `r2z04fcdhhzb` | Voice Agent API | 🟢 operational |
| `7n3stjcbj4bx` | Voice Agent API: Downstream Providers | 🟡 degraded_performance |

The incident degrades only the **Downstream Providers** sibling (the third-party/Gemini dependency); the base stays operational. Only `r2z04fcdhhzb` was in deepgram's curated `displayComponentIds`, and `resolveSvcComponents` matches by exact id — so the real degradation was hidden behind the operational base row.

## Fix
Add `7n3stjcbj4bx` to deepgram `displayComponentIds`, adjacent to `r2z04fcdhhzb`, so both Voice Agent rows render. **Display-only** — the badge stays on `statusComponentId` `cv8l6gg3cb9d` (Public API, independently degraded), unaffected (reviewer-confirmed: `resolveSvcStatus` never reads `displayComponentIds`).

## Tests / verification
- `SINGLE_OWNER_COUNT.deepgram` 8 → 9 (the only count that moves — no grand-total/leak-guard spans a single-owner page).
- Verified live ids (status.deepgram.com): `r2z04fcdhhzb`=operational, `7n3stjcbj4bx`=degraded_performance, badge `cv8l6gg3cb9d`=degraded_performance.
- `test:worker` **1734** · `typecheck:worker` clean · `wrangler --dry-run` green · PR review 0 Critical/Important.
- **In-browser verified** (local worker live data): Deepgram breakdown shows both Voice Agent rows (base operational + Downstream Providers degraded).

## Deploy
**Worker deploy required after merge.**

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)