### PR TITLE
fix(elevenlabs): surface ElevenCreative (Dubbing) in the breakdown (#685)

### DIFF
--- a/worker/src/__tests__/status-determination.test.ts
+++ b/worker/src/__tests__/status-determination.test.ts
@@ -440,7 +440,7 @@ describe('resolveSvcComponents — per-component snapshot (#604)', () => {
 describe('displayComponentIds config sanity (#606)', () => {
   // Exact curated counts — guards against a careless edit truncating the list
   // (the doc comments enumerate the excluded components, so the count is intentional).
-  const EXPECTED_COUNT: Record<string, number> = { elevenlabs: 6, replicate: 5 }
+  const EXPECTED_COUNT: Record<string, number> = { elevenlabs: 7, replicate: 5 }
 
   it('elevenlabs + replicate carry the exact curated displayComponentIds count and NO statusComponentIds (badge unchanged)', () => {
     for (const [id, count] of Object.entries(EXPECTED_COUNT)) {
@@ -452,6 +452,28 @@ describe('displayComponentIds config sanity (#606)', () => {
       // Display-only: must not feed the worst-of badge (#606 decoupling), so no statusComponentIds.
       expect(svc.statusComponentIds, id).toBeUndefined()
     }
+  })
+
+  it('#685 — surfaces a degraded ElevenCreative in the elevenlabs breakdown (no more all-green-while-badge-degraded)', () => {
+    const elevenlabs = SERVICES.find((s) => s.id === 'elevenlabs')!
+    const CREATIVE = '01JJM5RKYAEWNM3XYRHXM8FJQ3'
+    expect(elevenlabs.displayComponentIds, 'ElevenCreative must be curated in (the #685 fix)').toContain(CREATIVE)
+    // Summary where every curated component is operational EXCEPT ElevenCreative (degraded) — the exact
+    // shape that previously rendered all-green while the badge (overall indicator) read degraded.
+    const summary = {
+      status: { indicator: 'minor' },
+      components: elevenlabs.displayComponentIds!.map((id) => ({
+        id,
+        name: id === CREATIVE ? 'ElevenCreative' : `Surface ${id.slice(-4)}`,
+        status: id === CREATIVE ? 'degraded_performance' : 'operational',
+      })),
+    }
+    const out = resolveSvcComponents(elevenlabs, summary)
+    expect(out).toHaveLength(7)
+    const creative = out.find((c) => c.id === CREATIVE)
+    expect(creative, 'ElevenCreative now appears in the breakdown').toBeDefined()
+    expect(creative!.name).toBe('ElevenCreative')
+    expect(creative!.status).toBe('degraded') // degraded_performance normalized → 'degraded'
   })
 
   it('cohere + groq use dynamic displayAllComponents with the Docs/Website denylist, surface lists, and NO badge ids', () => {

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -93,9 +93,14 @@ export const SERVICES: ServiceConfig[] = [
   { id: 'openrouter', name: 'OpenRouter', provider: 'OpenRouter', category: 'api', statusUrl: 'https://status.openrouter.ai', apiUrl: null, onlineOrNotUrl: 'https://status.openrouter.ai', onlineOrNotComponent: 'Chat (/api/v1/chat/completions)' },
   // Voice & Speech AI
   // displayComponentIds (#606): curated availability surfaces for the breakdown card —
-  // TTS, STT, Conversations, RAG, Telephony, Other API endpoints (excludes UI/Quality/ElevenCreative/Other).
+  // TTS, STT, Conversations, RAG, Telephony, Other API endpoints, + ElevenCreative (excludes UI/Quality/Other).
+  // #685 — ElevenCreative (01JJM5RKYAEWNM3XYRHXM8FJQ3) is the ONLY component reflecting Dubbing health
+  // (a Voice-domain product within the ElevenCreative suite; no standalone Dubbing component exists). It
+  // was previously omitted, so a Dubbing/ElevenCreative degradation flipped the badge (overall indicator)
+  // while the breakdown stayed all-operational — a visible contradiction. The row label reads
+  // 'ElevenCreative' (broader suite), the accepted trade-off since no finer-grained component exists.
   // Display-only: badge stays on the overall page indicator (no statusComponentIds).
-  { id: 'elevenlabs', name: 'ElevenLabs', provider: 'ElevenLabs', category: 'api', statusUrl: 'https://status.elevenlabs.io', apiUrl: 'https://status.elevenlabs.io/api/v2/summary.json', incidentIoBaseUrl: 'https://status.elevenlabs.io/incidents', incidentIoComponentId: '01JP2RQVGDHPEEDAFM5KV2MH9P', incidentExclude: ['webpage'], displayComponentIds: ['01JP2RQVGDHPEEDAFM5KV2MH9P', '01JYDTNNSJBT4X90MAC47YPM9S', '01JY3H5SJJZNC33AYMAE4SK4TH', '01JY3H5SJJD2BMSGSW5FZE08ST', '01JY3H5SJJJG47J60JPKX882H8', '01JY3H5SJJFKTXYQHG5A8Z1KYH'] },
+  { id: 'elevenlabs', name: 'ElevenLabs', provider: 'ElevenLabs', category: 'api', statusUrl: 'https://status.elevenlabs.io', apiUrl: 'https://status.elevenlabs.io/api/v2/summary.json', incidentIoBaseUrl: 'https://status.elevenlabs.io/incidents', incidentIoComponentId: '01JP2RQVGDHPEEDAFM5KV2MH9P', incidentExclude: ['webpage'], displayComponentIds: ['01JP2RQVGDHPEEDAFM5KV2MH9P', '01JYDTNNSJBT4X90MAC47YPM9S', '01JY3H5SJJZNC33AYMAE4SK4TH', '01JY3H5SJJD2BMSGSW5FZE08ST', '01JY3H5SJJJG47J60JPKX882H8', '01JY3H5SJJFKTXYQHG5A8Z1KYH', '01JJM5RKYAEWNM3XYRHXM8FJQ3'] },
   // displayComponentIds (#606): curated user-facing API surfaces for assemblyai + deepgram
   // (excludes internal infra / Website / Billing / Docs, and the badge's umbrella statusComponentId
   // — the card shows the per-surface children). Display-only — badge stays on statusComponentId.


### PR DESCRIPTION
## Summary
An ElevenLabs incident (**"UI dubbing failures"**, minor) flipped the service badge to **degraded** (the overall page indicator), yet the **Component Status** breakdown showed all 6 curated components **operational** — a visible contradiction.

## Root cause
Dubbing is a Voice-domain product within the **ElevenCreative** suite, and `ElevenCreative` (`01JJM5RKYAEWNM3XYRHXM8FJQ3`) is the **only** component reflecting its health. It wasn't in elevenlabs' curated `displayComponentIds`, and `resolveSvcComponents` matches by exact id — so the degraded component was hidden while the badge (which follows the overall indicator) read degraded.

## Fix
Add `ElevenCreative` to elevenlabs `displayComponentIds` (6 → 7). **Display-only** — the badge still follows the overall indicator (no `statusComponentIds`), unaffected. The row label reads `ElevenCreative` (broader suite: voice/music/image/video) — the accepted trade-off since no finer-grained Dubbing component exists (documented at the config site).

## Tests / verification
- New unit test drives the **production** `resolveSvcComponents` with the **real** config + a degraded ElevenCreative → confirms it now surfaces degraded in the breakdown (no more all-green-while-badge-degraded). `EXPECTED_COUNT.elevenlabs` 6 → 7.
- Verified live id (status.elevenlabs.io): `01JJM5RKYAEWNM3XYRHXM8FJQ3` = ElevenCreative.
- `test:worker` **1735** · `typecheck:worker` clean · `wrangler --dry-run` green · PR review 0 Critical/Important.
- **In-browser verified on BOTH** the dashboard ServiceDetails **and** the is-down page (`renderComponents` reads the same `service.components` array) via a temporary forced-degraded mock, reverted before commit.

## Deploy
**Worker deploy required after merge.**

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)