### PR TITLE
fix(ai-analysis): dedup xAI per-region incidents to one AI analysis (#703)

### DIFF
--- a/worker/src/__tests__/xai-regions.test.ts
+++ b/worker/src/__tests__/xai-regions.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { XAI_REGION_RE, xaiRegionOf, xaiEventKey, collapseXaiRegionalIncidents } from '../xai-regions'
+
+const inc = (id: string, title: string) => ({ id, title })
+
+describe('xai-regions (#686/#703)', () => {
+  describe('xaiRegionOf', () => {
+    it('extracts the region label from a tagged title', () => {
+      expect(xaiRegionOf('[API (us-east-1.api.x.ai)] Increased Error rate')).toBe('us-east-1')
+      expect(xaiRegionOf('[API (eu-west-1.api.x.ai)] Increased Error rate')).toBe('eu-west-1')
+    })
+    it('returns null for a non-region-tagged title', () => {
+      expect(xaiRegionOf('Whole-service degradation')).toBeNull()
+      expect(xaiRegionOf('[API Console] Console not loading')).toBeNull() // not the region shape
+    })
+  })
+
+  describe('xaiEventKey', () => {
+    it('strips the region prefix so same-event-different-region collapses to one key', () => {
+      const a = xaiEventKey('[API (us-east-1.api.x.ai)] Increased Error rate on Image Generation Endpoint')
+      const b = xaiEventKey('[API (eu-west-1.api.x.ai)] Increased Error rate on Image Generation Endpoint')
+      expect(a).toBe('Increased Error rate on Image Generation Endpoint')
+      expect(a).toBe(b)
+    })
+    it('returns the title unchanged when not region-tagged (never collapses)', () => {
+      expect(xaiEventKey('Whole-service degradation')).toBe('Whole-service degradation')
+    })
+  })
+
+  describe('collapseXaiRegionalIncidents', () => {
+    it('collapses the same event across two regions to ONE (first kept) + annotates the title with all regions', () => {
+      const out = collapseXaiRegionalIncidents([
+        inc('us1', '[API (us-east-1.api.x.ai)] Increased Error rate on Image Generation Endpoint'),
+        inc('eu1', '[API (eu-west-1.api.x.ai)] Increased Error rate on Image Generation Endpoint'),
+      ])
+      expect(out.map((i) => i.id)).toEqual(['us1']) // eu1 dropped (same stripped event)
+      // the surviving incident's title names BOTH regions so the AI analysis covers both (#703)
+      expect(out[0].title).toBe('Increased Error rate on Image Generation Endpoint (regions: us-east-1, eu-west-1)')
+    })
+
+    it('keeps DISTINCT events separate even when both span two regions (each title region-annotated)', () => {
+      const out = collapseXaiRegionalIncidents([
+        inc('a-us', '[API (us-east-1.api.x.ai)] Increased Error rate on Image Generation Endpoint'),
+        inc('a-eu', '[API (eu-west-1.api.x.ai)] Increased Error rate on Image Generation Endpoint'),
+        inc('b-us', '[API (us-east-1.api.x.ai)] grok-code-fast-1 unavailable'),
+        inc('b-eu', '[API (eu-west-1.api.x.ai)] grok-code-fast-1 unavailable'),
+      ])
+      expect(out.map((i) => i.id)).toEqual(['a-us', 'b-us']) // one per distinct event
+      expect(out[0].title).toBe('Increased Error rate on Image Generation Endpoint (regions: us-east-1, eu-west-1)')
+      expect(out[1].title).toBe('grok-code-fast-1 unavailable (regions: us-east-1, eu-west-1)')
+    })
+
+    it('a SINGLE-region event keeps its original title (no annotation)', () => {
+      const out = collapseXaiRegionalIncidents([
+        inc('us1', '[API (us-east-1.api.x.ai)] Increased Error rate on Image Generation Endpoint'),
+      ])
+      expect(out.map((i) => i.id)).toEqual(['us1'])
+      expect(out[0].title).toBe('[API (us-east-1.api.x.ai)] Increased Error rate on Image Generation Endpoint')
+    })
+
+    it('passes non-region-tagged incidents through untouched (no collapse)', () => {
+      const out = collapseXaiRegionalIncidents([
+        inc('x', 'Whole-service degradation'),
+        inc('y', 'Another untagged incident'),
+      ])
+      expect(out.map((i) => i.id)).toEqual(['x', 'y'])
+    })
+
+    it('is a no-op for a non-xAI service incident list (no region-tagged titles)', () => {
+      const list = [inc('c1', 'API returning 500s'), inc('c2', 'Elevated latency')]
+      expect(collapseXaiRegionalIncidents(list)).toEqual(list)
+    })
+
+    it('a region-tagged + a non-tagged incident: tagged collapses by event, untagged kept', () => {
+      const out = collapseXaiRegionalIncidents([
+        inc('us1', '[API (us-east-1.api.x.ai)] Event A'),
+        inc('eu1', '[API (eu-west-1.api.x.ai)] Event A'),
+        inc('global', 'Whole-service degradation'),
+      ])
+      expect(out.map((i) => i.id)).toEqual(['us1', 'global'])
+    })
+  })
+
+  it('XAI_REGION_RE matches only the region shape (not [API Console])', () => {
+    expect(XAI_REGION_RE.test('[API (us-east-1.api.x.ai)] x')).toBe(true)
+    expect(XAI_REGION_RE.test('[API Console] x')).toBe(false)
+  })
+})

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -3,6 +3,7 @@
 
 import type { Incident, ServiceStatus } from './types'
 import { sanitize, kvPut, kvDel, type KVLike } from './utils'
+import { collapseXaiRegionalIncidents } from './xai-regions'
 
 // Workers AI model ID for the Gemma primary path. Exported so monthly-narrative.ts
 // (which runs its own hybrid call with a different prompt + response shape) reuses
@@ -462,7 +463,12 @@ export async function refreshOrReanalyze(
   const analyzedIncidents = new Map<string, string>()
 
   for (const svc of activeServices) {
-    const activeIncs = (svc.incidents ?? []).filter(i => i.status !== 'resolved' && !heldIncIds.has(i.id))
+    // #703 — collapse xAI per-region incidents (same event, different region) to ONE, so a 2-region
+    // xAI event is analyzed once (not twice) and the Analyze modal shows a single entry. No-op for
+    // every non-xAI service (only xAI titles carry the `[API (<region>.api.x.ai)]` prefix).
+    const activeIncs = collapseXaiRegionalIncidents(
+      (svc.incidents ?? []).filter(i => i.status !== 'resolved' && !heldIncIds.has(i.id)),
+    )
     if (activeIncs.length === 0) continue
 
     for (const inc of activeIncs) {

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -5,6 +5,7 @@ import { getFallbacks, buildFallbackText } from './fallback'
 import { sanitize, formatDuration, appendStatusHint } from './utils'
 import { computeLeadMs } from './detection-lead-log'
 import { kindFromKey, svcIdsForAlert, type AlertKind } from './alert-feed'
+import { XAI_REGION_RE } from './xai-regions'
 // #422 Phase 2 — region-switch hint in Discord alerts. We reuse the existing
 // Edge TS port rather than adding a third copy of SERVICE_REGIONS: the Worker
 // bundler (esbuild via wrangler) can import across dirs (unlike Vercel Edge,
@@ -366,9 +367,8 @@ export function mergeTogetherAlerts(alerts: AlertCandidate[]): AlertCandidate[] 
 // but near-identical titles differing only by a `[API (<region>.api.x.ai)] ` prefix (live: us-east-1 +
 // eu-west-1). buildIncidentAlerts groups by incidentId, so each region fires its own alert. Strip the
 // region prefix off the alert description (= the incident title) to derive a grouping key, so the SAME
-// event across regions merges while DISTINCT events stay separate. More precise than mergeTogetherAlerts'
-// blunt all-merge. xAI-only by design (other SERVICE_REGIONS feeds aren't verified to split per region).
-const XAI_REGION_RE = /^\[API \(([a-z0-9-]+)\.api\.x\.ai\)\]\s*/i
+// event across regions merges while DISTINCT events stay separate. The regex lives in xai-regions.ts
+// (#703) so the alert merge + the AI-analysis dedup can't drift. xAI-only by design.
 
 /**
  * Merge concurrent xAI (Grok) per-region incident alerts (same event, different region) into one

--- a/worker/src/xai-regions.ts
+++ b/worker/src/xai-regions.ts
@@ -1,0 +1,71 @@
+// Shared xAI per-region incident helpers (#686 alert merge + #703 AI-analysis dedup).
+//
+// xAI publishes the SAME event in multiple regions as SEPARATE incidents with distinct guids but
+// near-identical titles differing only by a `[API (<region>.api.x.ai)] ` prefix (live: us-east-1 +
+// eu-west-1). Two surfaces must collapse these to one:
+//   • #686 — the Discord/Slack alert merge (mergeXaiRegionalAlerts in alerts.ts).
+//   • #703 — the AI analysis: refreshOrReanalyze otherwise analyzes each region separately, so the
+//     Analyze modal shows one xAI card with two region-duplicate analysis entries + burns a 2nd
+//     Gemma/Sonnet call.
+// Both key on the region-tag-STRIPPED title, so the SAME event across regions collapses while DISTINCT
+// events (e.g. image-gen vs grok-code-fast-1) stay separate. This module is the single source of that
+// regex + the helpers, so the two surfaces can't drift. xAI-only by design (other SERVICE_REGIONS feeds
+// aren't verified to split incidentIds per region).
+
+export const XAI_REGION_RE = /^\[API \(([a-z0-9-]+)\.api\.x\.ai\)\]\s*/i
+
+/** The region label (e.g. 'us-east-1') from an xAI incident title, or null when not region-tagged. */
+export function xaiRegionOf(title: string): string | null {
+  return XAI_REGION_RE.exec(title)?.[1] ?? null
+}
+
+/** The region-tag-stripped event key used to group same-event-different-region incidents. A
+ *  non-region-tagged title returns itself (so it never collapses with anything). */
+export function xaiEventKey(title: string): string {
+  return title.replace(XAI_REGION_RE, '').trim()
+}
+
+/**
+ * Collapse xAI per-region incidents (same region-stripped title) to ONE — keeping the FIRST
+ * occurrence per event. Non-region-tagged incidents (and every incident of a non-xAI service, since
+ * only xAI titles carry the `[API (<region>.api.x.ai)]` prefix) pass through untouched, so this is a
+ * safe no-op on any other service's incident list. Used by the AI-analysis path (#703) so a 2-region
+ * xAI event is analyzed once. Generic over the incident shape — only `title` is read.
+ *
+ * "First kept" is intentionally aligned with `mergeXaiRegionalAlerts`'s `arr[0]` anchor (both walk
+ * `svc.incidents` order), so the region whose analysis the initial path wrote is the one the refresh
+ * path keeps refreshing — keep them in sync if either's ordering changes.
+ *
+ * NOTE the dedup is EVENTUAL, not instant: it only stops NEW/refresh writes for the dropped region.
+ * A stale `ai:analysis:xai:{droppedIncId}` from a pre-#703 cron cycle (or within its 1h TTL) still
+ * surfaces in `/api/status` until it expires — so the Analyze modal can briefly show 2 entries right
+ * after deploy if a 2-region xAI incident is already active. It self-heals within ~1h (the dropped
+ * region's key is never re-bumped).
+ */
+export function collapseXaiRegionalIncidents<T extends { title: string }>(incidents: T[]): T[] {
+  // Pass 1 — collect the affected regions per event (in first-seen order, deduped).
+  const regionsByEvent = new Map<string, string[]>()
+  for (const inc of incidents) {
+    if (!XAI_REGION_RE.test(inc.title)) continue
+    const key = xaiEventKey(inc.title)
+    const region = xaiRegionOf(inc.title)
+    if (!region) continue
+    const arr = regionsByEvent.get(key)
+    if (arr) { if (!arr.includes(region)) arr.push(region) }
+    else regionsByEvent.set(key, [region])
+  }
+  // Pass 2 — keep the FIRST incident per event; for a MULTI-region event, return a copy whose title
+  // names all affected regions, so the downstream AI analysis reflects EVERY region (not just the
+  // first one analyzed — #703, the "only us-east-1 shown" gap). Single-region + non-tagged: unchanged.
+  const kept = new Set<string>()
+  const out: T[] = []
+  for (const inc of incidents) {
+    if (!XAI_REGION_RE.test(inc.title)) { out.push(inc); continue }
+    const key = xaiEventKey(inc.title)
+    if (kept.has(key)) continue // a duplicate region of an already-kept event → drop
+    kept.add(key)
+    const regions = regionsByEvent.get(key) ?? []
+    out.push(regions.length > 1 ? { ...inc, title: `${key} (regions: ${regions.join(', ')})` } : inc)
+  }
+  return out
+}


### PR DESCRIPTION
Follow-up to #686. #686 merged the per-region xAI Discord **alerts**, but the **AI-analysis** path is separate — `refreshOrReanalyze` analyzes each active incident independently, so the same xAI event in 2 regions (us-east-1 + eu-west-1) produced **2 AI analyses** (2 Gemma/Sonnet calls) and the Analyze modal showed the xAI card with **2 region-duplicate analysis entries**.

## Fix
- **New shared module `worker/src/xai-regions.ts`** — the region-strip regex (MOVED out of `alerts.ts` so the #686 alert-merge and this dedup can't drift) + `collapseXaiRegionalIncidents`, which keeps the FIRST incident per region-stripped event. No-op for any non-xAI service (only xAI titles carry the `[API (<region>.api.x.ai)]` prefix).
- **`refreshOrReanalyze`** applies the collapse → a 2-region xAI event is analyzed **once** → `aiAnalysis.xai` carries one entry → the modal shows one (the modal's existing per-service grouping needs no frontend change). The initial-analysis path was already covered by #686's merged-alert skip.
- **Multi-region coverage:** the kept incident's title is rewritten to name ALL affected regions (`<event> (regions: us-east-1, eu-west-1)`) for the analysis prompt, so the single deduped analysis reflects **every** region — not just the first (the "only us-east-1 shown" gap caught during in-browser verify). Single-region + non-xAI titles unchanged.

## Eventual, not instant
The dedup stops new/refresh writes for the dropped region; a stale `ai:analysis:xai:{droppedIncId}` from a pre-#703 cron cycle self-heals within its 1h TTL (documented in `xai-regions.ts`). The modal can briefly show 2 entries right after deploy if a 2-region xAI incident is already active.

## Tests / verification
- **11 tests** (`xai-regions.test.ts`): collapse + region annotation + distinct-events-separate + single-region-no-annotation + non-xAI no-op + `xaiRegionOf`/`xaiEventKey`.
- `alerts.ts` migration to the shared regex is behavior-preserving (106 alert tests pass).
- `test:worker` **1754** · `typecheck:worker` clean · `wrangler --dry-run` green · PR review (2 rounds) 0 Critical/Important.
- **In-browser verified** (Analyze modal, mocked 2-region state): the xAI card shows **one** analysis entry naming **both** regions; reverted before commit.

## Deploy
**Worker deploy required after merge.**

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)