### PR TITLE
refactor(status): disambiguate service-badge vs calendar-impact labels (#674)

### DIFF
--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -793,7 +793,7 @@ export function renderShareButtons(seo: ServiceSEO, service: ServiceData | null,
   const aiSuffix = aiInsight ? `\nAI Analysis: ${aiInsight.summary.slice(0, 100)}. Est. recovery: ${formatRecoveryDisplay(aiInsight.estimatedRecovery)}.` : ''
   const n = seo.displayName
   const downTexts = [
-    `Is ${n} down? Current status: Major Outage.`,
+    `Is ${n} down? Current status: Down.`,
     `${n} is currently experiencing a major outage.`,
     `Heads up — ${n} appears to be down right now.`,
     `${n} outage detected. Check real-time status:`,

--- a/api/methodology/__tests__/html-template.test.ts
+++ b/api/methodology/__tests__/html-template.test.ts
@@ -86,15 +86,15 @@ describe('renderMethodologyPage', () => {
     expect(html).toMatch(/does not feed the AIWatch Score|Score나 인시던트 집계에는 반영되지 않/)
   })
 
-  it('uses the UI-facing status labels, not the raw internal names', () => {
-    // §2 must match what the dashboard actually shows: Operational / Partial Outage / Major Outage
+  it('uses the UI-facing status labels, not the raw internal names (#674 — badge ≠ impact axis)', () => {
+    // §2 must match the dashboard service BADGE (availability axis): Operational / Degraded / Down
     // (status.* labels), and the worst-of priority is stated in those displayed terms.
-    expect(html).toContain('Partial Outage')
-    expect(html).toContain('Major Outage')
-    expect(html).toContain('Major Outage > Partial Outage > Operational')
-    // §3 impact weights map to the calendar's 4-level labels (minor→Degraded, major→Partial, critical→Major)
-    expect(html).toMatch(/Major Outage \/ Partial Outage/)
-    expect(html).toMatch(/\(Degraded\)/)
+    expect(html).toContain('Operational · Degraded · Down')
+    expect(html).toContain('Down &gt; Degraded &gt; Operational')
+    // #674 — the badge axis must NOT carry the calendar's impact-scale words ("Partial Outage" /
+    // "Major Outage" are the OLD colliding labels; the calendar impact axis is now Minor/Major/Critical).
+    expect(html).not.toContain('Partial Outage')
+    expect(html).not.toContain('Major Outage')
     // §2 note links out to the open-source status-determination reference
     expect(html).toContain('docs/reference/status-determination.md')
   })

--- a/api/methodology/html-template.ts
+++ b/api/methodology/html-template.ts
@@ -295,12 +295,12 @@ ${CONSENT_INIT_SCRIPT}
 <section class="section" id="status">
   <p class="section-label">// 02</p>
   <h2 data-i18n="s2.title">상태 결정</h2>
-  <p class="lead" data-i18n="s2.lead">서비스별 상태는 계층화된 우선순위 체인으로 결정되며, 화면에는 <strong>Operational · Partial Outage · Major Outage</strong> 로 표기됩니다. 규칙은 위에서부터 순서대로 확인하며, 처음 일치하는 규칙에서 상태가 결정됩니다.</p>
+  <p class="lead" data-i18n="s2.lead">서비스별 상태는 계층화된 우선순위 체인으로 결정되며, 화면에는 <strong>Operational · Degraded · Down</strong> 로 표기됩니다. 규칙은 위에서부터 순서대로 확인하며, 처음 일치하는 규칙에서 상태가 결정됩니다.</p>
   <div class="chain">
     <div class="chain-step">
       <div class="cs-num">1 · <span data-i18n="s2.1.tag">worst-of</span></div>
       <div class="cs-title" data-i18n="s2.1.title">멀티 컴포넌트 worst-of</div>
-      <div class="cs-body" data-i18n="s2.1.body">하나의 서비스가 여러 컴포넌트로 구성된 경우(예: Cursor의 IDE + Cloud Agents + CLI), 그중 가장 심각한 상태를 서비스 배지에 표시합니다 (Major Outage &gt; Partial Outage &gt; Operational).</div>
+      <div class="cs-body" data-i18n="s2.1.body">하나의 서비스가 여러 컴포넌트로 구성된 경우(예: Cursor의 IDE + Cloud Agents + CLI), 그중 가장 심각한 상태를 서비스 배지에 표시합니다 (Down &gt; Degraded &gt; Operational).</div>
     </div>
     <div class="chain-step">
       <div class="cs-num">2 · <span data-i18n="s2.2.tag">component match</span></div>
@@ -341,7 +341,7 @@ ${CONSENT_INIT_SCRIPT}
     <li><strong data-i18n="s3.platform">Platform</strong> <span data-i18n="s3.platformDesc">— 상태 페이지 플랫폼(Better Stack)이 자체 모니터로 측정한 가동률 (Together · Fireworks · HuggingFace · Modal · Luma). 제공사 공식 SLA가 아닌 플랫폼 측정치입니다.</span></li>
     <li><strong data-i18n="s3.estimate">Estimate</strong> <span data-i18n="s3.estimateDesc">— 공식 수치가 없는 서비스(Bedrock·Azure OpenAI)는 최근 90일의 라이브·아카이브 인시던트를 합쳐 추정합니다. 영향을 준 인시던트가 없으면 %를 아예 산출하지 않습니다.</span></li>
   </ul>
-  <p data-i18n="s3.weighted"><strong>Atlassian 가중 영향 일수:</strong> 다운타임은 단순 인시던트 건수가 아니라, 각 날짜를 그날의 가장 심각한 영향도로 가중한 "영향 일수"로 집계합니다 — critical · major = 1.0 (Major Outage / Partial Outage), minor = 0.3 (Degraded), 정보성/null = 제외. uptime과 score 모두 같은 가중 방식을 씁니다.</p>
+  <p data-i18n="s3.weighted"><strong>Atlassian 가중 영향 일수:</strong> 다운타임은 단순 인시던트 건수가 아니라, 각 날짜를 그날의 가장 심각한 영향도로 가중한 "영향 일수"로 집계합니다 — critical · major = 1.0, minor = 0.3, 정보성/null = 제외. uptime과 score 모두 같은 가중 방식을 씁니다.</p>
 
   <div class="limits">
     <div class="limits-label">⚠ <span data-i18n="s3.limits.label">측정 한계와 그 이유</span></div>
@@ -553,8 +553,8 @@ const i18n = {
     's1.secDesc': '상태·신뢰도 측정과는 별개로, AI 스택에 영향을 주는 보안 이슈도 함께 추적해 <strong>월간 리포트</strong>에 집계합니다. 이 데이터는 AIWatch Score나 인시던트 집계에는 반영되지 않습니다.',
     's1.sec.osv': '— SDK 취약점 (PyPI · npm 24개 추적 패키지), GitHub Advisories로 상세 보강', 's1.sec.hn': '— AI 서비스 관련 보안 뉴스 (Algolia 검색 API)',
     's2.title': '상태 결정',
-    's2.lead': '서비스별 상태는 계층화된 우선순위 체인으로 결정되며, 화면에는 <strong>Operational · Partial Outage · Major Outage</strong> 로 표기됩니다. 규칙은 위에서부터 순서대로 확인하며, 처음 일치하는 규칙에서 상태가 결정됩니다.',
-    's2.1.tag': 'worst-of', 's2.1.title': '멀티 컴포넌트 worst-of', 's2.1.body': '하나의 서비스가 여러 컴포넌트로 구성된 경우(예: Cursor의 IDE + Cloud Agents + CLI), 그중 가장 심각한 상태를 서비스 배지에 표시합니다 (Major Outage > Partial Outage > Operational).',
+    's2.lead': '서비스별 상태는 계층화된 우선순위 체인으로 결정되며, 화면에는 <strong>Operational · Degraded · Down</strong> 로 표기됩니다. 규칙은 위에서부터 순서대로 확인하며, 처음 일치하는 규칙에서 상태가 결정됩니다.',
+    's2.1.tag': 'worst-of', 's2.1.title': '멀티 컴포넌트 worst-of', 's2.1.body': '하나의 서비스가 여러 컴포넌트로 구성된 경우(예: Cursor의 IDE + Cloud Agents + CLI), 그중 가장 심각한 상태를 서비스 배지에 표시합니다 (Down > Degraded > Operational).',
     's2.2.tag': 'component match', 's2.2.title': '컴포넌트 매칭', 's2.2.body': '해당 서비스의 주요 컴포넌트가 지정되어 있으면 그 컴포넌트의 상태를 사용합니다.',
     's2.3.tag': 'overall indicator', 's2.3.title': '전체 인디케이터 폴백', 's2.3.body': '컴포넌트를 찾지 못하면 상태 페이지의 전체 인디케이터로 폴백합니다. 단, 필터링 후 관련된 미해결 인시던트가 없으면 정상으로 간주해, 공유 상태 페이지에서 다른 서비스의 인시던트가 섞이는 것을 막습니다(예: ChatGPT 인시던트가 OpenAI API 상태에 영향을 주지 않도록).',
     's2.4.tag': 'incidentExclude bypass', 's2.4.title': 'incidentExclude 컴포넌트 우회', 's2.4.body': '제목 기반 제외 패턴에 걸리더라도, 인시던트의 컴포넌트 태그가 해당 서비스의 주요 컴포넌트로 시작하면 포함합니다. 제목 문자열 매칭보다 컴포넌트 태그를 더 우선하기 때문입니다.',
@@ -566,7 +566,7 @@ const i18n = {
     's3.official': 'Official', 's3.officialDesc': '— 상태 페이지가 공개한 %를 그대로 읽습니다(페이지마다 집계 기간이 다름).',
     's3.estimate': 'Estimate', 's3.estimateDesc': '— 공식 수치가 없는 서비스(Bedrock·Azure OpenAI)는 최근 90일의 라이브·아카이브 인시던트를 합쳐 추정합니다. 영향을 준 인시던트가 없으면 %를 아예 산출하지 않습니다.',
     's3.platform': 'Platform', 's3.platformDesc': '— 상태 페이지 플랫폼(Better Stack)이 자체 모니터로 측정한 가동률 (Together · Fireworks · HuggingFace · Modal · Luma). 제공사 공식 SLA가 아닌 플랫폼 측정치입니다.',
-    's3.weighted': '<strong>Atlassian 가중 영향 일수:</strong> 다운타임은 단순 인시던트 건수가 아니라, 각 날짜를 그날의 가장 심각한 영향도로 가중한 "영향 일수"로 집계합니다 — critical · major = 1.0 (Major Outage / Partial Outage), minor = 0.3 (Degraded), 정보성/null = 제외. uptime과 score 모두 같은 가중 방식을 씁니다.',
+    's3.weighted': '<strong>Atlassian 가중 영향 일수:</strong> 다운타임은 단순 인시던트 건수가 아니라, 각 날짜를 그날의 가장 심각한 영향도로 가중한 "영향 일수"로 집계합니다 — critical · major = 1.0, minor = 0.3, 정보성/null = 제외. uptime과 score 모두 같은 가중 방식을 씁니다.',
     's3.limits.label': '측정 한계와 그 이유',
     's3.limits.intro': '아래 서비스는 공식 상태 페이지에 비교 가능한 30일 롤링 uptime%가 없습니다. 임의로 추측해 채우는 대신 "— Not provided"로 명확히 표시합니다.',
     's3.limits.col1': '서비스', 's3.limits.col2': '측정 불가 사유',
@@ -635,8 +635,8 @@ const i18n = {
     's1.secDesc': 'On a track separate from status & reliability, we also track security issues affecting the AI stack, aggregated into the <strong>monthly report</strong>. This data does not feed the AIWatch Score or incident counts.',
     's1.sec.osv': '— SDK vulnerabilities (24 tracked PyPI · npm packages), enriched via GitHub Advisories', 's1.sec.hn': '— security news about AI services (Algolia search API)',
     's2.title': 'Status determination',
-    's2.lead': 'Per-service status is resolved by a layered priority chain and shown as <strong>Operational · Partial Outage · Major Outage</strong>. Rules apply top-to-bottom and stop at the first match.',
-    's2.1.tag': 'worst-of', 's2.1.title': 'Multi-component worst-of', 's2.1.body': 'When a user-facing surface spans multiple components (e.g. Cursor IDE + Cloud Agents + CLI), the worst of their statuses becomes the badge (Major Outage > Partial Outage > Operational).',
+    's2.lead': 'Per-service status is resolved by a layered priority chain and shown as <strong>Operational · Degraded · Down</strong>. Rules apply top-to-bottom and stop at the first match.',
+    's2.1.tag': 'worst-of', 's2.1.title': 'Multi-component worst-of', 's2.1.body': 'When a user-facing surface spans multiple components (e.g. Cursor IDE + Cloud Agents + CLI), the worst of their statuses becomes the badge (Down > Degraded > Operational).',
     's2.2.tag': 'component match', 's2.2.title': 'Component match', 's2.2.body': 'If the service has a designated primary component, use that component\\'s status.',
     's2.3.tag': 'overall indicator', 's2.3.title': 'Overall-indicator fallback', 's2.3.body': 'If no component is found, fall back to the page\\'s overall indicator — but if no relevant unresolved incidents remain after filtering, treat as operational. This prevents cross-contamination on shared status pages (e.g. a ChatGPT incident shouldn\\'t affect OpenAI API status).',
     's2.4.tag': 'incidentExclude bypass', 's2.4.title': 'incidentExclude component bypass', 's2.4.body': 'Even when a title-based exclude pattern matches, the incident is kept if its component tag starts with the service\\'s primary component. Component tagging is more authoritative than title substring matching.',
@@ -648,7 +648,7 @@ const i18n = {
     's3.official': 'Official', 's3.officialDesc': '— read directly from the % the status page publishes (window varies by page).',
     's3.estimate': 'Estimate', 's3.estimateDesc': '— services with no official metric (Bedrock · Azure OpenAI) are estimated from the combined 90-day live + archived incident set. If there is no impactful incident, no % is produced at all.',
     's3.platform': 'Platform', 's3.platformDesc': '— uptime measured by the status-page platform\\'s own monitors (Better Stack) — a platform measurement, not the provider\\'s official SLA (Together · Fireworks · HuggingFace · Modal · Luma).',
-    's3.weighted': '<strong>Atlassian-weighted affected days:</strong> downtime is counted not as raw incident count but as "affected days," where each day is weighted by its worst impact — critical · major = 1.0 (Major Outage / Partial Outage), minor = 0.3 (Degraded), informational/null = excluded. Uptime and the Score share the same weighting.',
+    's3.weighted': '<strong>Atlassian-weighted affected days:</strong> downtime is counted not as raw incident count but as "affected days," where each day is weighted by its worst impact — critical · major = 1.0, minor = 0.3, informational/null = excluded. Uptime and the Score share the same weighting.',
     's3.limits.label': 'Coverage & limits — what we can\\'t measure and why',
     's3.limits.intro': 'These services\\' status pages do not expose a comparable rolling 30-day uptime %. We never fill it with a guess — they show "— Not provided".',
     's3.limits.col1': 'Service', 's3.limits.col2': 'Reason',

--- a/docs/marketing-playbook.md
+++ b/docs/marketing-playbook.md
@@ -161,7 +161,7 @@ Adapt to the specific thread — never copy-paste verbatim across subreddits.
 It's down for everyone — just pulled this from AIWatch
 (ai-watch.dev/is-claude-down):
 
-- Status: Major Outage (confirmed [HH:MM UTC — pull from dashboard])
+- Status: Down (confirmed [HH:MM UTC — pull from dashboard])
 - Early RTT signal: [X minutes — ONLY if the dashboard shows one] — our probe
   flagged latency degradation before the official status update
 - AI analysis: [paste the current AIWatch AI analysis summary, 1-2 sentences]

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@
   --bg3: #1c2230;
   --bg4: #242b38;
 
-  /* Status: Operational / Degraded Performance / Partial Outage / Down */
+  /* Service badge (availability axis, #674): Operational (green) / Degraded (amber) / Down (red) */
   --green: #3fb950;
   --yellow: #faa72a;
   --amber: #e86235;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -31,14 +31,14 @@ const en = {
 
   // Status
   'status.operational': 'Operational',
-  'status.degraded': 'Partial Outage',
-  'status.down': 'Major Outage',
+  'status.degraded': 'Degraded',
+  'status.down': 'Down',
   'status.unknown': 'Unknown',
   // #663 — calendar's own impact-aligned status labels (decoupled from the 3-state badge status.* above)
   'cal.status.operational': 'Operational',
-  'cal.status.minor': 'Degraded',
-  'cal.status.major': 'Partial Outage',
-  'cal.status.critical': 'Major Outage',
+  'cal.status.minor': 'Minor',
+  'cal.status.major': 'Major',
+  'cal.status.critical': 'Critical',
   'status.partial.suffix': ' affected',
   'status.partial.tooltip': 'Some components are reporting issues on the provider status page; overall service availability is still nominal.',
 

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -31,14 +31,14 @@ const ko = {
 
   // Status
   'status.operational': '정상',
-  'status.degraded': '부분 장애',
-  'status.down': '주요 장애',
+  'status.degraded': '성능 저하',
+  'status.down': '다운',
   'status.unknown': '상태 불명',
   // #663 — 캘린더 전용 impact 정렬 상태 라벨 (위 3-state 배지 status.*와 분리)
   'cal.status.operational': '정상',
-  'cal.status.minor': '성능 저하',
-  'cal.status.major': '부분 장애',
-  'cal.status.critical': '주요 장애',
+  'cal.status.minor': '경미',
+  'cal.status.major': '주요',
+  'cal.status.critical': '심각',
   'status.partial.suffix': '개 영향',
   'status.partial.tooltip': '제공사 상태 페이지에서 일부 구성요소에 이슈가 보고됐습니다. 서비스 전체 가용성은 정상 범위입니다.',
 

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -571,7 +571,7 @@ const CALENDAR_OPACITY = { operational: 0.7, major: 0.8, critical: 0.9 } // mino
 
 function CalendarCell({ status, date, t }) {
   const [hovered, setHovered] = useState(false)
-  // #662/#663 — show the translated label ("Degraded"/"Partial Outage"/…), not the raw internal cell
+  // #662/#663 — show the translated label ("Minor"/"Major"/"Critical"/…), not the raw internal cell
   // key (minor/major/critical). cal.status.* is the calendar's own namespace, decoupled from the
   // 3-state badge `status.*`. Matches the legend (all four keys have ko/en labels).
   const label = t ? t(`cal.status.${status}`) : status

--- a/src/utils/__tests__/calendar.test.js
+++ b/src/utils/__tests__/calendar.test.js
@@ -242,3 +242,32 @@ describe('calendar cell keys ↔ cal.status.* i18n coverage (#663 decoupling pin
     }
   })
 })
+
+// #674 — the service-badge availability axis (status.*) and the calendar impact-severity axis
+// (cal.status.*) are two DIFFERENT taxonomies; no NON-operational label may map to both, or the same
+// word means two things (the old "Partial Outage" = badge `degraded` AND calendar `major` collision).
+// Industry-aligned: badge = Operational/Degraded/Down (aggregator-style); calendar = Operational +
+// Minor/Major/Critical (Statuspage incident-impact). "Operational" is shared but means the same on both.
+describe('status badge ↔ calendar impact label disjointness (#674 anti-collision pin)', () => {
+  for (const lang of ['en', 'ko']) {
+    it(`${lang}: no non-operational label is shared across status.* and cal.status.*`, async () => {
+      // static specifiers (no template literal) so Vite doesn't emit a dynamic-import-vars warning
+      const { default: L } = lang === 'en'
+        ? await import('../../locales/en')
+        : await import('../../locales/ko')
+      const badge = ['status.degraded', 'status.down'].map((k) => L[k])
+      const cal = ['cal.status.minor', 'cal.status.major', 'cal.status.critical'].map((k) => L[k])
+      badge.forEach((b) => expect(b, `badge label ${b} (${lang})`).toBeTruthy())
+      cal.forEach((c) => expect(c, `cal label ${c} (${lang})`).toBeTruthy())
+      const overlap = badge.filter((b) => cal.includes(b))
+      expect(overlap, `${lang}: badge/calendar labels must be disjoint, found shared: ${overlap.join(', ')}`).toEqual([])
+    })
+  }
+
+  it('en: exact label sets match the #674 decision', async () => {
+    const { default: en } = await import('../../locales/en')
+    expect([en['status.operational'], en['status.degraded'], en['status.down']]).toEqual(['Operational', 'Degraded', 'Down'])
+    expect([en['cal.status.operational'], en['cal.status.minor'], en['cal.status.major'], en['cal.status.critical']])
+      .toEqual(['Operational', 'Minor', 'Major', 'Critical'])
+  })
+})

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -8,7 +8,7 @@
 //   'major'       — orange: major impact (partial outage)
 //   'minor'       — yellow: minor / null / unknown impact (degraded)
 //   'operational' — green:  no incidents
-// User-facing labels are unchanged (Major Outage / Partial Outage / Degraded / Operational) via the
+// User-facing labels (#674: Critical / Major / Minor / Operational — the Statuspage impact axis) via the
 // `cal.status.*` i18n keys. Index 0 = oldest, last index = today.
 
 const STATUS_RANK = { operational: 0, minor: 1, major: 2, critical: 3 }

--- a/tests/service-details.spec.js
+++ b/tests/service-details.spec.js
@@ -30,10 +30,10 @@ test.describe('ServiceDetails page', () => {
 
   test('renders status calendar with legend', async ({ page }) => {
     const main = page.locator('main')
-    // Calendar legend should show status labels
+    // Calendar legend shows the impact-severity axis (#674): Operational / Minor / Major / Critical
     await expect(main.getByText(/Operational|정상/).first()).toBeVisible()
-    await expect(main.getByText(/Partial Outage|부분 장애/).first()).toBeVisible()
-    await expect(main.getByText(/Major Outage|주요 장애/).first()).toBeVisible()
+    await expect(main.getByText(/Minor|경미/).first()).toBeVisible()
+    await expect(main.getByText(/Critical|심각/).first()).toBeVisible()
     // Calendar should have 30 cells
     const calendarCells = main.locator('[aria-label*=":"]')
     await expect(calendarCells.first()).toBeVisible()


### PR DESCRIPTION
## What

Two independent status taxonomies reused the **same label strings** for different internal values (surfaced while writing the `/methodology` page, #673):

| Old label | Service badge `status.*` | Calendar impact `cal.status.*` |
|---|---|---|
| "Partial Outage" | `degraded` | `major` |
| "Major Outage" | `down` | `critical` |

Same word, two different axes → confusing to read. This PR removes the ambiguity so no single label maps to two internal values.

## Decision

Resolved per the industry two-axis convention (verified: Atlassian Statuspage separates component-**STATUS** words from incident-**IMPACT** words; aggregators normalize availability to up/degraded/down):

- **Service badge (availability)**: `Operational / Degraded / Down` (ko: 정상 / 성능 저하 / 다운)
- **Calendar impact (severity)**: `Operational / Minor / Major / Critical` (ko: 정상 / 경미 / 주요 / 심각)

**Labels-only** — internal value keys (`status.*`, `cal.status.*`) unchanged, **no behavior change**. The calendar painting logic and 3-vs-4-state models are untouched (a minor "degraded performance" day stays green, matching the official status.anthropic.com uptime bar). `is-down` SSR already rendered `Operational / Degraded Performance / Down` (no collision there); only a down-state share-template string was aligned.

## Files

- `src/locales/{en,ko}.js` — the 5 changed label values per language
- `api/methodology/html-template.ts` (+ test) — §2 badge axis (`Operational · Degraded · Down`, worst-of `Down > Degraded > Operational`), §3 redundant gloss dropped
- `api/is-down/html-template.ts` — a down-state share-template string
- `src/utils/__tests__/calendar.test.js` — anti-collision **disjointness pin** + exact label-set pin
- `tests/service-details.spec.js` — calendar legend e2e now asserts the new impact labels
- stale comments (`calendar.js` / `ServiceDetails.jsx` / `index.css`) + `docs/marketing-playbook.md`

## Acceptance (#674)

- [x] No label string maps to two different internal values across `status.*` / `cal.status.*` (disjointness test pins both en + ko)
- [x] Service badge, calendar legend, is-down SSR, methodology page all consistent
- [x] Unit + e2e assertion pinning the label set

## Verification

- `npm run test:src` → **504 passed**; calendar unit tests pass; `npm run build` clean; `npm run lint` 0 errors
- `npm test` (Playwright e2e) → **131 passed** (incl. updated `service-details` legend assertion)
- PR review (label changes): **0 Critical / 0 Important**
- In-browser confirmed by operator: dashboard calendar matches the official Anthropic page, legend + badge carry the new labels, methodology §2 consistent

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)