### PR TITLE
fix(types): clear the 16 production-source worker type errors (#533 Phase 2)

### DIFF
--- a/api/is-down/region-status.ts
+++ b/api/is-down/region-status.ts
@@ -123,7 +123,7 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
   // True when an incident names one of THIS service's tracked regions (title or
   // componentNames substring) — same match the main loop uses below.
   const mentionsRegion = (inc: IncidentLike): boolean => {
-    const t = (inc.title || '').toLowerCase()
+    const t = String(inc.title || '').toLowerCase() // title is typed `unknown` (#533 Phase 2 — coerce, never throw)
     const comp = (Array.isArray(inc.componentNames) ? inc.componentNames : []).map((n) => String(n).toLowerCase())
     return regionDefs.some((r) => {
       const k = r.key.toLowerCase()

--- a/worker/src/ai-analysis.ts
+++ b/worker/src/ai-analysis.ts
@@ -391,7 +391,10 @@ export async function analyzeWithSonnet(
  * Hybrid analysis: try Gemma first (Workers AI), fall back to Sonnet on failure.
  */
 export async function analyzeIncident(
-  apiKey: string,
+  // #533 Phase 2 — honest type: callers gate on `(apiKey || ai)`, so apiKey may be undefined here when
+  // only the Gemma binding is present. The `if (!apiKey) return null` guard below already handles it
+  // (Sonnet is skipped), so this is a type-accuracy fix, not a behavior change.
+  apiKey: string | undefined,
   serviceName: string,
   currentIncident: { id: string; title: string; status: string; startedAt: string; impact: string | null; timeline?: Array<{ stage: string; text: string | null; at: string }> },
   allIncidents: Incident[],

--- a/worker/src/cors.ts
+++ b/worker/src/cors.ts
@@ -36,10 +36,10 @@
  * @returns The string to send back as `Access-Control-Allow-Origin`, or `''`
  *   when the origin is not allowed.
  */
-export function matchOrigin(origin: string, allowedOrigin: string | undefined): string {
+export function matchOrigin(origin: string | null, allowedOrigin: string | undefined): string {
   if (!allowedOrigin) return ''
   if (allowedOrigin === '*') return '*'
-  if (!origin) return ''
+  if (!origin) return '' // narrows `origin` to a non-null string for the matching below
   for (const raw of allowedOrigin.split(',')) {
     const pattern = raw.trim()
     if (!pattern) continue
@@ -61,8 +61,12 @@ export function matchOrigin(origin: string, allowedOrigin: string | undefined): 
  * CORS response headers for the matched origin, or `{}` when not allowed.
  * `Vary: Origin` ensures CDN/proxy caches don't serve a response targeted
  * at one origin to a different one.
+ *
+ * Returns a concrete `Record<string, string>` (not the wider `HeadersInit`) so callers can both
+ * spread it (`{ ...cors }`) and pass it to handlers typed `Record<string, string>` (#533 Phase 2).
+ * `origin` accepts `null` — the raw `request.headers.get('Origin')` — since `matchOrigin` fails closed.
  */
-export function corsHeaders(origin: string, allowedOrigin: string | undefined): HeadersInit {
+export function corsHeaders(origin: string | null, allowedOrigin: string | undefined): Record<string, string> {
   const allowOrigin = matchOrigin(origin, allowedOrigin)
   if (!allowOrigin) return {}
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1167,7 +1167,8 @@ async function handleAdminAnalyze(request: Request, env: Env, cors: Record<strin
   const { service, incident } = active
   const similar = findSimilarIncidents(incident.title, service.incidents ?? [])
   const prompt = buildAnalysisPrompt(service.name, {
-    id: incident.id, title: incident.title, status: incident.status,
+    // #533 Phase 2 — buildAnalysisPrompt's param has no `id` (unused by the prompt); drop the excess key.
+    title: incident.title, status: incident.status,
     startedAt: incident.startedAt, impact: incident.impact, timeline: incident.timeline,
   }, similar)
   const timelineAt = incident.timeline?.at(-1)?.at ?? ''

--- a/worker/src/parsers/onlineornot.ts
+++ b/worker/src/parsers/onlineornot.ts
@@ -1,6 +1,6 @@
 // OnlineOrNot (React Router SSR) Parser — for status pages like OpenRouter
 
-import type { Incident } from '../types'
+import type { Incident, TimelineEntry } from '../types'
 import { formatDuration } from '../utils'
 
 /**
@@ -90,7 +90,7 @@ export function parseOnlineOrNotIncidents(html: string): Incident[] {
     const endDate = ended ? new Date(ended) : null
     const isResolved = endDate != null && !isNaN(endDate.getTime())
 
-    const timeline: { stage: string; text: string; at: string }[] = [
+    const timeline: TimelineEntry[] = [
       { stage: 'investigating', text: title, at: startDate.toISOString() },
     ]
     if (isResolved) {


### PR DESCRIPTION
## What

**#533 Phase 2** — fix every production-source TypeScript type-mismatch error so a later phase can promote the `typecheck:worker` CI gate from **TS2304-only** (the #532 undefined-name class) to a full `tsc --noEmit`. All **type-accuracy fixes on already-correct runtime code — ZERO behavior change.**

The original inventory listed 20; the `services.ts ×5` (`StatusResolverSummary`) cluster was already fixed by later component work, leaving **16** prod-source errors (TS2345 ×10, TS2339 ×4, TS2353 ×1, TS2322 ×1).

## Clusters

| # | File | Fix |
|---|---|---|
| A (×8) | `worker/src/cors.ts` | `corsHeaders` return `HeadersInit`→`Record<string,string>` (handlers are typed `Record<string,string>`) and `origin: string \| null` (matches `request.headers.get('Origin')`); `matchOrigin` widened too (already fails closed on falsy). Fixes 8 `index.ts` call-site errors at the source. |
| B (×1) | `worker/src/index.ts` | Drop the unused `id` key from the `buildAnalysisPrompt` object literal (param type has no `id`). |
| C (×2) | `worker/src/ai-analysis.ts` | `analyzeIncident(apiKey: string \| undefined)` — callers gate on `apiKey \|\| ai` and the body already has `if (!apiKey) return null`. |
| D (×3) | `worker/src/detection-lead-log.ts` | Destructure `{svcId,incId,leadMs}` BEFORE the `isValidEntry` type-predicate guard (which narrows `entry` to `never` in the failure branch). |
| E (×1) | `worker/src/parsers/onlineornot.ts` | Annotate the local `timeline` as `TimelineEntry[]` (its `stage:string` literal didn't fit the union) + import the type. |
| F (×1) | `api/is-down/region-status.ts` | `String(inc.title \|\| '')` — `title` is typed `unknown`; coerce so it can't throw (the upstream `ongoing` filter already guards `typeof title === 'string'`, so type-only). |

## Verification

- Full `tsc -p worker/tsconfig.typecheck.json` → **0 production-source errors** (16 → 0)
- `typecheck:worker` (Phase 1 TS2304 gate) still **green**
- `npm run test:worker` **1762** · `npm run test:src` **501** · `npm run lint` 0 errors · `wrangler --dry-run` OK
- PR review: **0 Critical / 0 Important** — zero-behavior-change confirmed across all 6 clusters, no `as any`/`!` masking

## Scope notes

- **No new test** — these are type-accuracy fixes with no reachable runtime behavior change (an initially-added region-status test was removed once confirmed the non-string path is unreachable through `regionStatusOf`).
- `detection-lead-log.ts` is **deleted by the open PR #705** (#679) — the fix here is harmless either way (vanishes in rebase if #705 merges first; correctly fixes the `never`-narrowing error meanwhile).
- The gate is **still TS2304-only** — promoting it to full `tsc` is **Phase 4**. **Phases 3 (rootDir scoping) and 4 remain → issue stays open.**

> **Worker deploy after merge** (`npm run deploy:worker`, once, after approval) — though this PR ships no runtime change, so it can also ride the next worker deploy.

refs #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)