### PR TITLE
fix(ci): verify-reminders skips completed (checked) verify-after lines (#541)

### DIFF
--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -17,20 +17,34 @@ import { execFileSync } from 'node:child_process'
 // line as a free-form note. Case-insensitive; `after` may be followed by space, `:` or `-`.
 const VERIFY_RE = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})([^\n]*)/gi
 
+// A CHECKED markdown task-list marker at the start of a line (`- [x]` / `* [X]` / `+ [x]`, leading
+// indent ok). Ticking the box is the SSOT "this verify is done" action, so a verify-after on such a
+// line must STOP firing — otherwise a completed item re-fires forever (the old whole-body scan
+// ignored the checkbox; #586's done `- [x] verify-after 2026-06-12` re-fired for 7 days). Unchecked
+// boxes (`- [ ]`) and plain prose lines still fire. The marker→`[` space is REQUIRED (`\s+`): GFM
+// renders `-[x]` (no space) as literal text, NOT a checked task, so it must still fire (don't
+// over-suppress a genuinely-open reminder).
+const CHECKED_BOX_RE = /^\s*[-*+]\s+\[[xX]\]/
+
 /** True only for a real calendar date (rejects 2026-02-30, which Date would silently roll over). */
 export function isValidIsoDate(s) {
   const d = new Date(`${s}T00:00:00Z`)
   return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s
 }
 
-/** Extract every {date, note} pair from an issue body. Calendar-invalid dates are skipped. */
+/** Extract every {date, note} pair from an issue body. Calendar-invalid dates are skipped, and a
+ *  verify-after on a CHECKED checkbox line (`- [x]`) is skipped — a done item must not keep firing. */
 export function parseVerifyAfter(body) {
   const out = []
   if (!body) return out
-  for (const m of body.matchAll(VERIFY_RE)) {
-    if (!isValidIsoDate(m[1])) continue
-    const note = m[2].replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
-    out.push({ date: m[1], note })
+  // Scan line-by-line so a per-line CHECKED checkbox can suppress that line's verify-after.
+  for (const line of body.split('\n')) {
+    if (CHECKED_BOX_RE.test(line)) continue
+    for (const m of line.matchAll(VERIFY_RE)) {
+      if (!isValidIsoDate(m[1])) continue
+      const note = m[2].replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
+      out.push({ date: m[1], note })
+    }
   }
   return out
 }

--- a/scripts/verify-reminders.test.mjs
+++ b/scripts/verify-reminders.test.mjs
@@ -48,6 +48,22 @@ test('parseVerifyAfter — skips calendar-invalid dates (rollover guard)', () =>
   assert.equal(parseVerifyAfter('verify-after 2026-02-28 ok')[0].date, '2026-02-28')
 })
 
+test('parseVerifyAfter — skips a CHECKED checkbox line; unchecked + prose still fire (#541/#586)', () => {
+  // A done item (`- [x]`) must STOP firing — ticking the box is the SSOT "done" action.
+  assert.deepEqual(parseVerifyAfter('- [x] **verify-after 2026-06-12** — done'), [])
+  assert.deepEqual(parseVerifyAfter('* [X] verify-after 2026-06-12 done (alt marker + caps)'), [])
+  assert.deepEqual(parseVerifyAfter('+ [x] verify-after 2026-06-12 done (+ marker)'), [])
+  assert.deepEqual(parseVerifyAfter('   - [x] verify-after 2026-06-12 indented done'), [])
+  // Unchecked + prose lines are unaffected.
+  assert.equal(parseVerifyAfter('- [ ] verify-after 2026-07-02 still open')[0].date, '2026-07-02')
+  assert.equal(parseVerifyAfter('Open: verify-after 2026-07-02 (prose ref)')[0].date, '2026-07-02')
+  // GFM needs a space after the marker — `-[x]` is literal text (NOT a checked task) → must still fire.
+  assert.equal(parseVerifyAfter('-[x] verify-after 2026-07-02 not a real checkbox')[0].date, '2026-07-02')
+  // The #586 shape: one done (skipped) + one open (fires) → only the open date returns.
+  const body = '- [x] **verify-after 2026-06-12** — daily cron counters\n- [ ] **verify-after 2026-07-02** — archive month'
+  assert.deepEqual(parseVerifyAfter(body), [{ date: '2026-07-02', note: 'archive month' }])
+})
+
 test('isValidIsoDate', () => {
   assert.equal(isValidIsoDate('2026-06-03'), true)
   assert.equal(isValidIsoDate('2026-02-29'), false) // 2026 not a leap year


### PR DESCRIPTION
## Problem

The daily `verify-reminders` Action re-fired a **completed** checklist item. `parseVerifyAfter` (`scripts/verify-reminders.mjs`) matched the `verify-after <date>` token anywhere in the issue body and **ignored the markdown checkbox state** — so a ticked `- [x] verify-after 2026-06-12` kept Discord-pinging the operator. **#586**'s done item re-fired for 7 days ("7d overdue") even though its box was checked and the Status block said "prod-verified".

## Fix

`parseVerifyAfter` now scans **line-by-line** and skips a `verify-after` that sits on a **CHECKED** task-list line (`- [x]` / `* [X]` / `+ [x]`, leading indent allowed). Ticking the box is the source-of-truth "this verify is done" action, so it now silences the reminder. **Unchecked** boxes (`- [ ]`) and **plain prose** references still fire.

The marker→`[` space is **required** (`\s+`): GFM renders `-[x]` (no space) as literal text, not a checked task, so it must still fire — avoid over-suppressing a genuinely-open reminder (the worse failure for a reminder system).

## Verification

- Pure-function change to the unit-tested `parseVerifyAfter`; **behavior preserved** for every non-checked line (multiple dates, `:`/`-` separators, case-insensitivity, calendar-invalid-date skip, note trim) — confirmed in review.
- `npm run test:scripts` → **52 pass**. New test pins **both directions** (checked→skipped, unchecked/prose/`-[x]`→fires) + the real #586 mixed-body shape with exact note extraction (alt `*`/`+` markers, caps `[X]`, indent covered).
- PR review: **0 Critical / 0 Important**; the one suggestion (GFM `\s+` vs `\s*`) is applied.

> Companion to a manual cleanup on **#586** (removed stale `verify-overdue` label + neutralized the done 6/12 line) that stopped the immediate re-fire; this PR fixes the root cause so it can't recur for any future completed verify-after item. Takes effect on the next scheduled Action run after merge (no deploy).

refs #541, refs #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)