### PR TITLE
fix(sidebar): category-order the service list + cross-category Recent Incidents (refs #676)

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,7 +6,7 @@ import { usePage } from '../utils/pageContext'
 import { useLang } from '../hooks/useLang'
 import { usePolling } from '../hooks/usePolling'
 import { trackEvent } from '../utils/analytics'
-import { SERVICE_CATEGORIES, ALL_SERVICES_FEED_URL } from '../utils/constants'
+import { SERVICE_CATEGORIES, ALL_SERVICES_FEED_URL, categoryRankOf } from '../utils/constants'
 import { isUnreliableUptime } from '../utils/serviceReliability'
 import RssCopyIcon from './RssCopyIcon'
 
@@ -169,6 +169,10 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
   const categoryServices = categoryIds
     ? visibleServices.filter((s) => categoryIds.includes(s.id))
     : visibleServices
+  // #676 — order the flat list by category rank (LLM → Agents → Voice → Inference → Video → Apps) so it
+  // matches the filter chips + Overview sections (Apps last, Agents directly after LLM) instead of the
+  // raw worker order (api → apps → agents). Stable sort keeps the worker order WITHIN each bucket.
+  const orderedServices = [...categoryServices].sort((a, b) => categoryRankOf(a.id) - categoryRankOf(b.id))
 
   const issueCount = useMemo(() => services.filter((s) => s.status !== 'operational').length, [services])
   // Count only unresolved incidents (investigating/identified/monitoring), deduplicated
@@ -299,15 +303,9 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
         </div>
       </div>
 
-      {/* ── Filtered service list (unified, divider between non-agent/agent in All tab) ── */}
-      <nav className="overflow-y-auto" style={{ padding: '0 12px' }}>
-        {categoryServices.filter((s) => s.category !== 'agent').map((svc) => (
-          <ServiceNavItem key={svc.id} svc={svc} page={page} setPage={setPage} onNavigate={onNavigate} />
-        ))}
-        {categoryFilter === 'all' && categoryServices.some((s) => s.category === 'agent') && (
-          <div style={{ height: '1px', background: 'var(--border)', margin: '6px 0' }} />
-        )}
-        {categoryServices.filter((s) => s.category === 'agent').map((svc) => (
+      {/* ── Filtered service list — single flat list in #658 category order (#676) ── */}
+      <nav className="overflow-y-auto" style={{ padding: '0 12px' }} aria-label={t('nav.services')}>
+        {orderedServices.map((svc) => (
           <ServiceNavItem key={svc.id} svc={svc} page={page} setPage={setPage} onNavigate={onNavigate} />
         ))}
       </nav>

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -657,8 +657,12 @@ export default function Overview() {
   const sevenDaysAgo = Date.now() - 7 * 86_400_000
   // Dedup by incident ID (Anthropic bulk-links one incident to claude.ai + Claude API + Claude Code)
   // while collecting every affected service name. Mirrors the Incidents.jsx aggregation pattern.
+  // Recent Incidents intentionally spans ALL enabled services (`services`), NOT the category-filtered
+  // `catServices` — a category filter scopes the stats/sections/latency, but the incidents panel is a
+  // cross-category "what's happening right now" view, so picking a category must not hide live incidents
+  // from other categories. (Still honors the user's enabled-services subset via `services`.)
   const incMap = new Map()
-  for (const s of catServices) {
+  for (const s of services) {
     for (const inc of s.incidents ?? []) {
       const existing = incMap.get(inc.id)
       if (existing) {

--- a/src/utils/__tests__/constants.test.js
+++ b/src/utils/__tests__/constants.test.js
@@ -3,7 +3,7 @@
 // because the worker can't import frontend code at runtime.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, getGroupedFallbacksExcludingRegionSwitchable, hasRegionSwitch, shouldShowFallback, hasActiveIncident, SERVICE_CATEGORIES, ALL_SERVICE_IDS } from '../constants'
+import { tierFor, tierLabelFor, API_TIER, TIER_LABEL, getFallbacks, getGroupedFallbacks, getGroupedFallbacksExcludingRegionSwitchable, hasRegionSwitch, shouldShowFallback, hasActiveIncident, SERVICE_CATEGORIES, ALL_SERVICE_IDS, categoryRankOf } from '../constants'
 
 // #646 — the Overview renders one section per SERVICE_CATEGORIES bucket (llm/agents/voice/inference/
 // video/apps, #658). Its render has a defensive "other" catch-all for any service no bucket claims,
@@ -25,6 +25,40 @@ describe('SERVICE_CATEGORIES partitions ALL_SERVICE_IDS (#646 Overview sections)
 
   it('the six section buckets cover every service in ALL_SERVICE_IDS (no leftover, no extra)', () => {
     expect([...sectionIds].sort()).toEqual([...ALL_SERVICE_IDS].sort())
+  })
+})
+
+// #676 — the sidebar service list sorts by categoryRankOf so it mirrors the filter chips + Overview
+// sections (LLM → Agents → Voice → Inference → Video → Apps; Agents before Apps, Apps last).
+describe('categoryRankOf (#676 sidebar/list category order)', () => {
+  const SECTION_KEYS = ['llm', 'agents', 'voice', 'inference', 'video', 'apps']
+
+  it('ranks each bucket by its #658 canonical position (llm=0 … apps=5)', () => {
+    SECTION_KEYS.forEach((key, rank) => {
+      for (const id of SERVICE_CATEGORIES[key].ids) {
+        expect(categoryRankOf(id), `${id} (${key})`).toBe(rank)
+      }
+    })
+  })
+
+  it('orders Agents before Apps, and Apps last (the #676 fix)', () => {
+    expect(categoryRankOf('claudecode')).toBeLessThan(categoryRankOf('claudeai')) // agent < app
+    const appRank = categoryRankOf('chatgpt')
+    for (const id of ALL_SERVICE_IDS) {
+      if (!SERVICE_CATEGORIES.apps.ids.includes(id)) {
+        expect(categoryRankOf(id), `${id} must rank before apps`).toBeLessThan(appRank)
+      }
+    }
+  })
+
+  it('sorting ALL_SERVICE_IDS by rank yields a stable LLM→Agents→Voice→Inference→Video→Apps grouping', () => {
+    const sorted = [...ALL_SERVICE_IDS].sort((a, b) => categoryRankOf(a) - categoryRankOf(b))
+    const ranks = sorted.map(categoryRankOf)
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b)) // non-decreasing → buckets contiguous + ordered
+  })
+
+  it('returns Infinity for an unknown id (sorts last, never throws)', () => {
+    expect(categoryRankOf('not-a-service')).toBe(Infinity)
   })
 })
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -59,6 +59,19 @@ export const SERVICE_CATEGORIES = {
   apps:      { labelKey: 'filter.apps',      ids: ['claudeai', 'chatgpt', 'characterai', 'deepseekapp'] },
 }
 
+// #676 — the rankable category buckets in #658 canonical order (LLM → Agents → Voice → Inference →
+// Video → Apps), excluding `all` (ids:null). Single source of truth for ordering a flat service list.
+const RANKABLE_CATEGORY_KEYS = Object.keys(SERVICE_CATEGORIES).filter((k) => SERVICE_CATEGORIES[k].ids)
+
+// #676 — a service's category rank = the index of its bucket in RANKABLE_CATEGORY_KEYS, so a flat
+// service list can be sorted to mirror the filter chips + Overview sections (Agents before Apps, Apps
+// last). Unknown id → Infinity (sorts last). Used by the Sidebar service list; shareable by any
+// consumer that needs the canonical category order.
+export function categoryRankOf(id) {
+  const r = RANKABLE_CATEGORY_KEYS.findIndex((k) => SERVICE_CATEGORIES[k].ids.includes(id))
+  return r === -1 ? Infinity : r
+}
+
 // Services excluded from fallback recommendations (not interchangeable with LLM APIs)
 // Keep in sync with worker/src/fallback.ts EXCLUDE_FALLBACK
 export const EXCLUDE_FALLBACK = ['replicate', 'huggingface', 'pinecone', 'stability', 'voyageai', 'modal', 'langsmith', 'characterai', 'bedrock', 'azureopenai']

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -37,4 +37,28 @@ test.describe('Sidebar navigation', () => {
     await expect(reportsLink).toBeVisible()
     await expect(reportsLink).toHaveAttribute('href', '/reports/')
   })
+
+  test('service list is ordered by category — Agents before Apps, Apps last (#676)', async ({ page }) => {
+    // Pre-#676 the sidebar rendered raw worker order (api → apps → divider → agents), putting Apps
+    // before Agents. Now it's a single flat list sorted by SERVICE_CATEGORIES rank (#658): LLM →
+    // Agents → Voice → Inference → Video → Apps. Mock a service in an LLM / agent / app bucket and
+    // assert the rendered order.
+    const svc = (id, name, category) => ({ id, category, name, provider: 'x', status: 'operational', latency: 150, uptime30d: 99.9, calendarDays: 30, incidents: [] })
+    const mock = { json: { services: [
+      svc('chatgpt', 'ChatGPT', 'app'),          // app — must end up LAST
+      svc('claudecode', 'Claude Code', 'agent'), // agent — must precede the app
+      svc('claude', 'Claude API', 'api'),        // llm — must come first
+    ], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.goto('/')
+    await waitForDataLoad(page)
+    const serviceNav = page.locator('aside').first().getByRole('navigation', { name: /Services|서비스/ })
+    const names = await serviceNav.locator('button').allTextContents()
+    const idx = (n) => names.findIndex((x) => x.includes(n))
+    // LLM < Agent < App  (the #676 canonical order; Apps last)
+    expect(idx('Claude API'), names.join(' | ')).toBeGreaterThanOrEqual(0)
+    expect(idx('Claude API')).toBeLessThan(idx('Claude Code'))
+    expect(idx('Claude Code')).toBeLessThan(idx('ChatGPT'))
+  })
 })

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -180,6 +180,31 @@ test.describe('Overview page', () => {
     expect(entryText).toContain('Claude Code')
   })
 
+  test('Recent Incidents spans all categories — a category filter does not hide other-category incidents (#676)', async ({ page }) => {
+    // The category filter scopes the stats/sections/latency to one bucket, but Recent Incidents is a
+    // cross-category "what's live right now" panel: picking a category must NOT hide an active incident
+    // from another category. Pre-#676 it iterated the category-filtered list, so an LLM filter hid an
+    // app outage from the panel.
+    const appInc = { id: 'app-outage-676', title: 'ChatGPT app outage 676', status: 'investigating', impact: 'major', startedAt: new Date(Date.now() - 60_000).toISOString(), duration: null, timeline: [] }
+    const mock = { json: { services: [
+      { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.9, calendarDays: 30, incidents: [] },
+      { id: 'chatgpt', category: 'app', name: 'ChatGPT', provider: 'OpenAI', status: 'degraded', latency: 150, uptime30d: 99.5, calendarDays: 30, incidents: [appInc] },
+    ], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.goto('/')
+    await waitForDataLoad(page)
+    // Under default 'all', the app incident shows in Recent Incidents.
+    await expect(page.locator('main').getByText(/ChatGPT app outage 676/).first()).toBeVisible({ timeout: 10000 })
+    // Filter to LLM → the ChatGPT card leaves the grid (it's an app)…
+    const tablist = page.getByRole('tablist', { name: /Services|서비스/ })
+    await tablist.getByRole('tab', { name: /LLM/ }).click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('main button').filter({ hasText: 'ChatGPT' })).toHaveCount(0)
+    // …but its incident is STILL listed in Recent Incidents (cross-category panel, #676).
+    await expect(page.locator('main').getByText(/ChatGPT app outage 676/).first()).toBeVisible()
+  })
+
   test('Recent Incidents date label exposes contextual label via tooltip (#406)', async ({ page }) => {
     // Vitest suite covers `getContextualTime` correctness directly; this test guards the
     // Overview.jsx call site so reverting `incident.startedAt` or dropping the `title` attribute


### PR DESCRIPTION
Two category-UX fixes on the Overview / Sidebar (frontend-only).

## 1. #676 — sidebar service list order
The sidebar rendered the raw worker order (`api → apps → divider → agents`), putting **AI Apps above Coding Agents** — contradicting the filter chips + Overview sections (#658 canonical order: **LLM → Agents → Voice → Inference → Video → Apps**, Apps last).

- **`src/utils/constants.js`** — add `categoryRankOf(id)`: rank = index of the service's bucket in `SERVICE_CATEGORIES` key order (skipping `all`/`ids:null`; unknown → `Infinity`). Single source of truth for the canonical category order.
- **`src/components/Sidebar.jsx`** — render **one flat list** sorted by `categoryRankOf` (stable sort preserves the worker order *within* each bucket); drop the old non-agent/agent divider split. Added `aria-label` to the service-list `<nav>` landmark (a11y + a clean test hook).

## 2. Recent Incidents — cross-category (additional finding, bundled per request)
The Overview "Recent Incidents" panel iterated `catServices` (the **category-filtered** list), so picking a category **hid live incidents from other categories**. A category filter is meant to scope the stats / sections / latency, but Recent Incidents is a cross-category *"what's live right now"* view.

- **`src/pages/Overview.jsx`** — iterate `services` (the enabled, all-category list; still honors the user's enabled-services subset) instead of `catServices`. The stats / sections / latency stay category-scoped by design.

> Note: this second fix is not in the #676 issue body (which covers sidebar ordering only) — it's bundled here at the user's request, hence `refs #676` (not `closes`).

## Tests
- `src/utils/__tests__/constants.test.js` — `categoryRankOf` ranks, Agents-before-Apps / Apps-last, stable non-decreasing order, unknown→Infinity.
- `tests/navigation.spec.js` — sidebar renders **LLM < Agent < App**.
- `tests/overview.spec.js` — an **LLM filter still shows an app incident** in Recent Incidents.

## Review / verification
PR review (code-reviewer) → **0 Critical/Important**. Frontend: build · `test:src` **513** · lint 0 errors · SPA e2e (desktop + mobile) green. The 17 full-suite failures are `[reports]` + `[consent]` Edge-SSR tests whose Vercel dev server (:3333) exited mid-run — unrelated to this SPA-only change.

## Acceptance (#676)
- [x] Sidebar order matches the filter chips (LLM → Agents → Voice → Inference → Video → Apps); Apps last, Agents directly after LLM
- [x] Order correct under a category filter + a custom visible-services subset (sort runs on `categoryServices` = already category- + visibility-scoped)
- [x] `test:src` + SPA e2e green; unit assertion pinning the order to `SERVICE_CATEGORIES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)