### PR TITLE
Add shared multi-agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+This repository supports multiple coding agents. Keep this file short and use it as the neutral,
+agent-agnostic entrypoint.
+
+If you are using Claude Code, also read [CLAUDE.md](./CLAUDE.md) for Claude-specific workflow and
+project automation details.
+
+## Project Overview
+
+- AIWatch is a React + Vite frontend with Vercel Edge Functions and a Cloudflare Worker backend.
+- The repo is TypeScript/JavaScript, with tests in Vitest and Playwright.
+- The worker code lives under `worker/`; the main frontend lives under `src/`.
+
+## Setup
+
+- Install root dependencies with `npm install`.
+- Install worker dependencies with `cd worker && npm install`.
+- Use Node.js 20+.
+
+## Common Commands
+
+- `npm run dev` for the frontend dev server.
+- `npm run dev:worker` for the worker dev server.
+- `npm run dev:all` to run both locally.
+- `npm run build` for the production frontend build.
+- `npm run lint` for ESLint.
+- `npm run test:src` for frontend unit tests.
+- `npm run test:worker` for worker unit tests.
+- `npm test` for Playwright end-to-end tests.
+
+## Working Rules
+
+- Keep changes small and focused.
+- Prefer existing project patterns over new abstractions.
+- Update tests when behavior changes.
+- Do not introduce unrelated refactors.
+- For UI changes, verify both desktop and mobile behavior.
+- For worker or external API changes, check the relevant runtime and test coverage.
+
+## Code Style
+
+- Follow the existing file conventions in the touched area.
+- Keep markdown concise and factual.
+- Use the project’s existing design tokens and utilities instead of ad hoc styling.
+- Add comments only when the code would otherwise be hard to follow.
+
+## Environment Notes
+
+- Frontend environment variables live in `.env.example`.
+- Worker local variables live in `worker/.dev.vars.example`.
+- Do not commit secrets or local machine configuration.
+
+## If You Need More Detail
+
+- Read `README.md` for setup and commands.
+- Read `CONTRIBUTING.md` for contribution workflow.
+- Read the relevant `docs/reference/*` file for subsystem-specific rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,17 @@ Thank you for your interest in contributing to AIWatch!
 
 ## Development Workflow
 
-Follow the steps in [CLAUDE.md](../CLAUDE.md) — especially:
+Use [AGENTS.md](./AGENTS.md) as the shared repository entrypoint.
+
+If you are working with Claude Code, also follow [CLAUDE.md](../CLAUDE.md) for Claude-specific
+workflow and automation details.
+
+Shared workflow — especially:
 
 1. **Build + Test** before committing
 2. **Code review** before committing
 3. **Fix all Critical/Important** review findings
-4. Include `closes #N` in commit messages
+4. Include `closes #N` in commit messages when the work is fully verified
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to AIWatch!
 
 Use [AGENTS.md](./AGENTS.md) as the shared repository entrypoint.
 
-If you are working with Claude Code, also follow [CLAUDE.md](../CLAUDE.md) for Claude-specific
+If you are working with Claude Code, also follow [CLAUDE.md](./CLAUDE.md) for Claude-specific
 workflow and automation details.
 
 Shared workflow — especially:

--- a/README.md
+++ b/README.md
@@ -386,9 +386,14 @@ worker/
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
+If you are using a non-Claude coding agent, start with [AGENTS.md](AGENTS.md). Claude Code
+contributors should also read [CLAUDE.md](CLAUDE.md) for the repo-specific workflow and automation
+rules.
+
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)
-3. Follow the development workflow in [CLAUDE.md](CLAUDE.md)
+3. Follow the shared workflow in [AGENTS.md](AGENTS.md); Claude Code contributors should also
+   follow [CLAUDE.md](CLAUDE.md)
 4. Build + test: `npm run build && npm test && npm run test:worker`
 5. Submit a pull request using the [PR template](.github/pull_request_template.md)
 


### PR DESCRIPTION
## Summary

- Add a neutral AGENTS.md entrypoint for multi-agent use.
- Clarify README and CONTRIBUTING guidance so non-Claude agents start from AGENTS.md, while Claude Code users also follow CLAUDE.md.

## Verification

- git diff --check
- Reviewed public docs for instruction clarity

closes #728

Co-Authored-By: OpenAI Codex <noreply@openai.com>
