### PR TITLE
docs(readme): group Monitored Services by dashboard category taxonomy (refs #601)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -63,7 +63,9 @@
 
 ## 모니터링 서비스
 
-### AI API 서비스 (29개)
+대시보드 카테고리 분류 기준(총 39개 — 사이드바 필터 / Overview 섹션과 동일).
+
+### LLM API (15개)
 
 | 서비스 | 제공업체 | 상태 소스 |
 |--------|----------|-----------|
@@ -77,34 +79,11 @@
 | Fireworks AI | Fireworks | Better Stack RSS + 가동률 API |
 | Cerebras Inference | Cerebras | Atlassian Statuspage (멀티 컴포넌트 worst-of) |
 | Perplexity | Perplexity AI | Instatus (Next.js SSR) |
-| Hugging Face | HuggingFace | Better Stack RSS + 가동률 API |
-| Replicate | Replicate | incident.io (Atlassian 호환) |
-| ElevenLabs | ElevenLabs | incident.io (Atlassian 호환) |
-| AssemblyAI | AssemblyAI | Atlassian Statuspage |
-| Deepgram | Deepgram | Atlassian Statuspage |
 | xAI (Grok) | xAI | RSS 피드 |
 | DeepSeek API | DeepSeek | Flashduty (브라우저 렌더 피드) |
 | OpenRouter | OpenRouter | OnlineOrNot (React Router SSR) |
 | Amazon Bedrock | AWS | AWS Health Dashboard |
-| Pinecone | Pinecone | Atlassian Statuspage |
-| Stability AI | Stability AI | Atlassian Statuspage |
-| Voyage AI | Voyage AI | Atlassian Statuspage |
-| Modal | Modal | Better Stack RSS + 가동률 API |
-| LangChain (LangSmith) | LangChain | Atlassian Statuspage (incident.io) |
-| Helicone | Helicone | Better Stack RSS + 가동률 API |
-| Langfuse | Langfuse | incident.io (Atlassian compat) |
-| Runway | Runway | Atlassian Statuspage |
-| Luma (Dream Machine) | Luma | Better Stack RSS + 가동률 API |
 | Azure OpenAI | Microsoft | Azure Status RSS |
-
-### AI 앱 (4개)
-
-| 서비스 | 제공업체 |
-|--------|----------|
-| claude.ai | Anthropic |
-| ChatGPT | OpenAI |
-| Character.AI | Character AI |
-| DeepSeek App | DeepSeek |
 
 ### 코딩 에이전트 (6개)
 
@@ -116,6 +95,49 @@
 | GitHub Copilot | Microsoft |
 | Windsurf | Codeium |
 | Junie | JetBrains |
+
+### 음성 (3개)
+
+| 서비스 | 제공업체 | 상태 소스 |
+|--------|----------|-----------|
+| ElevenLabs | ElevenLabs | incident.io (Atlassian 호환) |
+| AssemblyAI | AssemblyAI | Atlassian Statuspage |
+| Deepgram | Deepgram | Atlassian Statuspage |
+
+### 추론 & 인프라 (6개)
+
+| 서비스 | 제공업체 | 상태 소스 |
+|--------|----------|-----------|
+| Hugging Face | HuggingFace | Better Stack RSS + 가동률 API |
+| Replicate | Replicate | incident.io (Atlassian 호환) |
+| Pinecone | Pinecone | Atlassian Statuspage |
+| Stability AI | Stability AI | Atlassian Statuspage |
+| Voyage AI | Voyage AI | Atlassian Statuspage |
+| Modal | Modal | Better Stack RSS + 가동률 API |
+
+### 관측 (3개)
+
+| 서비스 | 제공업체 | 상태 소스 |
+|--------|----------|-----------|
+| LangChain (LangSmith) | LangChain | Atlassian Statuspage (incident.io) |
+| Helicone | Helicone | Better Stack RSS + 가동률 API |
+| Langfuse | Langfuse | incident.io (Atlassian 호환) |
+
+### 영상 (2개)
+
+| 서비스 | 제공업체 | 상태 소스 |
+|--------|----------|-----------|
+| Runway | Runway | Atlassian Statuspage |
+| Luma (Dream Machine) | Luma | Better Stack RSS + 가동률 API |
+
+### AI 앱 (4개)
+
+| 서비스 | 제공업체 |
+|--------|----------|
+| claude.ai | Anthropic |
+| ChatGPT | OpenAI |
+| Character.AI | Character AI |
+| DeepSeek App | DeepSeek |
 
 ## 기술 스택
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 
 ## Monitored Services
 
-### AI API Services (29)
+Grouped by the dashboard's category taxonomy (39 total — sidebar filters / Overview sections mirror these).
+
+### LLM APIs (15)
 
 | Service | Provider | Status Source |
 |---------|----------|---------------|
@@ -78,34 +80,11 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | Fireworks AI | Fireworks | Better Stack RSS + uptime API |
 | Cerebras Inference | Cerebras | Atlassian Statuspage (multi-component worst-of) |
 | Perplexity | Perplexity AI | Instatus (Next.js SSR) |
-| Hugging Face | HuggingFace | Better Stack RSS + uptime API |
-| Replicate | Replicate | incident.io (Atlassian compat) |
-| ElevenLabs | ElevenLabs | incident.io (Atlassian compat) |
-| AssemblyAI | AssemblyAI | Atlassian Statuspage |
-| Deepgram | Deepgram | Atlassian Statuspage |
 | xAI (Grok) | xAI | RSS feed |
 | DeepSeek API | DeepSeek | Flashduty (browser-rendered feed) |
 | OpenRouter | OpenRouter | OnlineOrNot (React Router SSR) |
 | Amazon Bedrock | AWS | AWS Health Dashboard |
-| Pinecone | Pinecone | Atlassian Statuspage |
-| Stability AI | Stability AI | Atlassian Statuspage |
-| Voyage AI | Voyage AI | Atlassian Statuspage |
-| Modal | Modal | Better Stack RSS + uptime API |
-| LangChain (LangSmith) | LangChain | Atlassian Statuspage (incident.io) |
-| Helicone | Helicone | Better Stack RSS + uptime API |
-| Langfuse | Langfuse | incident.io (Atlassian compat) |
-| Runway | Runway | Atlassian Statuspage |
-| Luma (Dream Machine) | Luma | Better Stack RSS + uptime API |
 | Azure OpenAI | Microsoft | Azure Status RSS |
-
-### AI Apps (4)
-
-| Service | Provider |
-|---------|----------|
-| claude.ai | Anthropic |
-| ChatGPT | OpenAI |
-| Character.AI | Character AI |
-| DeepSeek App | DeepSeek |
 
 ### Coding Agents (6)
 
@@ -117,6 +96,49 @@ Visit **[ai-watch.dev](https://ai-watch.dev)** — no signup required. Updated e
 | GitHub Copilot | Microsoft |
 | Windsurf | Codeium |
 | Junie | JetBrains |
+
+### Voice (3)
+
+| Service | Provider | Status Source |
+|---------|----------|---------------|
+| ElevenLabs | ElevenLabs | incident.io (Atlassian compat) |
+| AssemblyAI | AssemblyAI | Atlassian Statuspage |
+| Deepgram | Deepgram | Atlassian Statuspage |
+
+### Inference & Infra (6)
+
+| Service | Provider | Status Source |
+|---------|----------|---------------|
+| Hugging Face | HuggingFace | Better Stack RSS + uptime API |
+| Replicate | Replicate | incident.io (Atlassian compat) |
+| Pinecone | Pinecone | Atlassian Statuspage |
+| Stability AI | Stability AI | Atlassian Statuspage |
+| Voyage AI | Voyage AI | Atlassian Statuspage |
+| Modal | Modal | Better Stack RSS + uptime API |
+
+### Observability (3)
+
+| Service | Provider | Status Source |
+|---------|----------|---------------|
+| LangChain (LangSmith) | LangChain | Atlassian Statuspage (incident.io) |
+| Helicone | Helicone | Better Stack RSS + uptime API |
+| Langfuse | Langfuse | incident.io (Atlassian compat) |
+
+### Video (2)
+
+| Service | Provider | Status Source |
+|---------|----------|---------------|
+| Runway | Runway | Atlassian Statuspage |
+| Luma (Dream Machine) | Luma | Better Stack RSS + uptime API |
+
+### AI Apps (4)
+
+| Service | Provider |
+|---------|----------|
+| claude.ai | Anthropic |
+| ChatGPT | OpenAI |
+| Character.AI | Character AI |
+| DeepSeek App | DeepSeek |
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
The README "Monitored Services" used a coarse 3-way grouping — **AI API Services (29)** / AI Apps (4) / Coding Agents (6) — which mirrors the worker's *internal* `category` field (api/app/agent), **not how the dashboard presents services**. The dashboard splits that "API" bucket into LLM / Voice / Inference / Observability / Video (peers of Apps + Agents), with no "API Services" umbrella.

Restructured into the dashboard's **7-way category taxonomy** as top-level sections, in `SECTION_KEYS` order:

**LLM APIs (15) · Coding Agents (6) · Voice (3) · Inference & Infra (6) · Observability (3) · Video (2) · AI Apps (4) = 39**

- Each section IS the category (drops the artificial "API Services" umbrella + the interim Category-column approach).
- Mirrors the dashboard **sidebar filters / Overview sections** + the methodology breakdown.
- **README.md** (EN labels) + **README.ko.md** (KO labels matching the `filter.*` ko.js chips: LLM API / 코딩 에이전트 / 음성 / 추론 & 인프라 / 관측 / 영상 / AI 앱).
- Status Source column preserved for the former-API sections (LLM/Voice/Inference/Observability/Video); Coding Agents + AI Apps stay Service|Provider (no invented data).

## Verification
Docs-only. PR review 0 Critical/Important — all 39 services cross-checked against `src/utils/constants.js` `SERVICE_CATEGORIES` (each in the correct section, none dropped/duplicated); section order matches `SECTION_KEYS`; counts sum to 39; EN/KO consistent.

`refs #601`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)