### PR TITLE
fix(ui): floor the 'Recent user reports' hour label (90m → '1h ago', not '2h ago')

### DIFF
--- a/src/components/RecentUserReports.jsx
+++ b/src/components/RecentUserReports.jsx
@@ -16,7 +16,7 @@ function relTime(ts, now) {
   const m = Math.max(0, Math.round((now - ts) / 60_000))
   if (m < 1) return 'just now'
   if (m < 60) return `${m}m ago`
-  return `${Math.round(m / 60)}h ago`
+  return `${Math.floor(m / 60)}h ago`
 }
 
 /**

--- a/src/components/__tests__/RecentUserReports.test.js
+++ b/src/components/__tests__/RecentUserReports.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+vi.mock('../../hooks/useLang', () => ({ useLang: () => ({ t: (k) => k }) }))
+
+const { default: RecentUserReports } = await import('../RecentUserReports')
+
+const render = (items) => renderToStaticMarkup(createElement(RecentUserReports, { items }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RecentUserReports time labels', () => {
+  it('keeps sub-hour reports in minutes instead of rounding them up to an hour', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    const html = render([
+      { cat: 'errors', desc: 'Spiking', ts: 1_000_000 - 35 * 60_000 },
+    ])
+
+    expect(html).toContain('35m ago')
+    expect(html).not.toContain('1h ago')
+  })
+
+  it('floors hour labels', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    const html = render([
+      { cat: 'errors', desc: 'Spiking', ts: 1_000_000 - 90 * 60_000 },
+    ])
+
+    expect(html).toContain('1h ago')
+    expect(html).not.toContain('2h ago')
+  })
+})


### PR DESCRIPTION
## Problem
`relTime()` in `RecentUserReports.jsx` used `Math.round(m / 60)` for the hours label, so a 90-minute-old report rendered **"2h ago"** (`round(1.5)=2`). For an elapsed "N hours ago" label, **floor** is correct — an hour has elapsed, not two.

## Fix
`Math.round(m / 60)` → `Math.floor(m / 60)`. The `<60m` branch is unchanged (0–59m still shows minutes).

## Test
New component-render test (renders `RecentUserReports`, mocks `Date.now`):
- 35m report → "35m ago" (not rounded up to "1h")
- 90m report → "1h ago" (not "2h ago") — **fails under the old `round()`**

build · src 556 · e2e 146 · review 0 Critical/Important.

Surfaced during the #772 crowd-report-window debugging (the report card's time display). Display-only — no behavior change beyond the label. (No issue; free-form fix salvaged from the working tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)