### PR TITLE
feat(rss): Slack /feed format polish — dividers + drop redundant 'Also affecting' (closes #760)

### DIFF
--- a/worker/src/__tests__/rss.test.ts
+++ b/worker/src/__tests__/rss.test.ts
@@ -507,12 +507,10 @@ describe('buildRssFeed — shared incident (per-surface providers)', () => {
     // One item, not three — the Slack /feed subscriber gets a single consolidated message
     expect((xml.match(/<item>/g) ?? []).length).toBe(1)
     // #724 — provider-grouped title (mirrors Discord "Anthropic (Claude API, claude.ai, Claude Code)").
-    // Primary = first in SERVICES order (Claude API); its "Also affecting" still names the rest.
+    // Primary = first in SERVICES order (Claude API); the title carries the full co-affected set.
     expect(xml).toContain('🔴 Anthropic (Claude API, claude ai, Claude Code): Elevated errors') // 'major' → 🔴, #539 brand defused
-    expect(xml).toContain('Also affecting: claude ai, Claude Code') // #539 brand defused
-    // The other surfaces' items (and their inverse "Also affecting" lines) are gone
-    expect(xml).not.toContain('Also affecting: Claude API, Claude Code')
-    expect(xml).not.toContain('Also affecting: Claude API, claude.ai')
+    // #760 — the redundant "Also affecting" line is dropped; the grouped title already lists the set.
+    expect(xml).not.toContain('Also affecting')
   })
 
   it('uses a per-incident guid for the collapsed item (no Slack re-post churn)', () => {
@@ -528,9 +526,10 @@ describe('buildRssFeed — shared incident (per-surface providers)', () => {
     expect(xml).not.toContain('Also affecting:')
   })
 
-  it('keeps the note + single item in a service-scoped feed using the full service list', () => {
+  it('keeps a single consolidated item in a service-scoped feed; the grouped title carries the co-affected set (#760)', () => {
     const xml = buildRssFeed(anthropic, { scope: 'service', service: anthropic[0] }, NOW)
-    expect(xml).toContain('Also affecting: claude ai, Claude Code') // #539 brand defused
+    expect(xml).toContain('🔴 Anthropic (Claude API, claude ai, Claude Code): Elevated errors') // #539 brand defused
+    expect(xml).not.toContain('Also affecting') // #760 — dropped (redundant with the grouped title)
     expect((xml.match(/<item>/g) ?? []).length).toBe(1)
   })
 
@@ -809,5 +808,43 @@ describe('buildRssFeed — publish-before-analysis hold (#759)', () => {
     const SIX_MIN_AGO = '2026-05-19T08:54:00.000Z' // exactly 6 min before NOW
     const xml = buildRssFeed([service({ incidents: [activeInc] })], { scope: 'all' }, NOW, undefined, { 'inc-1': SIX_MIN_AGO })
     expect(xml).toContain('aiwatch:claude:inc-1</guid>') // age === AI_HOLD_MS → released
+  })
+})
+
+describe('buildRssFeed — #760 feed format polish (dividers + no redundant "Also affecting")', () => {
+  const DIV = '<p>┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈</p>'
+  const ai: RssAiAnalysisMap = { claude: [{ incidentId: 'inc-1', summary: 'root cause', estimatedRecovery: '1h', affectedScope: ['Claude API'] }] }
+
+  it('inserts a divider before the 🤖 AI block and before the ↪ Try-instead line (mirrors Discord)', () => {
+    // Down service so the fallback ("Try instead") line is present; AI present so the AI block is too.
+    const svcs = [
+      service({ id: 'claude', name: 'Claude API', status: 'down', incidents: [incident({ id: 'inc-1', impact: 'major' })] }),
+      service({ id: 'openai', name: 'OpenAI API', status: 'operational', uptime30d: 99.9 }),
+    ]
+    const xml = buildRssFeed(svcs, { scope: 'all' }, NOW, ai, { 'inc-1': NOW.toISOString() })
+    const desc = (xml.match(/<description><!\[CDATA\[([\s\S]*?)\]\]><\/description>/) || [])[1] ?? ''
+    // two dividers: one before AI, one before Try-instead (count full DIV strings, not a substring)
+    expect(desc.split(DIV).length - 1).toBe(2)
+    // ordering: impact label … DIV … AI … DIV … Try instead
+    expect(desc.indexOf(DIV)).toBeLessThan(desc.indexOf('🤖 AI analysis'))
+    expect(desc.indexOf('🤖 AI analysis')).toBeLessThan(desc.lastIndexOf(DIV))
+    expect(desc.lastIndexOf(DIV)).toBeLessThan(desc.indexOf('↪'))
+  })
+
+  it('no divider on a plain active item with neither AI nor fallback', () => {
+    // operational-status service can still carry an incident; no fallback (not down/degraded), no AI.
+    const xml = buildRssFeed([service({ status: 'operational', incidents: [incident({ id: 'inc-1' })] })], { scope: 'all' }, NOW, undefined, { 'inc-1': NOW.toISOString() })
+    const desc = (xml.match(/<description><!\[CDATA\[([\s\S]*?)\]\]><\/description>/) || [])[1] ?? ''
+    expect(desc).not.toContain('┈┈┈┈┈┈')
+  })
+
+  it('drops "Also affecting" for a multi-surface incident (title already lists the set)', () => {
+    const svcs = [
+      service({ id: 'claude', name: 'Claude API', incidents: [incident({ id: 'shared', title: 'Errors' })] }),
+      service({ id: 'claudeai', name: 'claude.ai', incidents: [incident({ id: 'shared', title: 'Errors' })] }),
+    ]
+    const xml = buildRssFeed(svcs, { scope: 'all' }, NOW)
+    expect(xml).toContain('Anthropic') // provider-grouped title present
+    expect(xml).not.toContain('Also affecting')
   })
 })

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -98,6 +98,12 @@ const MAX_ITEMS = 50
 // posts (just without AI). Usually adds zero latency (AI lands within seconds).
 const AI_HOLD_MS = 6 * 60_000
 
+// #760 — section divider mirroring the Discord operator embed's `┈┈…` (index.ts DIV), so the Slack
+// `/feed` description (which flattens the <p> tags) renders the same scannable section breaks. A
+// `<p>` so it joins with the same `\n` separator as the other paragraphs; box-drawing chars only (no
+// HTML-significant chars → no escaping needed).
+const FEED_DIV = '<p>┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈</p>'
+
 // Service IDs whose ID differs from their /is-{slug}-down SEO page slug.
 // Most services use their ID verbatim; only these dropped a dash in the ID.
 // Canonical source: SERVICE_ID_TO_SLUG in api/is-down/slug-map.ts — this copy
@@ -192,8 +198,9 @@ function rfc822(iso: string): string {
 
 // Map of incident ID → every service name carrying it. A provider that reports
 // per-surface (Anthropic: Claude API / claude.ai / Claude Code) links one root
-// incident to multiple services, so the same ID surfaces as several items —
-// the "Also affecting" note tells a subscriber it's one event, not three.
+// incident to multiple services, so the same ID would surface as several items —
+// the provider-grouped title ("Anthropic (Claude API, claude.ai, Claude Code): …", #724) tells a
+// subscriber it's one event, not three (the old "Also affecting" line was dropped in #760 as a dup).
 function buildIncidentServiceMap(services: ServiceStatus[]): Map<string, string[]> {
   const map = new Map<string, string[]>()
   for (const svc of services) {
@@ -261,7 +268,6 @@ function cap(s: string): string {
 function descHtml(
   service: ServiceStatus,
   inc: Incident,
-  coAffected: string[],
   opts: { kind: ItemKind; fallbackText?: string; analysis?: RssAiAnalysis },
 ): string {
   const isResolved = opts.kind === 'resolved'
@@ -279,28 +285,31 @@ function descHtml(
     // by the #759 hold. The evolving detail lives on the linked is-down / dashboard page; recovery is
     // a separate `:resolved` item (#467). Net per incident lifecycle: 1 active post + 1 resolved post.
     // NOTE this freezes only the status-driven churn — a SEMANTICALLY meaningful change still re-posts
-    // (and should): an impact escalation (major→critical), a surface joining "Also affecting", an AI
+    // (and should): an impact escalation (major→critical), a surface joining the provider-grouped title, an AI
     // re-analysis rewriting the summary, or a fallback recommendation flip. Stability holds *given*
     // stable impact / co-affected / AI / fallback — which is the common case across investigating→identified.
     const label = inc.impact ? cap(inc.impact) : service.status === 'down' ? 'Down' : 'Degraded'
     lines.push(`<p>${severityEmoji(service, inc, false)} <strong>${escHtml(label)}</strong></p>`)
   }
-  // #539: defuse bare "claude.ai" in co-affected service names + timeline text (Slack /feed unfurl).
-  if (coAffected.length > 0) lines.push(`<p>Also affecting: ${escHtml(defuseAutolinkDomain(coAffected.join(', ')))}</p>`)
+  // #760 — no "Also affecting" line: it only ever appeared when coAffected.length>0, which is EXACTLY
+  // when itemXml's title is provider-grouped ("Anthropic (Claude API, claude.ai, Claude Code): …") and
+  // already lists those services — pure duplication. The provider-grouped title carries the set.
   // #768 — per-update timeline text is shown ONLY on the resolved item (a one-time, stable resolution
-  // message). On the active item it churns across status transitions → Slack re-post.
+  // message; #539 defuses a bare brand domain in it). On the active item it churns across status
+  // transitions → Slack re-post.
   if (isResolved && latest?.text) lines.push(`<p>${escHtml(defuseAutolinkDomain(latest.text))}</p>`)
   // #724 — mirror the Discord embed's 🤖 AI ANALYSIS block (active items only; resolved items already
   // read "Resolved"). Public-safe fields only — never the operator-only tweet draft. defuse the
   // summary/scope so a bare brand domain doesn't auto-link in the Slack /feed unfurl.
   if (!isResolved && opts.analysis) {
     const a = opts.analysis
+    lines.push(FEED_DIV) // #760 — divider before the 🤖 AI block (mirrors Discord)
     lines.push(`<p>🤖 AI analysis: ${escHtml(defuseAutolinkDomain(a.summary))}</p>`)
     const detail = [`Est. recovery: ${escHtml(formatRecoveryDisplay(a.estimatedRecovery))}`]
     if (a.affectedScope.length > 0) detail.push(`Scope: ${escHtml(defuseAutolinkDomain(a.affectedScope.join(', ')))}`)
     lines.push(`<p>${detail.join(' · ')}</p>`)
   }
-  if (opts.fallbackText) lines.push(`<p>↪ ${escHtml(opts.fallbackText)}</p>`)
+  if (opts.fallbackText) { lines.push(FEED_DIV); lines.push(`<p>↪ ${escHtml(opts.fallbackText)}</p>`) } // #760 — divider before Try-instead
   // Join with a newline, not '' (#479): block-level <p> render with a break in real RSS readers,
   // but Slack's /feed app FLATTENS the tags and would otherwise concatenate adjacent paragraphs
   // ("lasted 14m" + "Qwen3…" → "14mQwen3…"). The newline is insignificant whitespace between block
@@ -332,7 +341,7 @@ function itemXml(
       <link>${xml(serviceLink(service.id, opts.kind))}</link>
       <guid isPermaLink="false">${xml(guid)}</guid>
       <pubDate>${rfc822(opts.pubDate)}</pubDate>${inc.impact ? `\n      <category>${xml(inc.impact)}</category>` : ''}
-      <description><![CDATA[${descHtml(service, inc, coAffected, opts)}]]></description>
+      <description><![CDATA[${descHtml(service, inc, opts)}]]></description>
     </item>`
 }
 
@@ -342,7 +351,7 @@ function itemXml(
  * root incident to several services, which would otherwise emit N near-identical items in the
  * all-services feed — and N Slack /feed messages. Callers pass entries in SERVICES order, so the
  * survivor is the deterministic "primary" surface (e.g. Claude API ahead of claude.ai / Claude Code);
- * itemXml's "Also affecting" line still names the rest. Exported for unit testing.
+ * itemXml's provider-grouped title names the rest (#724/#760). Exported for unit testing.
  *
  * Accepted edge: the survivor's guid is the primary's (`aiwatch:{primaryId}:{incId}`). If the primary
  * surface recovers BEFORE its siblings (partial recovery), the still-active item's primary shifts to the
@@ -423,8 +432,8 @@ export function buildRssFeed(
   // All-services feed (#520): collapse a multi-surface incident (one incidentId across Claude API /
   // claude.ai / Claude Code) into ONE item per (incidentId, kind) so a Slack /feed subscriber to
   // /feed.xml gets a single consolidated message instead of N near-identical ones. `sources` iterates
-  // in SERVICES order so the surviving "primary" is deterministic; itemXml's "Also affecting" lists
-  // the rest. Per-service feeds (scope:'service') have a single source, so this is a no-op there.
+  // in SERVICES order so the surviving "primary" is deterministic; itemXml's provider-grouped title
+  // names the rest (#760). Per-service feeds (scope:'service') have a single source, so this is a no-op there.
   const deduped = opts.scope === 'all' ? dedupeSharedIncidents(items) : items
   deduped.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
   const capped = deduped.slice(0, MAX_ITEMS)


### PR DESCRIPTION
Two cosmetic gaps vs the Discord operator embed, both in `rss.ts` `descHtml`:

**① Section dividers** — the active item now inserts `FEED_DIV` (`┈┈…`, mirroring Discord's divider) before the 🤖 AI block and before the ↪ Try-instead line, so Slack `/feed` (which flattens the `<p>` tags) renders the same scannable structure. Dividers appear only when their section follows (no AI / no fallback → no orphan; resolved items get none).

**② Drop "Also affecting"** — it only ever appeared when `coAffected.length>0`, which is exactly when `itemXml`'s title is provider-grouped (#724) and already lists those services → pure duplication. `coAffected` dropped from `descHtml`'s signature.

Rendered (Slack-flattened): `🟡 Minor` → `┈┈…` → `🤖 AI analysis: …` → `Est. recovery · Scope` → `┈┈…` → `↪ Try instead: …`.

Tests: divider count/ordering, no-divider edge, "Also affecting" drop; 2 existing tests updated. worker 1874 · rss 84 · typecheck 0 · dry-run. PR review converged (0 Critical/Important; stale comments refreshed).

Closes #760. refs #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)