### PR TITLE
test(is-down): de-flake the rankTied "(tied)" guard — deterministic unit tests, drop the live-tie e2e (closes #787)

### DIFF
--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -3,6 +3,7 @@
 import { SLUG_TO_SERVICE } from './is-down/slug-map'
 import { getSEOContent } from './is-down/seo-content'
 import { renderPage } from './is-down/html-template'
+import { computeRankPosition } from './is-down/ranking'
 import { regionStatusOf, type RegionStatusResult } from './is-down/region-status'
 
 export const config = { runtime: 'edge' }
@@ -151,13 +152,13 @@ export default async function handler(req: Request) {
             const scored = allServices
               .filter(s => Number.isFinite(s.aiwatchScore) && hasReliableData(s))
               .sort((a, b) => (b.aiwatchScore as number) - (a.aiwatchScore as number))
-            // findIndex by rounded score (not id) — gives the first-tied position, matching competition ranking
-            const rank = scored.findIndex(s => Math.round(s.aiwatchScore as number) === targetScore) + 1
-            const isTied = scored.filter(s => Math.round(s.aiwatchScore as number) === targetScore).length > 1
+            // #787 — rank by ROUNDED score (competition ranking: tied services share the first
+            // position), derivation extracted to the pure computeRankPosition for deterministic tests.
+            const { rank, tied: isTied, total } = computeRankPosition(scored as Array<{ aiwatchScore: number }>, targetScore)
             if (rank > 0) {
               (serviceData as any).rank = rank;
               (serviceData as any).rankTied = isTied;
-              (serviceData as any).totalRanked = scored.length
+              (serviceData as any).totalRanked = total
             } else {
               // Should be unreachable — target passed all filters but isn't in scored.
               // Log so the asymmetry between target-check and filter-check is visible.

--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -162,6 +162,19 @@ describe('renderPage <title> — live status (#566)', () => {
     expect(html).toContain('Monthly Reports &rarr;')
     expect(html).not.toContain('/reports/2026-03/') // the old hardcoded link is gone
   })
+
+  // #787 — DETERMINISTIC guard for the `${service.rankTied ? ' (tied)' : ''}` render branch. The old
+  // e2e (`tests/is-down.spec.js`) asserted a LIVE score tie existed among 6 services, which false-failed
+  // whenever scores drifted apart (it blocked unrelated PR #786's Edge E2E). The render path is pure, so
+  // it belongs in a unit test driven by an explicit rankTied flag — no live data, no flake.
+  it('renders "(tied)" iff rankTied is set', () => {
+    const tied = renderPage('claude', mkService({ status: 'operational', rank: 5, totalRanked: 31, rankTied: true }), mkSeo(), [])
+    expect(tied).toContain('is ranked <strong>#5 (tied)</strong>')
+
+    const untied = renderPage('claude', mkService({ status: 'operational', rank: 5, totalRanked: 31, rankTied: false }), mkSeo(), [])
+    expect(untied).toContain('is ranked <strong>#5</strong>')
+    expect(untied).not.toContain('(tied)')
+  })
 })
 
 // #722/#744 — when a BetterStack service reads operational but `partialCount > 0` (sub-threshold

--- a/api/is-down/__tests__/ranking.test.ts
+++ b/api/is-down/__tests__/ranking.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { computeRankPosition } from '../ranking'
+
+// #787 — deterministic guard for the rank + tie derivation that the removed flaky e2e
+// (tests/is-down.spec.js) only ever covered probabilistically (it needed a LIVE score tie to exist).
+const svc = (aiwatchScore: number) => ({ aiwatchScore })
+
+describe('computeRankPosition (#787)', () => {
+  it('ranks by position; no tie when the target score is unique', () => {
+    // scoredDesc sorted by score desc: 91, 88, 84, 70
+    const scored = [svc(91), svc(88), svc(84), svc(70)]
+    expect(computeRankPosition(scored, 84)).toEqual({ rank: 3, tied: false, total: 4 })
+  })
+
+  it('competition ranking — tied services share the FIRST position, tied:true', () => {
+    // two services round to 83 → both rank #2 (the first-tied slot), not #2 and #3
+    const scored = [svc(90), svc(83.4), svc(82.6), svc(70)] // 90, 83, 83, 70
+    expect(computeRankPosition(scored, 83)).toEqual({ rank: 2, tied: true, total: 4 })
+  })
+
+  it('rounds before comparing (82.6 and 83.4 both → 83, a tie)', () => {
+    const scored = [svc(83.4), svc(82.6)]
+    const r = computeRankPosition(scored, 83)
+    expect(r.tied).toBe(true)
+    expect(r.rank).toBe(1)
+  })
+
+  it('a top-scored unique leader is rank #1, not tied', () => {
+    expect(computeRankPosition([svc(95), svc(88), svc(88)], 95)).toEqual({ rank: 1, tied: false, total: 3 })
+  })
+
+  it('returns rank 0 when the target score is absent (caller guards rank > 0)', () => {
+    expect(computeRankPosition([svc(90), svc(80)], 75)).toEqual({ rank: 0, tied: false, total: 2 })
+  })
+
+  it('total reflects the full ranked set, not just the matches', () => {
+    expect(computeRankPosition([svc(90), svc(90), svc(90)], 90)).toEqual({ rank: 1, tied: true, total: 3 })
+  })
+})

--- a/api/is-down/ranking.ts
+++ b/api/is-down/ranking.ts
@@ -1,0 +1,20 @@
+// #787 — competition-ranking position for a service within the reliability-ranked set, extracted
+// from is-down.ts so the rank + tie DERIVATION is unit-testable WITHOUT live score data. The old
+// e2e (tests/is-down.spec.js) asserted a LIVE score tie existed among 6 services, which false-failed
+// whenever scores drifted apart (it blocked unrelated PR #786's Edge E2E). This pure helper lets the
+// derivation be guarded deterministically; the render branch is guarded separately in
+// api/is-down/__tests__/html-template.test.ts.
+//
+// `scoredDesc` = the services that passed the rank filters (finite aiwatchScore + reliable data),
+// already sorted by score DESCENDING. `targetScore` = the target service's ROUNDED aiwatchScore.
+// Ranking is by ROUNDED score (competition ranking: tied services share the FIRST position — the
+// findIndex gives that first-tied slot), matching the dashboard Ranking page.
+export function computeRankPosition(
+  scoredDesc: Array<{ aiwatchScore: number }>,
+  targetScore: number,
+): { rank: number; tied: boolean; total: number } {
+  const rounded = scoredDesc.map((s) => Math.round(s.aiwatchScore))
+  const rank = rounded.findIndex((s) => s === targetScore) + 1 // 0 = not found (caller guards rank > 0)
+  const tied = rounded.filter((s) => s === targetScore).length > 1
+  return { rank, tied, total: scoredDesc.length }
+}

--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -254,25 +254,12 @@ test.describe('Is X Down? SSR pages', () => {
     expect(Number(m[3])).toBeLessThanOrEqual(MAX_RANKED) // ≤ total service count (#643 — exact ranked count is dynamic)
   })
 
-  test('tied rank shows "(tied)" marker for services in a stable tie cluster', async ({ page }) => {
-    // Guards the rankTied render path — deleting ${service.rankTied ? ' (tied)' : ''} would fail this.
-    // AIWatch Scores drift with live data, so pinning a single tie pair is fragile: the old
-    // Cohere/Fireworks/DeepSeek "tied at 83" cluster un-tied. Instead scan a broad set spanning
-    // multiple clusters — the lower-60s band (claude/elevenlabs/deepgram) is a large, drift-stable
-    // multi-way tie, with deepseek/fireworks/cohere as secondary fallbacks. Passes if ANY candidate's
-    // SSR page renders "(tied)"; only if every cluster un-ties at once, refresh against /api/status.
-    const tiedCandidates = ['claude', 'elevenlabs', 'deepgram', 'deepseek', 'fireworks', 'cohere']
-    let foundTied = false
-    for (const slug of tiedCandidates) {
-      await page.goto(`/is-${slug}-down`, { waitUntil: 'domcontentloaded' })
-      const rankLine = page.locator('p.meta', { hasText: /is ranked #\d+/ })
-      if (await rankLine.isVisible().catch(() => false)) {
-        const text = (await rankLine.textContent()) || ''
-        if (text.includes('(tied)')) { foundTied = true; break }
-      }
-    }
-    expect(foundTied, `none of ${tiedCandidates.join('/')} rendered "(tied)" — score clusters may have drifted; refresh against /api/status`).toBe(true)
-  })
+  // #787 — the "(tied)" coverage moved to DETERMINISTIC unit tests: the render branch in
+  // api/is-down/__tests__/html-template.test.ts ('renders "(tied)" iff rankTied is set') and the
+  // rank+tie DERIVATION in api/is-down/__tests__/ranking.test.ts (computeRankPosition). The old e2e
+  // here asserted a LIVE score tie existed among 6 services, which false-failed whenever scores
+  // drifted apart (it blocked unrelated PR #786's Edge E2E). The SSR rank LINE stays covered by the
+  // 'is ranked #N' e2e; both halves of the tie path now need no live data.
 
   test('rank denominator stays within the total service count', async ({ page }) => {
     // The SEO rank line ("ranked #X of N AI services") must use the same ranked set as the


### PR DESCRIPTION
## Problem
The e2e `tied rank shows "(tied)" marker for services in a stable tie cluster` asserted that **at least one** of 6 services renders "(tied)" on its is-down SSR page. "(tied)" depends on the **live AIWatch Score** having a rounded-rank tie at test time; when scores drift apart, none renders "(tied)" → false CI failure. It **blocked unrelated PR #786's** Vercel-Preview Edge E2E. The test conflated a deterministic code path with a live-data property.

## Fix — coverage moved to deterministic unit tests (net-positive vs the flake)
- **Render branch** (`api/is-down/__tests__/html-template.test.ts`): `renderPage(rankTied:true)` → `#5 (tied)`; `rankTied:false` → `#5`, no "(tied)".
- **Derivation**: extracted the rank/tie computation from `is-down.ts` to a pure `computeRankPosition(scoredDesc, targetScore)` (`api/is-down/ranking.ts`) + unit-tested it (`ranking.test.ts`, 6 cases incl. competition-ranking "tied services share the FIRST position"). The `is-down.ts` swap is a **faithful no-behavior-change extraction** (semantic-equivalence reviewed).
- **Removed** the brittle e2e — its render coverage + the previously only-probabilistic tie-derivation coverage are now deterministic. The SSR rank-line wiring stays covered by the surviving `is ranked #N` e2e.

test:src 563 · build · 2× PR review (0 Critical/Important).

Closes #787. refs #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)