### PR TITLE
fix(incidents): order MOCK_SERVICES api→app→agent so the service filter lists APIs first (closes #796)

### DIFF
--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -25,52 +25,10 @@ function hist(degraded = [], down = []) {
   })
 }
 
-const MOCK_SERVICES = [
-  {
-    id: 'claudeai', category: 'app', name: 'claude.ai', provider: 'Anthropic', status: 'operational',
-    latency: null, uptime30d: 99.00,
-    history30d: hist([3, 9, 13, 19, 27]),
-    history3m: [{ month: '2026-01', uptime: 99.40 }, { month: '2026-02', uptime: 99.10 }, { month: '2026-03', uptime: 99.00 }],
-    incidents: [],
-  },
-  {
-    id: 'chatgpt', category: 'app', name: 'ChatGPT', provider: 'OpenAI', status: 'operational',
-    latency: null, uptime30d: 98.20,
-    history30d: hist([1, 4, 8, 12, 18, 22, 28]),
-    history3m: [{ month: '2026-01', uptime: 98.90 }, { month: '2026-02', uptime: 97.50 }, { month: '2026-03', uptime: 98.20 }],
-    incidents: [
-      { id: 'cg-1', title: 'Slow Response Times', startedAt: ago(1 * D + 3 * H), duration: '1h 20m', status: 'resolved',
-        timeline: [
-          { stage: 'investigating', text: 'ChatGPT 응답 시간이 평소보다 느립니다.', at: ago(1 * D + 3 * H) },
-          { stage: 'resolved', text: '캐시 서버 재시작 후 정상화.', at: ago(1 * D + 3 * H - 80 * M) },
-        ] },
-      { id: 'cg-2', title: 'Image Upload Failures', startedAt: ago(3 * D + 5 * H), duration: '45m', status: 'resolved',
-        timeline: [
-          { stage: 'investigating', text: '이미지 업로드가 간헐적으로 실패합니다.', at: ago(3 * D + 5 * H) },
-          { stage: 'resolved', text: 'CDN 설정 복구 후 정상화.', at: ago(3 * D + 5 * H - 45 * M) },
-        ] },
-      { id: 'cg-3', title: 'Login Errors for Some Users', startedAt: ago(5 * D), duration: '2h 10m', status: 'resolved',
-        timeline: [
-          { stage: 'investigating', text: '일부 사용자가 로그인에 실패하고 있습니다.', at: ago(5 * D) },
-          { stage: 'identified', text: 'OAuth 토큰 갱신 문제로 확인.', at: ago(5 * D - 30 * M) },
-          { stage: 'resolved', text: '토큰 서비스 패치 후 정상화.', at: ago(5 * D - 130 * M) },
-        ] },
-    ],
-  },
-  {
-    id: 'characterai', category: 'app', name: 'Character.AI', provider: 'Character AI', status: 'operational',
-    latency: null, uptime30d: null,
-    history30d: hist(),
-    history3m: null,
-    incidents: [],
-  },
-  {
-    id: 'deepseekapp', category: 'app', name: 'DeepSeek App', provider: 'DeepSeek', status: 'operational',
-    latency: null, uptime30d: 99.48,
-    history30d: hist([13, 18, 22]),
-    history3m: null,
-    incidents: [],
-  },
+// Exported for the #796 order-invariant test. The array order is load-bearing: mergeWithMock
+// preserves it, and the Incidents service-filter dropdown renders services unsorted, so this MUST
+// stay in the canonical api → app → agent order (matching worker/src/services.ts + the live API).
+export const MOCK_SERVICES = [
   // ── LLM API ──
   {
     id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational',
@@ -513,6 +471,55 @@ const MOCK_SERVICES = [
           { stage: 'resolved', text: 'Ray/UNI-1 추론 용량 복구 후 정상화.', at: ago(2 * D - 64 * M) },
         ] },
     ],
+  },
+  // ── AI Apps ──
+  // Ordered after the APIs (before the agents) to match the canonical worker SERVICES order
+  // (api → app → agent) and the live /api/status order; mergeWithMock preserves this order, so the
+  // Incidents service-filter dropdown (renders services unsorted) lists APIs first too (#796).
+  {
+    id: 'claudeai', category: 'app', name: 'claude.ai', provider: 'Anthropic', status: 'operational',
+    latency: null, uptime30d: 99.00,
+    history30d: hist([3, 9, 13, 19, 27]),
+    history3m: [{ month: '2026-01', uptime: 99.40 }, { month: '2026-02', uptime: 99.10 }, { month: '2026-03', uptime: 99.00 }],
+    incidents: [],
+  },
+  {
+    id: 'chatgpt', category: 'app', name: 'ChatGPT', provider: 'OpenAI', status: 'operational',
+    latency: null, uptime30d: 98.20,
+    history30d: hist([1, 4, 8, 12, 18, 22, 28]),
+    history3m: [{ month: '2026-01', uptime: 98.90 }, { month: '2026-02', uptime: 97.50 }, { month: '2026-03', uptime: 98.20 }],
+    incidents: [
+      { id: 'cg-1', title: 'Slow Response Times', startedAt: ago(1 * D + 3 * H), duration: '1h 20m', status: 'resolved',
+        timeline: [
+          { stage: 'investigating', text: 'ChatGPT 응답 시간이 평소보다 느립니다.', at: ago(1 * D + 3 * H) },
+          { stage: 'resolved', text: '캐시 서버 재시작 후 정상화.', at: ago(1 * D + 3 * H - 80 * M) },
+        ] },
+      { id: 'cg-2', title: 'Image Upload Failures', startedAt: ago(3 * D + 5 * H), duration: '45m', status: 'resolved',
+        timeline: [
+          { stage: 'investigating', text: '이미지 업로드가 간헐적으로 실패합니다.', at: ago(3 * D + 5 * H) },
+          { stage: 'resolved', text: 'CDN 설정 복구 후 정상화.', at: ago(3 * D + 5 * H - 45 * M) },
+        ] },
+      { id: 'cg-3', title: 'Login Errors for Some Users', startedAt: ago(5 * D), duration: '2h 10m', status: 'resolved',
+        timeline: [
+          { stage: 'investigating', text: '일부 사용자가 로그인에 실패하고 있습니다.', at: ago(5 * D) },
+          { stage: 'identified', text: 'OAuth 토큰 갱신 문제로 확인.', at: ago(5 * D - 30 * M) },
+          { stage: 'resolved', text: '토큰 서비스 패치 후 정상화.', at: ago(5 * D - 130 * M) },
+        ] },
+    ],
+  },
+  {
+    id: 'characterai', category: 'app', name: 'Character.AI', provider: 'Character AI', status: 'operational',
+    latency: null, uptime30d: null,
+    history30d: hist(),
+    history3m: null,
+    incidents: [],
+  },
+  {
+    id: 'deepseekapp', category: 'app', name: 'DeepSeek App', provider: 'DeepSeek', status: 'operational',
+    latency: null, uptime30d: 99.48,
+    history30d: hist([13, 18, 22]),
+    history3m: null,
+    incidents: [],
   },
   // ── Coding Agents ──
   {

--- a/src/hooks/usePolling.order.test.js
+++ b/src/hooks/usePolling.order.test.js
@@ -1,0 +1,32 @@
+// #796 — MOCK_SERVICES order invariant.
+// Bug: the mock fallback array listed the 4 AI apps FIRST (apps → apis → agents). mergeWithMock
+// preserves array order and the Incidents service-filter dropdown renders `services` unsorted, so
+// the dropdown showed AI apps before the APIs — diverging from the live /api/status order.
+// This pins the canonical category order so a re-introduction fails the build.
+import { describe, it, expect } from 'vitest'
+import { MOCK_SERVICES } from './usePolling'
+
+describe('MOCK_SERVICES order (#796)', () => {
+  const cats = MOCK_SERVICES.map((s) => s.category)
+
+  it('has the full 41-service roster', () => {
+    expect(MOCK_SERVICES.length).toBe(41)
+  })
+
+  it('is grouped in the canonical api → app → agent order (matches worker SERVICES + live API)', () => {
+    // Collapse to category runs and assert exactly [api, app, agent] — no app before any api.
+    const runs = cats.filter((c, i) => c !== cats[i - 1])
+    expect(runs).toEqual(['api', 'app', 'agent'])
+  })
+
+  it('places every app after every api (the exact dropdown-ordering regression)', () => {
+    const lastApi = cats.lastIndexOf('api')
+    const firstApp = cats.indexOf('app')
+    expect(firstApp).toBeGreaterThan(lastApi)
+  })
+
+  it('leads with the major LLM APIs, not an app', () => {
+    expect(MOCK_SERVICES[0].id).toBe('claude')
+    expect(MOCK_SERVICES[0].category).toBe('api')
+  })
+})

--- a/tests/multi-service-incident.spec.js
+++ b/tests/multi-service-incident.spec.js
@@ -72,7 +72,9 @@ test.describe('Multi-service incident display', () => {
     await expect(page.getByText('Opus 4.6 elevated rate of errors').first()).toBeVisible({ timeout: 20000 })
 
     const main = page.locator('main')
-    // All 3 affected service names should appear together (order depends on mock services array)
-    await expect(main.getByText(/claude\.ai, Claude API, Claude Code/).first()).toBeVisible()
+    // All 3 affected service names should appear together. Order follows the merged services-array
+    // order (mergeWithMock reorders the injected mock into MOCK_SERVICES order), which is the canonical
+    // api → app → agent order (#796): Claude API (api) → claude.ai (app) → Claude Code (agent).
+    await expect(main.getByText(/Claude API, claude\.ai, Claude Code/).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Closes #796 — the **Incidents** service-filter dropdown listed the 4 AI apps (claude.ai, ChatGPT, Character.AI, DeepSeek App) **before** the API services, diverging from the live `/api/status` order.

## Root cause

`MOCK_SERVICES` in `src/hooks/usePolling.js` was authored **apps-first** (`[app×4, api×31, agent×6]`). `mergeWithMock()` overlays live data but **iterates `MOCK_SERVICES.map(...)`**, so the merged `services` array preserves that order. The dropdown (`Incidents.jsx:68`) renders `services` **unsorted**, so apps surfaced first.

## Fix

Move the 4 app objects after the 31 APIs (before the agents) → canonical `api → app → agent`, matching `worker/src/services.ts` SERVICES + the live API. **Pure data reorder** — no app object's fields changed, 41 entries intact (code review confirmed byte-identical move).

- `export MOCK_SERVICES` + new `usePolling.order.test.js` pins the `api → app → agent` category-run invariant (regression guard).
- `multi-service-incident.spec.js`: the shared-incident affected-names order follows the merged array order, so the assertion updates `claude.ai, Claude API, Claude Code` → **`Claude API, claude.ai, Claude Code`** (the apps-first string was the bug).

## Verification

- **In-browser confirmed** on the Incidents page (service filter now lists APIs first, then apps, then agents).
- `npm run build` clean · `npm run test:src` **567 pass** (incl. 4 new order tests) · `npm test` (Playwright) **146 pass**.
- PR review (code-reviewer): **0 Critical/Important/Suggestion** — clean tested pure reorder.

## Scope

Frontend only; Vercel auto-deploys on merge. Deterministic ordering change — no production-data/time-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
