### PR TITLE
fix(overview): Latency Rankings spans all services regardless of category filter (closes #798)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -714,9 +714,11 @@ export default function Overview() {
   // Dedup by incident ID (Anthropic bulk-links one incident to claude.ai + Claude API + Claude Code)
   // while collecting every affected service name. Mirrors the Incidents.jsx aggregation pattern.
   // Recent Incidents intentionally spans ALL enabled services (`services`), NOT the category-filtered
-  // `catServices` — a category filter scopes the stats/sections/latency, but the incidents panel is a
+  // `catServices` — a category filter scopes the stats/sections, but the incidents panel is a
   // cross-category "what's happening right now" view, so picking a category must not hide live incidents
   // from other categories. (Still honors the user's enabled-services subset via `services`.)
+  // #798 — Latency Rankings (below) is ALSO cross-category for the same reason: it ranks fastest/slowest
+  // across everything, so it uses `services`, not `catServices` — only stats + the service grid scope.
   const incMap = new Map()
   for (const s of services) {
     for (const inc of s.incidents ?? []) {
@@ -737,7 +739,7 @@ export default function Overview() {
       .sort(compareIncidents)
   ).sort(compareGroupedRows).slice(0, 5)
 
-  const withLatency = catServices.filter((s) => s.latency != null)
+  const withLatency = services.filter((s) => s.latency != null) // #798 — all services, not catServices (cross-category like Recent Incidents)
   const sortedByLatency = [...withLatency].sort((a, b) => a.latency - b.latency)
   const maxLatency = withLatency.length ? Math.max(...withLatency.map((s) => s.latency)) : 1
 

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -181,10 +181,10 @@ test.describe('Overview page', () => {
   })
 
   test('Recent Incidents spans all categories — a category filter does not hide other-category incidents (#676)', async ({ page }) => {
-    // The category filter scopes the stats/sections/latency to one bucket, but Recent Incidents is a
+    // The category filter scopes the stats/sections to one bucket, but Recent Incidents is a
     // cross-category "what's live right now" panel: picking a category must NOT hide an active incident
     // from another category. Pre-#676 it iterated the category-filtered list, so an LLM filter hid an
-    // app outage from the panel.
+    // app outage from the panel. (Latency Rankings is likewise cross-category — see the #798 test below.)
     const appInc = { id: 'app-outage-676', title: 'ChatGPT app outage 676', status: 'investigating', impact: 'major', startedAt: new Date(Date.now() - 60_000).toISOString(), duration: null, timeline: [] }
     const mock = { json: { services: [
       { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.9, calendarDays: 30, incidents: [] },
@@ -203,6 +203,30 @@ test.describe('Overview page', () => {
     await expect(page.locator('main button').filter({ hasText: 'ChatGPT' })).toHaveCount(0)
     // …but its incident is STILL listed in Recent Incidents (cross-category panel, #676).
     await expect(page.locator('main').getByText(/ChatGPT app outage 676/).first()).toBeVisible()
+  })
+
+  test('Latency Rankings spans all categories — a category filter does not hide other-category latency (#798)', async ({ page }) => {
+    // Mirror of #676 for the Latency Rankings panel: it ranks fastest/slowest across EVERYTHING, so a
+    // category filter must not drop an app/agent's latency bar. Pre-#798 it iterated the category-filtered
+    // catServices, so an LLM filter hid the ChatGPT (app) bar from the rankings.
+    const mock = { json: { services: [
+      { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 120, uptime30d: 99.9, calendarDays: 30, incidents: [] },
+      { id: 'chatgpt', category: 'app', name: 'ChatGPT', provider: 'OpenAI', status: 'operational', latency: 150, uptime30d: 99.5, calendarDays: 30, incidents: [] },
+    ], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.goto('/')
+    await waitForDataLoad(page)
+    // Under 'all', the ChatGPT card is in the grid (a <button>).
+    await expect(page.locator('main button').filter({ hasText: 'ChatGPT' }).first()).toBeVisible({ timeout: 10000 })
+    // Filter to LLM → the ChatGPT CARD leaves the grid (it's an app)…
+    const tablist = page.getByRole('tablist', { name: /Services|서비스/ })
+    await tablist.getByRole('tab', { name: /LLM/ }).click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('main button').filter({ hasText: 'ChatGPT' })).toHaveCount(0)
+    // …but its latency bar (a non-button <span> name) is STILL in the Latency Rankings panel (#798).
+    // With the card gone, the only remaining ChatGPT text in main is the latency-bar label.
+    await expect(page.locator('main').getByText('ChatGPT', { exact: true }).first()).toBeVisible()
   })
 
   test('Recent Incidents date label exposes contextual label via tooltip (#406)', async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #798 — on the **Overview** page, the category filter (All / API / AI Apps / Coding) scoped the **Latency Rankings** panel to the selected category, hiding the other categories' services. **Recent Incidents** already spans all services regardless of the filter; Latency Rankings should behave the same — a cross-category fastest/slowest view.

## Root cause

`src/pages/Overview.jsx:740` derived the rankings from the **category-filtered** `catServices`:

```js
const withLatency = catServices.filter((s) => s.latency != null)
```

while Recent Incidents (`Overview.jsx:721`) iterates the full `services`.

## Fix

Use the full `services` list (same all-enabled-services variable Recent Incidents uses) instead of `catServices`. `withLatency` / `sortedByLatency` / `maxLatency` feed **only** the Latency Rankings panel (code review confirmed), so the change is isolated — stats + the service grid stay category-scoped.

- `Overview.jsx:740` `catServices → services`; the 716–721 rationale comment now documents the category filter as scoping **stats/sections only** (not latency), matching the incidents-panel reasoning.
- `tests/overview.spec.js`: new **#798** e2e mirroring the proven #676 Recent-Incidents test — a ChatGPT (app) latency bar stays in the Latency Rankings panel after filtering to LLM, where its grid card leaves. Plus a stale-comment fix on the #676 test.

## Verification

- **In-browser confirmed** on the Overview page (Latency Rankings stays full-list under a category filter; stats/grid still scope).
- `npm run build` clean · `npm run test:src` pass · `npm test` (Playwright) **147 pass** (incl. the new #798 regression test).
- PR review (code-reviewer): **0 Critical/Important** — verified the consumers are isolated and the new test is non-flaky.

## Scope

Frontend only; Vercel auto-deploys on merge. Deterministic UI behavior change — no production-data/time-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
