### PR TITLE
fix(score): coverage notice overlaps score number on mobile (#817)

### DIFF
--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -921,8 +921,8 @@ export default function ServiceDetails({ serviceId }) {
       {/* ── AIWatch Score Breakdown ── */}
       {service.aiwatchScore != null && !incidentsBlanked && (
         <section className="bg-[var(--bg1)] border border-[var(--border)] rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
-            <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center gap-1.5">
+          <div className="flex items-center justify-between gap-3 border-b border-[var(--border)]" style={{ padding: '12px 16px' }}>
+            <div className="mono text-[10px] text-[var(--text1)] uppercase tracking-wider flex items-center flex-wrap gap-1.5 min-w-0">
               <span className="rounded-full shrink-0" style={{ width: '5px', height: '5px', background: 'var(--teal)' }} />
               {t('score.label')}
               <span className="text-[var(--text2)] font-normal">— 30{t('settings.period.suffix')}</span>
@@ -932,7 +932,7 @@ export default function ServiceDetails({ serviceId }) {
                 <span className="text-[var(--amber)] font-normal normal-case tracking-normal">· {t('score.coverage.insufficient')}</span>
               )}
             </div>
-            <span className={`mono text-[18px] font-semibold ${SCORE_TEXT_CLASS[service.scoreGrade] ?? 'text-[var(--text2)]'}`}>
+            <span className={`mono text-[18px] font-semibold shrink-0 ${SCORE_TEXT_CLASS[service.scoreGrade] ?? 'text-[var(--text2)]'}`}>
               {service.aiwatchScore}
             </span>
           </div>

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -166,4 +166,40 @@ test.describe('Mobile viewport', () => {
     // Mobile sidebar should be gone (the entire overlay is removed from DOM)
     await expect(mobileSidebar).toHaveCount(0)
   })
+
+  // #817 — the score-card header's coverage notice (a recently-added <30d service shows
+  // "Building data (<30 days) — not yet ranked") used to overrun into the large score
+  // number on narrow widths because the left label group could not wrap/shrink and the
+  // score span was not shrink-protected. Assert the notice never invades the score.
+  test('#817 — score coverage notice does not overlap the score number on mobile', async ({ page }) => {
+    const mock = { json: { services: [
+      { id: 'bfl', category: 'api', name: 'Black Forest Labs (FLUX)', provider: 'Black Forest Labs',
+        status: 'operational', latency: 700, uptime30d: 100, aiwatchScore: 95, scoreGrade: 'excellent',
+        scoreConfidence: 'high', coverageDays: 4, calendarDays: 30, incidents: [],
+        scoreBreakdown: { uptime: 40, incidents: 25, recovery: 15, responsiveness: 15, responsivenessStatus: 'available' } },
+    ], lastUpdated: new Date().toISOString() } }
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.goto('/#bfl')
+    await page.reload()
+
+    const header = page.locator('section').filter({ hasText: 'AIWatch Score' }).locator('> div').first()
+    const notice = header.getByText(/Building data \(<30 days\)|데이터 수집 중 \(30일 미만\)/)
+    const score = header.locator(':scope > span') // the score number is the header's only direct span child
+    await expect(notice).toBeVisible({ timeout: 10000 })
+    // Pin `score` to the one score-number node so the geometry assertion can't silently
+    // degrade into measuring the wrong box if a refactor adds another direct-span child.
+    await expect(score).toHaveCount(1)
+    await expect(score).toHaveText('95')
+
+    const noticeBox = await notice.boundingBox()
+    const scoreBox = await score.boundingBox()
+    // The notice (in the left label group) must keep a real gap to the LEFT of the score number.
+    // In the buggy layout the un-wrappable label group pushed the notice's right edge flush
+    // against the score (gap ≈ 0px, the cramped IMG_7655 look); the fix wraps the notice within
+    // a min-w-0 column separated from the shrink-protected score by `gap-3` (≥12px). A required
+    // ≥8px gap distinguishes the two without being brittle to sub-pixel font rounding.
+    const gap = scoreBox.x - (noticeBox.x + noticeBox.width)
+    expect(gap).toBeGreaterThanOrEqual(8)
+  })
 })


### PR DESCRIPTION
## Problem

On the ServiceDetails page (mobile), the AIWatch Score card header's coverage notice — `· Building data (<30 days) — not yet ranked` (`score.coverage.insufficient`, #802) — overlapped the large score number (IMG_7655, Black Forest Labs / FLUX, score 95). The notice ran flush against the `95` (0px gap).

## Root cause

`src/pages/ServiceDetails.jsx:924` — the score-card header is a single `flex items-center justify-between` row:
- **Left**: a `flex items-center gap-1.5` group holding label + `— 30d` + the long notice — no `min-w-0` / `flex-wrap` → couldn't shrink or wrap.
- **Right**: the score number span — no `shrink-0`.

On narrow widths the un-wrappable left group pushed the notice's right edge flush against the score number.

## Fix (CSS only)

- Header row → `gap-3` (hard separation between the two columns).
- Left label group → `flex-wrap min-w-0` (notice wraps to a 2nd line within a shrinkable column).
- Score span → `shrink-0` (number never compressed/overrun).

Only recently-added (`coverageDays < 30`) services render the notice, so nothing else is affected. Desktop stays one line.

## Test

`tests/mobile.spec.js` — on a 375px viewport, mocks a `<30d` service with a score, opens its detail page, and asserts the notice's right edge keeps a **≥8px gap** left of the score number's left edge. Manually verified: **fails on the pre-fix layout (gap 0px), passes after (gap 33px, notice wrapped)**.

## Verification

- Local in-browser confirmation ✅ (`#bfl`, mobile viewport)
- `npm run build` ✅ · `npm run test:src` 593 ✅ · Playwright e2e 148 + new 1 ✅
- PR review: 0 Critical/Important after addressing two test-robustness findings (pinned the score locator with `toHaveCount(1)`/`toHaveText`, tightened the KO regex)

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)