### PR TITLE
fix(security): drop Show/Launch HN promo posts + dedupe provider-only alerts across sibling services (closes #821)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -11,6 +11,7 @@ import { usePolling } from '../hooks/usePolling'
 import { useSettings } from '../hooks/useSettings'
 import { trackEvent } from '../utils/analytics'
 import { isUnreliableUptime, noOfficialUptime } from '../utils/serviceReliability'
+import { tagServiceForAlert } from '../utils/securityAlerts'
 import { SCORE_BG_CLASS, SERVICE_CATEGORIES, getGroupedFallbacksExcludingRegionSwitchable, ALL_SERVICES_FEED_URL } from '../utils/constants'
 import RssCopyIcon from '../components/RssCopyIcon'
 import { regionStatusOf } from '../utils/regionStatus'
@@ -811,11 +812,14 @@ export default function Overview() {
               </span>
               {recent.slice(0, 3).map((a, i) => {
                 const safeUrl = a.url?.startsWith('https://') ? a.url : '#'
-                // Derive service tag: use service field (OSV) or detect from title (HN)
+                // Derive service tag: use service field (OSV) or detect from title (HN).
+                // #821 — provider-only HN matches resolve to the provider's primary service
+                // (shared helper, mirrors the detail-page matcher). Logic in src/utils/securityAlerts.js.
                 let tag = a.service || ''
                 if (!tag) {
-                  const titleLC = a.title?.toLowerCase() ?? ''
-                  const match = services.find(s => titleLC.includes(s.name.toLowerCase()) || titleLC.includes(s.provider.toLowerCase()))
+                  // Use the FULL service list (not the enabled-filtered `services`) so the
+                  // provider-primary resolution matches the detail page, which sees all services.
+                  const match = tagServiceForAlert(a, allServices)
                   if (match) tag = match.name
                 }
                 // #326: EPSS prefix mirroring ServiceDetails. Thresholds duplicated

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -18,6 +18,7 @@ import { compareGroupedRows, dominantGroupStatus } from '../utils/incidentSort'
 import { SCORE_TEXT_CLASS, feedUrlOf } from '../utils/constants'
 import { computeRecoveryStats, formatRecoveryMin } from '../utils/recovery'
 import { isUnreliableUptime, noOfficialUptime } from '../utils/serviceReliability'
+import { filterSecurityAlertsForService } from '../utils/securityAlerts'
 import { regionStatusOf, SERVICE_REGIONS } from '../utils/regionStatus'
 import { ServiceDetailsSkeleton } from '../components/SkeletonUI'
 import EmptyState from '../components/EmptyState'
@@ -1117,27 +1118,10 @@ export default function ServiceDetails({ serviceId }) {
       {/* ── Security Alerts (service-specific) ── */}
       {(() => {
         if (!securityAlerts?.length) return null
-        const nameLC = service.name.toLowerCase()
-        const providerLC = service.provider?.toLowerCase() ?? ''
-        // Map OSV service field → specific AIWatch service ID (SDK alerts are API-specific)
-        // Keep in sync with OSV_PACKAGES in worker/src/security-monitor.ts
-        const OSV_SERVICE_MAP = {
-          'OpenAI': 'openai', 'Anthropic (Claude)': 'claude', 'Google (Gemini)': 'gemini',
-          'Cohere': 'cohere', 'Mistral': 'mistral', 'Hugging Face': 'huggingface',
-          'Together': 'together', 'Groq': 'groq', 'Replicate': 'replicate',
-          'AssemblyAI': 'assemblyai', 'Deepgram': 'deepgram',
-          'LangChain': 'langsmith', // #561 — langchain ecosystem CVEs now have a detail-page home
-        }
-        const filtered = securityAlerts.filter(a => {
-          // OSV: match by mapped service ID (e.g., "Anthropic (Claude)" → only "claude", not "claudeai")
-          if (a.service) return OSV_SERVICE_MAP[a.service] === service.id
-          // HN (#785): match by service NAME or PROVIDER in the title — consistent with the Overview
-          // banner's tag derivation (Overview.jsx). Provider-scoped on purpose: an HN news item naming
-          // only the provider (e.g. "OpenAI agent actions" → ChatGPT/Codex/OpenAI all share provider
-          // "OpenAI") was tagged in the banner but had no detail-page home under name-only matching.
-          const titleLC = a.title?.toLowerCase() ?? ''
-          return titleLC.includes(nameLC) || (providerLC && titleLC.includes(providerLC))
-        })
+        // #785/#821 — OSV matches by mapped service id; HN matches by service name (exact) or,
+        // when only the provider is named, the provider's single primary service (no sibling
+        // fan-out). Logic + OSV_SERVICE_MAP in src/utils/securityAlerts.js.
+        const filtered = filterSecurityAlertsForService(securityAlerts, service, services)
         if (filtered.length === 0) return null
         // #785 — first SECURITY_PREVIEW, rest behind a toggle (same as incident history).
         const visibleAlerts = securityExpanded ? filtered : filtered.slice(0, SECURITY_PREVIEW)

--- a/src/utils/securityAlerts.js
+++ b/src/utils/securityAlerts.js
@@ -1,0 +1,72 @@
+// Security Alerts → service matching (#785, refined #821).
+//
+// Two alert sources reach the dashboard via `securityAlerts`:
+//   - OSV (SDK CVEs): carry a `service` label → matched to a specific AIWatch service id.
+//   - HN (Hacker News): no `service` → matched by the service NAME or PROVIDER appearing
+//     in the title.
+//
+// #821 refinement: a provider-only match (the title names the provider but NOT a specific
+// service, e.g. "OpenAI agent actions") used to fan the SAME item out to every sibling
+// service sharing that provider (openai/chatgpt/codex). It now attaches to a single
+// representative ("primary") service per provider, so the item shows once. Name-matched
+// items still attach to the exact service.
+
+// Maps an OSV `service` label → specific AIWatch service ID (SDK alerts are API-specific).
+// Keep in sync with OSV_PACKAGES in worker/src/security-monitor.ts.
+export const OSV_SERVICE_MAP = {
+  'OpenAI': 'openai', 'Anthropic (Claude)': 'claude', 'Google (Gemini)': 'gemini',
+  'Cohere': 'cohere', 'Mistral': 'mistral', 'Hugging Face': 'huggingface',
+  'Together': 'together', 'Groq': 'groq', 'Replicate': 'replicate',
+  'AssemblyAI': 'assemblyai', 'Deepgram': 'deepgram',
+  'LangChain': 'langsmith', // #561 — langchain ecosystem CVEs now have a detail-page home
+}
+
+// The representative service id for a provider: its first `api`-category service, else its
+// first service in list order. Deterministic given a stable `allServices` order — so a
+// provider-only HN item resolves to exactly one service id.
+export function primaryServiceIdForProvider(provider, allServices) {
+  if (!provider) return null
+  const sameProvider = (allServices ?? []).filter((s) => s.provider === provider)
+  if (sameProvider.length === 0) return null
+  const apiFirst = sameProvider.find((s) => s.category === 'api')
+  return (apiFirst ?? sameProvider[0]).id
+}
+
+// Whether a single security alert should render on `service`'s detail page.
+export function securityAlertMatchesService(alert, service, allServices) {
+  // OSV: match by mapped service ID (e.g. "Anthropic (Claude)" → "claude", not "claudeai").
+  if (alert.service) return OSV_SERVICE_MAP[alert.service] === service.id
+  // HN: name match → exact service; provider-only match → the provider's primary service only.
+  const titleLC = alert.title?.toLowerCase() ?? ''
+  const nameLC = service.name?.toLowerCase() ?? ''
+  const providerLC = service.provider?.toLowerCase() ?? ''
+  if (nameLC && titleLC.includes(nameLC)) return true
+  if (providerLC && titleLC.includes(providerLC)) {
+    return service.id === primaryServiceIdForProvider(service.provider, allServices)
+  }
+  return false
+}
+
+// All security alerts that should render on `service`'s detail page.
+export function filterSecurityAlertsForService(alerts, service, allServices) {
+  return (alerts ?? []).filter((a) => securityAlertMatchesService(a, service, allServices))
+}
+
+// The single service whose NAME the alert tag should show in the Overview banner (one line
+// per alert). Name match wins; otherwise the provider's primary service; null if neither.
+export function tagServiceForAlert(alert, allServices) {
+  if (alert.service) return null // OSV uses its own service label as the tag
+  const titleLC = alert.title?.toLowerCase() ?? ''
+  const byName = (allServices ?? []).find((s) => {
+    const n = s.name?.toLowerCase() ?? ''
+    return n && titleLC.includes(n)
+  })
+  if (byName) return byName
+  const byProvider = (allServices ?? []).find((s) => {
+    const p = s.provider?.toLowerCase() ?? ''
+    return p && titleLC.includes(p)
+  })
+  if (!byProvider) return null
+  const primaryId = primaryServiceIdForProvider(byProvider.provider, allServices)
+  return (allServices ?? []).find((s) => s.id === primaryId) ?? byProvider
+}

--- a/src/utils/securityAlerts.test.js
+++ b/src/utils/securityAlerts.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OSV_SERVICE_MAP,
+  primaryServiceIdForProvider,
+  securityAlertMatchesService,
+  filterSecurityAlertsForService,
+  tagServiceForAlert,
+} from './securityAlerts'
+import { OSV_PACKAGES } from '../../worker/src/security-monitor'
+
+// Minimal service fixtures — list order matters (primary = first api-category, else first).
+// langsmith included: its OSV label ('LangChain'), id ('langsmith') and name all differ,
+// so it's the most fragile OSV_SERVICE_MAP entry (#561) — pin it explicitly.
+const SERVICES = [
+  { id: 'openai', name: 'OpenAI API', provider: 'OpenAI', category: 'api' },
+  { id: 'chatgpt', name: 'ChatGPT', provider: 'OpenAI', category: 'app' },
+  { id: 'codex', name: 'Codex', provider: 'OpenAI', category: 'agent' },
+  { id: 'claude', name: 'Claude API', provider: 'Anthropic', category: 'api' },
+  { id: 'claudeai', name: 'claude.ai', provider: 'Anthropic', category: 'app' },
+  { id: 'langsmith', name: 'LangChain (LangSmith)', provider: 'LangChain', category: 'api' },
+]
+
+const svc = (id) => SERVICES.find((s) => s.id === id)
+
+describe('primaryServiceIdForProvider (#821)', () => {
+  it('picks the first api-category service for a provider', () => {
+    expect(primaryServiceIdForProvider('OpenAI', SERVICES)).toBe('openai')
+    expect(primaryServiceIdForProvider('Anthropic', SERVICES)).toBe('claude')
+  })
+
+  it('falls back to the first listed service when no api-category exists', () => {
+    const onlyApps = [
+      { id: 'a1', name: 'A One', provider: 'P', category: 'app' },
+      { id: 'a2', name: 'A Two', provider: 'P', category: 'agent' },
+    ]
+    expect(primaryServiceIdForProvider('P', onlyApps)).toBe('a1')
+  })
+
+  it('returns null for an unknown provider or missing input', () => {
+    expect(primaryServiceIdForProvider('Nope', SERVICES)).toBeNull()
+    expect(primaryServiceIdForProvider('', SERVICES)).toBeNull()
+    expect(primaryServiceIdForProvider('OpenAI', [])).toBeNull()
+  })
+})
+
+describe('securityAlertMatchesService — HN provider-only fan-out (#821)', () => {
+  // The exact regression: provider named, no specific service → must show on ONE service only.
+  const providerOnly = { title: 'Concerns raised about OpenAI agent actions and prompt injection' }
+
+  it('attaches a provider-only HN item to the primary service only', () => {
+    expect(securityAlertMatchesService(providerOnly, svc('openai'), SERVICES)).toBe(true)
+    expect(securityAlertMatchesService(providerOnly, svc('chatgpt'), SERVICES)).toBe(false)
+    expect(securityAlertMatchesService(providerOnly, svc('codex'), SERVICES)).toBe(false)
+  })
+
+  it('still attaches a name-matched HN item to the exact service (not just the primary)', () => {
+    const named = { title: 'ChatGPT conversations leaked in a data breach' }
+    expect(securityAlertMatchesService(named, svc('chatgpt'), SERVICES)).toBe(true)
+    // "ChatGPT" is not in OpenAI API's name and provider-match would route elsewhere → false
+    expect(securityAlertMatchesService(named, svc('openai'), SERVICES)).toBe(false)
+  })
+
+  it('does not match services of an unrelated provider', () => {
+    expect(securityAlertMatchesService(providerOnly, svc('claude'), SERVICES)).toBe(false)
+  })
+
+  it('OSV alerts match by mapped service id, not by title text', () => {
+    const osv = { service: 'Anthropic (Claude)', title: 'CVE in some sdk' }
+    expect(securityAlertMatchesService(osv, svc('claude'), SERVICES)).toBe(true)
+    expect(securityAlertMatchesService(osv, svc('claudeai'), SERVICES)).toBe(false)
+  })
+
+  it('maps the fragile LangChain OSV label to langsmith only (#561)', () => {
+    // OSV label, service id, and service name all differ — the entry most likely to rot.
+    const osv = { service: 'LangChain', title: 'Path traversal in langchain loaders' }
+    expect(securityAlertMatchesService(osv, svc('langsmith'), SERVICES)).toBe(true)
+    expect(securityAlertMatchesService(osv, svc('claude'), SERVICES)).toBe(false)
+  })
+
+  it('a title naming a provider AND a sibling service attaches to both name + primary, not the third sibling', () => {
+    // "OpenAI outage hits ChatGPT": chatgpt matches by name; openai matches by provider→primary;
+    // codex (neither named) does not. Pins this deliberate dual-attach against silent refactors.
+    const both = { title: 'OpenAI outage hits ChatGPT users' }
+    expect(securityAlertMatchesService(both, svc('chatgpt'), SERVICES)).toBe(true)
+    expect(securityAlertMatchesService(both, svc('openai'), SERVICES)).toBe(true)
+    expect(securityAlertMatchesService(both, svc('codex'), SERVICES)).toBe(false)
+  })
+
+  it('tolerates a missing title field without throwing', () => {
+    expect(securityAlertMatchesService({}, svc('openai'), SERVICES)).toBe(false)
+  })
+})
+
+describe('OSV_SERVICE_MAP ↔ worker OSV_PACKAGES cross-layer sync (#821)', () => {
+  it('every worker OSV `service` label is a key in OSV_SERVICE_MAP', () => {
+    // Authoritative sync: imports the REAL map + the REAL worker package list (not a
+    // hand-copied set). An OSV label without a map key silently drops its alerts from
+    // the Security Alerts card (OSV_SERVICE_MAP[label] === undefined → no service match).
+    for (const pkg of OSV_PACKAGES) {
+      expect(Object.keys(OSV_SERVICE_MAP)).toContain(pkg.service)
+    }
+  })
+
+  it('every OSV_SERVICE_MAP target id resolves to a known service shape', () => {
+    // Catch a typo'd target id (e.g. 'langsmith' → 'langchain') by requiring each value
+    // be a non-empty lowercase id string.
+    for (const id of Object.values(OSV_SERVICE_MAP)) {
+      expect(typeof id).toBe('string')
+      expect(id).toMatch(/^[a-z0-9]+$/)
+    }
+  })
+})
+
+describe('filterSecurityAlertsForService (#821)', () => {
+  it('a provider-only item appears once across sibling services, not three times', () => {
+    const alerts = [{ title: 'OpenAI prompt injection exploit disclosed' }]
+    const onAll = SERVICES.filter((s) => filterSecurityAlertsForService(alerts, s, SERVICES).length > 0)
+    expect(onAll.map((s) => s.id)).toEqual(['openai'])
+  })
+
+  it('tolerates null/empty alert lists', () => {
+    expect(filterSecurityAlertsForService(null, svc('openai'), SERVICES)).toEqual([])
+    expect(filterSecurityAlertsForService([], svc('openai'), SERVICES)).toEqual([])
+  })
+})
+
+describe('tagServiceForAlert — Overview banner tag (#821)', () => {
+  it('prefers an exact name match', () => {
+    expect(tagServiceForAlert({ title: 'Codex token leak' }, SERVICES)?.id).toBe('codex')
+  })
+
+  it('falls back to the provider primary for a provider-only item', () => {
+    expect(tagServiceForAlert({ title: 'OpenAI breach disclosed' }, SERVICES)?.id).toBe('openai')
+  })
+
+  it('returns null for OSV alerts (they carry their own service label) and for no match', () => {
+    expect(tagServiceForAlert({ service: 'OpenAI', title: 'x' }, SERVICES)).toBeNull()
+    expect(tagServiceForAlert({ title: 'Unrelated nginx CVE' }, SERVICES)).toBeNull()
+  })
+})

--- a/worker/src/__tests__/security-monitor.test.ts
+++ b/worker/src/__tests__/security-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED, OSV_PACKAGES, shouldAppendTimeline, appendTimelineEntry, osvTimelineKey, planOsvTimelineCycle, buildHNQuery, titleMatchesAiSecurity, fetchHNSecurityPosts } from '../security-monitor'
+import { mapOSVSeverity, detectSecurityAlerts, fetchOSVAlerts, fetchEPSS, enrichAlertsWithEPSS, formatEpssTag, formatSecurityDigest, securityDetectedKey, incrementSecurityCount, readRecentSecurityAlerts, EPSS_ACTIVE, EPSS_ELEVATED, OSV_PACKAGES, shouldAppendTimeline, appendTimelineEntry, osvTimelineKey, planOsvTimelineCycle, buildHNQuery, titleMatchesAiSecurity, isShowOrLaunchHN, fetchHNSecurityPosts } from '../security-monitor'
 import type { SecurityAlert, SecurityAlertMeta, OsvTimeline } from '../security-monitor'
 
 // #325: OSV_PACKAGES drives both querybatch input and the post-fetch enrichment
@@ -32,10 +32,11 @@ describe('OSV_PACKAGES invariants', () => {
 
   it('every service label is also a key in the frontend OSV_SERVICE_MAP', () => {
     // Cross-layer invariant: adding a `service` label here without also adding it
-    // to OSV_SERVICE_MAP in src/pages/ServiceDetails.jsx silently drops those
+    // to OSV_SERVICE_MAP in src/utils/securityAlerts.js silently drops those
     // alerts from the Security Alerts card — the filter there evaluates
     // `OSV_SERVICE_MAP[a.service] === service.id`, which is `undefined === id`
-    // (false) for unmapped labels. This mirror enforces the sync at test time.
+    // (false) for unmapped labels. This mirror is a worker-local tripwire; the
+    // authoritative sync (against the real map) lives in securityAlerts.test.js (#821).
     const KNOWN_SERVICE_LABELS = new Set([
       'OpenAI', 'Anthropic (Claude)', 'Google (Gemini)', 'Cohere', 'Mistral',
       'Hugging Face', 'LangChain',
@@ -117,6 +118,21 @@ describe('titleMatchesAiSecurity (#720)', () => {
   })
 })
 
+describe('isShowOrLaunchHN (#821)', () => {
+  it('flags Show HN / Launch HN announcements (the third-party-promo shape)', () => {
+    // The real false positive: trips titleMatchesAiSecurity (openai + prompt injection) yet
+    // is a promo for a tool that DEFENDS OpenAI agents, not an OpenAI security event.
+    expect(isShowOrLaunchHN('Show HN: Lelu – gate OpenAI agent actions on confidence and prompt injection')).toBe(true)
+    expect(isShowOrLaunchHN('Launch HN: Acme (YC W26) – AI breach detection')).toBe(true)
+    expect(isShowOrLaunchHN('show hn: openai vulnerability scanner')).toBe(true) // case-insensitive
+  })
+
+  it('does not flag genuine reporting that merely contains "show" elsewhere', () => {
+    expect(isShowOrLaunchHN('Logs show OpenAI keys leaked in a breach')).toBe(false)
+    expect(isShowOrLaunchHN('Critical Copilot vulnerability lets hackers steal codes')).toBe(false)
+  })
+})
+
 describe('fetchHNSecurityPosts — request wiring + post-filter (#720)', () => {
   afterEach(() => vi.unstubAllGlobals())
 
@@ -134,6 +150,8 @@ describe('fetchHNSecurityPosts — request wiring + post-filter (#720)', () => {
           { objectID: '3', title: 'New CVE found in nginx', url: null, points: 3, created_at_i: 3 },
           // dropped — substring-only false positive ("source" → rce)
           { objectID: '4', title: 'Show HN: open source Claude tool', url: 'https://ex/4', points: 1, created_at_i: 4 },
+          // dropped (#821) — passes (AI AND security) but is a Show HN promo, not a security event
+          { objectID: '5', title: 'Show HN: Lelu – gate OpenAI agent actions on confidence and prompt injection', url: 'https://github.com/Lelu-ai/lelu', points: 1, created_at_i: 5 },
         ],
       }), { status: 200 })
     }))

--- a/worker/src/security-monitor.ts
+++ b/worker/src/security-monitor.ts
@@ -74,6 +74,17 @@ export function titleMatchesAiSecurity(title: string): boolean {
   return AI_KEYWORD_RE.test(title) && SECURITY_KEYWORD_RE.test(title)
 }
 
+// "Show HN" / "Launch HN" posts are, by HN convention, "here's a thing I built"
+// announcements (#821). A tool that integrates with or DEFENDS a provider names
+// that provider as an integration TARGET, not as the subject of a breach — e.g.
+// "Show HN: Lelu – gate OpenAI agent actions on confidence and prompt injection"
+// trips titleMatchesAiSecurity (openai + prompt injection) but is a third-party
+// promo, not an OpenAI security event. Drop these from the security feed.
+const SHOW_LAUNCH_HN_RE = /^\s*(?:show|launch)\s+hn[:\s]/i
+export function isShowOrLaunchHN(title: string): boolean {
+  return SHOW_LAUNCH_HN_RE.test(title)
+}
+
 interface HNHit {
   objectID: string
   title: string
@@ -111,7 +122,7 @@ export async function fetchHNSecurityPosts(): Promise<SecurityAlert[]> {
   if (!json.hits) return []
 
   return json.hits
-    .filter(hit => hit.title && hit.objectID && titleMatchesAiSecurity(hit.title))
+    .filter(hit => hit.title && hit.objectID && titleMatchesAiSecurity(hit.title) && !isShowOrLaunchHN(hit.title))
     .map(hit => ({
       source: 'hackernews' as const,
       id: hit.objectID,
@@ -123,9 +134,10 @@ export async function fetchHNSecurityPosts(): Promise<SecurityAlert[]> {
 
 // ---------- OSV.dev (AI SDK vulnerabilities) ----------
 
-// Keep the OSV_SERVICE_MAP in src/pages/ServiceDetails.jsx in sync when editing
+// Keep the OSV_SERVICE_MAP in src/utils/securityAlerts.js in sync when editing
 // — its keys must cover every `service` label used here or the Security Alerts
-// card will silently drop entries for the unmapped service.
+// card will silently drop entries for the unmapped service. The cross-layer
+// invariant is enforced at test time in src/utils/securityAlerts.test.js (#821).
 // Exported for invariant tests only; production callers never import it directly.
 export const OSV_PACKAGES = [
   // Major LLM providers — PyPI


### PR DESCRIPTION
## Summary
Fixes Security Alerts false positives surfaced on the detail page (the "Show HN: Lelu – gate OpenAI agent actions…" item that appeared on **ChatGPT, Codex, and OpenAI**). Two root causes, both fixed.

### A — precision (worker)
`fetchHNSecurityPosts` now drops `Show HN:` / `Launch HN:` posts via the new exported `isShowOrLaunchHN`. These are, by HN convention, "here's a thing I built" — a tool that integrates with / defends a provider names it as an **integration target**, not as the subject of a breach, so it shouldn't enter the security feed even though it trips the AI∧security keyword filter.

### B — duplication (frontend)
Matching logic extracted to `src/utils/securityAlerts.js`. A HN finding that matches **only by provider** (service name absent from the title) now attaches to the provider's **single primary service** (first `api`-category service, else first listed) instead of fanning the same item out to every sibling sharing that provider (openai/chatgpt/codex). Name-matched items and OSV-mapped items are unchanged. `ServiceDetails` card and the `Overview` banner tag share the helper (Overview passes the full service list for parity with the detail page).

The stale prod KV entry (`security:seen:hn:48664025`) was manually deleted on 2026-06-29; this PR prevents recurrence.

## Tests
- `isShowOrLaunchHN` — unit (positive/case-insensitive/negatives) + **end-to-end** drop in the `fetchHNSecurityPosts` filter test (the Lelu title is actually dropped).
- `securityAlerts.js` — primary resolution (api-first / fallback / null), provider-only single-attach, name-match exactness, OSV id mapping, the **fragile LangChain** label (`LangChain`→`langsmith`), a **provider+sibling dual-attach** pin, and a real **cross-layer sync** importing worker `OSV_PACKAGES` (worker labels ⊆ `OSV_SERVICE_MAP` keys).
- Moved both `OSV_SERVICE_MAP` "keep in sync" pointers to the new file.

## Gates
- `npm run build` ✅ · `test:src` 615 ✅ · `test:worker` 1996 ✅ · `npm test` (e2e) 149 ✅ · `typecheck:worker` + dry-run ✅
- PR review (code / tests / comments agents) → Critical 0 / Important 0 after fixes
- Local in-browser verify ✅ — with a temp provider-only mock: item shows on `#openai` only, suppressed on `#chatgpt`/`#codex`, Overview banner tag `[OpenAI API]` (mock reverted before commit)

## Follow-ups (out of scope, noted)
- Provider matching is substring (`includes`), so a provider that is a common word / substring (e.g. `Together` → "working together"; `OpenAI` ⊂ "Azure OpenAI") can still mis-attach — #821 shrinks the blast radius (one primary, not all siblings) but doesn't add word-boundary parity with the worker's #720 matcher. Candidate for a separate issue if it surfaces.

Closes #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
