### PR TITLE
feat(is-down): outbound referral wedge on the alternatives section — #842 Deliverable A slice 1 (refs #842)

### DIFF
--- a/api/is-down/__tests__/html-template.test.ts
+++ b/api/is-down/__tests__/html-template.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { buildMetaDescription, renderIncidents, renderFooter, renderRegionRecommendation, renderComponents, renderShareButtons, renderBadgeEmbed, renderPage, linkifyFaqAnswer, FOOTER_CATEGORY_ORDER, type ServiceData } from '../html-template'
 import type { ServiceSEO } from '../seo-content'
-import { SLUG_TO_SERVICE, RELATED_SLUGS } from '../slug-map'
+import { SLUG_TO_SERVICE, RELATED_SLUGS, outboundReferralUrl, SERVICE_SITE_URL } from '../slug-map'
 import type { RegionStatusResult } from '../region-status'
 
 // Incidents are filtered to a rolling 30-day window (the `Date.now() - 30 * 86_400_000`
@@ -53,6 +53,54 @@ function mkService(overrides: Partial<ServiceData> = {}): ServiceData {
     ...overrides,
   }
 }
+
+describe('outboundReferralUrl (#842)', () => {
+  it('returns the curated provider URL with a disclosed ref param', () => {
+    expect(outboundReferralUrl('gemini')).toBe('https://ai.google.dev?ref=ai-watch.dev')
+    expect(outboundReferralUrl('claude')).toBe('https://claude.com?ref=ai-watch.dev')
+  })
+  it('returns null for a service with no curated URL (graceful)', () => {
+    expect(outboundReferralUrl('bedrock')).toBeNull()
+    expect(outboundReferralUrl('zzz')).toBeNull()
+  })
+  it('every curated URL is https', () => {
+    for (const u of Object.values(SERVICE_SITE_URL)) expect(u.startsWith('https://')).toBe(true)
+  })
+})
+
+describe('renderFallbacks — outbound referral wedge (#842)', () => {
+  it('renders a prominent disclosed "Open" outbound button (new tab, rel=nofollow unpaid, GA event) per curated alternative', () => {
+    const html = renderPage('claude', mkService({ status: 'down' }), mkSeo(), [
+      { id: 'gemini', name: 'Gemini API', score: 95, status: 'operational' },
+    ])
+    expect(html).toContain('class="fallback-try"')
+    expect(html).toContain('href="https://ai.google.dev?ref=ai-watch.dev"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="nofollow noopener noreferrer"') // unpaid editorial — NO `sponsored`
+    expect(html).not.toContain('sponsored')                      // must not contradict the "not paid" disclosure
+    expect(html).toContain('data-ga="outbound_fallback_click"')
+    expect(html).toContain('data-ga-to="gemini"')
+    expect(html).toContain('ranked by AIWatch Score, not paid') // disclosure
+  })
+  it('omits the button (and disclosure) when no alternative has a curated URL', () => {
+    const html = renderPage('claude', mkService({ status: 'down' }), mkSeo(), [
+      { id: 'bedrock', name: 'Amazon Bedrock', score: 90, status: 'operational' },
+    ])
+    expect(html).not.toContain('class="fallback-try"')
+    expect(html).not.toContain('outbound_fallback_click')
+    expect(html).not.toContain('ranked by AIWatch Score, not paid')
+  })
+  it('mixed list — exactly one outbound button for the curated alt, disclosure shown once', () => {
+    const html = renderPage('claude', mkService({ status: 'down' }), mkSeo(), [
+      { id: 'gemini', name: 'Gemini API', score: 95, status: 'operational' },      // curated → button
+      { id: 'bedrock', name: 'Amazon Bedrock', score: 90, status: 'operational' }, // no URL → no button
+    ])
+    expect((html.match(/class="fallback-try"/g) ?? []).length).toBe(1)
+    expect((html.match(/data-ga="outbound_fallback_click"/g) ?? []).length).toBe(1)
+    expect((html.match(/ranked by AIWatch Score, not paid/g) ?? []).length).toBe(1)
+    expect(html).toContain('href="https://ai.google.dev?ref=ai-watch.dev"') // the one button is Gemini's
+  })
+})
 
 describe('renderAIInsight — predicted vs actual (#827 F4)', () => {
   const resolvedInsight = {

--- a/api/is-down/html-template.ts
+++ b/api/is-down/html-template.ts
@@ -1,7 +1,7 @@
 // SSR HTML template for "Is X Down?" pages
 
 import type { ServiceSEO } from './seo-content'
-import { SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE, RELATED_SLUGS } from './slug-map'
+import { SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE, RELATED_SLUGS, outboundReferralUrl } from './slug-map'
 import { groupIncidents, type GroupingIncident, type GroupRow, type SingleRow } from './incident-grouping'
 import { compareGroupedRows } from './incident-sort'
 // #482 — is-down uses HASH-based CSP (not nonce): it stays edge-cached (s-maxage=60), and the
@@ -331,9 +331,13 @@ h2{font-size:18px;font-weight:600;margin:32px 0 16px;color:#e6edf3}
 .faq-item{margin:16px 0}
 .faq-q{font-weight:600;font-size:15px;margin-bottom:6px}
 .faq-a{font-size:14px;color:#8b949e}
-.fallback-item{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:#161b22;border-radius:6px;margin:8px 0}
+.fallback-item{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:10px 14px;background:#161b22;border-radius:6px;margin:8px 0}
 .fallback-name{font-weight:500;font-size:14px}
 .fallback-score{font-size:12px;color:#8b949e}
+.fallback-right{display:flex;align-items:center;gap:12px;flex-shrink:0}
+.fallback-try{display:inline-block;padding:5px 11px;border:1px solid #2ea043;color:#3fb950;border-radius:6px;font-size:12px;font-weight:600;text-decoration:none;white-space:nowrap}
+.fallback-try:hover{background:#2ea043;color:#fff}
+.fallback-disclosure{font-size:11px;color:#8b949e;opacity:0.85;margin:10px 2px 0}
 .footer{text-align:center;padding:32px 0;font-size:13px;color:#484f58;border-top:1px solid rgba(255,255,255,0.07);margin-top:40px}
 .btn{display:inline-block;padding:8px 20px;background:#161b22;border:1px solid rgba(255,255,255,0.14);border-radius:6px;color:#e6edf3;font-size:13px;font-weight:500;transition:background 0.2s}
 .btn:hover{background:#1c2230;text-decoration:none}
@@ -1060,6 +1064,7 @@ function renderFAQ(seo: ServiceSEO, fallbacks: Fallback[]): string {
 
 function renderFallbacks(seo: ServiceSEO, fallbacks: Fallback[], fromId?: string): string {
   if (fallbacks.length === 0) return ''
+  let anyOutbound = false
   const items = fallbacks.map(f => {
     const scoreText = f.score != null ? `Score: ${f.score}` : ''
     const color = statusColor(f.status)
@@ -1067,15 +1072,26 @@ function renderFallbacks(seo: ServiceSEO, fallbacks: Fallback[], fromId?: string
     const fbSlug = SERVICE_ID_TO_SLUG[f.id]
     const gaClick = fromId ? ` data-ga="fallback_click" data-ga-from="${esc(fromId)}" data-ga-to="${esc(f.id)}" data-ga-loc="is_down_page"` : ''
     const nameHtml = fbSlug ? `<a href="/is-${esc(fbSlug)}-down" style="color:#e6edf3"${gaClick}>${esc(f.name)}</a>` : esc(f.name)
+    // #842 — prominent, disclosed OUTBOUND "Open" button so a panic visitor can act on the
+    // (unpaid, Score-ranked) recommendation. `rel="nofollow"` = the accurate signal for an UNPAID
+    // editorial link (matches the "not paid" disclosure); `sponsored` is deliberately NOT used — it's
+    // Google's paid-placement marker and would contradict the disclosure. Add `sponsored` only if/when
+    // a service becomes an actual paid sponsor. GA via the delegated [data-ga] listener (CSP-clean).
+    const outUrl = outboundReferralUrl(f.id)
+    if (outUrl) anyOutbound = true
+    const tryBtn = outUrl
+      ? `<a class="fallback-try" href="${esc(outUrl)}" target="_blank" rel="nofollow noopener noreferrer" data-ga="outbound_fallback_click" data-ga-from="${esc(fromId ?? '')}" data-ga-to="${esc(f.id)}" data-ga-loc="is_down_page" aria-label="Open ${esc(f.name)} (opens provider site)">Open &#8599;</a>`
+      : ''
     return `<div class="fallback-item">
 <span class="fallback-name">${nameHtml}</span>
-<span class="fallback-score mono">${scoreText} &nbsp; <span style="color:${color}">${statusEmoji(f.status)} ${label}</span></span>
+<span class="fallback-right"><span class="fallback-score mono">${scoreText} &nbsp; <span style="color:${color}">${statusEmoji(f.status)} ${label}</span></span>${tryBtn}</span>
 </div>`
   }).join('\n')
 
   return `<h2>Alternatives When ${esc(seo.displayName)} is Down</h2>
 <div class="card">
 ${items}
+${anyOutbound ? `<p class="mono fallback-disclosure">Open &#8599; goes to the provider site &middot; ranked by AIWatch Score, not paid.</p>` : ''}
 <div class="links" style="margin-top:12px">
 <a href="https://ai-watch.dev/#ranking" data-ga="click_ranking" data-ga-loc="is_down_page" data-ga-source="alternatives">Reliability rankings &rarr;</a>
 <a href="/reports/" data-ga="click_reports" data-ga-loc="is_down_page" data-ga-source="alternatives">Monthly reports &rarr;</a>

--- a/api/is-down/slug-map.ts
+++ b/api/is-down/slug-map.ts
@@ -124,3 +124,29 @@ export const RELATED_SLUGS: Record<string, string[]> = {
 export const SERVICE_ID_TO_SLUG: Record<string, string> = Object.fromEntries(
   Object.entries(SLUG_TO_SERVICE).map(([slug, entry]) => [entry.id, slug])
 )
+
+// #842 — outbound referral wedge. Product/homepage URL per service that can be RECOMMENDED as a
+// fallback on the is-down page, so an outage-moment visitor can ACT on the (Score-ranked, UNPAID)
+// recommendation — and AIWatch can measure "we sent N users to alternatives at the failover moment"
+// (the Rung-1 sponsor evidence, #637/#842). Curated high-confidence set; a missing id → no outbound
+// affordance (graceful). NOT an endorsement or paid placement — the link is disclosed + `rel="nofollow"`
+// (unpaid editorial; `sponsored` would falsely mark it paid) and rankings stay Score-only. The SPA
+// mirror (if/when added) lives in src/utils/constants.js.
+export const SERVICE_SITE_URL: Record<string, string> = {
+  // LLM APIs
+  claude: 'https://claude.com', openai: 'https://platform.openai.com', gemini: 'https://ai.google.dev',
+  mistral: 'https://mistral.ai', cohere: 'https://cohere.com', groq: 'https://groq.com',
+  together: 'https://together.ai', fireworks: 'https://fireworks.ai', cerebras: 'https://cerebras.ai',
+  deepseek: 'https://www.deepseek.com', xai: 'https://x.ai', perplexity: 'https://www.perplexity.ai',
+  openrouter: 'https://openrouter.ai',
+  // Apps
+  chatgpt: 'https://chatgpt.com', claudeai: 'https://claude.ai',
+}
+
+/** Disclosed outbound referral URL for a recommended alternative (appends a `ref` param so the
+ *  destination can attribute AIWatch). Returns null when no curated URL → caller omits the affordance. */
+export function outboundReferralUrl(id: string): string | null {
+  const base = SERVICE_SITE_URL[id]
+  if (!base) return null
+  return `${base}${base.includes('?') ? '&' : '?'}ref=ai-watch.dev`
+}

--- a/docs/reference/ga4-events.md
+++ b/docs/reference/ga4-events.md
@@ -18,7 +18,8 @@ All events use `trackEvent()` from `src/utils/analytics.js`. GA4 is only active 
 | `select_service` | `service_id` | Overview (card click) | Service card click |
 | `view_service` | `service_id` | Sidebar (service list) | Sidebar service click |
 | `view_incident` | `incident_id` | Incidents page | Incident detail open |
-| `fallback_click` | `from_service`, `to_service`, `location` | ActionBanner, Is X Down | Fallback recommendation click |
+| `fallback_click` | `from_service`, `to_service`, `location` | ActionBanner, Is X Down | Fallback recommendation click (internal → the alternative's is-down/detail page) |
+| `outbound_fallback_click` | `from_service`, `to_service`, `location` (`is_down_page`) | Is X Down SSR (`renderFallbacks` "Open ↗" button) | #842 — disclosed OUTBOUND click to the recommended alternative's provider site (the Rung-1 referral evidence, #637). Fires from the delegated `[data-ga]` listener; the link is `rel="nofollow"` (unpaid editorial — `sponsored` is intentionally omitted so it doesn't contradict the "not paid" disclosure; add it only if a service becomes a paid sponsor), only rendered for services with a curated `SERVICE_SITE_URL`. GA is the consent-gated floor — a server-side consent-free counter is a follow-up slice of #842 |
 | `change_filter` | `filter` | Overview (filter tabs) | Status filter change |
 | `category_filter` | `category`, `location` | Sidebar (category) · Overview (category tabs) | Category filter change. `location` ∈ `sidebar` (omitted on the legacy sidebar call) / `overview` — the Overview surfaces the same category control as on-screen tabs (#646) |
 | `navigate_page` | `page` | Sidebar (nav) | Page navigation |


### PR DESCRIPTION
## What

#842 **Deliverable A, first slice** — the **outbound referral wedge** on the is-down page (where the outage-moment visitor actually lands via SEO / X). The "Alternatives When X is Down" section now makes each recommendation **actionable + measurable**: a prominent, disclosed **"Open ↗"** button per alternative that opens the provider's site in a new tab.

This is the **Rung-1 sponsor evidence** — "AIWatch sends outage-moment users to the alternative at the failover moment" (#637) — instrumented via a GA4 `outbound_fallback_click` event. Currently the fallback recommendation only linked *internally* (to the alt's own is-down page); there was **no outbound mechanism at all**, so this is the first surface that can produce the referral evidence the future sponsor pitch needs.

```
Gemini API     Score: 95   🟢 Operational   [ Open ↗ ]
OpenAI API     Score: 98   🟢 Operational   [ Open ↗ ]
↗ Open goes to the provider site · ranked by AIWatch Score, not paid.
```

## Changes (Edge / is-down only)

- **`api/is-down/slug-map.ts`** — `SERVICE_SITE_URL` (id → provider homepage; 15 curated high-confidence: 13 LLM APIs + OpenRouter + ChatGPT/claude.ai) + `outboundReferralUrl(id)` (appends a disclosed `?ref=ai-watch.dev`; `null` → no button). A missing id → **graceful** (name → internal is-down link only; voice/agents/image/video not yet curated).
- **`api/is-down/html-template.ts`** `renderFallbacks` — the "Open ↗" button (`target=_blank`, **`rel="nofollow"`** — UNPAID editorial; `sponsored` deliberately omitted so it never contradicts the "not paid" disclosure) fires the GA event from the **existing delegated `[data-ga]` listener** (CSP-clean, no new inline script). One-line disclosure shown only when ≥1 button renders. New CSS.
- **`docs/reference/ga4-events.md`** — `outbound_fallback_click` entry.

## Neutrality (load-bearing — per `discovery/track1-hibp-model.md`)

The link is the **same Score-ranked, UNPAID** recommendation made actionable + **disclosed**; rankings stay Score-only. It's the HIBP-style evidence-generating wedge, **not affiliate-on-rankings**. `rel="nofollow"` is the accurate signal for an unpaid editorial link; `sponsored` is added only if/when a service becomes an actual paid sponsor.

## Coverage

- ✅ **LLM API fully covered** (the category where outage traffic + gateway-sponsor relevance concentrate: is-claude-down → OpenAI/Gemini both get buttons).
- ⚪ Voice / agents / image / video / observability → no button yet (name → internal link, graceful). Cheap map extension, later.
- 🚫 EXCLUDE_FALLBACK services never appear as candidates anyway.

## Tests / verification

- `html-template.test.ts` + `is-down.test.ts` **130** — url helper (curated/null/https), render, omission-when-uncurated, **mixed list** (one button, disclosure once), **new-tab + `rel=nofollow` (no `sponsored`)**.
- `build` OK; full `test:src` **689**. **In-browser verified** on `/is-claude-down`.
- e2e: 148 pass; 1 pre-existing failure (`incidents-archive-merge`, a month-rollover/prod-data issue confirmed failing WITHOUT this change — unrelated to is-down).
- Code review → **0 Critical / 0 Important** (the `rel=sponsored`→`nofollow` contradiction was caught + fixed; mixed-list/new-tab test gaps filled).

## Notes

- **Edge/SPA auto-deploys on merge** (Vercel) — no worker deploy needed for this slice.
- Follow-up slices of #842-A: server-side **consent-free** referral counter (GA is the consent-gated floor), the same wedge on the Analyze modal / ActionBanner, and extending `SERVICE_SITE_URL` to more categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
