### PR TITLE
ci: gate frontend unit tests (test:src) via always-on job (#877)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,22 @@ jobs:
       # #541: node:test unit tests for scripts/*.mjs (verify-reminders parse/fire logic)
       - run: npm run test:scripts
 
+  src-unit:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+    # #877: gate the frontend vitest suite (~750 tests incl. the CSP drift pin
+    # api/__tests__/csp-headers.test.ts, which caught PR #871's vercel.json script-src
+    # hash drift). ALWAYS-ON, no path gate: the CSP pin can break from vercel.json /
+    # index.html / api/ / src/ — the e2e+build frontend detector regex matches none of
+    # vercel.json or api/, so any path gate would re-open the blind spot. Suite runs ~4s.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run test:src
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ npm run lint       # Run ESLint
 
 ```bash
 npm test           # Run Playwright E2E tests
-npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js)
+npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js + api/__tests__/*.test.ts incl. the CSP drift pin) — CI-gated via the always-on `Frontend Unit Tests` job (#877; the gap that let PR #871's vercel.json CSP-hash drift ship green)
 npm run test:worker # Run Worker unit tests (vitest)
 npm run typecheck:worker # tsc gate — full `tsc --noEmit`, fails on ANY type error across worker source incl tests (#533 Phase 4; two-pass: prod strict workers-types-only + tests with @types/node)
 npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders, #541)


### PR DESCRIPTION
## Summary
Adds an always-on `Frontend Unit Tests` CI job running `npm run test:src` (~750 frontend vitest tests, including the CSP drift pin `api/__tests__/csp-headers.test.ts`).

## Why
No CI job ran `test:src`, so **PR #871's `vercel.json` `script-src` CSP-hash drift shipped all-green** — the hashes no longer matched `index.html`'s inline scripts, which would block the SPA's inline scripts (font-swap + FOUC theme) in production. `csp-headers.test.ts` catches it, but only locally.

Secondary gap this closes: the e2e/build frontend-change detector regex `^(src/|public/|index\.html|vite\.config|package\.json)` matches **neither `vercel.json` nor `api/`**, so a pure CSP/Edge change skips those jobs. A path-gate on the new job would re-open the same blind spot — hence **always-on** (the workflow-level `paths-ignore` already skips docs-only PRs; the suite runs ~4s).

## Changes
- `.github/workflows/test.yml` — new `src-unit` / "Frontend Unit Tests" job (checkout → setup-node 20 → `npm ci` → `npm run test:src`), mirroring the `unit` job
- `CLAUDE.md` — note the new gate on the `test:src` command line

## Verification
- `npm run test:src` green: **750/750** (~4s, bare `npm ci`)
- Deliberately broke one `vercel.json` CSP hash → job goes **red** (reproduces the #871 class), then reverted

## Follow-up (repo settings — not in this diff)
Adding the job doesn't make it block merges. To fully meet #877's goal, add **"Frontend Unit Tests"** to `main`'s required status checks once it's proven stable:
```
gh api -X PATCH repos/bentleypark/aiwatch/branches/main/protection/required_status_checks --field 'contexts[]=Frontend Unit Tests'
```

## Checklist
- [x] YAML valid, job structure/consistency verified
- [x] `test:src` green on this branch
- [x] Gate proven to catch CSP-hash drift
- [ ] Promote to required status check (after stability, repo settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
