### PR TITLE
docs: add test:src to contributor test instructions (#877)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,9 @@
 
 ## Checklist
 - [ ] `npm run build` passes
-- [ ] `npm test` passes (27 Playwright E2E specs)
-- [ ] `npm run test:worker` passes (65 Vitest unit specs)
+- [ ] `npm test` passes (Playwright E2E)
+- [ ] `npm run test:src` passes (frontend vitest — incl. CSP hash pin, #877 CI-gated)
+- [ ] `npm run test:worker` passes (Worker vitest)
 - [ ] Code review completed (`/pr-review-toolkit:review-pr`)
 - [ ] Critical and Important review issues fixed
 - [ ] No hardcoded hex colors (use CSS design tokens)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,11 @@ Shared workflow — especially:
 
 ```bash
 npm test             # Playwright E2E tests
-npm run test:worker  # Vitest unit tests
+npm run test:src     # Frontend unit tests (vitest — incl. the CSP hash drift pin, #877 CI-gated)
+npm run test:worker  # Worker unit tests (vitest)
 ```
 
-All 92 tests must pass before submitting a PR.
+All tests must pass before submitting a PR — CI gates `test:src`, `test:worker`, and the E2E suite.
 
 ## Pull Request Guidelines
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -246,8 +246,9 @@ npm run dev:worker   # Worker 개발 서버 (localhost:8788)
 npm run dev:all      # 둘 다 동시 실행
 npm run build        # 프로덕션 빌드 → dist/
 npm run lint         # ESLint
-npm test             # Playwright E2E 테스트 (27개)
-npm run test:worker  # Worker 단위 테스트 (65개, vitest)
+npm test             # Playwright E2E 테스트
+npm run test:src     # 프론트엔드 단위 테스트 (vitest — CSP 해시 핀 포함)
+npm run test:worker  # Worker 단위 테스트 (vitest)
 
 # Worker 배포
 npm run deploy:worker  # Cloudflare 배포 (npm 스크립트만 사용)
@@ -420,7 +421,7 @@ worker/
 1. 레포지토리 포크
 2. 기능 브랜치 생성 (`git checkout -b feature/my-feature`)
 3. [CLAUDE.md](CLAUDE.md)의 개발 워크플로우 따르기
-4. 빌드 + 테스트: `npm run build && npm test && npm run test:worker`
+4. 빌드 + 테스트: `npm run build && npm test && npm run test:src && npm run test:worker`
 5. [PR 템플릿](.github/pull_request_template.md)으로 풀 리퀘스트 제출
 
 ### 이슈
@@ -431,7 +432,7 @@ worker/
 ### 풀 리퀘스트
 
 - PR당 하나의 기능 또는 수정
-- 모든 테스트 통과 (E2E 27개 + 단위 65개 = 92개)
+- 모든 테스트 통과 (`npm test` + `npm run test:src` + `npm run test:worker`, CI 게이트)
 - 커밋 메시지에 `closes #N` 포함
 - PR 체크리스트 작성
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ npm run dev:all      # Both simultaneously
 npm run build        # Production build → dist/
 npm run lint         # ESLint
 npm test             # Playwright E2E tests
+npm run test:src     # Frontend unit tests (vitest — incl. CSP hash pin)
 npm run test:worker  # Worker unit tests (vitest)
 
 # Worker deployment
@@ -426,7 +427,7 @@ rules.
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Follow the shared workflow in [AGENTS.md](AGENTS.md); Claude Code contributors should also
    follow [CLAUDE.md](CLAUDE.md)
-4. Build + test: `npm run build && npm test && npm run test:worker`
+4. Build + test: `npm run build && npm test && npm run test:src && npm run test:worker`
 5. Submit a pull request using the [PR template](.github/pull_request_template.md)
 
 ### Issues
@@ -437,7 +438,7 @@ rules.
 ### Pull Requests
 
 - One feature or fix per PR
-- All tests must pass (`npm test` + `npm run test:worker`)
+- All tests must pass (`npm test` + `npm run test:src` + `npm run test:worker`)
 - Include `closes #N` in commit messages
 - Fill out the PR checklist
 


### PR DESCRIPTION
## Summary
Docs-only follow-up to #878. That PR made `npm run test:src` a CI gate, but the contributor-facing test instructions still listed only `npm test` + `npm run test:worker` — the exact gap that let PR #871's `vercel.json` CSP-hash drift slip through (the contributor was never told to run `test:src`, which owns the CSP drift pin).

## Related Issue
refs #877

## Changes
- **CONTRIBUTING.md** — add `npm run test:src` to the Testing block; drop the stale "92 tests" total
- **.github/pull_request_template.md** — add a `test:src` checklist item
- **README.md / README.ko.md** — add `test:src` to the command list + the `build && test` one-liner + the "all tests must pass" line

Stale hardcoded counts (27/65/92) replaced with count-free phrasing so they don't rot on every test addition. AGENTS.md and CLAUDE.md already list `test:src` (no change needed).

## Checklist
- [x] `npm run test:src` verified as a real script (CSP pin included via `api/**/*.test.ts`)
- [x] EN/KO parity + command ordering consistent across all 4 files
- [x] Code review (0 Critical/Important)
- [x] Docs-only — no runtime surface, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
