### PR TITLE
chore(memory): retire MemPalace → LLM Wiki/OKF docs + skills (refs #891)

### DIFF
--- a/.claude/skills/memory-ingest/SKILL.md
+++ b/.claude/skills/memory-ingest/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: memory-ingest
+description: >-
+  Distill this session's durable knowledge into the file-based LLM Wiki memory (the `~/.claude/.../memory/`
+  bundle). Invoke at end-of-session, when the PreCompact hook fires (if wired), or whenever the user says "remember this"
+  / "기억해둬" / "메모리에 남겨". Captures user corrections + confirmed approaches (feedback), root-cause
+  findings / non-obvious fixes (debugging), ongoing goals/constraints not derivable from code (project), and
+  external-resource pointers (reference) — one concept per file, deduped against existing pages, with the
+  MEMORY.md index + log.md updated. Replaces the retired MemPalace ingest (#891).
+---
+
+# memory-ingest — write durable knowledge into the LLM Wiki
+
+The file memory (`~/.claude/projects/-Users-bentley-Desktop-bentely-aiwatch-aiwatch/memory/`) is the single
+persistent memory (MemPalace retired, #891). This skill is the **ingest** operation of the LLM-Wiki pattern.
+
+## When to run
+- End of a substantive session, or when the `PreCompact` hook fires (if wired in `.claude/settings.local.json`).
+- User says "기억해둬" / "remember this" / "메모리에 남겨".
+- A durable fact emerged: a user correction, a non-obvious root cause, a project constraint, a useful external pointer.
+
+## What NOT to ingest
+- Ephemeral task state, TODOs, "what I'm about to do next".
+- Anything the repo already records: code structure, past fixes, git history, CLAUDE.md content. If asked to
+  remember one of those, ask what was **non-obvious** about it and store that instead.
+
+## Procedure
+1. **Scan** the conversation for durable items matching one `type`:
+   - `feedback` — user correction / confirmed approach. Body MUST carry **Why:** and **How to apply:** lines.
+   - `debugging` — root-cause finding / non-obvious fix.
+   - `project` — ongoing work / goal / constraint not derivable from code (convert relative dates to absolute).
+   - `reference` — pointer to an external resource (URL, dashboard, ticket).
+2. **Dedup first**: `grep` MEMORY.md + the memory dir for an existing page on the same topic. If one exists,
+   **update it** (merge the new nuance, preserve the original **Why**) rather than creating a near-duplicate.
+   Redundant feedback clusters should be merged, not multiplied (see #891 Phase 1).
+3. **Write** the page: `memory/<type>_<kebab-slug>.md` with frontmatter `name` / `description` / `type`
+   (+ optional `title`/`tags`). Link related pages with `[[type_slug]]` — the **filename stem** (e.g.
+   `[[feedback_local_verify]]` → `feedback_local_verify.md`), NOT the bare frontmatter `name`. A not-yet-existing `[[link]]` is fine.
+   - **Quote any `description`/`title` containing a bare `#`** (e.g. `#N`) — unquoted YAML treats `#` as a
+     comment and truncates the value.
+   - The harness normalizes frontmatter on write (relocates `type`/`title`/`tags` under `metadata:`) — expected, don't fight it.
+4. **Index**: add one line to `MEMORY.md` under the right section (`- [Title](file.md) — hook`). Never put memory
+   content in MEMORY.md — one line per page.
+5. **Log**: append one line to `memory/log.md` — `YYYY-MM-DD ingest: <slug> (<why in a few words>)`.
+6. If a stored fact turned out wrong, delete the page (and its index line) instead of leaving it.
+
+## Relationship
+Complements `memory-lint` (periodic health check). The **query** side (load index → relevant pages) is native session-start auto-load, optionally nudged by a `SessionStart` hook if wired in `settings.local.json`.

--- a/.claude/skills/memory-lint/SKILL.md
+++ b/.claude/skills/memory-lint/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: memory-lint
+description: >-
+  Periodic health check of the file-based LLM Wiki memory (the `~/.claude/.../memory/` bundle) — the "lint"
+  operation of the Karpathy LLM-Wiki pattern. Invoke every week or two, or after a batch of memory-ingest
+  writes, or when the memory "feels stale". Finds contradictions, stale/superseded claims, orphan pages,
+  broken `[[wikilinks]]`, index drift (file↔MEMORY.md mismatch), unquoted-`#` frontmatter truncation, and
+  redundant clusters worth merging — then records findings in log.md. Read-only proposals for anything
+  destructive; the user confirms merges/deletions.
+---
+
+# memory-lint — keep the LLM Wiki healthy
+
+The file memory (`~/.claude/projects/-Users-bentley-Desktop-bentely-aiwatch-aiwatch/memory/`) compounds over
+time; without periodic linting it drifts. This is the **lint** operation of the LLM-Wiki pattern (#891).
+
+## When to run
+- Every 1–2 weeks, after a batch of `memory-ingest` writes, or when recall feels noisy/stale.
+
+## Checks
+1. **Index drift** — every `memory/*.md` (except MEMORY.md) has exactly one MEMORY.md line, and every MEMORY.md
+   link resolves to a file. Report `NOT INDEXED` / `MISSING FILE`.
+2. **Broken wikilinks** — every `[[stem]]` resolves to an existing `memory/stem.md` (wikilinks target the
+   `type_`-prefixed **filename stem**, not the frontmatter `name`; or a deliberate forward-marker). Report danglers.
+3. **Frontmatter integrity** — every page has `name` + `type`; no `description`/`title` truncated by an
+   unquoted bare `#` (grep for descriptions containing ` #` without surrounding quotes).
+4. **Contradictions / stale claims** — two pages that assert opposite things, or a page whose claim a later
+   session invalidated (e.g. a file/flag it names no longer exists — verify against current code before flagging).
+5. **Redundant clusters** — near-duplicate pages on one topic (e.g. the #891 Phase 1 review/close/verify
+   clusters) that should be merged into one, preserving each original's **Why**.
+
+## Output
+- Write a `YYYY-MM-DD lint: <n> findings (<summary>)` line to `memory/log.md`.
+- **Auto-fix only the safe, mechanical issues** (repoint a broken wikilink to its renamed target, add a missing
+  index line, quote a `#`-truncated description).
+- **Propose — do NOT auto-apply — anything lossy** (merging pages, deleting stale claims). Present the plan and
+  wait for user confirmation (user feedback is never deleted unilaterally; merge preserves the Why).
+
+## Relationship
+Pairs with `memory-ingest` (the write side). Neither touches the repo — the memory dir is harness-global.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,37 +2,27 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Persistent Memory (MemPalace MCP)
+## Persistent Memory (LLM Wiki / OKF)
 
-This project uses MemPalace MCP server for persistent memory that survives context compaction and session boundaries.
+Persistent memory is a **file-based LLM Wiki** (Karpathy's pattern, formalized by Google's Open Knowledge Format) in the harness memory dir `~/.claude/projects/-Users-bentley-Desktop-bentely-aiwatch-aiwatch/memory/` — markdown concept files + a `MEMORY.md` index + a `log.md` history + `[[wikilinks]]`. No vector DB: read the index, load the relevant pages. **MemPalace MCP is retired (#891)** — it was ~98.7% raw code-dump noise, dual-wrote the file memory, and its semantic search returned noise. Retirement is completed by a paired **local cutover** (remove the `mempalace` MCP server from `.claude/mcp.json` and global `~/.claude.json`, rewire the `SessionStart`/`PreCompact` hooks in `.claude/settings.local.json` off the mempalace tools, delete `.mempalace/`) — those are gitignored local/data files, not part of this PR. Single system.
 
-### Session Start
-- `SessionStart` hook auto-injects a reminder to call `mempalace_status` — call it on first turn
-- Call `mempalace_search` before answering questions about past decisions, architecture history, or debugging context
+### Three operations
+- **query** — before answering about past decisions / architecture history / debugging context (or when the user references past work: "지난번에", "이전에", "아까"), read `MEMORY.md` and load the relevant pages. Session-start memory auto-load is native; a `SessionStart` hook in `settings.local.json` may also nudge it.
+- **ingest** — run the `memory-ingest` skill (manually, or on the `PreCompact` hook if wired in `settings.local.json`) to distill decisions / debugging findings / user feedback into pages before context is lost; dedup against existing pages; append a `log.md` line. Skip ephemeral task state.
+- **lint** — run the `memory-lint` skill periodically to check for contradictions, stale claims, orphan pages, broken `[[wikilinks]]`, index drift; record findings in `log.md`.
 
-### When to Store
-Each drawer save specifies **wing + room + hall**. Hall is the memory type (fixed 5). Room is the topic (project-defined).
+### When to store (page `type`)
+| Store Type | `type` |
+|---|---|
+| User corrections / confirmed approaches (+ **Why** + **How to apply**) | `feedback` |
+| Root-cause findings, non-obvious fixes | `debugging` |
+| Ongoing work / goals / constraints not derivable from code | `project` |
+| Pointers to external resources (URLs, dashboards) | `reference` |
 
-| Store Type | Room | Hall | Tool |
-|---|---|---|---|
-| Architecture choice, trade-off reasoning | `decisions` | `events` | `mempalace_add_drawer` |
-| Root cause findings, non-obvious fixes | `debugging` | `discoveries` | `mempalace_add_drawer` |
-| User corrections, confirmed approaches | `feedback` | `preferences` or `advice` | `mempalace_add_drawer` |
-| Stable facts (API schema, service count) | `architecture` | `facts` | `mempalace_add_drawer` |
-| PR merges, deploys, major completions | `deployments` | `events` | `mempalace_diary_write` |
+Don't store what the repo already records (code structure, past fixes, git history, CLAUDE.md).
 
-### When to Search
-- Before proposing changes to areas with prior decisions
-- When user references past work ("지난번에", "이전에", "아까")
-- When context was compacted and details were lost
-
-### PreCompact Hook
-`PreCompact` hook auto-injects a reminder to save important decisions/debugging/feedback to MemPalace before context is lost. Scan the conversation and save what matches the table above — skip ephemeral task state.
-
-### Palace Structure
-- **Wing**: `aiwatch` (this project)
-- **Rooms** (topics): `architecture`, `debugging`, `feedback`, `decisions`, `deployments`
-- **Halls** (memory types, fixed): `facts`, `events`, `discoveries`, `preferences`, `advice`
+### OKF frontmatter convention
+Each page carries YAML frontmatter: `name`, `description`, `type` (+ optional `title`/`tags`). **Caveat: the harness normalizes memory frontmatter on write** (relocates `type`/`title`/`tags` under `metadata:`) — don't fight it; the fields survive under `metadata`. **Gotcha: quote any `description`/`title` containing a bare `#`** (e.g. `#N`) — unquoted YAML treats `#` as a comment and truncates the value (hit in #891 Phase 1). True OKF top-level conformance (for the Google graph visualizer) belongs in an in-repo bundle (`docs/reference/*`, deferred), not the harness memory dir.
 
 ## API Docs via Context Hub (chub)
 
@@ -70,7 +60,7 @@ the Workers AI doc shows only `res.response`, but `ai-analysis.ts` must also han
 OpenAI-compatible `res.choices[0].message.content` / `.reasoning` shape (model-dependent) plus
 `chat_template_kwargs:{enable_thinking:false}` for Gemma. Save such findings with `chub annotate`.
 
-**chub vs MemPalace**: chub = external API ground-truth (public, shared); MemPalace = this project's
+**chub vs LLM Wiki memory**: chub = external API ground-truth (public, shared); the file-based LLM Wiki (`memory/`) = this project's
 decisions/debugging/feedback (private, project-scoped). Complementary, different layers.
 
 ### modern-web-guidance + when-to-use-which


### PR DESCRIPTION
Phase 3 (tracked half) of #891 — retiring the MemPalace MCP memory server for a file-based **LLM Wiki / OKF** memory system.

## What changed (docs/skills only — no application code)
- **`CLAUDE.md`**: replaced the "Persistent Memory (MemPalace MCP)" section with **"Persistent Memory (LLM Wiki / OKF)"** — the three operations (query / ingest / lint), the four page `type`s (feedback/debugging/project/reference), and the OKF frontmatter convention incl. the harness-normalization + bare-`#` quoting caveats. Updated the "chub vs …" line.
- **New skills** `memory-ingest` (distill session knowledge → pages, dedup, log) and `memory-lint` (periodic health check: contradictions / stale / orphans / broken links / index drift).

## Review
Independent `code-reviewer` pass, 2 rounds → **0 Critical/Important**. Verified: no stray old-taxonomy references remain, skills mirror the CLAUDE.md section, frontmatter matches the existing skill convention, and every path named in the cutover note is real + gitignored.

## Paired local cutover (NOT in this PR — gitignored/local)
Retirement is only *complete* after the local cutover, done alongside merge:
- remove the `mempalace` MCP server from `.claude/mcp.json` **and global `~/.claude.json`**
- rewire the `SessionStart`/`PreCompact` hooks in `.claude/settings.local.json` off the mempalace tools
- delete `.mempalace/` (25MB) + `mempalace.yaml` — Phase 0 archived the 52 curated drawers first

## Scope
`refs #891` (not `closes`) — the local cutover + the optional Phase 4 (in-repo `docs/reference/*` OKF bundle) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)