### PR TITLE
docs(reference): promote docs/reference to an OKF bundle (refs #891)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ npm test           # Run Playwright E2E tests
 npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js + api/__tests__/*.test.ts incl. the CSP drift pin) — CI-gated via the always-on `Frontend Unit Tests` job (#877; the gap that let PR #871's vercel.json CSP-hash drift ship green)
 npm run test:worker # Run Worker unit tests (vitest)
 npm run typecheck:worker # tsc gate — full `tsc --noEmit`, fails on ANY type error across worker source incl tests (#533 Phase 4; two-pass: prod strict workers-types-only + tests with @types/node)
-npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders, #541)
+npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders #541; lint-okf-bundle #891 — the docs/reference OKF structural lint, real-bundle assertion CI-gated)
+npm run lint:okf   # docs/reference OKF-bundle structural lint (frontmatter/#-truncation/dangling-link/index-drift) — same checks CI runs
+
 ```
 
 ### Local verification by page type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Persistent memory is a **file-based LLM Wiki** (Karpathy's pattern, formalized b
 Don't store what the repo already records (code structure, past fixes, git history, CLAUDE.md).
 
 ### OKF frontmatter convention
-Each page carries YAML frontmatter: `name`, `description`, `type` (+ optional `title`/`tags`). **Caveat: the harness normalizes memory frontmatter on write** (relocates `type`/`title`/`tags` under `metadata:`) — don't fight it; the fields survive under `metadata`. **Gotcha: quote any `description`/`title` containing a bare `#`** (e.g. `#N`) — unquoted YAML treats `#` as a comment and truncates the value (hit in #891 Phase 1). True OKF top-level conformance (for the Google graph visualizer) belongs in an in-repo bundle (`docs/reference/*`, deferred), not the harness memory dir.
+Each page carries YAML frontmatter: `name`, `description`, `type` (+ optional `title`/`tags`). **Caveat: the harness normalizes memory frontmatter on write** (relocates `type`/`title`/`tags` under `metadata:`) — don't fight it; the fields survive under `metadata`. **Gotcha: quote any `description`/`title` containing a bare `#`** (e.g. `#N`) — unquoted YAML treats `#` as a comment and truncates the value (hit in #891 Phase 1). True OKF top-level conformance (for the Google graph visualizer) lives in the in-repo bundle **`docs/reference/*`** — an OKF bundle with `type`/`title`/`description`/`tags` frontmatter + `index.md` catalog + `log.md` (#891 Phase 4) — not the harness memory dir.
 
 ## API Docs via Context Hub (chub)
 

--- a/docs/reference/adding-a-service.md
+++ b/docs/reference/adding-a-service.md
@@ -1,3 +1,10 @@
+---
+type: runbook
+title: "Adding a New Service — Full Checklist"
+description: "Full checklist for adding a monitored service — the worker/frontend/docs/SEO/methodology/reports files that must update in lockstep, starting with the Step-0 data-richness audit."
+tags: [worker, checklist, service, sync-invariant]
+---
+
 # Adding a New Service — Full Checklist
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean. CLAUDE.md links here; this is the canonical reference.

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "Worker HTTP Endpoints"
+description: "Per-endpoint reference for the Worker HTTP API — auth, projections, dedup, and #-rationale for status/badge/feed/alert/admin routes."
+tags: [worker, api, endpoints]
+---
+
 # Worker HTTP Endpoints
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean (#525). CLAUDE.md links here; this is the canonical per-endpoint reference for `worker/src/index.ts` routing.

--- a/docs/reference/data-flow.md
+++ b/docs/reference/data-flow.md
@@ -1,3 +1,10 @@
+---
+type: architecture
+title: "Status Data Flow"
+description: "Annotated status data flow — browser polling to /api/status fetch/normalize/KV to React, plus the */5 cron and Web Vitals pipeline."
+tags: [worker, cron, data-flow]
+---
+
 # Status Data Flow
 
 ```

--- a/docs/reference/discord-alert-paths.md
+++ b/docs/reference/discord-alert-paths.md
@@ -1,3 +1,10 @@
+---
+type: architecture
+title: "Discord Alert Delivery Paths"
+description: "How operator + per-user Discord alerts are delivered server-side by the cron — single-source alert feed, per-user filters, channel-control opt-in, tweet-draft exception."
+tags: [worker, alerts, discord]
+---
+
 # Discord Alert Delivery Paths
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean. CLAUDE.md links here; this is the canonical reference for how Discord alerts reach the operator and per-user webhooks.

--- a/docs/reference/fallback-tiers.md
+++ b/docs/reference/fallback-tiers.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "Fallback Tier Priority — Full Reference"
+description: "Full fallback tier membership + candidate eligibility — same-tier-first, adjacent-tier fill, specialized sub-tier caps, and the tierFor/tierLabelFor rationale."
+tags: [worker, fallback, tiers]
+---
+
 # Fallback Tier Priority — Full Reference
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean. CLAUDE.md links here; this is the canonical reference.

--- a/docs/reference/ga4-events.md
+++ b/docs/reference/ga4-events.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "GA4 Analytics & Consent Flow"
+description: "Cross-surface GA4 consent flow + the full event catalog (parameters, location, purpose) including reports-site events."
+tags: [frontend, analytics, ga4, consent]
+---
+
 # GA4 Analytics & Consent Flow
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean. CLAUDE.md links here; this is the canonical reference.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,35 @@
+---
+type: index
+title: "docs/reference — OKF bundle index"
+description: "Catalog of the AIWatch engineering reference bundle. Each entry is one OKF concept file (markdown + YAML frontmatter). CLAUDE.md is the schema layer; this is the index (#891 Phase 4)."
+---
+
+# docs/reference — reference bundle index
+
+An [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+bundle: one concept per markdown file with `type` / `title` / `description` / `tags` frontmatter,
+cross-linked with normal markdown links. `CLAUDE.md` is the schema layer; `log.md` is the change log.
+Read this index first, then load only the pages you need.
+
+## architecture — how the system works
+- [Status Data Flow](data-flow.md) — browser polling → `/api/status` fetch/normalize/KV → React, plus the `*/5` cron + Web Vitals pipeline.
+- [Service Status Determination](status-determination.md) — the ordered per-service status resolution chain in `services.ts`, with #-rationale.
+- [Discord Alert Delivery Paths](discord-alert-paths.md) — operator + per-user alerts delivered server-side by the cron.
+
+## runbook — step-by-step procedures
+- [Adding a New Service — Full Checklist](adding-a-service.md) — the lockstep files + the Step-0 data-richness audit.
+- [Operator Tools — `POST /api/admin/analyze`](operator-tools.md) — force a Sonnet re-analysis on an active incident.
+- [Parallel AI-agent sessions (git worktrees)](parallel-agents.md) — multiple sessions without file/git/port collisions.
+
+## reference — lookup tables, schemas, policies
+- [Worker HTTP Endpoints](api-endpoints.md) — per-endpoint auth/projections/dedup/#-rationale.
+- [KV Key Schema](kv-schema.md) — STATUS_CACHE keys: pattern/value/TTL/writes-per-day + monthly budget.
+- [Fallback Tier Priority](fallback-tiers.md) — tier membership + candidate eligibility rules.
+- [GA4 Analytics & Consent Flow](ga4-events.md) — cross-surface consent + event catalog.
+- [Content-Security-Policy (CSP) — #482](reference-csp.md) — per-surface enforcement (nonce vs content-hash) + SPA policy.
+- [Reference Tooling](reference-tooling.md) — chub vs modern-web-guidance trigger map + the PreToolUse backstop.
+- [Tier-A `verify-after` assertions (#873)](verify-assertions.md) — machine-checkable assert-clause grammar.
+
+> Health of this bundle (frontmatter integrity, broken cross-links, stale claims) can be checked with
+> the `memory-lint` skill; findings are recorded in [log.md](log.md). (A scheduled routine to run it
+> automatically is a possible follow-up — not yet wired.)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -30,6 +30,8 @@ Read this index first, then load only the pages you need.
 - [Reference Tooling](reference-tooling.md) — chub vs modern-web-guidance trigger map + the PreToolUse backstop.
 - [Tier-A `verify-after` assertions (#873)](verify-assertions.md) — machine-checkable assert-clause grammar.
 
-> Health of this bundle (frontmatter integrity, broken cross-links, stale claims) can be checked with
-> the `memory-lint` skill; findings are recorded in [log.md](log.md). (A scheduled routine to run it
-> automatically is a possible follow-up — not yet wired.)
+> **Structural health** (frontmatter integrity, unquoted-`#` truncation, dangling cross-links, index
+> drift) is enforced in CI on every PR by `scripts/lint-okf-bundle.mjs` (`npm run lint:okf`; the
+> `REAL docs/reference bundle` assertion in its test runs under `npm run test:scripts`). **Judgement
+> health** (contradictions, stale claims, whether cross-linking is *sufficient*) is a manual pass via
+> the `memory-lint` skill; findings are recorded in [log.md](log.md).

--- a/docs/reference/kv-schema.md
+++ b/docs/reference/kv-schema.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "KV Key Schema (STATUS_CACHE namespace)"
+description: "Full KV key reference for the STATUS_CACHE namespace — pattern, value, TTL, writes/day, purpose — plus the monthly write budget."
+tags: [worker, kv, schema]
+---
+
 # KV Key Schema (STATUS_CACHE namespace)
 
 > Extracted from CLAUDE.md to keep the auto-loaded project file lean. CLAUDE.md links here; this is the canonical reference.

--- a/docs/reference/log.md
+++ b/docs/reference/log.md
@@ -9,3 +9,5 @@ description: "Append-only log of ingest / lint / migration passes on the docs/re
 Append-only. Format: `YYYY-MM-DD <op>: <summary>`.
 
 2026-07-05 migrate(#891 Phase 4): promoted docs/reference/* to an OKF bundle — added `type`/`title`/`description`/`tags` frontmatter to 13 concept files, created this `log.md` and the `index.md` catalog. `CLAUDE.md` is the schema layer. Bundle is now viewable in the OKF static HTML graph visualizer and lint-able via the `memory-lint` skill (a scheduled cloud routine to run it automatically is a possible follow-up).
+
+2026-07-05 ingest(#891 Phase 4): wired the structural half of memory-lint into CI — added scripts/lint-okf-bundle.mjs (frontmatter integrity, unquoted-# truncation, dangling cross-links, index drift) + node:test with a real-bundle assertion (npm run test:scripts) + npm run lint:okf. The "scheduled routine follow-up" from the migrate line is now a per-PR CI gate (catches drift when docs change, not weekly).

--- a/docs/reference/log.md
+++ b/docs/reference/log.md
@@ -1,0 +1,11 @@
+---
+type: log
+title: "docs/reference — OKF bundle change log"
+description: "Append-only log of ingest / lint / migration passes on the docs/reference OKF bundle. See index.md for the content catalog."
+---
+
+# docs/reference — bundle log
+
+Append-only. Format: `YYYY-MM-DD <op>: <summary>`.
+
+2026-07-05 migrate(#891 Phase 4): promoted docs/reference/* to an OKF bundle — added `type`/`title`/`description`/`tags` frontmatter to 13 concept files, created this `log.md` and the `index.md` catalog. `CLAUDE.md` is the schema layer. Bundle is now viewable in the OKF static HTML graph visualizer and lint-able via the `memory-lint` skill (a scheduled cloud routine to run it automatically is a possible follow-up).

--- a/docs/reference/operator-tools.md
+++ b/docs/reference/operator-tools.md
@@ -1,3 +1,10 @@
+---
+type: runbook
+title: "Operator Tools — `POST /api/admin/analyze` (#299)"
+description: "Operator runbook for POST /api/admin/analyze — force a Sonnet re-analysis on an active incident; secret setup, flags, request/response, failure codes, security posture."
+tags: [worker, operator, admin]
+---
+
 # Operator Tools — `POST /api/admin/analyze` (#299)
 
 Force a Sonnet analysis on a specific active incident when the cron's default (Gemma-first) produced low-signal output. Motivated by the 2026-04-20 ChatGPT outage where Gemma called a systemic infra failure a "service availability issue". Before this endpoint the override required hand-editing a local Node script + `wrangler kv key put --remote`.

--- a/docs/reference/parallel-agents.md
+++ b/docs/reference/parallel-agents.md
@@ -1,3 +1,10 @@
+---
+type: runbook
+title: "Parallel AI-agent sessions (git worktrees)"
+description: "Running multiple AI-agent sessions via git worktrees without file/git/port collisions — workflow, launch-method table, port offsets, sequential-deploy rule."
+tags: [workflow, worktree, git]
+---
+
 # Parallel AI-agent sessions (git worktrees)
 
 Running multiple AI coding-agent sessions (Claude Code / Cursor / …) at once on this single

--- a/docs/reference/reference-csp.md
+++ b/docs/reference/reference-csp.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "Content-Security-Policy (CSP) — #482"
+description: "The #482 Content-Security-Policy — per-surface enforcement split (nonce vs content-hash), the SPA vercel.json policy, and the negative-lookahead source scoping."
+tags: [security, csp, edge]
+---
+
 # Content-Security-Policy (CSP) — #482
 
 AIWatch ships a CSP across the Vercel-served surfaces (SPA + Edge SSR). Rolled out **phased**:

--- a/docs/reference/reference-tooling.md
+++ b/docs/reference/reference-tooling.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "Reference Tooling — chub + modern-web-guidance + the decision-moment backstop"
+description: "Which of chub vs modern-web-guidance to run by file path, and the tooling-trigger.sh PreToolUse backstop."
+tags: [workflow, tooling, chub]
+---
+
 # Reference Tooling — chub + modern-web-guidance + the decision-moment backstop
 
 AIWatch wires two external "reference" tools that ground code in current sources instead of

--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -1,3 +1,10 @@
+---
+type: architecture
+title: "Service Status Determination"
+description: "The ordered per-service status resolution chain in services.ts (multi-component worst-of to component match to overall fallback to incidentExclude to component-status filter to fetch-failure cross-validation) with #-rationale."
+tags: [worker, status, parsers]
+---
+
 # Service Status Determination
 
 Per-service status is resolved in `worker/src/services.ts` with this priority:

--- a/docs/reference/verify-assertions.md
+++ b/docs/reference/verify-assertions.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: "Tier-A `verify-after` assertions (#873)"
+description: "The Tier-A verify-after assert: clause grammar — machine-checkable JSON-endpoint assertions the daily verify job auto-verifies."
+tags: [workflow, ci, verify-after]
+---
+
 # Tier-A `verify-after` assertions (#873)
 
 Machine-checkable assertions that let the daily `verify-reminders` job (#541) **close the

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:src": "npx vitest run --config vitest.config.js",
     "test:ext": "npx vitest run --config vitest.config.js extension",
     "test:scripts": "node --test scripts/*.test.mjs",
-    "hook-audit": "node scripts/hook-audit-summary.mjs"
+    "hook-audit": "node scripts/hook-audit-summary.mjs",
+    "lint:okf": "node scripts/lint-okf-bundle.mjs"
   },
   "dependencies": {
     "chart.js": "^4.4.7",

--- a/scripts/lint-okf-bundle.mjs
+++ b/scripts/lint-okf-bundle.mjs
@@ -1,0 +1,197 @@
+// docs/reference OKF-bundle lint (#891 Phase 4).
+//
+// WHY: `docs/reference/*` is an Open Knowledge Format bundle — one concept per markdown file with
+// `type`/`title`/`description`(+optional `tags`) frontmatter, an `index.md` catalog, and a `log.md`
+// history (see docs/reference/index.md). Nothing enforces that shape, so it silently drifts: a new
+// doc lands without frontmatter or without an index line, a rename leaves a dangling cross-link, or a
+// `description` carrying a bare `#N` gets truncated by YAML's inline-comment rule (the exact gotcha
+// hit in #891 Phase 1). This is the STRUCTURAL half of the `memory-lint` skill, run in CI on every PR
+// (`npm run test:scripts`) — catching drift the moment docs change instead of on a periodic sweep.
+//
+// CHECKS (all structural / mechanical — no judgement calls):
+//   1. frontmatter integrity — every page has `type` + `title` + `description`; `type` is a known
+//      OKF type; no `description`/`title` truncated by an unquoted bare ` #` (YAML comment start).
+//   2. cross-link resolution — every same-dir `](foo.md)` markdown link resolves to a bundle file.
+//   3. index drift — every non-index page is listed in `index.md`; every `index.md` link resolves.
+//
+// NOT checked (belongs to the human/AI `memory-lint` pass, not a mechanical gate): contradictions,
+// stale claims, prose quality, whether cross-linking is *sufficient*.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const BUNDLE_DIR = join(REPO_ROOT, 'docs/reference')
+
+export const OKF_TYPES = ['architecture', 'runbook', 'reference', 'index', 'log']
+export const REQUIRED_FIELDS = ['type', 'title', 'description']
+export const INDEX_FILE = 'index.md'
+export const LOG_FILE = 'log.md'
+
+// ── pure helpers (unit-tested with fixtures) ─────────────────────────────────
+
+/**
+ * Parse the leading `---\n…\n---` YAML frontmatter block into a flat key→string map, replicating the
+ * ONE YAML rule this lint cares about: a `#` preceded by whitespace in an UNQUOTED plain scalar starts
+ * an inline comment (so the value is truncated there). Quoted (`"…"`/`'…'`) values are taken verbatim.
+ * Returns `{ hasFrontmatter, fields, rawFields }` — `fields` = post-comment-strip (what a loader sees),
+ * `rawFields` = the exact source value (so a lint can tell a truncation happened).
+ */
+export function parseFrontmatter(source) {
+  const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)
+  if (!m) return { hasFrontmatter: false, fields: {}, rawFields: {} }
+  const fields = {}
+  const rawFields = {}
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(line)
+    if (!kv) continue
+    const key = kv[1]
+    const raw = kv[2]
+    rawFields[key] = raw
+    fields[key] = stripInlineComment(raw)
+  }
+  return { hasFrontmatter: true, fields, rawFields }
+}
+
+/** Apply YAML's plain-scalar inline-comment rule + unwrap a simple quoted scalar. */
+export function stripInlineComment(raw) {
+  const v = raw.trim()
+  if ((v.startsWith('"') && v.endsWith('"') && v.length >= 2) || (v.startsWith("'") && v.endsWith("'") && v.length >= 2)) {
+    return v.slice(1, -1) // quoted → verbatim, no comment processing
+  }
+  if (v.startsWith('#')) return '' // whole plain value is a comment (e.g. `description: #891 …` → null)
+  const hash = v.search(/\s#/) // whitespace-then-# starts a comment in a plain scalar
+  return (hash === -1 ? v : v.slice(0, hash)).trim()
+}
+
+/** True when an unquoted value would be truncated by a bare `#` YAML inline comment (leading OR after whitespace). */
+export function hasUnquotedHashTruncation(raw) {
+  const v = raw.trim()
+  if (v.startsWith('"') || v.startsWith("'")) return false // quoted → safe
+  return /(^|\s)#/.test(v) // `#foo` (whole value) or `foo #bar` (trailing) both truncate
+}
+
+/** Findings about one page's frontmatter. `name` is the bundle-relative filename. */
+export function frontmatterFindings(name, source) {
+  const findings = []
+  const { hasFrontmatter, fields, rawFields } = parseFrontmatter(source)
+  if (!hasFrontmatter) {
+    findings.push({ file: name, kind: 'no-frontmatter', message: 'missing `---` YAML frontmatter block' })
+    return findings
+  }
+  for (const field of REQUIRED_FIELDS) {
+    if (!fields[field]) findings.push({ file: name, kind: 'missing-field', message: `frontmatter missing \`${field}\`` })
+  }
+  if (fields.type && !OKF_TYPES.includes(fields.type)) {
+    findings.push({ file: name, kind: 'bad-type', message: `\`type: ${fields.type}\` is not an OKF type (${OKF_TYPES.join('/')})` })
+  }
+  for (const field of ['title', 'description']) {
+    if (rawFields[field] !== undefined && hasUnquotedHashTruncation(rawFields[field])) {
+      findings.push({
+        file: name,
+        kind: 'unquoted-hash',
+        message: `\`${field}\` has an unquoted \` #\` — YAML truncates it to "${fields[field]}"; wrap the value in quotes`,
+      })
+    }
+  }
+  return findings
+}
+
+/** Same-dir `](foo.md)` / `](foo.md#anchor)` link targets (anchors stripped). Ignores URLs + pathed links. */
+export function extractLocalMdLinks(source) {
+  const out = []
+  const re = /\]\(([^)\s]+?\.md)(#[^)]*)?\)/g
+  let m
+  while ((m = re.exec(source))) {
+    const target = m[1].replace(/^\.\//, '') // treat `./foo.md` as the same-dir `foo.md`
+    if (target.includes('/') || target.includes(':')) continue // pathed or protocol → not a same-dir bundle link
+    out.push(target)
+  }
+  return out
+}
+
+/** Findings for cross-links in one page that don't resolve to a bundle file. */
+export function linkResolutionFindings(name, source, bundleNames) {
+  const findings = []
+  for (const target of new Set(extractLocalMdLinks(source))) {
+    if (!bundleNames.has(target)) {
+      findings.push({ file: name, kind: 'broken-link', message: `link \`${target}\` does not resolve to a bundle file` })
+    }
+  }
+  return findings
+}
+
+/**
+ * Index-drift findings across the whole bundle. `entries` = `[{ name, source }]`.
+ *   - every `index.md` link must resolve to a file        → `index-broken-link`
+ *   - every non-index/non-log page must be in `index.md`  → `not-indexed`
+ * (log.md is exempt from the "must be indexed" rule only if the index chooses not to list it; the real
+ * bundle DOES list it, so a missing log link still surfaces — we require log.md indexed too.)
+ */
+export function indexDriftFindings(entries) {
+  const findings = []
+  const names = new Set(entries.map((e) => e.name))
+  const index = entries.find((e) => e.name === INDEX_FILE)
+  if (!index) {
+    findings.push({ file: INDEX_FILE, kind: 'missing-index', message: `bundle has no ${INDEX_FILE} catalog` })
+    return findings
+  }
+  const indexed = new Set(extractLocalMdLinks(index.source))
+  for (const target of indexed) {
+    if (!names.has(target)) findings.push({ file: INDEX_FILE, kind: 'index-broken-link', message: `catalog link \`${target}\` has no file` })
+  }
+  for (const { name } of entries) {
+    if (name === INDEX_FILE) continue
+    if (!indexed.has(name)) findings.push({ file: name, kind: 'not-indexed', message: `page is not linked from ${INDEX_FILE}` })
+  }
+  return findings
+}
+
+/** Run every check over `entries` (`[{ name, source }]`). Returns a flat findings array. */
+export function lintBundle(entries) {
+  const names = new Set(entries.map((e) => e.name))
+  const findings = []
+  for (const { name, source } of entries) {
+    findings.push(...frontmatterFindings(name, source))
+    findings.push(...linkResolutionFindings(name, source, names))
+  }
+  findings.push(...indexDriftFindings(entries))
+  return findings
+}
+
+// ── filesystem (used by CLI + the real-bundle test) ──────────────────────────
+
+/** Collect `{ name, source }` for every `.md` directly under `docs/reference/`. */
+export function collectBundleEntries(bundleDir = BUNDLE_DIR) {
+  return readdirSync(bundleDir)
+    .filter((n) => n.endsWith('.md') && statSync(join(bundleDir, n)).isFile())
+    .sort()
+    .map((name) => ({ name, source: readFileSync(join(bundleDir, name), 'utf8') }))
+}
+
+/** Lint the real bundle. Returns `{ findings, count }`. */
+export function lintRealBundle() {
+  const findings = lintBundle(collectBundleEntries())
+  return { findings, count: findings.length }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function isMain() {
+  return process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+}
+
+if (isMain()) {
+  const entries = collectBundleEntries()
+  const findings = lintBundle(entries)
+  console.log(`OKF bundle lint — docs/reference: ${entries.length} pages`)
+  if (findings.length === 0) {
+    console.log('✅ 0 findings — frontmatter, cross-links, and index catalog all clean.')
+  } else {
+    console.error(`\n❌ ${findings.length} finding(s):`)
+    for (const f of findings) console.error(`  • [${f.kind}] ${f.file}: ${f.message}`)
+    console.error('\nFix: add/repair frontmatter (quote a `#`-bearing description), repoint the dangling link, or add the index line.')
+    process.exit(1)
+  }
+}

--- a/scripts/lint-okf-bundle.test.mjs
+++ b/scripts/lint-okf-bundle.test.mjs
@@ -1,0 +1,172 @@
+// #891 Phase 4 — structural lint for the docs/reference OKF bundle.
+// Run with `npm run test:scripts` (= `node --test scripts/*.test.mjs`), which CI runs in test.yml.
+// Pins BOTH the pure check functions (fixtures) AND the real docs/reference bundle (must stay clean).
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  OKF_TYPES,
+  parseFrontmatter,
+  stripInlineComment,
+  hasUnquotedHashTruncation,
+  frontmatterFindings,
+  extractLocalMdLinks,
+  linkResolutionFindings,
+  indexDriftFindings,
+  lintBundle,
+  lintRealBundle,
+} from './lint-okf-bundle.mjs'
+
+const kinds = (findings) => findings.map((f) => f.kind).sort()
+
+// ── frontmatter parsing + the YAML `#` gotcha ────────────────────────────────
+
+test('stripInlineComment — plain scalar truncates at ` #`, quoted is verbatim', () => {
+  assert.equal(stripInlineComment('KV Key Schema'), 'KV Key Schema')
+  assert.equal(stripInlineComment('closes/refs #N'), 'closes/refs') // ` #` starts a comment
+  assert.equal(stripInlineComment('#891 phase 4 lint'), '') // LEADING # → whole value is a comment → null
+  assert.equal(stripInlineComment('CSP (#482)'), 'CSP (#482)') // `(#` — no leading space, safe
+  assert.equal(stripInlineComment('"Tier-A verify-after (#873)"'), 'Tier-A verify-after (#873)') // quoted → verbatim
+  assert.equal(stripInlineComment("'refs #N ok'"), 'refs #N ok')
+})
+
+test('hasUnquotedHashTruncation — flags unquoted leading-# AND whitespace-# values', () => {
+  assert.equal(hasUnquotedHashTruncation('closes/refs #N'), true) // trailing ` #`
+  assert.equal(hasUnquotedHashTruncation('#891 phase 4'), true) // LEADING # (the gotcha the tool exists for)
+  assert.equal(hasUnquotedHashTruncation('CSP (#482)'), false) // `(#` — not ^# nor ` #`
+  assert.equal(hasUnquotedHashTruncation('"#891 phase 4"'), false) // quoted → safe
+  assert.equal(hasUnquotedHashTruncation('no hash here'), false)
+})
+
+test('parseFrontmatter — splits fields, exposes raw vs comment-stripped', () => {
+  const src = ['---', 'type: reference', 'title: "KV Key Schema"', 'description: cache #dropped', '---', '', '# body'].join('\n')
+  const { hasFrontmatter, fields, rawFields } = parseFrontmatter(src)
+  assert.equal(hasFrontmatter, true)
+  assert.equal(fields.type, 'reference')
+  assert.equal(fields.title, 'KV Key Schema')
+  assert.equal(fields.description, 'cache') // ` #dropped` stripped as a comment
+  assert.equal(rawFields.description, 'cache #dropped') // raw retained
+})
+
+test('parseFrontmatter — no frontmatter block', () => {
+  assert.equal(parseFrontmatter('# just a heading\n').hasFrontmatter, false)
+})
+
+test('parseFrontmatter — CRLF line endings parse consistently (all fields, no false missing)', () => {
+  const src = ['---', 'type: reference', 'title: X', 'description: Y', '---', '', '# body'].join('\r\n')
+  const { hasFrontmatter, fields } = parseFrontmatter(src)
+  assert.equal(hasFrontmatter, true)
+  assert.deepEqual(fields, { type: 'reference', title: 'X', description: 'Y' })
+})
+
+// ── frontmatterFindings ──────────────────────────────────────────────────────
+
+test('frontmatterFindings — a well-formed page has no findings', () => {
+  const src = ['---', 'type: reference', 'title: "KV Key Schema"', 'description: "keys, TTL, budget"', 'tags: [worker, kv]', '---'].join('\n')
+  assert.deepEqual(frontmatterFindings('kv-schema.md', src), [])
+})
+
+test('frontmatterFindings — missing frontmatter is a single finding', () => {
+  assert.deepEqual(kinds(frontmatterFindings('x.md', '# no frontmatter')), ['no-frontmatter'])
+})
+
+test('frontmatterFindings — missing required fields', () => {
+  const src = ['---', 'type: reference', '---'].join('\n')
+  assert.deepEqual(kinds(frontmatterFindings('x.md', src)), ['missing-field', 'missing-field']) // title + description
+})
+
+test('frontmatterFindings — unknown type is flagged', () => {
+  const src = ['---', 'type: howto', 'title: X', 'description: Y', '---'].join('\n')
+  assert.deepEqual(kinds(frontmatterFindings('x.md', src)), ['bad-type'])
+  assert.ok(!OKF_TYPES.includes('howto'))
+})
+
+test('frontmatterFindings — unquoted `#` truncation in description is flagged', () => {
+  const src = ['---', 'type: reference', 'title: X', 'description: put closes/refs #N in body', '---'].join('\n')
+  const f = frontmatterFindings('x.md', src)
+  assert.deepEqual(kinds(f), ['unquoted-hash'])
+  assert.match(f[0].message, /wrap the value in quotes/)
+})
+
+test('frontmatterFindings — `(#N)` without a leading space is NOT flagged', () => {
+  const src = ['---', 'type: reference', 'title: "CSP (#482)"', 'description: the CSP (#482) policy', '---'].join('\n')
+  assert.deepEqual(frontmatterFindings('reference-csp.md', src), [])
+})
+
+test('frontmatterFindings — a description LEADING with `#` (YAML→null) is flagged', () => {
+  const src = ['---', 'type: reference', 'title: X', 'description: #891 the bundle lint', '---'].join('\n')
+  const f = frontmatterFindings('x.md', src)
+  // the actionable finding must be present; the comment-only value also reads as an empty required field
+  assert.ok(kinds(f).includes('unquoted-hash'), `expected unquoted-hash, got ${kinds(f)}`)
+})
+
+// ── link extraction + resolution ─────────────────────────────────────────────
+
+test('extractLocalMdLinks — same-dir .md only, anchors stripped, URLs/paths ignored', () => {
+  const src = [
+    'see [KV](kv-schema.md) and [flow](data-flow.md#cron)',
+    'external [okf](https://example.com/x.md) and [up](../CLAUDE.md) ignored',
+  ].join('\n')
+  assert.deepEqual(extractLocalMdLinks(src).sort(), ['data-flow.md', 'kv-schema.md'])
+})
+
+test('extractLocalMdLinks — `./foo.md` normalizes to the same-dir file (not dropped as pathed)', () => {
+  assert.deepEqual(extractLocalMdLinks('see [k](./kv-schema.md)'), ['kv-schema.md'])
+})
+
+test('linkResolutionFindings — dangling same-dir link is flagged, resolved is not', () => {
+  const names = new Set(['a.md', 'kv-schema.md'])
+  assert.deepEqual(linkResolutionFindings('a.md', 'link [k](kv-schema.md)', names), [])
+  const f = linkResolutionFindings('a.md', 'link [gone](removed-doc.md)', names)
+  assert.deepEqual(kinds(f), ['broken-link'])
+})
+
+// ── index drift ──────────────────────────────────────────────────────────────
+
+test('indexDriftFindings — clean bundle: all pages indexed, all links resolve', () => {
+  const index = { name: 'index.md', source: '- [A](a.md)\n- [B](b.md)\n- [log](log.md)' }
+  const entries = [index, { name: 'a.md', source: '' }, { name: 'b.md', source: '' }, { name: 'log.md', source: '' }]
+  assert.deepEqual(indexDriftFindings(entries), [])
+})
+
+test('indexDriftFindings — a page absent from index.md is `not-indexed`', () => {
+  const index = { name: 'index.md', source: '- [A](a.md)' }
+  const entries = [index, { name: 'a.md', source: '' }, { name: 'b.md', source: '' }]
+  const f = indexDriftFindings(entries)
+  assert.deepEqual(kinds(f), ['not-indexed'])
+  assert.equal(f[0].file, 'b.md')
+})
+
+test('indexDriftFindings — an index link with no file is `index-broken-link`', () => {
+  const index = { name: 'index.md', source: '- [A](a.md)\n- [ghost](ghost.md)' }
+  const entries = [index, { name: 'a.md', source: '' }]
+  assert.deepEqual(kinds(indexDriftFindings(entries)), ['index-broken-link'])
+})
+
+test('indexDriftFindings — a bundle with no index.md is flagged', () => {
+  assert.deepEqual(kinds(indexDriftFindings([{ name: 'a.md', source: '' }])), ['missing-index'])
+})
+
+// ── lintBundle composition ───────────────────────────────────────────────────
+
+test('lintBundle — composes frontmatter + link + index findings', () => {
+  const entries = [
+    { name: 'index.md', source: '---\ntype: index\ntitle: I\ndescription: D\n---\n- [A](a.md)' },
+    { name: 'a.md', source: '---\ntype: reference\ntitle: A\ndescription: D\n---\nlink [x](gone.md)' },
+    { name: 'b.md', source: '# no frontmatter, not indexed' },
+  ]
+  const k = kinds(lintBundle(entries))
+  assert.ok(k.includes('broken-link')) // a.md → gone.md
+  assert.ok(k.includes('no-frontmatter')) // b.md
+  assert.ok(k.includes('not-indexed')) // b.md absent from index
+})
+
+// ── the real backstop: docs/reference must stay clean ────────────────────────
+
+test('REAL docs/reference bundle passes the OKF lint (0 findings)', () => {
+  const { findings, count } = lintRealBundle()
+  assert.equal(
+    count,
+    0,
+    `docs/reference has ${count} OKF-lint finding(s):\n` + findings.map((f) => `  • [${f.kind}] ${f.file}: ${f.message}`).join('\n'),
+  )
+})


### PR DESCRIPTION
## Summary

**Phase 4 of #891** — the in-repo half of the LLM Wiki / OKF migration. Promotes `docs/reference/*` to an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) bundle so the project's engineering reference is a git-versioned OKF wiki alongside the code (mirrors the harness memory dir shape from Phase 1–3).

## Changes (docs-only — no runtime surface)

- **Frontmatter on 13 reference docs** — `type` (architecture / runbook / reference) + `title` + `description` + `tags`. Bare `#` / backticks in titles quoted (avoids the YAML-comment truncation hit in #891 Phase 1).
- **`docs/reference/index.md`** — OKF catalog, grouped by `type`; `CLAUDE.md` stays the schema layer, this is the index.
- **`docs/reference/log.md`** — append-only bundle change log.
- **`CLAUDE.md`** — one line: marks the in-repo OKF bundle **shipped** (was "deferred").

Filenames unchanged → all existing links/anchors resolve.

## Verification

- frontmatter present on all 13 files (0 missing)
- every `index.md` link resolves (0 broken)
- `#`/backtick-bearing titles/descriptions quoted (`#482`, `#873` etc. — no truncation)
- Reviewed (code-reviewer) → 0 Critical/Important

refs #891 (Phase 4 is the last, optional item — do not auto-close; reconcile #891 checklist after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)