### PR TITLE
fix(ui): wrap mobile fallback line, not clip the Open pill (#903)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -1,7 +1,7 @@
 // Overview — summary stats, service grid, recent incidents, latency rankings, AI panel.
 // Design mockup: svc-card with left border, provider, 3-col metrics, variable-height history bars.
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, Fragment } from 'react'
 import IncidentTimeline from '../components/IncidentTimeline'
 import ReportModal from '../components/ReportModal'
 import RecentUserReports from '../components/RecentUserReports'
@@ -476,7 +476,7 @@ function SupplyChainBanner({ banner, setPage, t }) {
   )
 }
 
-function ActionBanner({ services, setPage, t }) {
+export function ActionBanner({ services, setPage, t }) {
   const affected = services.filter(s => s.status === 'down' || s.status === 'degraded')
   const withActiveIncidents = services.filter(s => s.status === 'operational' && (s.incidents ?? []).some(i => i.status !== 'resolved'))
   const monitoring = withActiveIncidents.filter(s => (s.incidents ?? []).some(i => i.status === 'monitoring') && !(s.incidents ?? []).some(i => i.status === 'investigating' || i.status === 'identified'))
@@ -613,24 +613,30 @@ function ActionBanner({ services, setPage, t }) {
               {grp.items.map((f, fi) => {
                 const outUrl = outboundReferralUrl(f.id)
                 return (
-                  <span key={f.id} style={{ whiteSpace: 'nowrap' }}>
+                  // #903 — the ', ' separator lives OUTSIDE the nowrap item span so a line
+                  // break can occur BETWEEN alternatives (else two glued items overflow the
+                  // banner on mobile, clipping the trailing "Open ↗" pill). Intra-item nowrap
+                  // still keeps each name+pill together.
+                  <Fragment key={f.id}>
                     {fi > 0 && ', '}
-                    <span
-                      className="text-[var(--green)] hover:underline cursor-pointer"
-                      onClick={() => { trackEvent('fallback_click', { from_service: 'banner', to_service: f.id, location: 'action_banner' }); setPage({ name: 'service', serviceId: f.id }) }}
-                    >
-                      {f.name}{f.aiwatchScore != null ? ` (${f.aiwatchScore})` : ''}
+                    <span style={{ whiteSpace: 'nowrap' }}>
+                      <span
+                        className="text-[var(--green)] hover:underline cursor-pointer"
+                        onClick={() => { trackEvent('fallback_click', { from_service: 'banner', to_service: f.id, location: 'action_banner' }); setPage({ name: 'service', serviceId: f.id }) }}
+                      >
+                        {f.name}{f.aiwatchScore != null ? ` (${f.aiwatchScore})` : ''}
+                      </span>
+                      {outUrl && (
+                        <a
+                          href={outUrl} target="_blank" rel="nofollow noopener noreferrer"
+                          className="text-[9px] rounded-sm border border-[var(--green)] text-[var(--green)] hover:bg-[var(--green)] hover:text-[var(--bg0)] no-underline"
+                          style={{ marginLeft: '4px', padding: '0 4px', verticalAlign: 'middle', lineHeight: '1.4' }}
+                          onClick={() => { trackEvent('outbound_fallback_click', { from_service: 'banner', to_service: f.id, location: 'action_banner' }); sendReferralBeacon('', f.id) }}
+                          aria-label={`Open ${f.name} (opens provider site)`}
+                        >{t('overview.banner.openAlt')}</a>
+                      )}
                     </span>
-                    {outUrl && (
-                      <a
-                        href={outUrl} target="_blank" rel="nofollow noopener noreferrer"
-                        className="text-[9px] rounded-sm border border-[var(--green)] text-[var(--green)] hover:bg-[var(--green)] hover:text-[var(--bg0)] no-underline"
-                        style={{ marginLeft: '4px', padding: '0 4px', verticalAlign: 'middle', lineHeight: '1.4' }}
-                        onClick={() => { trackEvent('outbound_fallback_click', { from_service: 'banner', to_service: f.id, location: 'action_banner' }); sendReferralBeacon('', f.id) }}
-                        aria-label={`Open ${f.name} (opens provider site)`}
-                      >{t('overview.banner.openAlt')}</a>
-                    )}
-                  </span>
+                  </Fragment>
                 )
               })}
             </span>

--- a/src/pages/__tests__/action-banner-fallback-wrap.test.js
+++ b/src/pages/__tests__/action-banner-fallback-wrap.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// The banner header renders RssCopyIcon, which calls useLang() and needs a
+// LangProvider context we don't set up here. Stub it — it's irrelevant to the
+// fallback-line structure under test.
+vi.mock('../../components/RssCopyIcon', () => ({ default: () => null }))
+
+// #903 — the mobile ActionBanner "Suggested fallback" line clipped the trailing
+// "Open ↗" pill on narrow widths because the inter-item separator ", " was rendered
+// INSIDE each item's `white-space:nowrap` span, gluing two alternatives onto one
+// line with no break opportunity. The fix moves ", " OUTSIDE the nowrap span so a
+// line break can occur BETWEEN alternatives while the name+pill stay glued.
+//
+// We render to a static SSR string (renderToStaticMarkup) — no layout engine is
+// involved, so we can't assert pixel overflow here. Instead we pin the DOM STRUCTURE
+// that causes/cures it: the comma must be a sibling text node of the nowrap span,
+// never its first child. (The pixel behavior itself was verified manually in-browser
+// at mobile width: old structure → single row + pill overflows; fixed → wraps to a
+// second row, no overflow.)
+const { ActionBanner } = await import('../Overview')
+
+const t = (k) => k // identity — assert structure, not localized copy
+
+// One degraded LLM service + two operational same-tier LLM alternatives → a single
+// fallback category with TWO items, i.e. the ", "-separated shape from the bug.
+const services = [
+  { id: 'mistral', name: 'Mistral API', category: 'api', status: 'degraded', incidents: [], aiwatchScore: 69 },
+  { id: 'cohere', name: 'Cohere API', category: 'api', status: 'operational', incidents: [], aiwatchScore: 90 },
+  { id: 'cerebras', name: 'Cerebras Inference', category: 'api', status: 'operational', incidents: [], aiwatchScore: 89 },
+]
+
+const render = () => renderToStaticMarkup(createElement(ActionBanner, { services, setPage: () => {}, t }))
+
+describe('#903 — ActionBanner fallback line wraps between alternatives', () => {
+  it('renders both same-category alternatives', () => {
+    const html = render()
+    expect(html).toContain('Cohere API')
+    expect(html).toContain('Cerebras Inference')
+  })
+
+  it('places the ", " separator OUTSIDE the nowrap span (break opportunity between items)', () => {
+    const html = render()
+    // OLD bug shape: comma is the first thing inside a nowrap span. Must NOT appear.
+    expect(html).not.toMatch(/white-space:nowrap">\s*,/)
+    // FIXED shape: a nowrap item span closes, then ", ", then the next nowrap item span opens.
+    expect(html).toMatch(/<\/span>,\s*<span style="white-space:nowrap"/)
+  })
+
+  it('keeps each item name+pill together inside a nowrap span (intra-item no-wrap preserved)', () => {
+    const html = render()
+    // At least two nowrap item spans (one per alternative).
+    const nowrapSpans = html.match(/<span style="white-space:nowrap"/g) || []
+    expect(nowrapSpans.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders the trailing "Open ↗" pill for each alternative (the element #903 clipped)', () => {
+    const html = render()
+    // The whole point of #903 is that the trailing outbound pill overflowed — assert it
+    // actually renders (both alternatives have an outbound URL), so a future change that
+    // dropped the pill can't leave the structural assertions passing on a gutted feature.
+    const pills = html.match(/rel="nofollow noopener noreferrer"/g) || []
+    expect(pills.length).toBe(2)
+  })
+})


### PR DESCRIPTION
## Problem

On mobile widths the Overview **ActionBanner** "Suggested fallback" line clipped the trailing **`Open ↗`** pill of the second alternative past the banner's right edge (e.g. `Cohere API (90) [Open ↗], Cerebras Inference (89) [Open ↗]`).

## Root cause

Each fallback item was wrapped in `<span style={{ whiteSpace: 'nowrap' }}>` with the **item separator `, ` rendered INSIDE that nowrap span**. Adjacent item spans therefore had no whitespace/break-opportunity between them, so the browser could not wrap between two alternatives — they stayed glued on one line and overflowed on narrow widths. Intra-item nowrap (name + pill glued) is intentional; only the *inter-item* separator was trapped inside it.

## Fix

Move the `, ` separator OUTSIDE the nowrap item span (into a `<Fragment>`) so a line break can occur BETWEEN alternatives while each name+pill stays glued. Item-granular wrapping, no clipping. All tracking events / outbound pill / `aria-label` preserved (only re-nested one level).

## Test

`ActionBanner` is now exported so `src/pages/__tests__/action-banner-fallback-wrap.test.js` can SSR-render the **real** component with a single-category 2-item fallback and pin the fixed DOM structure:
- the `, ` separator must NOT be the first child inside a nowrap span (old bug shape),
- it MUST sit between two nowrap item spans (fixed shape),
- both `Open ↗` pills render (the element #903 clipped).

Empirically confirmed the test flips red on the pre-fix structure. Pixel wrap verified manually in-browser at mobile width (no layout engine in the SSR unit test).

## Verification
- ✅ In-browser confirmed at ~375px — fallback line wraps, no pill clipping
- ✅ `npm run test:src` — 779 passed (incl. 4 new)
- ✅ `npm run build` clean, ESLint 0 errors
- ✅ PR review (code / test / comment) converged — 0 Critical/Important

closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)