### PR TITLE
docs(ship-issue): canonicalize verify-after placement in one bottom section

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -80,6 +80,18 @@ is the *procedure* — follow it top to bottom.
      `exists`); NOT GA4/GSC-CTR/consent-gated or behavioral checks — leave those as a plain human ping.
      Validate it before it ships: `node scripts/verify-assertions.mjs --issue N --dry-run`. Grammar +
      allowlist + fail-open semantics: **[docs/reference/verify-assertions.md](../../../docs/reference/verify-assertions.md)**.
+   - **Placement (canonical, #921 format):** collect EVERY `verify-after` line — each with its indented
+     `assert:` sub-line, if any — under ONE dedicated heading at the **bottom of the body**:
+     ```
+     ## Production-gated verification
+     - [ ] **verify-after YYYY-MM-DD** — what to check + where. PR #N.
+           assert: GET /api/status/cached | services[id=X].field == "value"
+     ```
+     One consistent home — NOT inline in a part's checklist, NOT a top `> Status:` callout — so the
+     reminder lines are always in the same place and the body-drift guard reads cleanly. A multi-part
+     issue lists one `verify-after` line per part under the same heading (keep each line's note so it's
+     clear which part it verifies). The `verify-reminders` scanner is whole-body, so placement is
+     cosmetic for the automation — this convention is purely for human consistency across issues.
    - **Cross-issue reconciliation** — also scan OTHER open issues this change touches:
      fully implements another → add `closes #M`; partially advances → `refs #M` + comment;
      **supersedes/invalidates** another (a newer finding/feature makes it moot) → comment the why + close it.


### PR DESCRIPTION
## What

Codifies the **#921 format** as the canonical placement for `verify-after` lines in the `ship-issue` skill: collect every `verify-after` line (with its indented `assert:` sub-line, if any) under ONE `## Production-gated verification` heading at the **bottom** of the issue body — not inline in a part's checklist, not a top `> Status:` callout.

## Why

The `verify-reminders` scanner is whole-body (`VERIFY_RE` matches `verify-after <date>` anywhere), so placement is **cosmetic for the automation** — this is purely for **human consistency**: reminder lines are always in the same predictable place, and the body-drift guard reads cleanly (the only unchecked non-`verify-after` boxes signal drift).

## Scope

- `.claude/skills/ship-issue/SKILL.md` — one bullet added under the step-8 verify-after guidance.
- **Applied retroactively** to the 16 open verify-after issues (#900 #883 #882 #873 #857 #847 #842 #837 #835 #827 #775 #605 #601 #574 #547 #428) via a precise task-list-only transform (moved real `- [ ] verify-after` boxes + their `assert:` sub-lines; left prose mentions + `> Status:` blockquotes untouched; preserved checkbox state). #873's Tier-A `assert:` re-validated post-move (`verify-assertions.mjs --dry-run` still parses it). Original bodies backed up locally.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)