### PR TITLE
fix(is-down): show all incidents' AI analysis in one card, not just the latest (#926)

### DIFF
--- a/api/__tests__/is-down.test.ts
+++ b/api/__tests__/is-down.test.ts
@@ -172,4 +172,43 @@ describe('is-down.ts — #827 F4 predicted-vs-actual on a resolved card', () => 
     expect(threwParseError).toBe(false)   // buggy version logs this; fixed version takes the clean path
     expect(res.status).toBeGreaterThanOrEqual(200) // resolves cleanly (service_missing → 503)
   })
+
+  // #926 — a service with multiple active incidents shows EVERY analysis (not just [0]), ordered
+  // newest-incident-first so the AI card matches the "Recent Incidents" list on the same page. The
+  // worker delivers aiAnalysis in push order (here OLDEST first) to prove the handler re-sorts.
+  it('renders all incidents newest-first, matching the Recent Incidents order', async () => {
+    const now = Date.now()
+    const iso = (msAgo: number) => new Date(now - msAgo).toISOString()
+    const payload = new Response(JSON.stringify({
+      services: [
+        {
+          id: 'claude', name: 'Claude API', category: 'api', status: 'down',
+          latency: null, uptime30d: 99.09, lastChecked: iso(0), aiwatchScore: 62, scoreGrade: 'fair', scoreConfidence: 'high',
+          incidents: [
+            { id: 'old-auth', title: 'Auth failures', status: 'investigating', impact: 'major', startedAt: iso(45 * 60000), duration: null, timeline: [] },
+            { id: 'new-stream', title: 'Streaming timeouts', status: 'identified', impact: 'minor', startedAt: iso(20 * 60000), duration: null, timeline: [] },
+          ],
+        },
+        // an operational alternative so the 🔄 Alternatives block resolves
+        { id: 'gemini', name: 'Gemini API', category: 'api', status: 'operational', latency: 210, uptime30d: 99.9, lastChecked: iso(0), incidents: [], aiwatchScore: 95, scoreGrade: 'excellent', scoreConfidence: 'high' },
+      ],
+      // Delivered oldest-first on purpose — the handler must re-sort newest-first.
+      aiAnalysis: { claude: [
+        { summary: 'OLDER — auth overload.', estimatedRecovery: '30m–1h', affectedScope: ['Login'], needsFallback: true, analyzedAt: iso(9 * 60000), incidentId: 'old-auth' },
+        { summary: 'NEWER — streaming stalls.', estimatedRecovery: '1–2h', affectedScope: ['Streaming'], needsFallback: true, analyzedAt: iso(4 * 60000), incidentId: 'new-stream' },
+      ] },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    fetchMock.mockResolvedValueOnce(payload)
+    const res = await handler(makeReq('claude'))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    // Both summaries present (the whole array is rendered, not just [0])…
+    expect(html).toContain('OLDER — auth overload.')
+    expect(html).toContain('NEWER — streaming stalls.')
+    // …and the NEWER incident's card sub-block appears BEFORE the older one.
+    expect(html.indexOf('NEWER — streaming stalls.')).toBeLessThan(html.indexOf('OLDER — auth overload.'))
+    // Single shared card — one header + one Alternatives block.
+    expect((html.match(/AI Analysis</g) ?? []).length).toBe(1)
+    expect((html.match(/🔄 Alternatives/g) ?? []).length).toBe(1)
+  })
 })

--- a/api/_is-down/__tests__/html-template.test.ts
+++ b/api/_is-down/__tests__/html-template.test.ts
@@ -129,6 +129,69 @@ describe('renderAIInsight — predicted vs actual (#827 F4)', () => {
   })
 })
 
+describe('renderAIInsight — multiple active incidents (#926, dashboard-modal parity)', () => {
+  const mkInsight = (over: Partial<{ summary: string; incidentTitle: string; affectedScope: string[] }> = {}) => ({
+    summary: over.summary ?? 'Elevated error rates on model inference.',
+    estimatedRecovery: '30m–1h', affectedScope: over.affectedScope ?? ['API'],
+    analyzedAt: new Date(Date.now() - 10 * 60000).toISOString(),
+    needsFallback: true,
+    ...(over.incidentTitle ? { incidentTitle: over.incidentTitle } : {}),
+  })
+  // renderPage positional args: slug, service, seo, fallbacks, aiInsight, regionRec, reports,
+  // ogStatusHint, supplyChainNote, ogIncidentToken, aiInsights.
+  const pageWith = (aiInsights: ReturnType<typeof mkInsight>[]) =>
+    renderPage('claude', mkService({ status: 'down' }), mkSeo(), [
+      { id: 'gemini', name: 'Gemini API', score: 95, status: 'operational' },
+    ], aiInsights[0], undefined, undefined, undefined, undefined, undefined, aiInsights)
+
+  it('shows every incident\'s analysis inside ONE card (single header), not just the first', () => {
+    const html = pageWith([
+      mkInsight({ summary: 'First incident: auth failures.', incidentTitle: 'Auth failures', affectedScope: ['Login'] }),
+      mkInsight({ summary: 'Second incident: streaming timeouts.', incidentTitle: 'Streaming timeouts', affectedScope: ['Streaming'] }),
+    ])
+    expect(html).toContain('First incident: auth failures.')
+    expect(html).toContain('Second incident: streaming timeouts.') // was DROPPED before #926
+    // ONE card → the "🤖 AI Analysis" header + Beta badge + disclaimer each render exactly once
+    expect((html.match(/AI Analysis</g) ?? []).length).toBe(1)
+    expect((html.match(/>Beta</g) ?? []).length).toBe(1)
+    expect((html.match(/AI-generated estimation/g) ?? []).length).toBe(1)
+    // incident titles label each sub-block when there are multiple
+    expect(html).toContain('Auth failures')
+    expect(html).toContain('Streaming timeouts')
+    // titles alone disambiguate — no "(N incidents)" count badge in the header
+    expect(html).not.toMatch(/\(\d+ incidents\)/)
+  })
+
+  it('renders the 🔄 Alternatives block only once for the whole card', () => {
+    const html = pageWith([
+      mkInsight({ summary: 'First.', incidentTitle: 'A' }),
+      mkInsight({ summary: 'Second.', incidentTitle: 'B' }),
+    ])
+    expect((html.match(/🔄 Alternatives/g) ?? []).length).toBe(1)
+  })
+
+  it('marks each sub-block title by its own resolved state (✅ resolved / 🔸 active)', () => {
+    // Operational service (isResolved) carrying one recently-recovered + one still-active analysis.
+    const recoveredAt = new Date(Date.now() - 3 * 60000).toISOString()
+    const html = renderPage('claude', mkService({ status: 'operational' }), mkSeo(), [], undefined,
+      undefined, undefined, undefined, undefined, undefined, [
+        { ...mkInsight({ summary: 'Recovered one.', incidentTitle: 'Recovered incident' }), resolvedAt: recoveredAt },
+        mkInsight({ summary: 'Still active one.', incidentTitle: 'Active incident' }),
+      ])
+    expect(html).toContain('✅ Recovered incident')
+    expect(html).toContain('🔸 Active incident')
+  })
+
+  it('single scalar aiInsight still renders exactly one card, no incident-title line / count badge (regression)', () => {
+    const html = renderPage('claude', mkService({ status: 'down' }), mkSeo(), [],
+      mkInsight({ summary: 'Only incident.', incidentTitle: 'Only' }))
+    expect(html).toContain('Only incident.')
+    expect((html.match(/AI Analysis</g) ?? []).length).toBe(1)
+    expect(html).not.toMatch(/\(\d+ incidents\)/) // no count badge
+    expect(html).not.toContain('🔸 Only') // title line suppressed for a single incident
+  })
+})
+
 describe('buildMetaDescription', () => {
   it('operational + uptime + incidents: all clauses in canonical order', () => {
     const svc = mkService({

--- a/api/_is-down/html-template.ts
+++ b/api/_is-down/html-template.ts
@@ -277,6 +277,11 @@ export function renderPage(
   // the stale card. canonical / <title> / JSON-LD stay clean (SEO indexes those, not og:url). The caller
   // (api/is-down.ts) has already sanitized it to id-safe chars.
   ogIncidentToken?: string | null,
+  // #926 — the FULL per-incident AI analysis list for the visible AI Analysis card, so a service with
+  // multiple active incidents renders one card each (parity with the dashboard AnalysisModal). The scalar
+  // `aiInsight` above remains the primary [0] for meta/share/OG. Omitted/empty → fall back to the single
+  // `aiInsight` (older callers / single-incident path) so the card still renders.
+  aiInsights?: Array<{ summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string; estimatedRecoveryHours?: number; startedAt?: string; incidentTitle?: string }> | null,
 ): string {
   // #566: lead the SERP title with the live status answer (falls back to "Live Status"
   // when status data is unavailable) so the result answers the query before the click.
@@ -481,7 +486,7 @@ textarea.report-input{min-height:72px;resize:vertical}
 ${renderStatusHeader(service, seo)}
 ${renderCTA(seo, service?.status ?? 'operational', slug, service?.id ?? slug)}
 ${isClaudeSurface(service?.id ?? slug) ? renderExtInstallCta(EXTENSION_STORE_URL, { loc: 'is_down_page', variant: 'is-down' }) : ''}
-${renderAIInsight(aiInsight, service?.status, fallbacks)}
+${renderAIInsight(aiInsights && aiInsights.length > 0 ? aiInsights : aiInsight, service?.status, fallbacks)}
 ${supplyChainNote ? `<p class="meta" style="color:#d29922">&#x26A0;&#xFE0F; AWS infrastructure issue (${esc(supplyChainNote.regions)}) &mdash; ${supplyChainNote.confirmed ? `${esc(seo.displayName)} is degraded and attributes it to an AWS/upstream issue` : `${esc(seo.displayName)} runs on AWS and may be affected`}</p>` : ''}
 ${renderRegionRecommendation(regionRec ?? null, slug)}
 ${renderComponents(service)}
@@ -649,33 +654,35 @@ function predictedVsActualEn(predictedHours: number, actualMin: number): string 
   return `${fmtMinEn(actualMin)} (${within})`
 }
 
-function renderAIInsight(insight?: { summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string; estimatedRecoveryHours?: number; startedAt?: string } | null, serviceStatus?: string, fallbacks?: Fallback[]): string {
+type AIInsight = { summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string; estimatedRecoveryHours?: number; startedAt?: string; incidentTitle?: string }
+
+// #926 — accepts a SINGLE insight or the full per-incident LIST and renders ONE card for the service,
+// mirroring the dashboard AnalysisModal (which groups a service's incidents into a single card, NOT one
+// card per incident): a single "🤖 AI Analysis" header, one 🔄 Alternatives block, and one disclaimer,
+// with each active incident as a sub-block inside. A per-incident title labels each sub-block only when
+// the card holds more than one incident. The single-incident render is visually unchanged (each body is
+// wrapped in a transparent <div>; the Alternatives block + disclaimer moved up to the card level).
+function renderAIInsight(insight?: AIInsight | AIInsight[] | null, serviceStatus?: string, fallbacks?: Fallback[]): string {
   if (!insight) return ''
-  const ago = Math.floor((Date.now() - new Date(insight.analyzedAt).getTime()) / 60000)
-  const agoText = ago < 1 ? 'just now' : ago < 60 ? `${ago}m ago` : `${Math.floor(ago / 60)}h ago`
+  const list = Array.isArray(insight) ? insight : [insight]
+  if (list.length === 0) return ''
   const isResolved = serviceStatus === 'operational'
-  // An ACTIVE incident that has already run past its estimated recovery upper bound: the stale short
-  // range is no longer credible (a 2–4h estimate on an incident ongoing for days). Show how long it's
-  // been running vs the estimate ("Ongoing ~12h · exceeded ~2–4h est.") — same gate as the dashboard
-  // modal. Meta/share surfaces keep the terse "Exceeded typical pattern" (reads cleaner in-sentence).
-  const recovery = recoveryEstimateExceeded(insight) ? exceededRecoveryTextEn(insight) : formatRecoveryDisplay(insight.estimatedRecovery)
-  const isRecentlyRecovered = isResolved && !!insight.resolvedAt
-  // #827 F4 — once resolved, replace the bare estimate with "predicted vs actual" (actual = startedAt→
-  // resolvedAt). Null until resolved or when the numeric estimate / startedAt isn't available.
-  const outcome = isResolved && insight.estimatedRecoveryHours != null && insight.startedAt && insight.resolvedAt
-    ? predictedVsActualEn(insight.estimatedRecoveryHours, Math.round((new Date(insight.resolvedAt).getTime() - new Date(insight.startedAt).getTime()) / 60000))
-    : null
+  const multi = list.length > 1
+  const isRecentlyRecovered = isResolved && list.some(i => !!i.resolvedAt)
   const resolvedBadge = isResolved
     ? '<span class="mono" style="font-size:10px;color:#3fb950;background:rgba(63,185,80,0.15);padding:2px 8px;border-radius:4px">Resolved</span>'
     : ''
-  // #641 — only render the Alternatives block when we actually have a recommendation; we don't
-  // assert "No operational alternatives" (a subjective claim from our own incomplete coverage).
-  const fallbackHtml = insight.needsFallback && !isResolved && fallbacks && fallbacks.length > 0
+  // #641 — only render the Alternatives block when we actually have a recommendation; we don't assert
+  // "No operational alternatives" (a subjective claim from our own incomplete coverage). Rendered ONCE
+  // per card (gated on ANY active incident wanting a fallback), like the modal.
+  const anyNeedsFallback = list.some(i => i.needsFallback)
+  const fallbackHtml = anyNeedsFallback && !isResolved && fallbacks && fallbacks.length > 0
     ? `<div style="margin-top:8px;padding:8px 10px;background:#0d1117;border-radius:6px;border-left:3px solid #d29922">
 <span class="mono" style="font-size:11px;color:#c9d1d9;font-weight:600">🔄 Alternatives</span>
 ${fallbacks.map(f => `<div class="mono" style="font-size:11px;color:#c9d1d9;margin-top:3px">• ${esc(f.name)}${f.score != null ? ` (Score: ${f.score})` : ''}</div>`).join('')}
 </div>`
     : ''
+  const bodies = list.map((ins, idx) => renderInsightBody(ins, isResolved, multi, idx)).join('')
   return `<div class="card" style="border-left:3px solid ${isResolved ? '#3fb950' : '#7C3AED'};margin:16px 0${isResolved && !isRecentlyRecovered ? ';opacity:0.75' : ''}">
 <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
 <span style="font-size:16px">🤖</span>
@@ -683,7 +690,33 @@ ${fallbacks.map(f => `<div class="mono" style="font-size:11px;color:#c9d1d9;marg
 <span class="mono" style="font-size:10px;color:#7C3AED;background:rgba(124,58,237,0.15);padding:2px 8px;border-radius:4px">Beta</span>
 ${resolvedBadge}
 </div>
-<p style="font-size:13px;color:#c9d1d9;line-height:1.6;margin-bottom:8px">${esc(insight.summary)}</p>
+${bodies}
+${fallbackHtml}
+<p class="mono" style="font-size:9px;color:#484f58;margin-top:8px;opacity:0.7">⚠️ AI-generated estimation based on historical data. Actual time may vary.</p>
+</div>`
+}
+
+// One incident's analysis block inside the shared card. `multi`/`idx` control the separator + the
+// incident-title line (shown only when the card holds more than one incident, like the modal).
+function renderInsightBody(insight: AIInsight, isResolved: boolean, multi: boolean, idx: number): string {
+  const ago = Math.floor((Date.now() - new Date(insight.analyzedAt).getTime()) / 60000)
+  const agoText = ago < 1 ? 'just now' : ago < 60 ? `${ago}m ago` : `${Math.floor(ago / 60)}h ago`
+  // An ACTIVE incident that has already run past its estimated recovery upper bound: the stale short
+  // range is no longer credible (a 2–4h estimate on an incident ongoing for days). Show how long it's
+  // been running vs the estimate ("Ongoing ~12h · exceeded ~2–4h est.") — same gate as the dashboard
+  // modal. Meta/share surfaces keep the terse "Exceeded typical pattern" (reads cleaner in-sentence).
+  const recovery = recoveryEstimateExceeded(insight) ? exceededRecoveryTextEn(insight) : formatRecoveryDisplay(insight.estimatedRecovery)
+  // #827 F4 — once resolved, replace the bare estimate with "predicted vs actual" (actual = startedAt→
+  // resolvedAt). Null until resolved or when the numeric estimate / startedAt isn't available.
+  const outcome = isResolved && insight.estimatedRecoveryHours != null && insight.startedAt && insight.resolvedAt
+    ? predictedVsActualEn(insight.estimatedRecoveryHours, Math.round((new Date(insight.resolvedAt).getTime() - new Date(insight.startedAt).getTime()) / 60000))
+    : null
+  const sep = multi && idx > 0 ? 'border-top:1px solid #21262d;margin-top:10px;padding-top:10px' : ''
+  const titleLine = multi && insight.incidentTitle
+    ? `<div class="mono" style="font-size:10px;color:#8b949e;font-weight:600;margin-bottom:4px">${insight.resolvedAt ? '✅' : '🔸'} ${esc(insight.incidentTitle)}</div>`
+    : ''
+  return `<div${sep ? ` style="${sep}"` : ''}>
+${titleLine}<p style="font-size:13px;color:#c9d1d9;line-height:1.6;margin-bottom:8px">${esc(insight.summary)}</p>
 <div class="mono" style="font-size:11px;color:#8b949e;display:flex;flex-direction:column;gap:4px">
 ${outcome
   ? `<span>🎯 <strong style="color:#c9d1d9">Predicted vs actual:</strong> ${esc(outcome)}</span>`
@@ -692,8 +725,6 @@ ${insight.affectedScope.length > 0 ? `<span>📡 <strong style="color:#c9d1d9">S
 ${insight.resolvedAt ? `<span>✅ Recovered: ${(() => { const m = Math.floor((Date.now() - new Date(insight.resolvedAt).getTime()) / 60000); return m < 1 ? 'just now' : m < 60 ? m + 'm ago' : Math.floor(m / 60) + 'h ago' })()}</span>` : ''}
 <span>🕐 ${agoText}</span>
 </div>
-${fallbackHtml}
-<p class="mono" style="font-size:9px;color:#484f58;margin-top:8px;opacity:0.7">⚠️ AI-generated estimation based on historical data. Actual time may vary.</p>
 </div>`
 }
 

--- a/api/is-down.ts
+++ b/api/is-down.ts
@@ -81,6 +81,11 @@ export default async function handler(req: Request) {
     let serviceData = null
     let fallbacks: Array<{ id: string; name: string; score: number | null; status: string }> = []
     let aiInsight: { summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string; estimatedRecoveryHours?: number; startedAt?: string } | null = null
+    // #926 — the worker returns ONE analysis per active incident (aiAnalysis: Record<svcId, AIAnalysisResult[]>).
+    // Keep the FULL array for the visible AI Analysis card (parity with the dashboard AnalysisModal, which
+    // renders every incident); `aiInsight` above stays the primary [0] used by the meta/share/OG surfaces,
+    // which can only carry a single summary.
+    let aiInsights: Array<{ summary: string; estimatedRecovery: string; affectedScope: string[]; analyzedAt: string; needsFallback?: boolean; resolvedAt?: string; estimatedRecoveryHours?: number; startedAt?: string; incidentTitle?: string }> = []
     // #574 — supply-chain note for THIS service (set if it's in the banner's affectedNow/mayBeAffected).
     let supplyChainNote: { regions: string; confirmed: boolean } | null = null
     // Track the precise reason for the fallback render so the Discord alert can
@@ -105,7 +110,10 @@ export default async function handler(req: Request) {
             components?: Array<{ id: string; name: string; status: 'operational' | 'degraded' | 'down'; group?: string }>
             componentGroupsInline?: boolean // array-order (groups interleaved) breakdown layout (replicate)
           }>
-          aiAnalysis?: Record<string, { summary: string; estimatedRecovery: string; affectedScope: string[]; needsFallback?: boolean; analyzedAt: string; incidentId: string; resolvedAt?: string; estimatedRecoveryHours?: number }>
+          // #926 — the worker returns an ARRAY per service (one entry per active incident). The prior
+          // non-array annotation was wrong (a runtime array was silently collapsed to [0]); the Array.isArray
+          // guard below still tolerates a stray single object defensively.
+          aiAnalysis?: Record<string, Array<{ summary: string; estimatedRecovery: string; affectedScope: string[]; needsFallback?: boolean; analyzedAt: string; incidentId: string; resolvedAt?: string; estimatedRecoveryHours?: number }>>
           // #574 — supply-chain banner: when this service is in affectedNow/mayBeAffected, render a note.
           supplyChainBanner?: {
             severity: 'degraded' | 'down'
@@ -246,19 +254,32 @@ export default async function handler(req: Request) {
             .map(s => ({ id: s.id, name: s.name, score: (s as any).aiwatchScore ?? null, status: s.status }))
         }
 
-        // Extract AI analysis for this service (first active analysis from array)
+        // Extract AI analysis for this service. #926 — take the WHOLE array (one entry per active
+        // incident), not just [0], so a multi-incident service renders every AI card (dashboard parity).
         const analyses = data.aiAnalysis?.[entry.id]
-        const analysis = Array.isArray(analyses) ? analyses[0] : analyses
+        const analysisList = Array.isArray(analyses) ? analyses : analyses ? [analyses] : []
         // Show AI insight if analysis exists (incident may be active even when status is operational)
-        if (analysis) {
-          // #827 F4 — attach the matching incident's startedAt so a RESOLVED card can show
+        if (analysisList.length > 0) {
+          // #827 F4 — attach each matching incident's startedAt so a RESOLVED card can show
           // "predicted vs actual" (actual = startedAt→resolvedAt); estimatedRecoveryHours rides on
           // the analysis. Incidents live on the fetched SERVICE (`target`), NOT the slug-config
           // `entry` (which has no `incidents`). `target` may be undefined on the `service_missing`
           // config-drift path (which doesn't return) while `aiAnalysis` still has an entry — optional-
           // chain so we never throw to the fallback render; absent → the card shows the bare estimate.
-          const inc = ((target?.incidents as Array<{ id?: string; startedAt?: string }> | undefined) ?? []).find(i => i.id === analysis.incidentId)
-          aiInsight = { ...analysis, ...(inc?.startedAt ? { startedAt: inc.startedAt } : {}) }
+          const incidents = (target?.incidents as Array<{ id?: string; startedAt?: string; title?: string }> | undefined) ?? []
+          aiInsights = analysisList
+            .map(a => {
+              const inc = incidents.find(i => i.id === a.incidentId)
+              // #926 — carry the incident title too so a multi-incident card can label each sub-block
+              // (the dashboard modal does the same, keyed on incidentId).
+              return { ...a, ...(inc?.startedAt ? { startedAt: inc.startedAt } : {}), ...(inc?.title ? { incidentTitle: inc.title } : {}) }
+            })
+            // #926 — order newest-incident-first so the AI card lines up with the "Recent Incidents"
+            // section on the same page. That section sorts status-tier-then-recency (active before
+            // resolved), so this pure startedAt-desc order matches it in the dominant all-active case;
+            // a mixed active+recently-resolved set can differ, which is acceptable. startedAt-less last.
+            .sort((a, b) => (b.startedAt ?? '').localeCompare(a.startedAt ?? ''))
+          aiInsight = aiInsights[0] // primary (freshest incident) — meta/share/OG carry a single summary
         }
 
         // #574 — supply-chain note: if this service is in the banner (confirmed-affected or estimated).
@@ -318,7 +339,7 @@ export default async function handler(req: Request) {
       }
     }
 
-    const html = renderPage(slug, serviceData as Parameters<typeof renderPage>[1], seo, fallbacks, aiInsight, regionRec, reports, ogStatusHint, supplyChainNote, ogIncidentToken)
+    const html = renderPage(slug, serviceData as Parameters<typeof renderPage>[1], seo, fallbacks, aiInsight, regionRec, reports, ogStatusHint, supplyChainNote, ogIncidentToken, aiInsights)
 
     // #378: when the upstream Worker fetch failed and we're rendering the
     // "Status data is temporarily unavailable" fallback, the response must NOT


### PR DESCRIPTION
## Problem

On an **Is X Down?** SEO page, when a service has **multiple active incidents**, only ONE AI analysis was shown. The dashboard **AI Analysis modal** (`AnalysisModal.jsx`) renders **all** incidents' analyses — a cross-surface inconsistency (closes #926).

## Root cause

The worker returns AI analysis per service as an **array** (`aiAnalysis: Record<svcId, AIAnalysisResult[]>`, one entry pushed per active incident). is-down collapsed it to `[0]` (`api/is-down.ts`), and `renderAIInsight` rendered a single card with no loop.

## Fix

- **`api/is-down.ts`** — keep the whole array (`aiInsights`); attach each incident's `startedAt` + `title`; **sort newest-incident-first** so the AI card lines up with the "Recent Incidents" section on the same page; keep `aiInsight = aiInsights[0]` as the primary for meta/share/OG (single-summary surfaces, unchanged). Also fixes the mistyped `aiAnalysis` annotation (was a single object; runtime is an array).
- **`api/_is-down/html-template.ts`** — `renderAIInsight` now renders **ONE card per service** with each incident as a sub-block (single 🤖 header, one 🔄 Alternatives block gated on ANY incident's `needsFallback`, one disclaimer), mirroring `src/components/AnalysisModal.jsx`. Per-incident title (`🔸`/`✅`) shown only when multiple; no count badge. Single-incident render is visually unchanged.

## Verification

- Local in-browser verify with a mock worker (Claude down + 2 active incidents): one card, two titled sub-blocks, newest-first, single Alternatives — confirmed by the operator.
- PR review (code-reviewer): **0 Critical/Important**. All dynamic values `esc()`-wrapped (strict CSP), sort/edge-cases verified.
- `npm run test:src` 783 pass · `npm run build` pass · tsc clean.

## Scope

Frontend/Edge only — **no worker deploy needed**. OG image / share links / meta description stay on the single primary insight (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)