### PR TITLE
fix(overview): sum flip durations in Recent Incidents group row, not just the newest

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -76,6 +76,7 @@ const en = {
   'overview.panel.latency.sub': 'Current · ms',
   'overview.stats.uptime.sub': 'Overall average',
   'overview.incidents.monitoring': 'Monitoring',
+  'overview.incidents.total': '{d} total',
   'overview.banner.degraded': 'Partially Degraded',
   'overview.banner.down': 'Down',
   'overview.banner.affected': '{n} services affected',

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -76,6 +76,7 @@ const ko = {
   'overview.panel.latency.sub': '현재 기준 ms',
   'overview.stats.uptime.sub': '전체 평균',
   'overview.incidents.monitoring': '모니터링 중',
+  'overview.incidents.total': '총 {d}',
   'overview.banner.degraded': '성능 저하',
   'overview.banner.down': '서비스 중단',
   'overview.banner.affected': '{n}개 서비스 장애',

--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -17,7 +17,7 @@ import { SCORE_BG_CLASS, SERVICE_CATEGORIES, getGroupedFallbacksExcludingRegionS
 import RssCopyIcon from '../components/RssCopyIcon'
 import { regionStatusOf } from '../utils/regionStatus'
 import { buildCalendarFromIncidents } from '../utils/calendar'
-import { compareIncidents, compareGroupedRows, getContextualTime, dominantGroupStatus } from '../utils/incidentSort'
+import { compareIncidents, compareGroupedRows, getContextualTime, dominantGroupStatus, sumGroupDuration, formatDurationMs } from '../utils/incidentSort'
 import { groupIncidents } from '../utils/incidentGrouping'
 import { formatTime, formatDate } from '../utils/time'
 import SkeletonUI from '../components/SkeletonUI'
@@ -278,7 +278,7 @@ function CategoryTabs({ categoryFilter, setCategoryFilter, t }) {
 }
 
 // Grouped flap incidents (same title, same day) — compact expandable row (#496)
-function GroupIncidentItem({ group, lang, t }) {
+export function GroupIncidentItem({ group, lang, t }) {
   const [expanded, setExpanded] = useState(false)
   // Use canonical dominantGroupStatus (handles 'ongoing' alias + uniformStatus fast-path)
   const dominantStatus = dominantGroupStatus(group)
@@ -287,6 +287,16 @@ function GroupIncidentItem({ group, lang, t }) {
   const representative = group.entries[0]
   const serviceName = representative.serviceName ?? representative.affectedNames?.[0] ?? ''
   const dateStr = formatDate(group.rangeEnd, lang).split(' ').slice(0, 2).join(' ')
+  // Show the SUM of all grouped flips' downtime (labeled "총"/"total"), not just
+  // the newest entry's duration — a "×N" group's impact is every flip combined.
+  // Reuses the canonical sumGroupDuration/formatDurationMs shared with Incidents.jsx;
+  // null when nothing has resolved yet → falls back to the monitoring/ongoing label.
+  const summed = sumGroupDuration(group)
+  const totalDuration = summed.resolvedCount === 0
+    ? null
+    : summed.hasOngoing
+      ? `${t('overview.incidents.total').replace('{d}', formatDurationMs(summed.totalMs))} + ${t('incidents.duration.ongoing')}`
+      : t('overview.incidents.total').replace('{d}', formatDurationMs(summed.totalMs))
   return (
     <div style={{ marginBottom: '8px' }}>
       <div
@@ -322,7 +332,8 @@ function GroupIncidentItem({ group, lang, t }) {
             </span>
           </div>
           <div className="mono text-[10px] text-[var(--text2)]">
-            {representative.duration ?? (dominantStatus === 'monitoring' ? t('overview.incidents.monitoring') : t('incidents.status.ongoing'))}
+            {totalDuration
+              ?? (dominantStatus === 'monitoring' ? t('overview.incidents.monitoring') : t('incidents.status.ongoing'))}
           </div>
         </div>
       </div>

--- a/src/pages/__tests__/group-incident-duration.test.js
+++ b/src/pages/__tests__/group-incident-duration.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// SSR render of the Overview "Recent Incidents" collapsed GROUP row. Pins the
+// fix where a ×N flap group showed only the NEWEST flip's duration instead of
+// the SUM (and guards the "34m total total" double-label regression). t is a
+// prop, so no context/provider is needed. Collapsed (useState(false)) render
+// emits only the summary line — exactly what we assert.
+const { GroupIncidentItem } = await import('../Overview')
+
+// Stub t with the real en strings for the keys this row uses, so the `{d}`
+// interpolation in the label is exercised (an identity stub would leave `{d}`
+// unreplaced and hide the label composition under test).
+const STRINGS = {
+  'overview.incidents.total': '{d} total',
+  'incidents.duration.ongoing': 'Ongoing',
+  'overview.incidents.monitoring': 'Monitoring',
+  'incidents.status.ongoing': 'In Progress',
+}
+const t = (k) => STRINGS[k] ?? k
+const render = (group) => renderToStaticMarkup(createElement(GroupIncidentItem, { group, lang: 'en', t }))
+
+// One flap entry: sumGroupDuration derives minutes from resolvedAt − startedAt.
+const flap = (startISO, durMin) => ({
+  id: `f-${startISO}`, title: 'GPT OSS 20B — recovered', status: 'resolved', impact: 'minor',
+  startedAt: startISO, resolvedAt: new Date(new Date(startISO).getTime() + durMin * 60_000).toISOString(),
+  duration: `${durMin}m`, serviceName: 'Fireworks AI', affectedNames: ['Fireworks AI'], timeline: [],
+})
+
+const groupOf = (entries) => ({
+  kind: 'group', count: entries.length, normalizedTitle: 'GPT OSS 20B',
+  rangeStart: entries[entries.length - 1].startedAt, rangeEnd: entries[0].startedAt,
+  statusCounts: entries.reduce((m, e) => ({ ...m, [e.status]: (m[e.status] ?? 0) + 1 }), {}),
+  uniformStatus: new Set(entries.map((e) => e.status)).size === 1, entries,
+})
+
+describe('GroupIncidentItem — summed group duration (Overview Recent Incidents)', () => {
+  it('shows the SUM of all flips labeled "total", not just the newest entry', () => {
+    // newest first (entries[0] is the representative): 5m + 20m + 9m = 34m
+    const html = render(groupOf([
+      flap('2026-07-08T07:13:25.000Z', 5),
+      flap('2026-07-08T06:30:38.000Z', 20),
+      flap('2026-07-08T03:31:00.000Z', 9),
+    ]))
+    expect(html).toContain('34m total')       // the SUM, with our label
+    expect(html).not.toContain('total total') // the double-label regression is gone
+  })
+
+  it('does not regress to the newest-only duration (5m) for a ×3 group', () => {
+    const html = render(groupOf([
+      flap('2026-07-08T07:13:25.000Z', 5),
+      flap('2026-07-08T06:30:38.000Z', 20),
+      flap('2026-07-08T03:31:00.000Z', 9),
+    ]))
+    // the standalone newest "5m" (without the summed 34m) must not be the shown duration
+    expect(html).not.toMatch(/>\s*5m\s*</)
+  })
+
+  it('appends the ongoing marker when some entries are still active', () => {
+    const active = { id: 'a1', title: 'GPT OSS 20B — recovered', status: 'investigating', impact: 'minor',
+      startedAt: '2026-07-08T08:00:00.000Z', duration: null, serviceName: 'Fireworks AI', affectedNames: ['Fireworks AI'], timeline: [] }
+    const html = render(groupOf([active, flap('2026-07-08T06:30:38.000Z', 20)]))
+    expect(html).toContain('20m total') // sum of the resolved entry
+    expect(html).toContain('Ongoing')   // + ongoing marker
+  })
+})


### PR DESCRIPTION
## Bug

The Overview **"Recent Incidents"** collapsed group row (`GroupIncidentItem`) showed only the **newest** flip's duration (`representative.duration`) for a ×N flap group. A ×3 Fireworks *"OpenAI GPT OSS 20B chat completion API"* group displayed **"5m"** (the last flip) instead of the combined downtime of all three.

## Fix

Reuse the existing canonical `sumGroupDuration` + `formatDurationMs` (`src/utils/incidentSort.js` — the **same helpers `Incidents.jsx` already uses**) to show the **sum**, labeled `총 {d}` (ko) / `{d} total` (en) via a new i18n key `overview.incidents.total`.

- `resolvedCount === 0` → falls back to the existing monitoring/ongoing label.
- some entries still active → `{sum} total + Ongoing` (mirrors `Incidents.jsx`).

## Verification

Confirmed **in-browser against real production data** (via the local worker): Fireworks ×3 on 2026-07-08 KST → **`34m total`** (= 5m + 20m + 9m), instead of the old `5m`.

- `npm run build` clean · `npm run test:src` **804 pass** (58 files, +3 new)
- PR review: 0 Critical/Important.

## Tests

Exported `GroupIncidentItem` + added `src/pages/__tests__/group-incident-duration.test.js` — an SSR-render regression test covering: the summed label, the newest-only regression, the `+ Ongoing` case, and the double-label (`34m total total`) regression.

Files: `src/pages/Overview.jsx`, `src/locales/en.js`, `src/locales/ko.js`, new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)