### PR TITLE
docs(verify-assertions): fix example field predictionAccuracy.sampleCount → .total (refs #827)

### DIFF
--- a/docs/reference/verify-assertions.md
+++ b/docs/reference/verify-assertions.md
@@ -40,7 +40,7 @@ An indented `assert:` line **directly under** a `verify-after` checkbox (the nex
 | part | rule |
 |---|---|
 | **source** | `GET` optional. A leading-`/` path resolves against the prod worker (`VERIFY_ASSERT_BASE`, default `aiwatch-worker.p2c2kbf.workers.dev`), or an absolute `https://` URL. **Must be an allowlisted AIWatch host** (SSRF guard) — the ai-watch.dev set + the pinned prod worker host; extras via `VERIFY_ASSERT_ALLOW`. Response must be JSON. Prefer the fast KV-backed `/api/status/cached` over the live `/api/status` fan-out. |
-| **selector** | dot-path with an optional `[key=value]` array filter, e.g. `services[id=turbopuffer].scoreConfidence`, `supplyChainBanner.active`, `predictionAccuracy.sampleCount`. The `[key=value]` picks the first array element whose `key` string-equals `value`. |
+| **selector** | dot-path with an optional `[key=value]` array filter, e.g. `services[id=turbopuffer].scoreConfidence`, `supplyChainBanner.active`, `predictionAccuracy.total`. The `[key=value]` picks the first array element whose `key` string-equals `value`. |
 | **operator** | `==` · `!=` · `>=` · `<=` · `contains` (substring, or array membership) · `exists` (no operand) |
 | **expected** | a literal: quoted string `"medium"` / `'x'`, number `30`, boolean `true`/`false`. Omitted for `exists`. |
 
@@ -73,7 +73,7 @@ Add one when the acceptance can be expressed as a predicate over an AIWatch JSON
 | a `/api/status` field | ✅ | `services[id=turbopuffer].scoreConfidence == "medium"` |
 | a `/api/status` count/threshold | ✅ | `services[id=turbopuffer].coverageDays >= 30` |
 | presence of a structure | ✅ | `supplyChainBanner exists` |
-| a `/api/report` aggregate | ✅ (verify the field is exposed) | `predictionAccuracy.sampleCount >= 1` |
+| a `/api/report` aggregate | ✅ (verify the field is exposed) | `predictionAccuracy.total >= 1` |
 | GA4 / GSC-CTR / consent-gated | ❌ | leave as a human ping (no `assert:`) |
 | behavioral ("no alert fired", a flap) | ❌ | no static signal — human ping |
 | is-down `<title>` HTML text | ❌ (v1) | JSON-only today; HTML/text-body mode is a follow-up |

--- a/scripts/verify-assertions.test.mjs
+++ b/scripts/verify-assertions.test.mjs
@@ -13,8 +13,8 @@ test('parseAssertionLine — valid GET + selector + quoted expected', () => {
 })
 
 test('parseAssertionLine — GET optional, absolute url, numeric op', () => {
-  const a = parseAssertionLine('assert: https://ai-watch.dev/api/report | predictionAccuracy.sampleCount >= 1')
-  assert.deepEqual(a, { source: 'https://ai-watch.dev/api/report', selector: 'predictionAccuracy.sampleCount', op: '>=', expected: '1' })
+  const a = parseAssertionLine('assert: https://ai-watch.dev/api/report | predictionAccuracy.total >= 1')
+  assert.deepEqual(a, { source: 'https://ai-watch.dev/api/report', selector: 'predictionAccuracy.total', op: '>=', expected: '1' })
 })
 
 test('parseAssertionLine — exists takes no operand', () => {


### PR DESCRIPTION
## Problem
`docs/reference/verify-assertions.md` (the Tier-A `assert:` grammar reference, #873) and a parse-test example used the selector field **`predictionAccuracy.sampleCount`** — which does **not exist** on the `AccuracyStats` type (`worker/src/incident-history.ts`). The real field is **`total`** (records that had a prediction — the denominator), exposed via `MonthlyArchive.predictionAccuracy` on `/api/report`.

## Why it matters
Surfaced during an issue-triage sweep while adding a Tier-A assert to **#827**: copying the doc's example verbatim produced `assert: … | predictionAccuracy.sampleCount >= 1`, which selects a non-existent path → `evalSelector` returns `{found:false}` → the assert **fails-open forever** (pings indefinitely) instead of auto-draining when the corpus fills. A wrong example field silently defeats the auto-verify loop.

## Change
- `docs/reference/verify-assertions.md` — the **selector** row example + the **`/api/report` aggregate** row example: `predictionAccuracy.sampleCount` → `predictionAccuracy.total`.
- `scripts/verify-assertions.test.mjs` — the parse-test example updated in lockstep (input + expected). The parser is field-agnostic, so this is a consistency fix, not a behavior change.

## Verification
- Repo-wide `sampleCount` references after the rename: **0**.
- `npm run test:scripts` — **109/109 green** (`verify-assertions.test.mjs` 20/20).
- `npm run lint:okf` — **0 findings** (frontmatter / cross-links / index catalog clean).
- `predictionAccuracy.total` confirmed real + reachable (`AccuracyStats.total` → `MonthlyArchive.predictionAccuracy` → `/api/report`).
- PR review (code-reviewer): **0 Critical / 0 Important**.

Docs-only + a test-example rename — no runtime surface.

refs #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)