### PR TITLE
fix(archive): stop the monthly archive claiming an "Official Uptime" the Score never used (refs #951)

### DIFF
--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -133,6 +133,33 @@ Two different reasons an incident.io service can end up with `uptime30d = null`,
 
 **Rotation guard.** A list is a roster we expect to find whole, but incident.io ULIDs are not guaranteed stable — a rotated id simply stops matching on a **200-OK page**, so neither the source-liveness check (keyed on 4xx/5xx) nor the #135 component-miss alert (keyed on `statusComponentId`, which a list-configured service does not set) fires. A partial rotation would quietly shrink the worst-of to the surviving regions and could report a healthy 100% while a vanished region is down. `parseIncidentIoUptime` therefore **warns** when a configured id resolves to nothing (list configs only — a single unmatched id is the ordinary "no such component" case). That warn only reaches Workers logs; routing it to the operator, and detecting the broader `uptime30d` non-null → null transition across all services, are tracked in **#957**.
 
+### The monthly archive's `officialUptime` must agree with the Score (#951)
+
+The archive carries three uptime-ish fields and they answer different questions, which is how the report came to print **"Official · 100.00% uptime"** beside a Score that had been rescaled over `/60` as if no uptime existed:
+
+| field | source | window |
+|---|---|---|
+| `uptime` | AIWatch's own daily `ok/total` counters | the month |
+| `officialUptime` | `computeMonthlyOfficialUptime` — a daily snapshot of `ServiceStatus.uptime30d` | *was* **any** day in the month; now the final days |
+| `score` | snapshot of the **live** 30-day Score at build time (the 1st of the next month) | build day |
+
+Two ways the display and the score drifted apart, both real:
+
+1. **Pre-#713 estimate residue.** The daily counter stores `uptime30d` **without its `uptimeSource`**, so the incident-derived estimate that #713 removed (merged 2026-06-19) is indistinguishable from an official % in the snapshot. `computeMonthlyOfficialUptime` kept the **last non-null** value over the whole month — despite its docstring saying "as of the LATEST day" — so one pre-#713 day stamped a fabricated "official" figure on all of June 2026: Stability 100%, Replicate 99.34%, ElevenLabs 99.18%. The build-time Score, computed after #713, had already dropped uptime.
+2. **A source that dies mid-window.** Character.AI's Statuspage was deactivated (#689/#800), leaving a real-but-dead 99.58% behind the same way.
+
+The fix is two layers, because they answer different questions:
+
+- **`computeMonthlyOfficialUptime` now means what it said** — only the final `OFFICIAL_UPTIME_TAIL_DAYS` (3) days with data may supply the value. A figure last seen on the 17th is residue, not month-end data. Three days tolerates a transient status-page failure on the last day (the snapshot is that day's last cron cycle) without tolerating a source that went away mid-month. This removes both contaminations at their origin.
+- **`resolveArchiveOfficialUptime` then requires the Score to have consumed it** (`scoreConfidence === 'high'` ⟺ `score.ts` `hasUptime`), so display and score cannot contradict each other. The archive also persists `scoreConfidence`, so the report labels the uptime source from data rather than a hand-maintained service list.
+
+Two deliberate non-obvious behaviours in that gate:
+
+- Withholding a month-end value the Score didn't consume **warns**. It is reachable without any contamination: `scoreConfidence` comes from ONE read of `services:latest` on build day, so a status-page fetch that fails on that read makes a service which published uptime all month read `medium` and lose its figure. The number is still withheld (a displayed uptime beside a `/60` score is the contradiction this issue exists to remove — and that archived score is wrong too), but discarding a month-observed figure silently would be the very defect being fixed.
+- **No score data at all → keep the month-end value.** `scoreSvc === undefined` means `services:latest` was unreadable; the daily snapshots stand on their own and there is no score to contradict. Tying `officialUptime` to `scoreData` would let one parse failure erase every service's uptime from an archive the cron never rebuilds (it only builds when the entry is absent).
+
+**Archives written before this shipped keep the contaminated values and are corrected out-of-band — do not reach for `/api/admin/rebuild-archive`.** It is not idempotent: it rebuilds `scoreData` from the **current** `services:latest`, so a historical month's scores are overwritten with today's. And because the gate above reads that same current `scoreConfidence`, rebuilding a month whose service has *since* lost its source (Character.AI) also withholds the uptime it genuinely published back then. Patch the `archive:{period}` KV entry directly instead.
+
 Concretely:
 - **Worker** (`services.ts`): when no official uptime is found, leave `uptime30d` null and set no `uptimeSource`. The card incident COUNT + Incident History stay the live `filtered` set.
 - **Score** (`score.ts`): computed on the **AVAILABLE components only, rescaled to 100** — `(uptime? 40) + incidents 25 + recovery 15 + (probe? 20)` over the available max. A no-official-uptime service drops the 40-pt uptime component (no assumed value) and is scored on incidents + recovery (+ probe if any); `confidence` = `hasUptime ? 'high' : probe ? 'medium' : 'low'`. Backward-compatible (uptime+probe → /100 unchanged; no-probe → /80 = ×1.25 unchanged).

--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   computeMonthlyUptime,
   computeMonthlyComponentUptime,
@@ -27,6 +27,7 @@ import {
   buildMonthlyAccuracy,
   filterSuppressedFromMonthly,
   aggregateIncidentDurations,
+  resolveArchiveOfficialUptime,
 } from '../monthly-archive'
 import type { SuppressionEntry } from '../suppression'
 import type { ServiceStatus, Incident } from '../types'
@@ -307,13 +308,18 @@ describe('curateComponentUptime (#605 Phase 3)', () => {
 // ── computeMonthlyOfficialUptime (#586 daily snapshot) ───────────────
 describe('computeMonthlyOfficialUptime (#586)', () => {
   it('returns the most-recent day\'s officialUptime per service', () => {
+    // #951 — the fixture is dense enough that the 1st falls OUTSIDE the tail window, so this now
+    // guards the cutoff too: the later day wins for chatgpt, and openai's early-only value is residue
+    // (it published nothing for the rest of the month) rather than a month-end figure to be "carried".
     const daily = {
       '2026-06-01': { chatgpt: { ok: 200, total: 288, officialUptime: 98.5 }, openai: { ok: 288, total: 288, officialUptime: 99.9 } },
-      '2026-06-30': { chatgpt: { ok: 210, total: 288, officialUptime: 99.83 } }, // later day wins for chatgpt
+      '2026-06-28': { chatgpt: { ok: 210, total: 288, officialUptime: 99.7 } },
+      '2026-06-29': { chatgpt: { ok: 210, total: 288, officialUptime: 99.8 } },
+      '2026-06-30': { chatgpt: { ok: 210, total: 288, officialUptime: 99.83 } },
     }
     const r = computeMonthlyOfficialUptime(daily)
-    expect(r.chatgpt).toBe(99.83)  // month-end value, not the earlier 98.5
-    expect(r.openai).toBe(99.9)    // only present on the 1st → carried
+    expect(r.chatgpt).toBe(99.83)   // month-end value, not the earlier 98.5
+    expect(r.openai).toBeUndefined() // last seen on the 1st → not month-end data (pre-#951 carried it)
   })
   it('omits services with no officialUptime on any day (→ caller falls back to null)', () => {
     const daily = { '2026-06-01': { cohere: { ok: 288, total: 288 } } } // no officialUptime field
@@ -325,6 +331,89 @@ describe('computeMonthlyOfficialUptime (#586)', () => {
       '2026-06-15': { gemini: { ok: 288, total: 288, officialUptime: null } }, // null does not clobber
     }
     expect(computeMonthlyOfficialUptime(daily).gemini).toBe(97.0)
+  })
+
+  // #951 — "as of the LATEST day" now means it. A sticky last-non-null let a value observed mid-month
+  // stand in for month end, which is how the pre-#713 estimate and Character.AI's dead source survived.
+  it('#951 ignores a value that stopped being published before the month\'s final days', () => {
+    const daily: Record<string, Record<string, { ok: number; total: number; officialUptime?: number | null }>> = {}
+    for (let d = 13; d <= 30; d++) {
+      const day = `2026-06-${String(d).padStart(2, '0')}`
+      daily[day] = {
+        stability: { ok: 288, total: 288, officialUptime: d <= 17 ? 100 : null }, // estimate until #713 (06-19)
+        groq: { ok: 288, total: 288, officialUptime: 100 },                       // a real source, all month
+      }
+    }
+    const r = computeMonthlyOfficialUptime(daily)
+    expect(r.stability).toBeUndefined() // last seen 06-17, thirteen days before month end → residue
+    expect(r.groq).toBe(100)
+  })
+
+  it('#951 tolerates a transient null on the final day (the snapshot is that day\'s last cron cycle)', () => {
+    const daily = {
+      '2026-06-28': { groq: { ok: 288, total: 288, officialUptime: 100 } },
+      '2026-06-29': { groq: { ok: 288, total: 288, officialUptime: 99.98 } },
+      '2026-06-30': { groq: { ok: 288, total: 288, officialUptime: null } }, // one bad fetch
+    }
+    expect(computeMonthlyOfficialUptime(daily).groq).toBe(99.98)
+  })
+
+  it('#951 drops a source that has been silent for the whole tail window', () => {
+    const daily = {
+      '2026-06-28': { characterai: { ok: 288, total: 288, officialUptime: null } },
+      '2026-06-29': { characterai: { ok: 288, total: 288, officialUptime: null } },
+      '2026-06-30': { characterai: { ok: 288, total: 288, officialUptime: null } },
+    }
+    expect(computeMonthlyOfficialUptime(daily).characterai).toBeUndefined()
+  })
+})
+
+// ── resolveArchiveOfficialUptime (#951 — display must agree with the Score) ──
+// The archive showed "Official · 100.00% uptime" beside a Score that was rescaled over /60 as if no
+// uptime existed. Two independent ways the two drifted apart, both reproduced below.
+describe('resolveArchiveOfficialUptime (#951)', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('emits the month-end value for a service the Score actually scored on uptime', () => {
+    expect(resolveArchiveOfficialUptime(100, { id: 'groq', scoreConfidence: 'high', officialUptime: 100 })).toBe(100)
+  })
+
+  it('prefers the month-end daily snapshot over the build-time value (#586 month accuracy kept)', () => {
+    expect(resolveArchiveOfficialUptime(99.83, { id: 'chatgpt', scoreConfidence: 'high', officialUptime: 99.7 })).toBe(99.83)
+  })
+
+  it('falls back to the build-time value when no day carried one', () => {
+    expect(resolveArchiveOfficialUptime(undefined, { id: 'groq', scoreConfidence: 'high', officialUptime: 100 })).toBe(100)
+  })
+
+  it('withholds a month-end value the Score did not consume (would print "Official" beside a /60 score)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(resolveArchiveOfficialUptime(100, { id: 'groq', scoreConfidence: 'medium', officialUptime: null })).toBeNull()
+    // Discarding a month-observed figure is exactly the silent drop this issue is about — it must warn.
+    // (Reachable when a status-page fetch fails on the single build-day read of services:latest.)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('withholding month-end official uptime 100')
+  })
+
+  it('does NOT warn when there was no month-end value to discard (openrouter never publishes one)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(resolveArchiveOfficialUptime(undefined, { id: 'openrouter', scoreConfidence: 'medium', officialUptime: null })).toBeNull()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the month-end value when services:latest was unreadable (no score to contradict)', () => {
+    // index.ts console.errors the parse failure and passes scoreData=[]. Nulling everything would let
+    // ONE parse failure erase every service's official uptime from an archive the cron never rebuilds.
+    expect(resolveArchiveOfficialUptime(99.83, undefined)).toBe(99.83)
+    expect(resolveArchiveOfficialUptime(undefined, undefined)).toBeNull()
+  })
+
+  it('warns, then falls back to the pre-#951 gate, for a caller that omits scoreConfidence', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(resolveArchiveOfficialUptime(99.5, { id: 'legacy', officialUptime: 99.4 })).toBe(99.5)
+    expect(resolveArchiveOfficialUptime(99.5, { id: 'legacy', officialUptime: null })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(2)
+    expect(warn.mock.calls[0][0]).toContain('omits scoreConfidence')
   })
 })
 
@@ -1056,6 +1145,48 @@ describe('buildMonthlyArchive', () => {
       { id: 'claude', aiwatchScore: 85, scoreGrade: 'excellent' as const },
     ])
     expect(archive.services.claude.officialUptime).toBeNull()
+  })
+
+  // #951 — the June 2026 contamination, reproduced through the full builder. The daily counter stores
+  // `uptime30d` WITHOUT its `uptimeSource`, so the incident-derived estimate that #713 removed on
+  // 2026-06-19 is indistinguishable from an official % in the snapshot. `computeMonthlyOfficialUptime`
+  // is a sticky last-non-null, so one pre-#713 day stamped "Official · 100.00%" on Stability's whole
+  // month — beside a Score the build (2026-07-01) had already rescaled over /60 as if no uptime existed.
+  it('#951 does not surface a month-end uptime the Score never consumed', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {}) // the withheld-value warning
+    const juneKV = {
+      get: async (key: string) => ({
+        // 06-17: pre-#713 — stability's estimate and groq's real official uptime look identical here.
+        'history:2026-06-17': JSON.stringify({
+          stability: { ok: 288, total: 288, officialUptime: 100 },
+          groq: { ok: 288, total: 288, officialUptime: 100 },
+        }),
+        // 06-29: post-#713 — stability's value is gone; groq's real one persists.
+        'history:2026-06-29': JSON.stringify({
+          stability: { ok: 288, total: 288, officialUptime: null },
+          groq: { ok: 288, total: 288, officialUptime: 100 },
+        }),
+      } as Record<string, string>)[key] ?? null,
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    } as unknown as KVNamespace
+
+    const archive = await buildMonthlyArchive(juneKV, 2026, 6, [
+      // Scored at build time (post-#713): no uptime component → medium confidence, /60 rescale.
+      { id: 'stability', aiwatchScore: 76, scoreGrade: 'good' as const, scoreConfidence: 'medium' as const, officialUptime: null },
+      { id: 'groq', aiwatchScore: 85, scoreGrade: 'good' as const, scoreConfidence: 'high' as const, officialUptime: 100 },
+    ])
+
+    // The sticky 100 from 06-17 must NOT resurface as Stability's "Official Uptime".
+    expect(archive.services.stability.officialUptime).toBeNull()
+    expect(archive.services.stability.uptime).toBe(100)   // AIWatch-measured — untouched, still honest
+    expect(archive.services.stability.score).toBe(76)     // the /60 score the display now agrees with
+    expect(archive.services.stability.scoreConfidence).toBe('medium')
+
+    // A service that really does publish uptime keeps it, month-end value and all.
+    expect(archive.services.groq.officialUptime).toBe(100)
+    expect(archive.services.groq.scoreConfidence).toBe('high')
   })
 
   it('#591 threads incidentSourceStale into the archive (only when set)', async () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1796,7 +1796,7 @@ async function handleAdminRebuildArchive(request: Request, env: Env, cors: Recor
       const probeSummaries = await readProbeSummaries(env.STATUS_CACHE, 'admin/rebuild-archive')
       scoreData = services.map((s) => {
         const r = scoreFor(s, probeSummaries)
-        return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
+        return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, scoreConfidence: r.confidence, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
       })
       for (const s of services) serviceNames[s.id] = s.name
     } catch (parseErr) {
@@ -2380,7 +2380,7 @@ export default {
               const probeSummaries = await readProbeSummaries(env.STATUS_CACHE, 'monthly-archive')
               scoreData = services.map((s) => {
                 const r = scoreFor(s, probeSummaries)
-                return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
+                return { id: s.id, aiwatchScore: r.score, scoreGrade: r.grade, scoreConfidence: r.confidence, officialUptime: s.uptime30d ?? null, ...(s.incidentSourceStale ? { incidentSourceStale: true } : {}) }
               })
               for (const s of services) serviceNames[s.id] = s.name
             } catch (parseErr) {

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -17,6 +17,9 @@ import { readSuppressionsFresh, isSuppressedByIdTitle, type SuppressionEntry } f
 import { kvPut } from './utils'
 
 export type ScoreGrade = 'excellent' | 'good' | 'fair' | 'degrading' | 'unstable'
+// #951 — mirrors AIWatchScore.confidence. 'high' ⟺ the service had an official uptime% at score
+// time, i.e. the Score included the 40-pt uptime component (`score.ts` `hasUptime`).
+export type ScoreConfidence = 'high' | 'medium' | 'low'
 
 /** Per-incident snapshot kept in the permanent monthly archive (#375).
  *  Sourced from accumulated incidents:monthly:{period} at archive build time, before its
@@ -41,9 +44,10 @@ export interface MonthlyIncidentEntry {
 
 export interface MonthlyServiceData {
   uptime: number | null          // AIWatch-measured uptime% from daily ok/total counters — feeds the Score (null if no data)
-  officialUptime: number | null  // #586 — status-page rolling-30d uptime (month-end daily snapshot, build-time fallback) for the "Official Uptime" DISPLAY table; separate from the daily-counter `uptime` that feeds the Score. null if the service publishes no metric
+  officialUptime: number | null  // #586 — status-page rolling-30d uptime (month-end daily snapshot, build-time fallback) for the "Official Uptime" DISPLAY table; separate from the daily-counter `uptime` that feeds the Score. #951 — emitted ONLY when the Score actually consumed an official uptime (scoreConfidence 'high'); null otherwise
   score: number | null           // AIWatch Score at archive time (null if unavailable)
   grade: ScoreGrade | null       // Score grade (null if score unavailable)
+  scoreConfidence?: ScoreConfidence | null // #951 — 'high' = the Score included the 40-pt uptime component; the report labels the uptime source from this instead of a hardcoded service list
   incidents: number              // incident count for the month (from accumulated data)
   avgResolutionMin: number | null // average resolution time in minutes (null if no resolved incidents)
   totalDowntimeMin: number | null // sum of all incident durations for the month (null if no resolved incidents — unresolved durations are tracked as 0 upstream)
@@ -409,21 +413,88 @@ type DailyCounters = Record<string, {
   components?: Record<string, { ok: number; total: number; name: string }>
 }>
 
+/** How many of the month's FINAL days may supply the "as of month end" official uptime. A value last
+ *  observed earlier than this is not month-end data — it is residue (#951). Three days tolerates a
+ *  transient status-page fetch failure on the last day (the snapshot is the day's last cron cycle)
+ *  without tolerating a source that went away mid-month. */
+export const OFFICIAL_UPTIME_TAIL_DAYS = 3
+
 /** #586 — per-service "Official Uptime" for the month: the status-page rolling-30d value as of the
  *  LATEST day in the window (≈ the month, since uptime30d trails 30 days). Reads the per-cycle daily
  *  snapshots (DailyCounters.officialUptime) rather than a one-shot build-time snapshot, so it stays
  *  month-accurate and survives a later rebuild. Omits a service when no day carried a value (months
- *  before this shipped, or a service that publishes no metric) → the caller falls back to null. */
+ *  before this shipped, or a service that publishes no metric) → the caller falls back to null.
+ *
+ *  #951 — "as of the LATEST day" is now what the code actually does. It used to scan every day and keep
+ *  the last NON-NULL value, so a figure last seen on the 17th was still reported as the month's official
+ *  uptime even though the source published nothing for the final two weeks. That is how the pre-#713
+ *  incident-derived ESTIMATE (removed 2026-06-19; the daily counter stores `uptime30d` without its
+ *  `uptimeSource`, so an estimate is indistinguishable from an official %) stamped a fabricated
+ *  "Official · 100.00%" on Stability/ElevenLabs/Replicate for all of June 2026 — and how Character.AI
+ *  kept a real-but-dead 99.58% after its status page was deactivated (#689/#800). Only the final
+ *  OFFICIAL_UPTIME_TAIL_DAYS days with data can supply the value now. */
 export function computeMonthlyOfficialUptime(
   dailyData: Record<string, DailyCounters>,
 ): Record<string, number> {
   const result: Record<string, number> = {}
-  for (const date of Object.keys(dailyData).sort()) { // ascending → later dates overwrite (most-recent wins)
+  const dates = Object.keys(dailyData).sort()
+  const tail = dates.slice(-OFFICIAL_UPTIME_TAIL_DAYS)
+  for (const date of tail) { // ascending → later dates overwrite (most-recent wins)
     for (const [id, c] of Object.entries(dailyData[date])) {
       if (c.officialUptime !== null && c.officialUptime !== undefined) result[id] = c.officialUptime
     }
   }
   return result
+}
+
+/** #951 — SECOND line of defence, after `computeMonthlyOfficialUptime` narrowed the value to the
+ *  month's final days. The archive's "Official Uptime" DISPLAY must agree with what the Score actually
+ *  consumed, or the report prints "Official · 100.00%" beside a score rescaled over /60 as if no
+ *  uptime existed. `scoreConfidence === 'high'` ⟺ `score.ts` `hasUptime` ⟺ the 40-pt uptime component
+ *  was included.
+ *
+ *  The two signals can legitimately disagree, and the disagreement is worth surfacing rather than
+ *  silently resolving. The month-end value comes from the daily snapshots; `scoreConfidence` comes from
+ *  ONE read of `services:latest` on build day. If a status-page fetch happened to fail on that read,
+ *  a service that published uptime all month reads `medium` and loses its figure. That is a real way to
+ *  discard correct data, so we warn — the same class of silent drop this whole issue is about. We still
+ *  withhold the number (a displayed uptime beside a `/60` score is the contradiction #951 exists to
+ *  remove), but the operator can see it happened; the archived `score` is wrong in that case too.
+ *
+ *  `scoreSvc === undefined` means `services:latest` was unreadable (index.ts logs the parse failure and
+ *  passes an empty scoreData). Do NOT null everything then: the month-end daily snapshots stand on their
+ *  own, and there is no score to contradict. This is what the pre-#951 code did — tying officialUptime
+ *  to scoreData would let one parse failure erase every service's uptime from an archive the cron never
+ *  rebuilds (it only builds when the entry is absent).
+ *
+ *  Historical archives written before this shipped still carry the contaminated values and are corrected
+ *  out-of-band — do NOT reach for `/api/admin/rebuild-archive`. It is not idempotent (it re-snapshots
+ *  `score` from the CURRENT `services:latest`), and because this gate reads that same current confidence,
+ *  rebuilding a month whose service has since LOST its source (Character.AI, #689/#800) also withholds the
+ *  uptime it genuinely published back then. Patch the `archive:{period}` KV entry directly instead. */
+export function resolveArchiveOfficialUptime(
+  monthEndValue: number | undefined,
+  scoreSvc: ArchiveScoreInput | undefined,
+): number | null {
+  if (!scoreSvc) return monthEndValue ?? null
+  if (scoreSvc.scoreConfidence == null) {
+    // Both production callers pass it; this only guards an external caller. `officialUptime != null` is a
+    // weaker proxy for "the Score consumed an uptime" — it happens to be equivalent for the two callers
+    // (both derive it from the same `s.uptime30d`) but nothing enforces that, so make the omission audible.
+    console.warn(`[monthly-archive] ${scoreSvc.id}: scoreData omits scoreConfidence — gating on the weaker officialUptime presence check`)
+    return scoreSvc.officialUptime != null ? (monthEndValue ?? scoreSvc.officialUptime) : null
+  }
+  if (scoreSvc.scoreConfidence !== 'high') {
+    if (monthEndValue != null) {
+      console.warn(
+        `[monthly-archive] ${scoreSvc.id}: withholding month-end official uptime ${monthEndValue} — ` +
+        `build-time scoreConfidence=${scoreSvc.scoreConfidence} (uptime30d was null when the Score was ` +
+        `snapshotted, so the archived score is a /60 rescale). Transient status-page failure on build day?`,
+      )
+    }
+    return null
+  }
+  return monthEndValue ?? scoreSvc.officialUptime ?? null
 }
 
 /** Compute per-service uptime% from daily counters */
@@ -664,6 +735,9 @@ export interface ArchiveScoreInput {
   id: string
   aiwatchScore?: number | null
   scoreGrade?: ScoreGrade | null
+  // #951 — the confidence the Score was computed at. 'high' ⟺ an official uptime% was available and
+  // the 40-pt uptime component was included. This is what gates `officialUptime` below.
+  scoreConfidence?: ScoreConfidence | null
   // #586 hybrid — FALLBACK source for officialUptime: the live status-page rolling-30d uptime
   // (ServiceStatus.uptime30d) snapshotted from services:latest at archive-build time. The PRIMARY
   // source is computeMonthlyOfficialUptime (the month-end daily snapshot), which is month-accurate
@@ -942,9 +1016,11 @@ export async function buildMonthlyArchive(
       uptime: uptimeMap[id] ?? null,
       // #586 — prefer the daily-snapshot month-end value (month-accurate, rebuild-safe); fall back
       // to the build-time services:latest snapshot (scoreData) for months with no daily snapshots.
-      officialUptime: officialUptimeMap[id] ?? scoreSvc?.officialUptime ?? null,
+      // #951 — but only when the Score itself consumed an official uptime, so display ≡ score.
+      officialUptime: resolveArchiveOfficialUptime(officialUptimeMap[id], scoreSvc),
       score: scoreSvc?.aiwatchScore ?? null,
       grade: scoreSvc?.scoreGrade ?? null,
+      ...(scoreSvc?.scoreConfidence ? { scoreConfidence: scoreSvc.scoreConfidence } : {}),
       incidents: incSvc?.count ?? 0,
       avgResolutionMin,
       totalDowntimeMin,


### PR DESCRIPTION
## Problem

The monthly report printed **"Official · 100.00% uptime"** for Stability AI beside a **Score of 76** — impossible under the formula, whose floor is 80 once uptime is present. Same shape for OpenRouter (80). Anyone reasoning from "100% uptime → 76" was reasoning from inconsistent data; it surfaced while writing the June report's Key Insight.

## Root cause

The archive's three uptime-ish fields answer different questions:

| field | source | window |
|---|---|---|
| `uptime` | AIWatch's own daily `ok/total` counters | the month |
| `officialUptime` | a daily snapshot of `ServiceStatus.uptime30d` | **any** day in the month |
| `score` | the live 30-day Score, snapshotted | build day |

`computeMonthlyOfficialUptime` kept the last **non-null** value over the whole month — despite its docstring promising *"the value as of the LATEST day in the window"*. A figure last observed on the 17th therefore still stood in for month end. Two things rode in on that:

1. **Pre-#713 estimate residue.** The daily counter stores `uptime30d` **without its `uptimeSource`**, so the incident-derived estimate #713 removed (merged **2026-06-19**) is indistinguishable from an official %. One pre-#713 day stamped a fabricated "official" figure on all of June: Stability 100%, Replicate 99.34%, ElevenLabs 99.18%.
2. **A source that dies mid-window.** Character.AI's Statuspage was deactivated (#689/#800), leaving a real-but-dead 99.58% behind the same way.

The build-time Score, computed after #713, had already dropped uptime. Display and score were reading different instants.

Confirmed against production KV — the `officialUptime` daily snapshots flip for exactly three services across the #713 merge, and for nothing else:

```
date        stability  groq  elevenlabs  replicate
2026-06-17     100      100     99.18      99.34
2026-06-19     None     100     None       None      <- #713 merged 06-19 23:12
```

## Fix — two layers, because they answer different questions

- **`computeMonthlyOfficialUptime` now means what it said.** Only the final `OFFICIAL_UPTIME_TAIL_DAYS` (3) days with data may supply the value. Three days tolerates a transient status-page failure on the last day (the snapshot is that day's last cron cycle) without tolerating a source that went away mid-month. This removes both contaminations at their origin.
- **`resolveArchiveOfficialUptime` then requires the Score to have consumed it** (`scoreConfidence === 'high'` means `score.ts` `hasUptime`), so display and score cannot contradict each other. The archive now persists `scoreConfidence`, so the report can label the uptime source from data instead of a hand-maintained service list — that list has drifted in both directions: it calls Mistral "Estimate" although Mistral publishes official uptime, and OpenRouter "Official" although it publishes none.

### Two deliberate behaviours in that gate

Both are silent failures that the **first draft of this fix introduced** and review caught:

- **Withholding a month-end value the Score didn't consume WARNS.** `scoreConfidence` comes from ONE read of `services:latest` on build day, so a status-page fetch that fails on that read makes a service which published uptime all month read `medium` and lose its figure. We still withhold (a displayed uptime beside a `/60` score is the contradiction this issue exists to remove — and that archived score is wrong too), but discarding a month-observed figure *silently* would be the very defect being fixed.
- **No score data at all → keep the month-end value.** `scoreSvc === undefined` means `services:latest` was unreadable; the daily snapshots stand on their own and there is nothing to contradict. Tying `officialUptime` to `scoreData` would let one parse failure erase every service's uptime from an archive the cron never rebuilds (it only builds when the entry is absent).

## Verification against production data

Running the fixed pipeline over the real June KV daily counters + live confidence:

```
service        archive(now)  -> corrected
  azureopenai         100  ->  None
  bedrock              97  ->  None
  characterai       99.58  ->  None
  elevenlabs        99.18  ->  None
  replicate         99.34  ->  None
  stability           100  ->  None

changed 6 / 41 services
```

The other **35 services keep their values** — no legitimate uptime is lost. All 6 fall out of layer 1 alone (no month-end value); the layer-2 gate is insurance that never fires on current data.

Gates: `npm run test:worker` 2410 passed (83 files) · `npm run typecheck:worker` 0 errors · `wrangler --dry-run` OK · `npm run lint:okf` clean. **Both layers ship a test that fails without them** (verified by reverting each in turn).

## Historical archives

Already-written archives keep the contaminated values and are corrected **out-of-band**. Do **not** use `/api/admin/rebuild-archive`: it is not idempotent (it re-snapshots `score` from the **current** `services:latest`), and since this gate reads that same current confidence, rebuilding a month whose service has *since* lost its source withholds the uptime it genuinely published. The `archive:{period}` KV entry is patched directly instead.

## Scope

`refs #951` — the report-side labelling (`aiwatch-reports`: derive the "Uptime Source" column and `buildWhy` from the data rather than the drifted `NO_PUBLIC_UPTIME` set) and the June archive correction follow.

## Deploy

Worker change → manual `npm run deploy:worker` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
