### PR TITLE
fix(ci): gate the OKF lint on docs PRs — they ran zero jobs (refs #961)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,69 @@
+name: Docs Lint
+
+# #961 — the OKF structural lint that guards `docs/reference/` was never gated on a docs change.
+#
+# `test.yml` sets `paths-ignore` for `docs/**` / `*.md` on BOTH its triggers, and `paths-ignore` is
+# evaluated at the WORKFLOW level — so a docs-only PR started no jobs at all. The lint
+# (`scripts/lint-okf-bundle.mjs`) only ever ran inside that workflow's `unit` job via
+# `npm run test:scripts`, i.e. on every PR that does NOT touch docs, and never on the ones that do.
+# Same shape as #877, where a conditional job let PR #871's CSP-hash drift ship green.
+#
+# Dropping `paths-ignore` from `test.yml` is the wrong fix: it would run the worker unit tests, tsc,
+# Playwright E2E and the bundle build on every one-line doc edit. That filter is doing its job. This
+# workflow instead fires on exactly the paths `test.yml` ignores, so a mixed code+docs PR triggers
+# both and every PR is gated by exactly the checks its diff needs.
+#
+# `lint-okf-bundle.mjs` imports only `node:fs` / `node:path` / `node:url`, so there is no `npm ci`
+# step — the job is a few seconds of runner time.
+#
+# ⚠️ DO NOT make `Docs Lint` a REQUIRED status check on `main`.
+# A workflow-level `paths:` filter means the workflow does not RUN on a code-only PR, so its check
+# context is never reported — and a required check that never reports blocks the merge forever.
+# (A job-level `if:` skip is different: it reports `skipped`, which satisfies a required check.)
+# `test.yml` carries the same shape via its `paths-ignore`, so this applies to its four jobs too.
+# As of 2026-07-09 `main` has NO required status checks, so the trap is latent, not live.
+# If you ever want these required, first move the path decision from the workflow trigger into the
+# job (always run the workflow; skip the lint step when no docs changed) — note that doing so
+# removes the `paths:` list that `scripts/workflow-paths-sync.test.mjs` asserts against, so that
+# guard would need rewriting too.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - '.github/**/*.md'
+      - 'scripts/lint-okf-bundle.mjs'      # the guard guards itself
+      - '.github/workflows/docs-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '*.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - '.github/**/*.md'
+      - 'scripts/lint-okf-bundle.mjs'
+      - '.github/workflows/docs-lint.yml'
+
+permissions:
+  contents: read
+
+# Mirrors test.yml: a new push on the same head_ref cancels the previous run instead of stacking.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  okf-lint:
+    name: OKF Bundle Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # Zero-dependency script (node: builtins only) — deliberately no `npm ci`.
+      # Checks: frontmatter integrity, unquoted-`#` truncation, dangling cross-links, index.md drift.
+      - run: node scripts/lint-okf-bundle.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ npm test           # Run Playwright E2E tests
 npm run test:src   # Run frontend unit tests (vitest, src/**/*.test.js + api/__tests__/*.test.ts incl. the CSP drift pin) — CI-gated via the always-on `Frontend Unit Tests` job (#877; the gap that let PR #871's vercel.json CSP-hash drift ship green)
 npm run test:worker # Run Worker unit tests (vitest)
 npm run typecheck:worker # tsc gate — full `tsc --noEmit`, fails on ANY type error across worker source incl tests (#533 Phase 4; two-pass: prod strict workers-types-only + tests with @types/node)
-npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders #541; lint-okf-bundle #891 — the docs/reference OKF structural lint, real-bundle assertion CI-gated)
-npm run lint:okf   # docs/reference OKF-bundle structural lint (frontmatter/#-truncation/dangling-link/index-drift) — same checks CI runs
+npm run test:scripts # node:test unit tests for scripts/*.mjs (e.g. verify-reminders #541; lint-okf-bundle #891 — incl. its real-bundle assertion). Runs in the `Test` workflow, which `paths-ignore`s docs — so it gates CODE PRs
+npm run lint:okf   # docs/reference OKF-bundle structural lint (frontmatter/#-truncation/dangling-link/index-drift) — gated on DOCS PRs by the separate `Docs Lint` workflow (#961; `test.yml`'s paths-ignore means a docs-only PR starts none of its jobs)
 
 ```
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -33,7 +33,10 @@ Read this index first, then load only the pages you need.
 - [Product constraints](product-constraints.md) — AI analysis, fallback gating, deploy/cron rules, CSP, PWA, Edge SSR surfaces.
 
 > **Structural health** (frontmatter integrity, unquoted-`#` truncation, dangling cross-links, index
-> drift) is enforced in CI on every PR by `scripts/lint-okf-bundle.mjs` (`npm run lint:okf`; the
-> `REAL docs/reference bundle` assertion in its test runs under `npm run test:scripts`). **Judgement
+> drift) is enforced in CI on every PR by `scripts/lint-okf-bundle.mjs` — on a **docs** PR by the
+> `Docs Lint` workflow (`.github/workflows/docs-lint.yml`, #961), and on a **code** PR by the
+> `REAL docs/reference bundle` assertion in its test, which runs under `npm run test:scripts` in
+> `test.yml`. The split exists because `test.yml` `paths-ignore`s `docs/**`, so a docs-only PR starts
+> none of its jobs (#961 — the lint was skipped exactly when docs changed). **Judgement
 > health** (contradictions, stale claims, whether cross-linking is *sufficient*) is a manual pass via
 > the `memory-lint` skill; findings are recorded in [log.md](log.md).

--- a/scripts/lint-okf-bundle.mjs
+++ b/scripts/lint-okf-bundle.mjs
@@ -5,8 +5,15 @@
 // history (see docs/reference/index.md). Nothing enforces that shape, so it silently drifts: a new
 // doc lands without frontmatter or without an index line, a rename leaves a dangling cross-link, or a
 // `description` carrying a bare `#N` gets truncated by YAML's inline-comment rule (the exact gotcha
-// hit in #891 Phase 1). This is the STRUCTURAL half of the `memory-lint` skill, run in CI on every PR
-// (`npm run test:scripts`) — catching drift the moment docs change instead of on a periodic sweep.
+// hit in #891 Phase 1). This is the STRUCTURAL half of the `memory-lint` skill — catching drift the
+// moment docs change instead of on a periodic sweep.
+//
+// CI wiring (#961): a DOCS PR is gated by `.github/workflows/docs-lint.yml`, which runs this file
+// directly (`node scripts/lint-okf-bundle.mjs`). A CODE PR is gated by the `REAL docs/reference
+// bundle` assertion in `lint-okf-bundle.test.mjs`, under `npm run test:scripts` in `test.yml`. Two
+// workflows because `test.yml` `paths-ignore`s `docs/**`, so a docs-only PR starts none of its jobs
+// — which is how this lint came to be skipped exactly when docs changed. `workflow-paths-sync.test.mjs`
+// pins the two path lists complementary.
 //
 // CHECKS (all structural / mechanical — no judgement calls):
 //   1. frontmatter integrity — every page has `type` + `title` + `description`; `type` is a known

--- a/scripts/workflow-paths-sync.test.mjs
+++ b/scripts/workflow-paths-sync.test.mjs
@@ -1,0 +1,199 @@
+// #961 — regression guard for the CI gap where a docs-only PR started NO jobs.
+//
+// `test.yml` sets `paths-ignore` at the WORKFLOW level, so a PR touching only those paths runs
+// none of its jobs — including the `unit` job that carries the OKF structural lint. The lint that
+// guards `docs/reference/` was therefore skipped exactly when `docs/reference/` changed.
+//
+// `docs-lint.yml` closes that hole by firing on precisely the paths `test.yml` ignores. The two
+// files must stay complementary: **every path `test.yml` ignores must be a path `docs-lint.yml`
+// watches**, or a doc path silently becomes ungated again. That invariant is what this file pins.
+//
+// A regex parser rather than a YAML dependency: the two blocks have a fixed, trivial shape, and the
+// parser itself is unit-tested against a synthetic fixture below.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const wf = (name) => readFileSync(join(repoRoot, '.github/workflows', name), 'utf8')
+
+/**
+ * Parse one YAML scalar — `'a'`, `"a"`, or bare `a` — stripping any trailing `# comment`.
+ * A quoted scalar must consume the whole item (bar a comment): otherwise an escaped-quote form
+ * like `- 'a''b.md'` would silently yield `a`. Throw instead — a wrong value here is invisible,
+ * and this parser exists so the guard cannot silently stop guarding.
+ */
+function scalar(raw, context) {
+  const quoted = raw.match(/^'([^']*)'/) ?? raw.match(/^"([^"]*)"/)
+  if (quoted) {
+    const rest = raw.slice(quoted[0].length).trim()
+    if (rest !== '' && !rest.startsWith('#')) {
+      throw new Error(`trailing text after quoted scalar in ${context}: ${JSON.stringify(raw)}`)
+    }
+    return quoted[1]
+  }
+  const bare = raw.match(/^([^\s#]+)/)
+  if (bare) return bare[1]
+  throw new Error(`unparseable YAML scalar in ${context}: ${JSON.stringify(raw)}`)
+}
+
+/**
+ * Collect the entries of a `paths:` / `paths-ignore:` list nested under an `on:` trigger.
+ * Returns [] when the trigger or the key is absent. Pure.
+ *
+ *   on:
+ *     pull_request:        <- trigger
+ *       paths-ignore:      <- key
+ *         - 'docs/**'      <- collected (quote style irrelevant; trailing `# comment` stripped)
+ *
+ * THROWS on a list item it cannot destructure. That is deliberate: an earlier version matched only
+ * single-quoted entries and `break`ed on anything else, so a single double-quoted path added to
+ * `test.yml` would truncate the parsed list and the sync assertion below would go GREEN while the
+ * new path was left ungated — the guard would silently stop guarding. Fail loud instead.
+ */
+export function pathsUnder(yaml, trigger, key) {
+  const lines = yaml.split('\n')
+  const triggerAt = lines.findIndex((l) => l.match(new RegExp(`^  ${trigger}:\\s*$`)))
+  if (triggerAt === -1) return []
+
+  const where = `${trigger}.${key}`
+  const out = []
+  let inKey = false
+
+  for (const line of lines.slice(triggerAt + 1)) {
+    if (/^\S/.test(line) || /^  \S/.test(line)) break // left the trigger block
+
+    const keyLine = line.match(new RegExp(`^    ${key}:(.*)$`))
+    if (keyLine) {
+      const inline = keyLine[1].trim()
+      if (inline === '') {
+        inKey = true // block style — entries follow
+        continue
+      }
+      const flow = inline.match(/^\[(.*)\]$/) // flow style — `paths: ['a', "b", c]`
+      if (!flow) throw new Error(`unrecognised ${where} value: ${JSON.stringify(inline)}`)
+      return flow[1]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => scalar(s, where))
+    }
+
+    if (!inKey) continue
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) continue
+    const item = line.match(/^\s+- (.*)$/)
+    if (item) {
+      out.push(scalar(item[1].trim(), where))
+      continue
+    }
+    if (/^    \S/.test(line)) break // sibling key at the trigger's indent — list ended
+    throw new Error(`unexpected line inside ${where}: ${JSON.stringify(line)}`)
+  }
+  return out
+}
+
+test('pathsUnder parses a nested paths list and strips trailing comments', () => {
+  const fixture = [
+    'on:',
+    '  push:',
+    '    branches: [main]',
+    '    paths-ignore:',
+    "      - 'a.md'",
+    "      - 'docs/**'   # inline comment",
+    '  pull_request:',
+    '    paths:',
+    "      - 'b.md'",
+    'jobs:',
+  ].join('\n')
+
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths-ignore'), ['a.md', 'docs/**'])
+  assert.deepEqual(pathsUnder(fixture, 'pull_request', 'paths'), ['b.md'])
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths'), [], 'absent key → []')
+  assert.deepEqual(pathsUnder(fixture, 'schedule', 'paths'), [], 'absent trigger → []')
+})
+
+test('pathsUnder does not leak entries across sibling triggers', () => {
+  const fixture = ['on:', '  push:', '    paths:', "      - 'x.md'", '  pull_request:', '    paths:', "      - 'y.md'"].join('\n')
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths'), ['x.md'])
+})
+
+test('pathsUnder accepts every quote style, blank lines and comment lines', () => {
+  const fixture = [
+    'on:',
+    '  push:',
+    '    paths-ignore:',
+    "      - 'single.md'",
+    '      - "double.md"',
+    '      - bare.md',
+    '',
+    '      # a standalone comment',
+    "      - 'docs/**'",
+    'jobs:',
+  ].join('\n')
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths-ignore'), ['single.md', 'double.md', 'bare.md', 'docs/**'])
+})
+
+test('pathsUnder reads flow-style lists', () => {
+  const fixture = ['on:', '  push:', "    paths-ignore: ['a.md', \"b.md\", c.md]", 'jobs:'].join('\n')
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths-ignore'), ['a.md', 'b.md', 'c.md'])
+})
+
+// The regression this parser exists to prevent: a MIXED-quote edit must never truncate the list.
+// The old single-quote-only matcher `break`ed on `- "assets/**"`, so `ignored` lost every entry
+// after it and the sync assertion passed while `assets/**` ran no CI at all.
+test('a double-quoted entry does not truncate the list (guard cannot silently stop guarding)', () => {
+  const fixture = [
+    'on:',
+    '  pull_request:',
+    '    paths-ignore:',
+    "      - '*.md'",
+    '      - "assets/**"',
+    "      - 'docs/**'",
+    'jobs:',
+  ].join('\n')
+  assert.deepEqual(pathsUnder(fixture, 'pull_request', 'paths-ignore'), ['*.md', 'assets/**', 'docs/**'])
+})
+
+test('pathsUnder throws on a list item it cannot destructure, rather than dropping it', () => {
+  const fixture = ['on:', '  push:', '    paths-ignore:', "      - 'ok.md'", '      - # nothing here', 'jobs:'].join('\n')
+  assert.throws(() => pathsUnder(fixture, 'push', 'paths-ignore'), /unparseable YAML scalar/)
+})
+
+// The only case where the parser could return a WRONG value instead of throwing: YAML's escaped
+// single-quote (`''`). Real YAML reads `'a''b.md'` as `a'b.md`; a naive match stops at the second
+// quote and yields `a`. Silently wrong is the failure mode this whole file exists to prevent.
+test('pathsUnder throws on an escaped-quote scalar rather than silently truncating it', () => {
+  const fixture = ['on:', '  push:', '    paths-ignore:', "      - 'a''b.md'", 'jobs:'].join('\n')
+  assert.throws(() => pathsUnder(fixture, 'push', 'paths-ignore'), /trailing text after quoted scalar/)
+})
+
+test('pathsUnder still accepts a legitimate trailing comment after a quoted scalar', () => {
+  const fixture = ['on:', '  push:', '    paths:', "      - 'docs/**'    # the bundle", 'jobs:'].join('\n')
+  assert.deepEqual(pathsUnder(fixture, 'push', 'paths'), ['docs/**'])
+})
+
+for (const trigger of ['push', 'pull_request']) {
+  test(`every path test.yml ignores on ${trigger} is watched by docs-lint.yml (#961)`, () => {
+    const ignored = pathsUnder(wf('test.yml'), trigger, 'paths-ignore')
+    const watched = pathsUnder(wf('docs-lint.yml'), trigger, 'paths')
+
+    assert.ok(ignored.length > 0, `test.yml must still declare paths-ignore on ${trigger}`)
+
+    const ungated = ignored.filter((p) => !watched.includes(p))
+    assert.deepEqual(
+      ungated,
+      [],
+      `these paths run NO CI: test.yml ignores them and docs-lint.yml does not watch them → ${ungated.join(', ')}`,
+    )
+  })
+}
+
+test('docs-lint.yml guards its own inputs — the lint script and itself', () => {
+  const watched = pathsUnder(wf('docs-lint.yml'), 'pull_request', 'paths')
+  assert.ok(watched.includes('scripts/lint-okf-bundle.mjs'), 'a change to the lint must re-run the lint')
+  assert.ok(watched.includes('.github/workflows/docs-lint.yml'), 'a change to the guard must re-run the guard')
+})


### PR DESCRIPTION
Refs #961.

## Problem

`test.yml` sets `paths-ignore` for `*.md` / `CLAUDE.md` / `docs/**` / `.github/**/*.md` on **both** its `push` and `pull_request` triggers. `paths-ignore` is evaluated at the **workflow** level, so a docs-only PR starts **no jobs at all** — including the `unit` job that carries `npm run test:scripts`, the only place the OKF structural lint (`scripts/lint-okf-bundle.mjs`) ever ran.

**The lint that guards `docs/reference/` was skipped exactly when `docs/reference/` changed.**

Confirmed on PR #959 (docs-only, two new bundle pages): `gh run list` returned zero workflow runs, and the only checks were Vercel's. That PR carried dangling `](docs/reference/…)` cross-links and two pages missing from `index.md` — both caught by running the lint **by hand**, not by CI.

Same shape as #877, where a conditional job let PR #871's `vercel.json` CSP-hash drift ship green.

## Fix

A new `.github/workflows/docs-lint.yml` firing on exactly the paths `test.yml` ignores (plus the lint script and the workflow file itself, so the guard guards itself).

Dropping `paths-ignore` from `test.yml` would run the worker unit tests, `tsc`, Playwright E2E and the bundle build on every one-line doc edit — that filter earns its keep. A mixed code+docs PR now triggers **both** workflows. The job is checkout → `node scripts/lint-okf-bundle.mjs`; **no `npm ci`**, since the script imports only `node:` builtins.

## The regression guard, and the bug in the guard

`scripts/workflow-paths-sync.test.mjs` pins the invariant the fix rests on: *every path `test.yml` ignores must be a path `docs-lint.yml` watches.*

Review caught that its first parser matched only single-quoted entries and `break`ed on anything else. So adding `- "assets/**"` to `test.yml` would **truncate the parsed list and the guard would pass green while that path ran no CI** — a regression test that silently stops testing, which is the same failure mode this PR exists to fix.

The parser now accepts single-quoted, double-quoted, bare and flow-style entries, and **throws** on an item it cannot destructure rather than dropping it. It also throws on YAML's escaped-quote form (`'a''b.md'`), the one remaining case where it could return a silently-wrong value.

Both regressions are **mutation-verified**: removing `docs/**` from `docs-lint.yml`, and injecting a double-quoted path into `test.yml`, each make the guard fail loud.

## Also corrected

Three claims that were false the moment they were written:

- `CLAUDE.md` — "lint-okf-bundle … real-bundle assertion **CI-gated**" and "**same checks CI runs**"
- `docs/reference/index.md` — "**enforced in CI on every PR**"
- `scripts/lint-okf-bundle.mjs` header — "run in CI on every PR (`npm run test:scripts`)"

All three were true for code PRs and false for docs PRs. They now name the two-workflow split.

## ⚠️ `Docs Lint` must never be a required status check

A workflow-level `paths:` filter means the workflow does **not run** on a code-only PR, so its check context is never reported — and a required check that never reports blocks the merge forever. (A job-level `if:` skip is different: it reports `skipped`, which satisfies a required check.) `test.yml` already carries the same shape via `paths-ignore`.

`main` currently has **no** required status checks, so this is latent, not live. Recorded in the workflow header and in #961's scope. Making these required would first require moving the path decision from the trigger into the job — which removes the `paths:` list the guard asserts against.

## `refs`, not `closes`

"A docs-only PR shows the check" is only observable once this PR is pushed. Verified on this PR before merge.

## Verification

- `npm run test:scripts` — 120 pass, 0 fail
- `npm run lint:okf` — 17 pages, 0 findings
- workflow YAML cross-checked against a real YAML parser (`ruby -ryaml`); `ignored ⊆ watched` holds on both triggers
- two review rounds, converged to 0 Critical / 0 Important
- #671 (`actions/*@v4` → Node 24) must now also cover this new workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)