### PR TITLE
chore(worktree): copy the Vercel project link into worktrees so `vercel dev` stops minting throwaway projects

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,7 +1,21 @@
 # Gitignored local config copied into every new git worktree (Claude Code `--worktree`,
 # subagent `isolation: worktree`, desktop parallel sessions). Gitignore syntax; only files
 # that match AND are gitignored are copied, so tracked files are never duplicated.
+# Read from the MAIN checkout's copy of this file, so an edit here only takes effect once
+# it is merged and pulled into main.
 # See docs/reference/parallel-agents.md.
 .env
 .env.local
 .dev.vars
+
+# Vercel project link. Without it `vercel dev` (required to verify /intro, /is-*-down and the
+# other Edge SSR pages locally) sees no link, and `--yes` silently CREATES a new Vercel project
+# named after the worktree directory. Eight such throwaway projects had accumulated, one per
+# worktree that ever ran the Edge dev server. Copying the link points every worktree at the same
+# project the main checkout uses. Only `project.json` — never the `.vercel` build cache.
+#
+# `aiwatch-dev` is the PRODUCTION project despite its name (main merges auto-deploy to it), so a
+# linked worktree could `vercel deploy --prod` straight to prod. That is not a new hazard — the
+# main checkout is linked to the same project and already carries it — and this repo never ships
+# the frontend via the CLI (`git push origin main` does). Worktrees just reach parity with main.
+.vercel/project.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,11 @@ session is active → branch in a NEW worktree, never in-place on the shared mai
 session can `git checkout` it out from under you, dragging its uncommitted WIP into your diff). **Launched from the VS Code
 extension button** (no `--worktree` flag)? Say **"work in a worktree"** right after the session
 starts — Claude relocates via the `EnterWorktree` tool (the Desktop app auto-creates one per
-session; the extension does not). `.worktreeinclude` copies `.env`/`.dev.vars` into each; run
+session; the extension does not). `.worktreeinclude` copies `.env`/`.dev.vars`/`.vercel/project.json`
+into a `--worktree`/`EnterWorktree` worktree (a **subagent** worktree gets only the top-level entries
+— no `worker/.dev.vars`, no Vercel link); it is read from the MAIN checkout, so an edit to it only
+takes effect once merged. Without the Vercel link `vercel dev --yes` silently creates a throwaway
+project per worktree. Run
 `npm install` per worktree; offset dev-server ports by `+100·N` per slot; **deployment stays
 sequential** (single prod Worker/KV). Full workflow + launch-method table + port table:
 **[docs/reference/parallel-agents.md](docs/reference/parallel-agents.md)**.

--- a/docs/reference/parallel-agents.md
+++ b/docs/reference/parallel-agents.md
@@ -72,12 +72,43 @@ git worktree remove ../aiwatch-wt-852                                # when done
 A worktree is a **fresh checkout**, so it starts without dependencies or gitignored local
 config.
 
-1. **Local env** — handled automatically. [`.worktreeinclude`](../../.worktreeinclude) copies
-   `.env`, `.env.local`, and `.dev.vars` into every Claude-Code-created worktree (gitignore
-   syntax; only gitignored matches are copied). Manual `git worktree add` does **not** run
-   this — copy them yourself.
+1. **Local env** — handled automatically. [`.worktreeinclude`](../../.worktreeinclude) lists the
+   gitignored local config to copy into a new worktree: `.env`, `.env.local`, `.dev.vars`, and
+   `.vercel/project.json` (gitignore syntax; only gitignored matches are copied). **Which of those
+   you actually get depends on the copier** — see below; a `--worktree` / `EnterWorktree` worktree
+   gets all four, a subagent worktree gets only the top-level two. Manual `git worktree add` copies
+   **nothing** — do it yourself.
+
+   There are **two copiers** and they do not behave the same. All of this was established by probe,
+   not assumed:
+   - Common to both: **the list and the source files are read from the MAIN checkout**, not from the
+     worktree you happen to be sitting in. So an edit to `.worktreeinclude` only takes effect once it
+     is merged and pulled into main — you cannot test a new entry from inside a worktree.
+   - **`--worktree` / `EnterWorktree`** — patterns match at **any depth** and the copier **creates
+     missing directories**: `.dev.vars` picks up `worker/.dev.vars`, and `.vercel/project.json` lands
+     even though a fresh worktree has no `.vercel/`.
+   - **Subagent (`isolation: worktree`)** — **top-level matches only**. It gets `.env` and
+     `.env.local` but *neither* nested entry, so no `worker/.dev.vars` and no `.vercel/project.json`.
+     A subagent worktree can therefore run neither the local Worker nor `vercel dev`, and the
+     Vercel-link fix below does not reach it.
 2. **Dependencies** — **not** shared. Run `npm install` in each new worktree (`node_modules`
    and Python venvs are per-directory).
+
+> **Why `.vercel/project.json` is on the list.** Verifying an Edge SSR page (`/intro`,
+> `/is-*-down`, `/methodology`, …) needs `vercel dev`. In an unlinked worktree `vercel dev --yes`
+> does not fail — it silently **creates a new Vercel project named after the worktree directory**
+> and links to it. Eight such empty throwaway projects had accumulated (`fix-940-…`, `fix-926-…`,
+> `aiwatch-951`, …), one per worktree that ever ran the Edge dev server. Copying the link points
+> every worktree at the same project the main checkout uses. Only `project.json` is copied — never
+> the `.vercel` build cache (which also holds `README.txt` and build output).
+>
+> The file carries `projectId` / `orgId` / `projectName` and **no credentials** — Vercel CLI auth
+> lives in the global `~/.vercel` store — and `.vercel` is gitignored, so a copied link can never be
+> committed. Note that **`aiwatch-dev` is the production project despite its name**: main merges
+> auto-deploy to it. So a linked worktree could `vercel deploy --prod` straight to production. That
+> is not a *new* hazard — the main checkout is linked to the same project and already carries it,
+> and the frontend never ships via the CLI (`git push origin main` does) — worktrees simply reach
+> parity with main.
 
 ## Port-offset convention (concurrent dev servers)
 


### PR DESCRIPTION
## The bug

Verifying an Edge SSR page (`/intro`, `/is-*-down`, `/methodology`) locally requires `vercel dev`. A
git worktree has no `.vercel/project.json`, and **`vercel dev --yes` does not fail on that** — it
silently *creates a new Vercel project named after the worktree directory* and links to it.

Ten such empty projects had accumulated in the account, one per worktree that ever ran the Edge dev
server:

```
fix-940-xai-region-collapse   fix-926-isdown-multi-ai-analysis   aiwatch-951
feat-888-ext-cta-url          feat-888-install-cta               fix-911-instatus-en-locale
fix-900-recovery-est          fix-vercel-function-limit          feat-837-extension-privacy
fix-973-region-docs-url       ← created while verifying #973, which is how this surfaced
```

All ten had zero deployments and no domains; they have been deleted. This PR stops the next one from
appearing.

## The fix

Add `.vercel/project.json` to `.worktreeinclude`, so every worktree inherits the main checkout's link
instead of minting its own project. Only the link file — never the `.vercel` build cache (which also
holds `README.txt` and build output).

**Safety.** `project.json` carries `projectId` / `orgId` / `projectName` and **no credentials** —
Vercel CLI auth lives in the global `~/.vercel` store. `.vercel` is gitignored (`.gitignore:46`), so a
copied link can never be committed.

**One thing worth saying out loud:** `aiwatch-dev` is the **production** project despite its name —
main merges auto-deploy to it. So a linked worktree could `vercel deploy --prod` straight to
production. That is *not a new hazard*: the main checkout is linked to the same project and already
carries it, and this repo ships the frontend via `git push origin main`, never the CLI. Worktrees
simply reach parity with main. Both `.worktreeinclude` and the reference doc now state this.

## Three copier behaviours, none previously written down

Each established by probe rather than assumed — and the first one is why this change is awkward to
verify:

1. **The file list and the source files are read from the MAIN checkout**, not from the worktree you
   are sitting in. An edit to `.worktreeinclude` therefore only takes effect once merged and pulled.
   You cannot test a new entry from inside a worktree — the obvious verification path is a dead end.
2. **`--worktree` / `EnterWorktree` matches patterns at any depth and creates missing directories.**
   `.dev.vars` has been silently picking up `worker/.dev.vars` all along, and `.vercel/project.json`
   lands even though a fresh worktree has no `.vercel/`. This is what makes the fix work at all.
3. **Subagent (`isolation: worktree`) worktrees copy top-level matches only.** They get `.env` and
   `.env.local` but neither nested entry — no `worker/.dev.vars`, no Vercel link. A subagent worktree
   can run neither the local Worker nor `vercel dev`, and **this fix does not reach them.**

## Verification

Because of (1), this could not be verified from a worktree. Instead: temporarily appended the line to
the **main** checkout's `.worktreeinclude`, created a harness worktree, and confirmed
`.vercel/project.json` was copied — with the `.vercel/` directory created for it — alongside the
controls (`.env` top-level, `worker/.dev.vars` nested-existing-dir). Then reverted main, verified by
`sha256` match and a clean `git status`, and removed the probe worktree.

`npm run lint:okf` passes (docs bundle). `CLAUDE.md` stays under the 40k guideline (36.8k).

## Review

Three rounds → converged at 0 Critical/Important. Every finding was in my *prose*, not the config:
round 1 caught that I had assumed `aiwatch-dev` was a dev project without checking (it is production);
round 2 caught that I described two different copiers as "three behaviours of the copier", reading as a
contradiction; round 3 caught that the summary line still promised the link to "every
Claude-Code-created worktree" while the paragraph below excluded subagent worktrees — the exact trap
the doc exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
