### PR TITLE
fix(sidebar): mobile drawer couldn't scroll — the service list collapsed to 0px (closes #978)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,8 @@ All colors are CSS custom properties defined in `src/index.css`. **Never use har
 
 Theme switching: add `data-theme="light"` to `<html>` — CSS variables remap automatically. Default is dark.
 
+**Footgun — Tailwind margin/padding utilities silently compute to `0`.** `src/index.css` declares an *unlayered* `* { margin: 0; padding: 0 }` reset, and unlayered rules outrank **any** `@layer`ed rule — which is where Tailwind v4 emits its utilities. So `pt-[48px]`, `py-[7px]`, `mt-auto`, … apply to nothing, on every element (not just buttons). Only margin/padding are affected; `height`/`top`/`flex`/`gap`/`overflow` utilities work normally. Use an inline `style` for spacing, or express the layout with a non-reset property. This has bitten twice: the sidebar's inline `navItemStyle`, and #978 (the mobile drawer's dead `pt-[48px]` + an inert `mt-auto` footer).
+
 ### i18n
 `src/locales/ko.js` and `en.js` export flat `{ 'dot.key': 'string' }` maps (default exports).
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -68,9 +68,13 @@ export default function Layout({
             onClick={onSidebarClose}
             aria-hidden="true"
           />
+          {/* Sits BELOW the topbar rather than under a `pt-[48px]` inset: index.css's unlayered
+              `* { padding: 0 }` reset outranks Tailwind's layered padding utilities, so that
+              padding never applied and the drawer painted over the topbar (#978).
+              `dvh` so the drawer tracks the collapsing mobile URL bar. */}
           <aside
-            className="fixed left-0 top-0 z-[80] h-full w-[220px] pt-[48px]
-                       overflow-y-auto overflow-x-hidden md:hidden
+            className="fixed left-0 top-[48px] z-[80] h-[calc(100dvh-48px)] w-[220px]
+                       overflow-y-auto overflow-x-hidden overscroll-contain md:hidden
                        bg-[var(--bg1)] border-r border-[var(--border)]"
           >
             {sidebar}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -204,12 +204,19 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
     , 0)
   }, [services])
 
+  // h-full only from md up. Pinning the height at every breakpoint made the content exactly fill the
+  // mobile drawer, so the drawer's own overflow-y-auto never engaged (#978). Below md the content
+  // sizes itself and the drawer scrolls. (Don't reach for `min-h-full` here to bottom-pin the footer
+  // on a sparse list: the footer's `mt-auto` is inert — the unlayered `* { margin: 0 }` reset kills
+  // it — so that only adds dead space below the footer. Desktop pins it via the flex-1 list.)
   return (
-    <div className="flex flex-col h-full" style={{ padding: '16px 0' }}>
+    <div className="flex flex-col md:h-full" style={{ padding: '16px 0' }}>
 
       {/* ── Dashboard section ── */}
-      {/* NOTE: inline styles used because Tailwind v4 fails to apply certain utilities
-           (py-[7px], px-[8px], gap-[8px]) on button elements due to base layer reset. */}
+      {/* NOTE: inline styles used because index.css's unlayered `* { margin: 0; padding: 0 }` reset
+           outranks Tailwind v4's *layered* utilities, so py-[7px]/px-[8px] compute to 0 — on every
+           element, not just buttons. It is what silently nullified the mobile drawer's `pt-[48px]`
+           too (#978). gap-[8px] is kept inline alongside them for consistency. */}
       <nav style={{ padding: '0 12px', marginBottom: '8px' }} aria-label="Dashboard">
         <div style={sectionTitleStyle}>{t('nav.dashboard')}</div>
         {DASHBOARD_ITEMS.map((item) => {
@@ -346,10 +353,15 @@ export default function Sidebar({ visibleServiceIds, onNavigate }) {
       </div>
 
       {/* ── Filtered service list — single flat list in #658 category order (#676).
-           flex-1 min-h-0 so the list takes the remaining height and scrolls WITHIN itself
-           (not the whole sidebar), keeping the footer pinned + always-visible regardless of
-           how many services are listed (#601 — broke at 39 services without this). ── */}
-      <nav className="flex-1 min-h-0 overflow-y-auto" style={{ padding: '0 12px' }} aria-label={t('nav.services')}>
+           From md up, flex-1 so the list takes the remaining height and scrolls WITHIN itself
+           (not the whole sidebar), keeping the footer pinned regardless of how many services are
+           listed (#601 — broke at 39 services without this).
+           Being the only flexible child, it also absorbed the ENTIRE height shortfall on a short
+           viewport and collapsed to 0px, hiding every service (#978). The 160px floor (~5 rows)
+           replaces the old `min-h-0` so it can no longer vanish: once the sidebar can't fit, the
+           overflow moves out to the sidebar's own scroll container. Below md there is no floor to
+           enforce — the mobile drawer scrolls as a whole. ── */}
+      <nav className="md:flex-1 md:min-h-[160px] md:overflow-y-auto" style={{ padding: '0 12px' }} aria-label={t('nav.services')}>
         {orderedServices.map((svc) => (
           <ServiceNavItem key={svc.id} svc={svc} page={page} setPage={setPage} onNavigate={onNavigate} />
         ))}

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -167,6 +167,56 @@ test.describe('Mobile viewport', () => {
     await expect(mobileSidebar).toHaveCount(0)
   })
 
+  // #978 — the Dashboard nav grew (methodology #673, badges #805, Claude Code section #920) until
+  // nav + filter + footer alone exceeded a short mobile viewport. The drawer could not scroll (its
+  // child was pinned to `h-full`), so the only flexible child — the service list — absorbed the whole
+  // shortfall and collapsed to 0px, leaving all 43 services unreachable. Assert the drawer scrolls as
+  // a whole and the list keeps its height. A 600px-tall viewport is what a 844px phone actually shows
+  // once browser chrome is subtracted.
+  test('#978 — mobile sidebar scrolls as a whole; the service list never collapses', async ({ page }) => {
+    // Pin the service list so the assertion measures the layout, not whatever prod data returns.
+    const mock = { json: { services: [
+      { id: 'claude', category: 'api', name: 'Claude API', provider: 'Anthropic', status: 'operational', latency: 300, uptime30d: 99.99, incidents: [] },
+      { id: 'openai', category: 'api', name: 'OpenAI API', provider: 'OpenAI', status: 'operational', latency: 250, uptime30d: 99.95, incidents: [] },
+      { id: 'chatgpt', category: 'apps', name: 'ChatGPT', provider: 'OpenAI', status: 'operational', latency: null, uptime30d: 99.9, incidents: [] },
+    ], lastUpdated: new Date().toISOString() } }
+    // usePolling hits /api/status/cached first, then /api/status — both need the fixture.
+    await page.route('**/api/status**', (route) => route.fulfill(mock))
+    await page.route('**/api/status/cached', (route) => route.fulfill(mock))
+    await page.setViewportSize({ width: 375, height: 600 })
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    await page.locator('header button').first().click()
+    const sidebar = page.locator('aside.md\\:hidden')
+    await expect(sidebar).toBeVisible()
+
+    // The drawer sits below the 48px topbar. `pt-[48px]` silently computed to 0 because the
+    // unlayered `* { padding: 0 }` reset in index.css outranks Tailwind's layered utilities.
+    expect((await sidebar.boundingBox()).y).toBeCloseTo(48, 0)
+
+    const list = sidebar.getByRole('navigation', { name: /Services|서비스/ })
+    // The collapse this test guards: the list used to be exactly 0px tall here.
+    expect((await list.boundingBox()).height).toBeGreaterThan(0)
+
+    // Content taller than the drawer → the drawer itself scrolls (it used to be pinned to h-full).
+    const scrollable = await sidebar.evaluate((el) => el.scrollHeight > el.clientHeight)
+    expect(scrollable).toBe(true)
+
+    // Both the bottom-most filter chip and the last service are reachable by scrolling.
+    const lastChip = sidebar.getByRole('button', { name: /AI Apps|AI 앱/ })
+    await lastChip.scrollIntoViewIfNeeded()
+    await expect(lastChip).toBeInViewport()
+
+    // usePolling's mergeWithMock overlays the fetched payload onto the full fixture service set, so
+    // the row count is stable at 43 regardless of what the fetch returned.
+    const rows = list.locator('button')
+    expect(await rows.count()).toBeGreaterThan(10)
+    const lastService = rows.last()
+    await lastService.scrollIntoViewIfNeeded()
+    await expect(lastService).toBeInViewport()
+  })
+
   // #817 — the score-card header's coverage notice (a recently-added <30d service shows
   // "Building data (<30 days) — not yet ranked") used to overrun into the large score
   // number on narrow widths because the left label group could not wrap/shrink and the

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -61,4 +61,57 @@ test.describe('Sidebar navigation', () => {
     expect(idx('Claude API')).toBeLessThan(idx('Claude Code'))
     expect(idx('Claude Code')).toBeLessThan(idx('ChatGPT'))
   })
+
+  // #978 made the MOBILE drawer scroll as a whole. With room to spare the desktop sidebar keeps the
+  // opposite contract (#601) — footer pinned, service list scrolling within itself — so guard that
+  // the `md:`-gating of `h-full` / `flex-1` didn't leak across the 768px breakpoint.
+  test('#978 — roomy desktop sidebar keeps its pinned footer and inner-scrolling list', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 1000 })
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    const sidebar = page.locator('aside').first()
+    const serviceNav = sidebar.getByRole('navigation', { name: /Services|서비스/ })
+    await expect(serviceNav).toBeVisible()
+
+    // The list — not the sidebar — is the scroll container. Were the mobile whole-drawer scroll to
+    // leak past `md:`, the sidebar would overflow and the list would stop scrolling internally.
+    expect(await sidebar.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(false)
+    expect(await serviceNav.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true)
+
+    // Footer stays pinned and visible without scrolling anything.
+    await expect(sidebar.getByText(/aiwatch\.dev · v/)).toBeInViewport()
+  })
+
+  // #978 — the desktop half of the same collapse. Once the nav grew (#673/#805/#920), nav + filter
+  // + footer left the flex-1 list with a few pixels at best — zero in the locales with the tallest
+  // nav — so a short desktop window showed no usable service list. The 160px floor keeps the list
+  // present and pushes the overflow out to the sidebar's own scroll container.
+  //
+  // Sets its own viewport rather than leaning on this file's 1280x720 default: the collapse depends
+  // on the nav's rendered height, so a test that must overflow should say so at the test site.
+  test('#978 — short desktop window: the service list never collapses and the footer stays reachable', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 640 })
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    const sidebar = page.locator('aside').first()
+    const serviceNav = sidebar.getByRole('navigation', { name: /Services|서비스/ })
+
+    // Used to be 0 here. The floor is 160px; assert against it rather than a bare `> 0` so a
+    // future regression that leaves a sliver of a row still fails.
+    expect((await serviceNav.boundingBox()).height).toBeGreaterThanOrEqual(160)
+
+    // The sidebar itself now scrolls, so everything below the tall nav is reachable. At this height
+    // the list starts below the fold, so "reachable" — not "already on screen" — is the contract.
+    expect(await sidebar.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true)
+
+    const firstService = serviceNav.locator('button').first()
+    await firstService.scrollIntoViewIfNeeded()
+    await expect(firstService).toBeInViewport()
+
+    const footer = sidebar.getByText(/aiwatch\.dev · v/)
+    await footer.scrollIntoViewIfNeeded()
+    await expect(footer).toBeInViewport()
+  })
 })


### PR DESCRIPTION
## Problem

On mobile the sidebar drawer could not scroll, so the category filter chips and the entire 43-service list were unreachable — you could not select a service at all. The same collapse also hit the **desktop** sidebar on short windows (a 1280×720 window — the e2e suite's own default — showed no usable service list).

## Root cause

The mobile overlay `<aside>` is `overflow-y-auto`, but the `Sidebar` root was `h-full`: its content was always pinned to exactly the drawer's height, so the drawer's scroll never engaged. The only flexible child, the `flex-1 min-h-0` service list, then absorbed the entire height shortfall and shrank to **0px**.

Measured at 390px wide (local worker, real data, 43 services):

| Sidebar height | Service list | Category filter | Max scroll |
|---|---|---|---|
| 844px | 204px | visible | 0px |
| 700px | 60px | visible | 0px |
| 640px | **0px** | visible | 0px |
| 600px | **0px** | clipped at the fold | 23px |
| ≤560px | **0px** | **not visible** | 23px |

The "inner scroll + pinned footer" model came from #601, sized for a desktop sidebar whose nav comfortably fit. The nav has since grown — methodology (#673), badges (#805), the Claude Code section (#920) — to 416px, so nav + filter + footer alone now exceed a short viewport at *both* breakpoints.

## Changes

- **`Sidebar` root** `h-full` → `md:h-full` — the mobile drawer scrolls as a whole.
- **Service list** `flex-1 min-h-0` → `md:flex-1 md:min-h-[160px]` — the 160px floor (~5 rows) stops the desktop collapse and pushes overflow out to the sidebar's own scroll container. Roomy desktop keeps the #601 contract unchanged (footer pinned, list scrolls internally).
- **Mobile aside** `top-0 pt-[48px]` → `top-[48px] h-[calc(100dvh-48px)]` + `overscroll-contain`.

That `pt-[48px]` computed to `padding-top: 0px`: `index.css`'s **unlayered** `* { margin: 0; padding: 0 }` reset outranks Tailwind v4's **layered** utilities. The drawer had been painting over the fixed topbar. `dvh` tracks the collapsing mobile URL bar (per the `modern-web-guidance` css-layout guide, which also names this exact anti-pattern: *"Don't size both the container and its children to fill each other"*).

## Verification

- Measured before/after in a browser at 390×600 / 390×900 and 1280×{620,720,800,1000} against the local worker (real data). After the fix: 1000px → no outer scroll, footer pinned; 800/720/620px → list holds at 160px, sidebar scrolls 65/145/245px.
- In-browser confirmation by the maintainer on both mobile and desktop.
- `npm run build` clean · `npm run lint` 0 errors · `npm run test:src` 809 pass · full `npm test` **146 pass**.

### Tests

Three regression tests. The two that catch the bugs were confirmed to **fail against the pre-fix code** (mobile: drawer `y` 0 ≠ 48, then list height 0; desktop: list height 0 < 160). The third ("roomy desktop") passes on both — it guards the `md:` gating against leaking across the 768px breakpoint.

`dvh` and `overscroll-contain` are not observable in Playwright; they were verified manually, not in CI.

## Notes

- Documents the reset footgun in CLAUDE.md's Design System section — it has now bitten twice.
- The footer's `mt-auto` is **inert** for the same reason (computes to `margin-top: 0`). Harmless — desktop pins the footer via the `flex-1` list, not that margin — so it is left in place and recorded in a comment rather than turned into a behavior change. This is also why `min-h-full` is deliberately *not* used to bottom-pin the mobile footer: it would only add dead space below it.

closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
