### PR TITLE
docs(worktree): retract the false "subagent worktrees copy only top-level entries" claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,11 +149,11 @@ session is active → branch in a NEW worktree, never in-place on the shared mai
 session can `git checkout` it out from under you, dragging its uncommitted WIP into your diff). **Launched from the VS Code
 extension button** (no `--worktree` flag)? Say **"work in a worktree"** right after the session
 starts — Claude relocates via the `EnterWorktree` tool (the Desktop app auto-creates one per
-session; the extension does not). `.worktreeinclude` copies `.env`/`.dev.vars`/`.vercel/project.json`
-into a `--worktree`/`EnterWorktree` worktree (a **subagent** worktree gets only the top-level entries
-— no `worker/.dev.vars`, no Vercel link); it is read from the MAIN checkout, so an edit to it only
-takes effect once merged. Without the Vercel link `vercel dev --yes` silently creates a throwaway
-project per worktree. Run
+session; the extension does not). `.worktreeinclude` copies `.env`/`.env.local`/`.dev.vars`/`.vercel/project.json`
+into every Claude-Code-created worktree (`--worktree`/`EnterWorktree` **and** subagent
+`isolation: worktree`), matching at any depth (`.dev.vars` → `worker/.dev.vars`) and creating missing
+dirs; it is read from the MAIN checkout, so an edit to it only takes effect once merged. Without the
+Vercel link `vercel dev --yes` silently creates a throwaway project per worktree. Run
 `npm install` per worktree; offset dev-server ports by `+100·N` per slot; **deployment stays
 sequential** (single prod Worker/KV). Full workflow + launch-method table + port table:
 **[docs/reference/parallel-agents.md](docs/reference/parallel-agents.md)**.

--- a/docs/reference/parallel-agents.md
+++ b/docs/reference/parallel-agents.md
@@ -73,24 +73,26 @@ A worktree is a **fresh checkout**, so it starts without dependencies or gitigno
 config.
 
 1. **Local env** — handled automatically. [`.worktreeinclude`](../../.worktreeinclude) lists the
-   gitignored local config to copy into a new worktree: `.env`, `.env.local`, `.dev.vars`, and
-   `.vercel/project.json` (gitignore syntax; only gitignored matches are copied). **Which of those
-   you actually get depends on the copier** — see below; a `--worktree` / `EnterWorktree` worktree
-   gets all four, a subagent worktree gets only the top-level two. Manual `git worktree add` copies
-   **nothing** — do it yourself.
+   gitignored local config copied into every Claude-Code-created worktree: `.env`, `.env.local`,
+   `.dev.vars`, and `.vercel/project.json` (gitignore syntax; only gitignored matches are copied).
+   Both copiers — `--worktree` / `EnterWorktree` **and** subagent `isolation: worktree` — copy all
+   four. Manual `git worktree add` copies **nothing**; do it yourself.
 
-   There are **two copiers** and they do not behave the same. All of this was established by probe,
-   not assumed:
-   - Common to both: **the list and the source files are read from the MAIN checkout**, not from the
-     worktree you happen to be sitting in. So an edit to `.worktreeinclude` only takes effect once it
-     is merged and pulled into main — you cannot test a new entry from inside a worktree.
-   - **`--worktree` / `EnterWorktree`** — patterns match at **any depth** and the copier **creates
-     missing directories**: `.dev.vars` picks up `worker/.dev.vars`, and `.vercel/project.json` lands
-     even though a fresh worktree has no `.vercel/`.
-   - **Subagent (`isolation: worktree`)** — **top-level matches only**. It gets `.env` and
-     `.env.local` but *neither* nested entry, so no `worker/.dev.vars` and no `.vercel/project.json`.
-     A subagent worktree can therefore run neither the local Worker nor `vercel dev`, and the
-     Vercel-link fix below does not reach it.
+   Two behaviours, common to both copiers, each established by probe rather than assumed:
+   - **The list and the source files are read from the MAIN checkout**, not from the worktree you
+     happen to be sitting in. So an edit to `.worktreeinclude` only takes effect once it is merged
+     and pulled into main — you cannot test a new entry from inside a worktree.
+   - Patterns match at **any depth** and the copier **creates missing directories**: `.dev.vars`
+     picks up `worker/.dev.vars`, and `.vercel/project.json` lands even though a fresh worktree has
+     no `.vercel/`.
+
+   > **Correction (2026-07-10).** PR #977 claimed a subagent worktree receives only the top-level
+   > entries. That was wrong, and it is worth recording *why*: the probe `stat`ed the subagent's
+   > worktree **after the subagent finished**, and the harness auto-removes an unchanged worktree —
+   > so "file not found" was reading a deleted directory, not an uncopied file. Re-probed twice from
+   > inside a live subagent: `worker/.dev.vars` and `.vercel/project.json` are both present. When
+   > probing a worktree's contents, run the check **inside** the worktree's own session; a
+   > post-mortem `ls` from outside proves nothing.
 2. **Dependencies** — **not** shared. Run `npm install` in each new worktree (`node_modules`
    and Python venvs are per-directory).
 


### PR DESCRIPTION
Follow-up to #977, which merged a **false statement** into `CLAUDE.md` and `docs/reference/parallel-agents.md`.

## What was wrong

#977 documented that a subagent (`isolation: worktree`) worktree receives only the top-level
`.worktreeinclude` entries — no `worker/.dev.vars`, no `.vercel/project.json` — and concluded that such
a worktree "can run neither the local Worker nor `vercel dev`" and that the Vercel-link fix "does not
reach them."

All of that is false. Both nested entries are copied, exactly as they are for a
`--worktree` / `EnterWorktree` worktree.

## Why it was wrong — the part worth keeping

The probe `stat`ed the subagent's worktree directory **after the subagent had finished**. The harness
auto-removes a worktree it finds unchanged, so `ls: No such file or directory` was reading a **deleted
directory**, not an uncopied file. The `.env` result looked right only because that came from the
subagent's own live `ls`, which I never repeated for the nested paths.

Re-probed twice from **inside a live subagent session**:

```
worker/.dev.vars      PRESENT (100 bytes)
.vercel/project.json  PRESENT
.env                  PRESENT
.env.local            PRESENT
```

## What this PR does

Corrects both docs, and keeps a dated **Correction** callout in the reference doc rather than silently
flipping the guidance. The durable lesson is methodological, not factual: *check a worktree's contents
from inside that worktree's own session; a post-mortem `ls` from outside proves nothing.* A reader who
saw the old text deserves to know why it changed, and a future engineer re-probing the same question
should not have to rediscover the trap.

Consequences of the retraction, now stated correctly: a subagent worktree **can** run the local Worker
and `vercel dev`, and #977's Vercel-link fix **does** reach it.

Also fixes a pre-existing omission the correction surfaced: the `CLAUDE.md` line never listed
`.env.local`, though `.worktreeinclude` has always copied it.

## Verification

`npm run lint:okf` clean · `CLAUDE.md` 37.6k (under the 40k guideline) · grepped `CLAUDE.md`, `docs/`,
`.worktreeinclude`, `.claude/skills/` and the repo's scripts — no surviving assertion of the old claim
outside the Correction callout that retracts it.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
