### PR TITLE
feat(score): archive a calendar-month Score (refs #993)

### DIFF
--- a/worker/src/__tests__/monthly-archive.test.ts
+++ b/worker/src/__tests__/monthly-archive.test.ts
@@ -5,6 +5,7 @@ import {
   curateComponentUptime,
   computeMonthlyOfficialUptime,
   computeMonthlyLatency,
+  computeMonthlyScore,
   computeMonthlyLatencyStats,
   getMonthDates,
   isInMonthlyArchiveWindow,
@@ -2219,5 +2220,57 @@ describe('stripInternalFields (#975)', () => {
     const out = buildPartialIncidentArchive('2026-07', acc)
     expect(out.services.pinecone.incidentList[0]).not.toHaveProperty('missedRuns')
     expect(JSON.stringify(out)).not.toContain('missedRuns')
+  })
+})
+
+describe('computeMonthlyScore (#993)', () => {
+  const WINDOW = { startISO: '2026-06-01T00:00:00.000Z', endISO: '2026-07-01T00:00:00.000Z' }
+  const noProbe = new Map() // empty summaries → unsupported/insufficient, matching a no-probe month
+
+  const inc = (startedAt: string, durationMin: number, impact: 'minor' | 'major' | 'critical' = 'major') => ({
+    id: startedAt, title: 't', startedAt, resolvedAt: startedAt, durationMin,
+    finalStatus: 'resolved' as const, impact,
+  })
+
+  it('scores over the calendar month, not a build-day snapshot — fewer/shorter incidents ⇒ higher Score', () => {
+    // The Deepgram paradox this fixes: month-aggregate incidents improved yet the snapshot Score fell.
+    // With a month-windowed score, a genuinely better month must score at least as well.
+    const bad = computeMonthlyScore('x', [inc('2026-06-05T00:00:00Z', 600), inc('2026-06-12T00:00:00Z', 600), inc('2026-06-20T00:00:00Z', 600)], 99, noProbe, WINDOW, undefined)
+    const good = computeMonthlyScore('x', [inc('2026-06-10T00:00:00Z', 60)], 99, noProbe, WINDOW, undefined)
+    expect(good.score).not.toBeNull()
+    expect(bad.score).not.toBeNull()
+    expect(good.score!).toBeGreaterThan(bad.score!)
+  })
+
+
+  it('includes a last-second incident regardless of sub-second precision (#993 boundary)', () => {
+    // A next-day-midnight end bound is precision-agnostic; a `…T23:59:59.999Z` bound would exclude a
+    // `…T23:59:59Z` (no ms) incident because 'Z' > '.' in a string compare.
+    const lastSecNoMs = computeMonthlyScore('x', [inc('2026-06-30T23:59:59Z', 600)], 99, noProbe, WINDOW, undefined)
+    const lastSecMs = computeMonthlyScore('x', [inc('2026-06-30T23:59:59.000Z', 600)], 99, noProbe, WINDOW, undefined)
+    const empty = computeMonthlyScore('x', [], 99, noProbe, WINDOW, undefined)
+    // Both last-second incidents must be counted → a worse score than the incident-free month.
+    expect(lastSecNoMs.score!).toBeLessThan(empty.score!)
+    expect(lastSecNoMs.score).toBe(lastSecMs.score)
+  })
+
+  it('only counts incidents INSIDE the window', () => {
+    // An incident in May (before the window) must not drag June's score down.
+    const withMay = computeMonthlyScore('x', [inc('2026-05-15T00:00:00Z', 600), inc('2026-06-10T00:00:00Z', 60)], 99, noProbe, WINDOW, undefined)
+    const juneOnly = computeMonthlyScore('x', [inc('2026-06-10T00:00:00Z', 60)], 99, noProbe, WINDOW, undefined)
+    expect(withMay.score).toBe(juneOnly.score)
+  })
+
+  it('no official uptime ⇒ Uptime component dropped ⇒ low confidence (mirrors the live #713 rule)', () => {
+    // Deepgram's real shape: no official uptime, no probe → score computed on incidents+recovery only.
+    const r = computeMonthlyScore('x', [inc('2026-06-10T00:00:00Z', 60)], null, noProbe, WINDOW, undefined)
+    expect(r.confidence).toBe('low')
+    expect(r.score).toBeNull() // #713 withholds a low-confidence score
+  })
+
+  it('a clean month with official uptime and no incidents scores high', () => {
+    const r = computeMonthlyScore('x', [], 100, noProbe, WINDOW, undefined)
+    expect(r.confidence).toBe('high')
+    expect(r.score).toBeGreaterThan(80)
   })
 })

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -7,7 +7,10 @@
 // incident counts, unlike services:latest which is a point-in-time snapshot.
 
 import type { ProbeDailyData } from './probe-archival'
-import type { ServiceStatus, Incident, ServiceConfig } from './types'
+import { summariesFromDailyData } from './probe-archival'
+import type { ServiceStatus, Incident, ServiceConfig, ProbeSummary } from './types'
+import { calculateAIWatchScore, classifyProbe } from './score'
+import { resolveProbeId, PROBE_TARGETS } from './probe'
 import type { OsvTimeline, OsvTimelineEntry } from './security-monitor'
 import { osvTimelineKey, isPubliclyVerifiedAlert } from './security-monitor'
 import { generateMonthlyNarrative, type MonthlyNarrativeDraft, type NarrativeAiOptions } from './monthly-narrative'
@@ -58,6 +61,17 @@ export interface MonthlyServiceData {
   officialUptime: number | null  // #586 — status-page rolling-30d uptime (month-end daily snapshot, build-time fallback) for the "Official Uptime" DISPLAY table; separate from the daily-counter `uptime` that feeds the Score. #951 — emitted ONLY when the Score actually consumed an official uptime (scoreConfidence 'high'); null otherwise
   score: number | null           // AIWatch Score at archive time (null if unavailable)
   grade: ScoreGrade | null       // Score grade (null if score unavailable)
+  // #993 — Score computed over THIS CALENDAR MONTH (score.ts run on the month's incidents + monthly
+  // probe summary), as opposed to `score` which is a build-day snapshot of the rolling live Score.
+  // The report's trend chart + Notable Movers read this so the Score delta shares the month window
+  // with the MTTR/downtime deltas. CAVEAT: only the Incidents (25) and Recovery (15) components are
+  // truly calendar-windowed; the 40-pt Uptime component still uses the month-END rolling-30d
+  // official-uptime snapshot (status pages expose no calendar-month uptime), and Responsiveness uses
+  // the month's probe summary. Still a strict improvement over the build-day `score`. Absent on
+  // archives built before #993 → consumers fall back to `score`.
+  monthlyScore?: number | null
+  monthlyGrade?: ScoreGrade | null
+  monthlyScoreConfidence?: ScoreConfidence | null
   scoreConfidence?: ScoreConfidence | null // #951 — 'high' = the Score included the 40-pt uptime component; the report labels the uptime source from this instead of a hardcoded service list
   incidents: number              // incident count for the month (from accumulated data)
   avgResolutionMin: number | null // average resolution time in minutes (null if no resolved incidents)
@@ -806,6 +820,61 @@ export function curateComponentUptime(
   return kept.length >= 2 ? kept : undefined
 }
 
+const PROBED_IDS = new Set(PROBE_TARGETS.map((t) => t.id))
+
+/** Format integer minutes back to the "Xh Ym" string score.ts's MTTR parser expects (lossless). */
+function minutesToDurationString(mins: number): string {
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`
+}
+
+/**
+ * A calendar-month AIWatch Score (#993). PURE. Runs the SAME `calculateAIWatchScore` the live path
+ * uses, but over an explicit month window: the month's incidents (adapted from the archived
+ * per-incident entries), the month's official uptime, and a month-scoped probe summary. This makes
+ * the archived Score share the calendar-month window with the MTTR/downtime aggregates beside it, so
+ * the report's Notable Movers stops juxtaposing two different windows. Reuses score.ts as the single
+ * source of the formula — no reimplementation. (Uptime input is the month-END rolling official
+ * uptime, not a calendar-month figure — status pages expose none; incidents + recovery are the
+ * calendar-windowed parts.) Returns null when there is nothing to score.
+ */
+export function computeMonthlyScore(
+  id: string,
+  monthIncidents: MonthlyIncidentEntry[] | undefined,
+  officialUptime: number | null,
+  monthlySummaries: Map<string, ProbeSummary>,
+  window: { startISO: string; endISO: string },
+  svcConfig: ServiceConfig | undefined,
+): { score: number | null; grade: ScoreGrade | null; confidence: ScoreConfidence } {
+  // Adapt the archived incident entries to the minimal Incident shape calculateAIWatchScore reads
+  // (startedAt, impact, status, duration). finalStatus → status; durationMin → the "Xh Ym" string
+  // its MTTR parser expects (lossless for integer minutes); missing impact → null (informational).
+  const incidents: Incident[] = (monthIncidents ?? []).map((e) => ({
+    id: e.id,
+    title: e.title,
+    status: e.finalStatus,
+    impact: e.impact ?? null,
+    startedAt: e.startedAt,
+    resolvedAt: e.resolvedAt,
+    duration: e.finalStatus === 'resolved' ? minutesToDurationString(e.durationMin) : null,
+    timeline: [],
+  }))
+  const service: ServiceStatus = {
+    id,
+    name: svcConfig?.name ?? id,
+    provider: svcConfig?.provider ?? '',
+    category: svcConfig?.category ?? 'api',
+    status: 'operational', // unread by calculateAIWatchScore; the window + incidents drive the score
+    latency: null,
+    uptime30d: officialUptime, // month official uptime — null drops the Uptime component (as live)
+    lastChecked: window.endISO,
+    incidents,
+  }
+  const probeId = resolveProbeId(id) // #883 — inheriting services score against the parent's probe
+  const probe = classifyProbe(probeId, PROBED_IDS.has(probeId), monthlySummaries)
+  const r = calculateAIWatchScore(service, 30 /* unused when window is set */, probe, window)
+  return { score: r.score, grade: r.grade, confidence: r.confidence }
+}
+
 /** Compute per-service average probe RTT (p75) from daily probe summaries */
 export function computeMonthlyLatency(
   probeData: Record<string, ProbeDailyData>,
@@ -1213,6 +1282,19 @@ export async function buildMonthlyArchive(
   // established + genuine mid-month adds are kept (the #802 ranking gate still handles partial coverage).
   const monthEnd = dates[dates.length - 1] // 'YYYY-MM-DD'
 
+  // #993 — a month-scoped probe summary (same cvCombined logic as the live 7-day path) and the
+  // calendar-month window, computed ONCE for the monthly-Score pass below. The window uses CLEAN DAY
+  // boundaries ([month-01 00:00, next-month-01 00:00)) rather than `...T23:59:59.999Z`: incident
+  // `startedAt` values are compared as STRINGS, and a mixed-precision compare ('…59Z' vs '…59.999Z')
+  // wrongly excludes a last-second incident because 'Z' > '.' lexically. A next-day midnight bound
+  // is precision-agnostic.
+  const monthlySummaries = summariesFromDailyData(Object.values(probeData))
+  const nextMonth = month === 12 ? { y: year + 1, m: 1 } : { y: year, m: month + 1 }
+  const monthWindow = {
+    startISO: `${period}-01T00:00:00.000Z`,
+    endISO: `${nextMonth.y}-${String(nextMonth.m).padStart(2, '0')}-01T00:00:00.000Z`,
+  }
+
   for (const id of allIds) {
     if (!existedInMonth(SERVICE_ADDED_AT[id], monthEnd)) continue
     const scoreSvc = scoreData?.find(s => s.id === id)
@@ -1249,6 +1331,10 @@ export async function buildMonthlyArchive(
       score: scoreSvc?.aiwatchScore ?? null,
       grade: scoreSvc?.scoreGrade ?? null,
       ...(scoreSvc?.scoreConfidence ? { scoreConfidence: scoreSvc.scoreConfidence } : {}),
+      ...(() => { // #993 — calendar-month Score (window-aligned with the MTTR/downtime aggregates)
+        const m = computeMonthlyScore(id, incSvc?.incidents, officialUptimeMap[id] ?? null, monthlySummaries, monthWindow, SERVICES.find((s) => s.id === id))
+        return { monthlyScore: m.score, monthlyGrade: m.grade, ...(m.confidence ? { monthlyScoreConfidence: m.confidence } : {}) }
+      })(),
       incidents: incSvc?.count ?? 0,
       avgResolutionMin,
       totalDowntimeMin,

--- a/worker/src/probe-archival.ts
+++ b/worker/src/probe-archival.ts
@@ -87,8 +87,6 @@ export function aggregateProbeDaily(
 /** Compute 7-day probe summary per service from daily archives.
  *  Returns Map<serviceId, ProbeSummary> for Responsiveness scoring. */
 export async function computeProbeSummaries(kv: KVNamespace, days = 7): Promise<Map<string, ProbeSummary>> {
-  const result = new Map<string, ProbeSummary>()
-
   // Read daily archives in parallel (skip today — not yet archived)
   const keys = Array.from({ length: days }, (_, i) => {
     return `probe:daily:${new Date(Date.now() - (i + 1) * 86_400_000).toISOString().split('T')[0]}`
@@ -109,6 +107,17 @@ export async function computeProbeSummaries(kv: KVNamespace, days = 7): Promise<
     } catch (err) { console.warn('[probe-archival] malformed daily data:', err instanceof Error ? err.message : err) }
   }
 
+  return summariesFromDailyData(dailyData)
+}
+
+/**
+ * PURE core of computeProbeSummaries: turn a list of daily probe stats into per-service
+ * ProbeSummary (p50 / p95 / cvCombined / validDays). Extracted (#993) so the monthly archive can
+ * build a MONTH's summary from the same logic the live 7-day path uses — the single source of the
+ * cvCombined formula, rather than re-deriving it. Empty when <2 usable days (CV needs ≥2 points).
+ */
+export function summariesFromDailyData(dailyData: ProbeDailyData[]): Map<string, ProbeSummary> {
+  const result = new Map<string, ProbeSummary>()
   if (dailyData.length < 2) return result // need at least 2 days for CV
 
   // Collect per-service daily p50 and p95 values

--- a/worker/src/score.ts
+++ b/worker/src/score.ts
@@ -1,6 +1,6 @@
 // AIWatch Score — service reliability composite score (0-100)
 
-import type { ProbeSummary, ServiceStatus } from './types'
+import type { Incident, ProbeSummary, ServiceStatus } from './types'
 import { INCIDENT_IO_IMPACT_WEIGHTS } from './parsers/impact-weights'
 
 export interface AIWatchScore {
@@ -110,17 +110,28 @@ export function calculateAIWatchScore(
   service: ServiceStatus,
   cutoffDays: number,
   probe: ProbeContext,
+  window?: { startISO: string; endISO: string },
 ): AIWatchScore {
-  const cutoff = new Date(Date.now() - cutoffDays * 86_400_000).toISOString()
-  const incidents30d = (service.incidents ?? []).filter((i) => i.startedAt >= cutoff)
-  const incidentCount = incidents30d.length
+  // #993 — incident selection is the only place this function derives a time window internally.
+  // Default: the trailing `cutoffDays` from now (the live 30-day Score). An explicit
+  // {startISO, endISO} scores a FIXED past window (a calendar month) so the monthly archive can
+  // persist a month-aligned Score instead of a build-day snapshot of the rolling one. `uptime30d`
+  // and the probe summary are already scoped by the caller, so only this filter changes.
+  const inWindow: (i: Incident) => boolean = window
+    ? (i) => i.startedAt >= window.startISO && i.startedAt < window.endISO
+    : (() => {
+        const cutoff = new Date(Date.now() - cutoffDays * 86_400_000).toISOString()
+        return (i: Incident) => i.startedAt >= cutoff
+      })()
+  const windowIncidents = (service.incidents ?? []).filter(inWindow)
+  const incidentCount = windowIncidents.length
 
   // Affected days — only count incidents with measurable impact (#261).
   // null-impact entries are informational (component renames, post-mortems) — including
   // them in affected_days inflates services like cohere/groq whose feeds mix info posts
   // with real incidents, producing scores ~10pts lower than reality.
   const impactfulDays = new Set(
-    incidents30d.filter((i) => i.impact != null).map((i) => i.startedAt.slice(0, 10)),
+    windowIncidents.filter((i) => i.impact != null).map((i) => i.startedAt.slice(0, 10)),
   )
   const affectedDays = impactfulDays.size
 
@@ -132,7 +143,7 @@ export function calculateAIWatchScore(
   // so this is the catch-all log for new Atlassian impact levels reaching score calc.
   const dailyMaxWeight = new Map<string, number>()
   const unknownImpacts = new Set<string>()
-  for (const inc of incidents30d) {
+  for (const inc of windowIncidents) {
     if (inc.impact == null) continue
     const weight = INCIDENT_IO_IMPACT_WEIGHTS[inc.impact]
     if (weight === undefined) {
@@ -153,8 +164,8 @@ export function calculateAIWatchScore(
   // revocation, deprecation) has a duration but is NOT a reliability recovery, so counting it would
   // zero the Recovery score on a service that never actually went down (symmetric with the #261
   // null-impact exclusion from affectedDays / the uptime estimate).
-  const impactfulIncidents30d = incidents30d.filter((i) => i.impact != null)
-  const durations = impactfulIncidents30d
+  const impactfulWindowIncidents = windowIncidents.filter((i) => i.impact != null)
+  const durations = impactfulWindowIncidents
     .filter((i) => i.status === 'resolved' && i.duration)
     .map((i) => parseDurationMin(i.duration!))
     .filter((m) => m > 0)
@@ -182,7 +193,7 @@ export function calculateAIWatchScore(
   // null-impact advisories has no reliability recovery to penalize → full 15, not 0.
   const recoveryScore = mttrHours != null
     ? 15 * Math.exp(-mttrHours / 4)
-    : impactfulIncidents30d.length > 0 ? 0 : 15
+    : impactfulWindowIncidents.length > 0 ? 0 : 15
 
   // Responsiveness (probe) — compute first so the rescale below knows whether it's an available
   // component. Exhaustive switch — adding a new ProbeContext kind is a compile error until handled.


### PR DESCRIPTION
## What

Adds a calendar-month `monthlyScore`/`monthlyGrade`/`monthlyScoreConfidence` to each service in the monthly archive, computed at build time with the **same** `score.ts` formula — over the month window instead of the build-day rolling snapshot.

## Why

The archive's `score` is a build-day snapshot of the rolling live Score; the sibling MTTR/downtime/uptime columns are calendar-month aggregates. The report's Notable Movers juxtaposed a Score delta and MTTR/downtime deltas measured over **different windows** — the "Deepgram improved but Score fell" reader confusion, where a service whose month-aggregate incidents improved still showed a lower snapshot Score.

## How

- `calculateAIWatchScore` gains an optional `window?: {startISO, endISO}`. Absent → **byte-identical** rolling behavior (the live path is unchanged). Present → a fixed past window; only incident selection uses it (uptime30d + probe are caller-supplied).
- `summariesFromDailyData` extracted (pure) from `computeProbeSummaries` so the archive builds a month's probe summary with the **same cvCombined logic** the live 7-day path uses — no reimplementation.
- `computeMonthlyScore` (pure) runs `score.ts` over the month window: incidents adapted from the archived per-incident entries, month official uptime, month probe summary. Stores the three `monthly*` fields; legacy archives lack them (the report falls back to `score`).

Window uses clean day boundaries `[month-01, next-month-01)` so a last-second incident isn't dropped by a mixed-precision ISO string compare (`'…59Z'` vs `'…59.999Z'`). **Caveat:** only Incidents (25) + Recovery (15) are truly calendar-windowed; the 40-pt Uptime component still uses the month-end rolling official-uptime snapshot (status pages expose no calendar-month figure).

## Deploy note

`monthlyScore` is populated on the **next archive build** (or an `/api/admin/rebuild-archive` for months within probe/incident retention). Until then the report uses the snapshot fallback.

## Tests

`typecheck:worker` 0 errors; `test:worker` 2610 passed (incl. the calendar-window score, the window boundary, the withheld-low-confidence path). Reviewed to 0 Critical/Important across two rounds.

Refs #993, #951, #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)