### PR TITLE
fix(worker): operator per-incident duration-override layer (refs #1019)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,7 @@ worker/src/          # Cloudflare Worker: status polling, KV cache, cron, alerts
   rss.ts             # Incident RSS feeds (/feed.xml, /feed/:slug) + Slack-poller behaviours
   fallback.ts        # Fallback recommendation (tiered, Score-ranked)
   suppression.ts     # Operator incident-suppression layer (#904)
+  overrides.ts       # Operator incident duration-override layer (#1019) — pins a paperwork-inflated duration, keeps the incident
   probe.ts probe-archival.ts   # Direct RTT probing (32 targets) + daily archival
   daily-summary.ts weekly-briefing.ts monthly-archive.ts monthly-narrative.ts  # Discord reports + archives
   api-traffic.ts outage-audience.ts referral.ts vitals.ts   # WAE/KV instrumentation

--- a/docs/reference/operator-tools.md
+++ b/docs/reference/operator-tools.md
@@ -95,3 +95,47 @@ plus `incId` (incident scope) or `svcId` + `match` (service-pattern scope), opti
 Failure modes: 401 `unauthorized`, 400 (missing/invalid scope or fields), 502 (KV read/write failed),
 503 (`STATUS_CACHE` unavailable). Auth reuses `X-Admin-Key` / `ADMIN_API_KEY`. The isolate caches the list
 for 60s (a write invalidates its own isolate immediately; others converge within ≤60s).
+
+# Operator Tools — `GET/POST /api/admin/duration-override` (#1019)
+
+**Sibling of suppress, different verb.** Suppress HIDES an incident; a duration override KEEPS it but
+PINS its `duration` to an operator-stated value. Use it when a provider left an incident open long AFTER
+the affected component recovered, so the paperwork `duration` (`resolved_at − created_at`) overstates real
+impact — inflating MTTR/Recovery and the monthly report's `longestIncidentMin`/`totalDowntimeMin`.
+Reference case: Cursor `h71m65my586h` (2026-07-14) reads 13h 20m; the component actually recovered in
+~18 min (sibling `96m8j04k15r5` resolved in 18 min). See [status-determination.md](status-determination.md).
+
+```bash
+# List current overrides
+curl -s https://<worker>/api/admin/duration-override -H "X-Admin-Key: $ADMIN_API_KEY"
+
+# Pin an incident's duration (minutes). Re-adding the same id UPDATES its value (a correction, not idempotent):
+curl -s -X POST https://<worker>/api/admin/duration-override -H "X-Admin-Key: $ADMIN_API_KEY" \
+  -d '{"action":"add","id":"h71m65my586h","durationMin":18,"reason":"provider left incident open ~13h after IDE recovered; real window ~18m (sibling Sol)"}'
+
+# Remove (restore the provider duration):
+curl -s -X POST https://<worker>/api/admin/duration-override -H "X-Admin-Key: $ADMIN_API_KEY" \
+  -d '{"action":"remove","id":"h71m65my586h"}'
+```
+
+**Where it applies** (all read the single `incident:duration-overrides` KV key, each right after
+suppression): `buildMonthlyArchive` build-time (rebuild-safe — run `POST /api/admin/rebuild-archive` for a
+past month), the `/api/report` current-month partial (dashboard 30/90-day list), and the weekly briefing.
+It recomputes `totalMinutes`/`longestMinutes` from the `durations` map, updates `incidents[].durationMin`,
+and (for a resolved entry) sets `incidents[].resolvedAt = startedAt + durationMin` so the grouped-incident
+row + Uptime calendar span agree. It also lands in the calendar-month `monthlyScore` (#993) — its MTTR
+reads the same durations — so the report's Score/ranking is corrected too, not just the display stats.
+
+**Caveats:**
+- **Applied on READ/BUILD, never by editing the accumulator** — `accumulateMonthlyIncidents`'s monotonic
+  `if (dur > oldDur)` guard would re-inflate a raw KV edit on the next cron while the incident is still in
+  the live feed. So a plain `wrangler kv put` correction does NOT stick; use this endpoint.
+- **Current-month dashboard lag**: for a still-live current-month incident, the live `/api/status` value
+  wins in `mergeArchiveIntoMap`, so the corrected duration shows on the dashboard only once the incident
+  ages out of the upstream feed. The permanent archive (built on the 1st) is unaffected.
+- **Live Score not overridden**: MTTR/Recovery on `/api/status` still uses the provider duration (median is
+  robust at ≥3 resolved incidents). General MTTR robustness is #1019 Part B.
+
+**Request body** (POST, JSON): `action` (`'add' | 'remove'`), `id`, `durationMin` (add only, finite ≥ 0),
+optional `reason`. **Response**: `{ ok, changed, overrides }` on 200. Failure modes mirror suppress
+(401/400/502/503). No isolate cache (the apply sites read fresh).

--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -69,6 +69,38 @@ e.g. `{svcId:'openai', match:'fedramp'}`). Applied at two points: `fetchAllServi
 unaffected** — suppression runs after status determination, removing the incident only from the LIST +
 Score inputs. Removing a suppression restores the incident with zero code change.
 
+### Duration override — the "correct but overstated" sibling of suppression (#1019)
+
+Suppression HIDES an incident; a **duration override** KEEPS it but PINS its duration. The problem it
+solves: an incident's `duration` is the provider's **paperwork** span (`resolved_at − created_at`;
+`parsers/statuspage.ts`), and some providers leave an incident open in `investigating`/`monitoring` long
+**after the affected component actually recovered**. Cursor `h71m65my586h` (2026-07-14) — IDE went
+`degraded_performance` at 19:52 UTC and was already `operational` well before the formal 09:11 UTC resolve
+(its `affected_components` on the resolve update reads `operational → operational`), yet the stored
+duration is **13h 20m**; the sibling `96m8j04k15r5` ("- Sol") on the same component resolved in **18 min**,
+the best proxy for when the shared degradation cleared. That overstated duration feeds **MTTR / the
+Recovery score** (median-robust at ≥3 resolved incidents, but the `<3` mean fallback lets one such outlier
+tank a low-incident service) and the monthly report's `longestIncidentMin` / `totalDowntimeMin`.
+
+The **override layer** (`worker/src/overrides.ts`, operated via `GET/POST /api/admin/duration-override`)
+mirrors suppression: an `incident:duration-overrides` KV list of `{ id, durationMin, reason }`, applied by
+`applyDurationOverrides` which recomputes each affected service's `totalMinutes`/`longestMinutes` from the
+`durations` map (the `filterSuppressedFromMonthly` pattern) and updates `incidents[].durationMin` (the #915
+`aggregateIncidentDurations` source of truth) AND, for a resolved entry, `incidents[].resolvedAt` (=
+`startedAt + durationMin`) so the timestamp-derived consumers — the grouped-incident row duration
+(`sumGroupDuration`) and the Uptime calendar span — agree rather than still painting the paperwork span.
+It also flows into the calendar-month `monthlyScore` (#993), whose MTTR reads the same per-incident
+durations. Applied on **READ/BUILD** of the monthly accumulator — NOT
+by editing it — because `accumulateMonthlyIncidents`'s monotonic `if (dur > oldDur)` guard would re-inflate
+a lowered stored value on the next cron while the incident is still in the live feed. Three apply points,
+each right after suppression: `buildMonthlyArchive` (rebuild-safe), the `/api/report` current-month partial
+(dashboard 30/90-day list — but for a still-live current-month incident the live `/api/status` value wins
+in `mergeArchiveIntoMap`, so the override's visible effect there lags until the incident ages out of the
+feed; the permanent archive is unaffected), and the weekly briefing. The live `/api/status` Score is
+deliberately **not** overridden — MTTR robustness for the general case is tracked as #1019 Part B (a
+confidence-gate or small-sample shrinkage on MTTR, vs. computing duration from AIWatch's own observed
+`degraded → operational` edge). Removing an override restores the provider duration with zero code change.
+
 ## Per-component snapshot — `resolveSvcComponents` (#604)
 
 `resolveSvcStatus` collapses the `statusComponentIds` subset into one worst-of badge and **discards** the per-component statuses. `resolveSvcComponents(config, summaryData)` is the **display counterpart**: it preserves the same matched subset as `ServiceComponent[]` (`{ id, name, status }`, normalized, in configured order) on `ServiceStatus.components`, so the ServiceDetails + "Is X Down" surfaces can render a per-component breakdown card (parity with StatusGator / IsDown).

--- a/worker/src/__tests__/overrides.test.ts
+++ b/worker/src/__tests__/overrides.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeOverrides,
+  overrideMap,
+  applyDurationOverrides,
+  mutateOverrides,
+  readOverridesFresh,
+  type DurationOverride,
+} from '../overrides'
+import {
+  accumulateMonthlyIncidents,
+  aggregateIncidentDurations,
+  type MonthlyIncidents,
+} from '../monthly-archive'
+import type { ServiceStatus } from '../types'
+
+// A monthly accumulator holding Cursor's real July shape: the 13h20m paperwork incident + a couple of
+// short ones. 799 min = 13h 19m ≈ the observed h71m65my586h open→close span.
+function cursorMonthly(): MonthlyIncidents {
+  return {
+    lastUpdated: '2026-07-15T10:00:00Z',
+    services: {
+      cursor: {
+        count: 3,
+        totalMinutes: 799 + 18 + 92,
+        longestMinutes: 799,
+        dates: ['2026-07-14', '2026-07-06'],
+        incidentIds: ['h71m65my586h', '96m8j04k15r5', 'aaa'],
+        durations: { h71m65my586h: 799, '96m8j04k15r5': 18, aaa: 92 },
+        incidents: [
+          { id: 'h71m65my586h', title: 'Investigating service degradation', startedAt: '2026-07-14T19:52:29Z', resolvedAt: '2026-07-15T09:11:48Z', durationMin: 799, finalStatus: 'resolved', impact: 'minor' },
+          { id: '96m8j04k15r5', title: 'Investigating service degradation - Sol', startedAt: '2026-07-14T19:55:36Z', resolvedAt: '2026-07-14T20:10:38Z', durationMin: 18, finalStatus: 'resolved', impact: 'minor' },
+          { id: 'aaa', title: 'Investigating service degradation', startedAt: '2026-07-06T00:00:00Z', resolvedAt: '2026-07-06T01:32:00Z', durationMin: 92, finalStatus: 'resolved', impact: 'minor' },
+        ],
+      },
+    },
+  }
+}
+
+describe('normalizeOverrides', () => {
+  it('keeps well-formed rows and drops malformed ones', () => {
+    const parsed = [
+      { id: 'a', durationMin: 18, reason: 'paperwork left open' },
+      { id: 'b', durationMin: 0 },                 // 0 is valid (zeroes downtime)
+      { id: '', durationMin: 10 },                 // empty id → drop
+      { id: 'c', durationMin: -5 },                // negative → drop
+      { id: 'd', durationMin: 'nope' },            // non-number → drop
+      { id: 'e' },                                 // missing durationMin → drop
+      { durationMin: 10 },                         // missing id → drop
+      null, 'x', 42,                               // non-objects → drop
+    ]
+    expect(normalizeOverrides(parsed)).toEqual([
+      { id: 'a', durationMin: 18, reason: 'paperwork left open' },
+      { id: 'b', durationMin: 0 },
+    ])
+  })
+  it('returns [] for non-array input', () => {
+    expect(normalizeOverrides(null)).toEqual([])
+    expect(normalizeOverrides({})).toEqual([])
+  })
+})
+
+describe('overrideMap', () => {
+  it('last entry wins on duplicate id', () => {
+    const m = overrideMap([{ id: 'a', durationMin: 10 }, { id: 'a', durationMin: 18 }])
+    expect(m.get('a')).toBe(18)
+  })
+})
+
+describe('applyDurationOverrides', () => {
+  it('pins the paperwork incident and recomputes total + longest from survivors', () => {
+    const out = applyDurationOverrides(cursorMonthly(), [{ id: 'h71m65my586h', durationMin: 18 }])
+    const svc = out.services.cursor
+    // Incident stays; only its duration is corrected.
+    expect(svc.count).toBe(3)
+    expect(svc.incidentIds).toContain('h71m65my586h')
+    expect(svc.durations.h71m65my586h).toBe(18)
+    expect(svc.incidents!.find(e => e.id === 'h71m65my586h')!.durationMin).toBe(18)
+    // Aggregates recompute from the durations map: 18 + 18 + 92 = 128, longest now 92 (not 799).
+    expect(svc.totalMinutes).toBe(128)
+    expect(svc.longestMinutes).toBe(92)
+  })
+
+  it('recomputes resolvedAt = startedAt + durationMin so timestamp-derived surfaces agree', () => {
+    const out = applyDurationOverrides(cursorMonthly(), [{ id: 'h71m65my586h', durationMin: 18 }])
+    const e = out.services.cursor.incidents!.find(x => x.id === 'h71m65my586h')!
+    // startedAt 2026-07-14T19:52:29Z + 18 min → 20:10:29Z (was the provider's next-day 09:11:48Z).
+    expect(e.resolvedAt).toBe('2026-07-14T20:10:29.000Z')
+    // resolvedAt − startedAt now equals the pinned duration.
+    expect((Date.parse(e.resolvedAt!) - Date.parse(e.startedAt)) / 60000).toBe(18)
+  })
+
+  it('leaves resolvedAt untouched for an unresolved (open) entry — never fabricates a resolution', () => {
+    const data = cursorMonthly()
+    const open = data.services.cursor.incidents!.find(x => x.id === 'aaa')!
+    open.resolvedAt = null
+    open.finalStatus = 'monitoring'
+    const out = applyDurationOverrides(data, [{ id: 'aaa', durationMin: 5 }])
+    const e = out.services.cursor.incidents!.find(x => x.id === 'aaa')!
+    expect(e.durationMin).toBe(5)      // duration still pinned
+    expect(e.resolvedAt).toBeNull()    // but no synthetic resolution
+  })
+
+  it('corrects aggregates when the override id is TRUNCATED out of incidents[] (accumulator fallback)', () => {
+    // A busy service caps its detail array (#375) but keeps the full `durations` map, so an override on
+    // a truncated id must still correct totalMinutes/longestMinutes (aggregateIncidentDurations then
+    // reads the corrected accumulator totals, since incidents.length < count).
+    const data: MonthlyIncidents = {
+      lastUpdated: '2026-07-15T10:00:00Z',
+      services: {
+        cursor: {
+          count: 2,
+          totalMinutes: 799 + 30,
+          longestMinutes: 799,
+          dates: ['2026-07-14'],
+          incidentIds: ['h71m65my586h', 'kept'],
+          durations: { h71m65my586h: 799, kept: 30 },
+          // detail truncated: only 'kept' survived the cap, 'h71m65my586h' is gone from incidents[]
+          incidents: [
+            { id: 'kept', title: 'x', startedAt: '2026-07-14T00:00:00Z', resolvedAt: '2026-07-14T00:30:00Z', durationMin: 30, finalStatus: 'resolved', impact: 'minor' },
+          ],
+        },
+      },
+    }
+    const out = applyDurationOverrides(data, [{ id: 'h71m65my586h', durationMin: 18 }])
+    const svc = out.services.cursor
+    expect(svc.durations.h71m65my586h).toBe(18)
+    expect(svc.totalMinutes).toBe(48)     // 18 + 30
+    expect(svc.longestMinutes).toBe(30)   // no longer 799
+    const agg = aggregateIncidentDurations(svc.incidents, svc.count, svc.totalMinutes, svc.longestMinutes)
+    expect(agg.longestMin).toBe(30)       // truncated → falls back to the corrected accumulator total
+    expect(agg.totalMin).toBe(48)
+  })
+
+  it('flows through aggregateIncidentDurations (#915) — report longest/total corrected', () => {
+    const out = applyDurationOverrides(cursorMonthly(), [{ id: 'h71m65my586h', durationMin: 18 }])
+    const svc = out.services.cursor
+    const agg = aggregateIncidentDurations(svc.incidents, svc.count, svc.totalMinutes, svc.longestMinutes)
+    expect(agg.longestMin).toBe(92)   // was 799 before the override
+    expect(agg.totalMin).toBe(128)
+  })
+
+  it('is identity when no id matches or the list is empty', () => {
+    const data = cursorMonthly()
+    expect(applyDurationOverrides(data, [])).toBe(data)
+    expect(applyDurationOverrides(data, [{ id: 'not-here', durationMin: 5 }])).toBe(data)
+  })
+
+  it('returns structurally-corrupt input as-is (no throw)', () => {
+    const bad = { lastUpdated: 'x' } as unknown as MonthlyIncidents
+    expect(applyDurationOverrides(bad, [{ id: 'a', durationMin: 1 }])).toBe(bad)
+  })
+
+  it('REGRESSION: survives a re-accumulation cycle that would re-inflate a raw KV edit', () => {
+    // The monotonic guard in accumulateMonthlyIncidents (`if (dur > oldDur)`) re-inflates any lowered
+    // stored duration back to the provider value while the incident is still in the live feed. The
+    // override is applied AFTER accumulation, so it wins regardless of what the accumulator holds.
+    const stored = cursorMonthly()
+    // Simulate the next cron re-seeing the still-live 799-min incident.
+    const liveSvc: ServiceStatus = {
+      id: 'cursor', name: 'Cursor', provider: 'Anysphere', category: 'agent',
+      status: 'operational', uptime: null, uptime30d: null, latency: null,
+      incidents: [{ id: 'h71m65my586h', title: 'Investigating service degradation', status: 'resolved', impact: 'minor', startedAt: '2026-07-14T19:52:29Z', resolvedAt: '2026-07-15T09:11:48Z', duration: '13h 19m', timeline: [] }],
+    } as unknown as ServiceStatus
+    const reAccumulated = accumulateMonthlyIncidents(stored, [liveSvc], '2026-07', [])
+    expect(reAccumulated.services.cursor.durations.h71m65my586h).toBe(799) // guard re-inflated
+    // Applying the override on read/build corrects it back down.
+    const corrected = applyDurationOverrides(reAccumulated, [{ id: 'h71m65my586h', durationMin: 18 }])
+    expect(corrected.services.cursor.durations.h71m65my586h).toBe(18)
+    expect(corrected.services.cursor.longestMinutes).toBe(92)
+  })
+})
+
+describe('mutateOverrides', () => {
+  const base: DurationOverride[] = [{ id: 'a', durationMin: 10 }]
+  it('add appends a new id', () => {
+    const r = mutateOverrides(base, { action: 'add', id: 'b', durationMin: 18, reason: 'x' })
+    expect(r.ok && r.changed).toBe(true)
+    expect(r.ok && r.list).toEqual([{ id: 'a', durationMin: 10 }, { id: 'b', durationMin: 18, reason: 'x' }])
+  })
+  it('re-adding an id UPDATES its duration (a correction, not idempotent)', () => {
+    const r = mutateOverrides(base, { action: 'add', id: 'a', durationMin: 18 })
+    expect(r.ok && r.changed).toBe(true)
+    expect(r.ok && r.list).toEqual([{ id: 'a', durationMin: 18 }])
+  })
+  it('re-adding the SAME value is a no-op change', () => {
+    const r = mutateOverrides(base, { action: 'add', id: 'a', durationMin: 10 })
+    expect(r.ok && r.changed).toBe(false)
+  })
+  it('remove drops the id', () => {
+    const r = mutateOverrides(base, { action: 'remove', id: 'a' })
+    expect(r.ok && r.changed).toBe(true)
+    expect(r.ok && r.list).toEqual([])
+  })
+  it('rejects a missing id and an invalid durationMin', () => {
+    expect(mutateOverrides(base, { action: 'add', durationMin: 5 }).ok).toBe(false)
+    expect(mutateOverrides(base, { action: 'add', id: 'z', durationMin: -1 }).ok).toBe(false)
+    expect(mutateOverrides(base, { action: 'add', id: 'z' }).ok).toBe(false)
+  })
+})
+
+describe('readOverridesFresh', () => {
+  const kvOf = (val: string | null, throwOn = false): KVNamespace =>
+    ({ get: async () => { if (throwOn) throw new Error('kv down'); return val } }) as unknown as KVNamespace
+
+  it('parses a stored list', async () => {
+    const kv = kvOf(JSON.stringify([{ id: 'a', durationMin: 18 }, { id: 'bad' }]))
+    expect(await readOverridesFresh(kv)).toEqual([{ id: 'a', durationMin: 18 }])
+  })
+  it('returns [] for absent kv / empty key / read error / bad JSON', async () => {
+    expect(await readOverridesFresh(undefined)).toEqual([])
+    expect(await readOverridesFresh(kvOf(null))).toEqual([])
+    expect(await readOverridesFresh(kvOf('not json'))).toEqual([])
+    expect(await readOverridesFresh(kvOf(null, true))).toEqual([])
+  })
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,6 +4,7 @@
 
 import { fetchAllServices, CACHE_KEY, COMPONENT_ID_SERVICES, SERVICES, type ServiceStatus } from './services'
 import { SUPPRESSIONS_KEY, normalizeSuppressions, mutateSuppressions, invalidateSuppressionCache, readSuppressionsFresh, type SuppressionEntry } from './suppression'
+import { OVERRIDES_KEY, normalizeOverrides, mutateOverrides, readOverridesFresh, applyDurationOverrides, type DurationOverride } from './overrides'
 import { calculateAIWatchScore, classifyProbe } from './score'
 import { buildIncidentAlerts, buildServiceAlerts, mergeTogetherAlerts, mergeXaiRegionalAlerts, detectServiceCountDrop, isFlapSuppressible, flapSuppressionKey, shouldHoldNewIncident, shouldHoldForAiAnalysis, pendingAiKey, pendingNewKey, PENDING_NEW_TTL_S, buildTweetDrafts, appendTweetDraftSection, buildTweetSearches, buildTweetSearchUrl, buildReplyDraft, pushTargetFor, appendTweetSearchSection, defuseAutolinkDomain, parseAlertedRoster, sourceLivenessOf, decideSourceDeadAction, shouldSuppressSourceDeadAlert, pendingSourceDeadKey, PENDING_SOURCE_DEAD_TTL_S, buildSourceDeadEmbed } from './alerts'
 import { analyzeIncidentDetailed, analyzeIncidentWithBudget, analyzeWithSonnetDetailed, refreshOrReanalyze, analysisKey, buildAnalysisPrompt, findSimilarIncidents, formatAnalysisEmbedSection, parseAnalysis, putAnalysis, shouldSkipInitialAnalysis, recordUsage, parseUsage, summarizeAiUsageTrend, type AIAnalysisResult, type AnalysisAttempt, type AnalysisFailureKind } from './ai-analysis'
@@ -1966,6 +1967,62 @@ async function handleAdminSuppress(request: Request, env: Env, cors: Record<stri
   return json(200, { ok: true, changed: result.changed, suppressions: result.list })
 }
 
+// ── #1019: GET/POST /api/admin/duration-override ──────────────────
+// Operator-managed incident duration-override list (see overrides.ts). GET returns the current list;
+// POST { action:'add'|'remove', id, durationMin?, reason? } mutates it. Auth via X-Admin-Key (same
+// ADMIN_API_KEY). Pure add/remove logic lives in mutateOverrides; no cache to invalidate (the apply
+// sites read fresh). Corrects a paperwork-inflated duration WITHOUT hiding the incident.
+interface AdminOverrideRequest {
+  action?: unknown
+  id?: unknown
+  durationMin?: unknown
+  reason?: unknown
+}
+
+async function handleAdminOverride(request: Request, env: Env, cors: Record<string, string>): Promise<Response> {
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { ...cors, 'Content-Type': 'application/json' } })
+
+  if (!env.ADMIN_API_KEY) return json(401, { ok: false, error: 'unauthorized' })
+  const provided = request.headers.get('X-Admin-Key') ?? ''
+  if (!constantTimeEqual(provided, env.ADMIN_API_KEY)) return json(401, { ok: false, error: 'unauthorized' })
+  if (!env.STATUS_CACHE) return json(503, { ok: false, error: 'Service unavailable' })
+
+  let current: DurationOverride[]
+  try {
+    const raw = await env.STATUS_CACHE.get(OVERRIDES_KEY)
+    current = raw ? normalizeOverrides(JSON.parse(raw)) : []
+  } catch (err) {
+    console.error('[admin/duration-override] KV read failed:', err instanceof Error ? err.message : err)
+    return json(502, { ok: false, error: 'failed to read override list' })
+  }
+
+  if (request.method === 'GET') return json(200, { ok: true, overrides: current })
+
+  let body: AdminOverrideRequest
+  try { body = await request.json() } catch { return json(400, { ok: false, error: 'invalid JSON body' }) }
+
+  const result = mutateOverrides(current, {
+    action: body.action === 'remove' ? 'remove' : body.action === 'add' ? 'add' : ('' as 'add'),
+    id: typeof body.id === 'string' ? body.id : undefined,
+    durationMin: typeof body.durationMin === 'number' ? body.durationMin : undefined,
+    reason: typeof body.reason === 'string' ? body.reason : undefined,
+    by: 'admin',
+    createdAt: new Date().toISOString(),
+  })
+  if (!result.ok) return json(400, { ok: false, error: result.error })
+
+  if (result.changed) {
+    try {
+      await env.STATUS_CACHE.put(OVERRIDES_KEY, JSON.stringify(result.list))
+    } catch (err) {
+      console.error('[admin/duration-override] KV write failed:', err instanceof Error ? err.message : err)
+      return json(502, { ok: false, error: 'failed to write override list' })
+    }
+  }
+  return json(200, { ok: true, changed: result.changed, overrides: result.list })
+}
+
 export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
     // Use the scheduled trigger time (not wall-clock) so time-of-day checks like
@@ -2305,12 +2362,14 @@ export default {
           // #904 — filter operator-suppressed incidents out of the raw accumulator before summarizing,
           // else a suppressed incident (e.g. FedRAMP) resurfaces in the weekly Discord incident summary.
           const weeklySuppressions = await readSuppressionsFresh(env.STATUS_CACHE)
+          const weeklyOverrides = await readOverridesFresh(env.STATUS_CACHE) // #1019
           for (const mk of [currMonthKey, prevMonthKey]) {
             const mRaw = await env.STATUS_CACHE.get(mk).catch(() => null)
             if (!mRaw) continue
             try {
               const parsed = JSON.parse(mRaw) as MonthlyIncidents
-              const filtered = weeklySuppressions.length ? filterSuppressedFromMonthly(parsed, weeklySuppressions) : parsed
+              const suppressed = weeklySuppressions.length ? filterSuppressedFromMonthly(parsed, weeklySuppressions) : parsed
+              const filtered = weeklyOverrides.length ? applyDurationOverrides(suppressed, weeklyOverrides) : suppressed
               allMonthlyIncidents.push(...parseMonthlyIncidents(filtered, serviceNameMap))
             } catch (err) { console.warn(`[cron] ${mk} parse failed:`, err instanceof Error ? err.message : String(err)) }
           }
@@ -3211,6 +3270,14 @@ export default {
       return handleAdminSuppress(request, env, cors)
     }
 
+    // #1019 — GET/POST /api/admin/duration-override — operator incident duration-override list. POST
+    // adds/removes { id, durationMin }; GET lists. Pins a paperwork-inflated incident's duration to the
+    // real value across the monthly archive, the report partial, and the weekly briefing (keeps the
+    // incident; only corrects its duration — unlike suppression, which hides it).
+    if ((request.method === 'POST' || request.method === 'GET') && url.pathname === '/api/admin/duration-override') {
+      return handleAdminOverride(request, env, cors)
+    }
+
     // #486 — server-side per-user Discord subscription endpoints. The browser POSTs the raw URL +
     // filters here; the worker stores the AES-GCM-encrypted URL and (PR3) the cron fan-out delivers
     // directly, so alerts fire tab-independently. Ownership is proven by a confirm code sent THROUGH
@@ -4096,6 +4163,10 @@ export default {
           if (incidentData) {
             const suppressions = await readSuppressionsFresh(env.STATUS_CACHE)
             if (suppressions.length) incidentData = filterSuppressedFromMonthly(incidentData, suppressions)
+            // #1019 — pin any operator-overridden incident duration so the dashboard 30/90-day list
+            // shows the corrected value, not the provider's paperwork-inflated open→close span.
+            const overrides = await readOverridesFresh(env.STATUS_CACHE)
+            if (overrides.length) incidentData = applyDurationOverrides(incidentData, overrides)
           }
           const partial = buildPartialIncidentArchive(month, incidentData)
           return new Response(JSON.stringify(partial), {

--- a/worker/src/monthly-archive.ts
+++ b/worker/src/monthly-archive.ts
@@ -17,6 +17,7 @@ import { generateMonthlyNarrative, type MonthlyNarrativeDraft, type NarrativeAiO
 import { SERVICE_ADDED_AT, SERVICES, existedInMonth } from './services'
 import { readIncidentHistory, summarizeAccuracy, type AccuracyStats, type IncidentHistoryRecord } from './incident-history'
 import { readSuppressionsFresh, readSuppressionsFreshOrNull, isSuppressedByIdTitle, type SuppressionEntry } from './suppression'
+import { readOverridesFresh, applyDurationOverrides } from './overrides'
 import { kvPut } from './utils'
 
 export type ScoreGrade = 'excellent' | 'good' | 'fair' | 'degrading' | 'unstable'
@@ -1224,6 +1225,10 @@ export async function buildMonthlyArchive(
     // manual, correctness-critical one-shot, so it must see a just-added suppression immediately.
     const suppressions = await readSuppressionsFresh(kv)
     if (suppressions.length) incidentData = filterSuppressedFromMonthly(incidentData, suppressions)
+    // #1019 — build-time duration overrides: pin a paperwork-inflated incident's duration to the
+    // operator value, recomputing downtime/longest from the survivors (rebuild-safe, no KV surgery).
+    const overrides = await readOverridesFresh(kv)
+    if (overrides.length) incidentData = applyDurationOverrides(incidentData, overrides)
   }
 
   // Snapshot accumulated security alerts before their 60d TTL lapses (#290). Missing

--- a/worker/src/overrides.ts
+++ b/worker/src/overrides.ts
@@ -1,0 +1,175 @@
+// #1019 — Operator incident duration-OVERRIDE layer.
+//
+// Sibling of the #904 suppression layer, for a different problem. An incident's `duration` is derived
+// from the provider's PAPERWORK timestamps (`resolved_at − created_at`; parsers/statuspage.ts). When a
+// provider leaves an incident open long AFTER the affected component actually recovered, that duration
+// massively overstates real impact — e.g. Cursor `h71m65my586h` (2026-07-14): IDE went
+// `degraded_performance` at 19:52 UTC and was already `operational` well before the formal 09:11 UTC
+// resolve, yet our stored duration is 13h 20m (the sibling "- Sol" incident on the same component
+// resolved in 18 min — the best proxy for when the shared degradation actually cleared).
+//
+// Suppression HIDES an incident; an override KEEPS it but PINS its duration to an operator-stated value.
+// It corrects the monthly-report duration stats a paperwork-inflated duration distorts
+// (`longestIncidentMin`, `totalDowntimeMin`, `avgResolutionMin`, AND the calendar-month `monthlyScore`
+// whose MTTR reads the same per-incident durations — #993) and the per-incident duration on the read
+// surfaces, WITHOUT deleting the incident (which suppression would). It corrects BOTH `durationMin` AND
+// the derived `resolvedAt` (= `startedAt + durationMin`), so timestamp-derived consumers — the grouped-
+// incident row duration (`sumGroupDuration`) and the Uptime calendar span — agree with `durationMin`
+// rather than still painting the paperwork span.
+//
+// WHY A DEDICATED MECHANISM, NOT A ONE-OFF KV EDIT: `accumulateMonthlyIncidents` has a MONOTONIC guard
+// (`if (dur > oldDur)`) that re-inflates a manually-lowered duration back to the provider value on the
+// next cron while the incident is still in the live feed. An override is applied on READ/BUILD instead
+// (the same rebuild-safe shape as `filterSuppressedFromMonthly`), so it never fights the accumulator.
+//
+// APPLY POINTS — the monthly-accumulator read/build paths, right after suppression:
+//   1. `buildMonthlyArchive` build-time — corrects a rebuilt/first-built month's archive.
+//   2. `/api/report` current-month partial — the dashboard 30/90-day incident list.
+//   3. the weekly briefing — reads the raw accumulator directly.
+// The live `/api/status` Score is intentionally NOT overridden here: MTTR is median-based for services
+// with ≥3 resolved incidents (robust to one outlier), and the going-forward scoring robustness is
+// tracked separately (#1019 Part B).
+
+import type { MonthlyIncidents, MonthlyIncidentServiceData } from './monthly-archive'
+
+/** KV key holding the operator duration-override list (single JSON array, no TTL — permanent). */
+export const OVERRIDES_KEY = 'incident:duration-overrides'
+
+/** Pin ONE incident's duration (by id) to an operator-stated minute value. */
+export interface DurationOverride {
+  id: string
+  durationMin: number
+  reason?: string
+  createdAt?: string
+  by?: string
+}
+
+/** Pure: validate/normalize a parsed KV value into well-formed entries (drops malformed rows). A row
+ *  needs a non-empty `id` and a finite `durationMin >= 0` (0 zeroes the incident's downtime, allowed). */
+export function normalizeOverrides(parsed: unknown): DurationOverride[] {
+  if (!Array.isArray(parsed)) return []
+  const out: DurationOverride[] = []
+  for (const raw of parsed) {
+    if (!raw || typeof raw !== 'object') continue
+    const e = raw as Record<string, unknown>
+    if (typeof e.id !== 'string' || !e.id) continue
+    if (typeof e.durationMin !== 'number' || !Number.isFinite(e.durationMin) || e.durationMin < 0) continue
+    const o: DurationOverride = { id: e.id, durationMin: e.durationMin }
+    if (typeof e.reason === 'string') o.reason = e.reason
+    if (typeof e.createdAt === 'string') o.createdAt = e.createdAt
+    if (typeof e.by === 'string') o.by = e.by
+    out.push(o)
+  }
+  return out
+}
+
+/** Pure: id → durationMin map for the current list. Last entry wins on a duplicate id. */
+export function overrideMap(list: DurationOverride[]): Map<string, number> {
+  const m = new Map<string, number>()
+  for (const o of list) m.set(o.id, o.durationMin)
+  return m
+}
+
+/** Pure: return the monthly-accumulator data with overridden incidents' durations PINNED to the
+ *  operator value, recomputing each affected service's `totalMinutes`/`longestMinutes` from the
+ *  `durations` map (the exact pattern `filterSuppressedFromMonthly` uses) and updating the per-incident
+ *  detail: `incidents[].durationMin` (the #915 `aggregateIncidentDurations` source of truth) AND, for an
+ *  already-resolved entry with a parseable `startedAt`, `incidents[].resolvedAt = startedAt + durationMin`
+ *  so timestamp-derived surfaces (grouped-row duration, uptime calendar span) agree. `count` and
+ *  `incidentIds` are unchanged — the incident stays; only its duration is corrected.
+ *
+ *  Identity-preserving when nothing applies (no needless object churn). Structurally-corrupt input is
+ *  returned as-is, mirroring `filterSuppressedFromMonthly`, so a caller outside a try/catch can't throw. */
+export function applyDurationOverrides(data: MonthlyIncidents, list: DurationOverride[]): MonthlyIncidents {
+  if (!list.length || !data?.services || typeof data.services !== 'object') return data
+  const byId = overrideMap(list)
+  const services: Record<string, MonthlyIncidentServiceData> = {}
+  let anyChange = false
+  for (const [svcId, svc] of Object.entries(data.services)) {
+    const ids = svc.incidentIds ?? []
+    if (!ids.some((id) => byId.has(id))) { services[svcId] = svc; continue }
+    anyChange = true
+    const durations: Record<string, number> = { ...(svc.durations ?? {}) }
+    for (const id of Object.keys(durations)) {
+      if (byId.has(id)) durations[id] = byId.get(id)!
+    }
+    const incidents = (svc.incidents ?? []).map((e) => {
+      if (!byId.has(e.id)) return e
+      const durationMin = byId.get(e.id)!
+      const next = { ...e, durationMin }
+      // Keep resolvedAt consistent with the pinned duration so consumers that derive length from
+      // `resolvedAt − startedAt` (not `durationMin`) agree. Only for an already-resolved entry with a
+      // parseable start — never fabricate a resolution for a still-open incident.
+      const startMs = e.startedAt ? Date.parse(e.startedAt) : NaN
+      if (e.resolvedAt && !Number.isNaN(startMs)) {
+        next.resolvedAt = new Date(startMs + durationMin * 60_000).toISOString()
+      }
+      return next
+    })
+    const durationVals = Object.values(durations)
+    services[svcId] = {
+      ...svc,
+      totalMinutes: durationVals.reduce((a, b) => a + b, 0),
+      longestMinutes: durationVals.reduce((m, d) => Math.max(m, d), 0),
+      durations,
+      incidents,
+    }
+  }
+  return anyChange ? { ...data, services } : data
+}
+
+// ── Admin mutation (mirrors mutateSuppressions) ──────────────────────────────
+
+export interface OverrideMutation {
+  action: 'add' | 'remove'
+  id?: string
+  durationMin?: number
+  reason?: string
+  by?: string
+  createdAt?: string
+}
+
+export type OverrideMutationResult =
+  | { ok: true; list: DurationOverride[]; changed: boolean }
+  | { ok: false; error: string }
+
+/** Pure: apply an add/remove mutation to the override list. Add is keyed by `id` (re-adding the same id
+ *  UPDATES its durationMin/metadata — an override is a correction, so the latest value should win, unlike
+ *  a suppression which is idempotent). Remove drops the id. */
+export function mutateOverrides(list: DurationOverride[], m: OverrideMutation): OverrideMutationResult {
+  if (!m.id) return { ok: false, error: 'id is required' }
+  if (m.action === 'remove') {
+    const next = list.filter((e) => e.id !== m.id)
+    return { ok: true, list: next, changed: next.length !== list.length }
+  }
+  if (m.action === 'add') {
+    if (typeof m.durationMin !== 'number' || !Number.isFinite(m.durationMin) || m.durationMin < 0) {
+      return { ok: false, error: 'durationMin must be a finite number >= 0' }
+    }
+    const entry: DurationOverride = {
+      id: m.id,
+      durationMin: m.durationMin,
+      ...(m.reason ? { reason: m.reason } : {}),
+      ...(m.by ? { by: m.by } : {}),
+      ...(m.createdAt ? { createdAt: m.createdAt } : {}),
+    }
+    const existing = list.find((e) => e.id === m.id)
+    const next = existing ? list.map((e) => (e.id === m.id ? entry : e)) : [...list, entry]
+    const changed = !existing || existing.durationMin !== entry.durationMin || existing.reason !== entry.reason
+    return { ok: true, list: next, changed }
+  }
+  return { ok: false, error: 'action must be "add" or "remove"' }
+}
+
+/** Fresh (uncached) read of the override list from KV — the apply sites are the rare, correctness-
+ *  critical archive-build / report-partial / weekly-briefing reads (same callers as
+ *  `readSuppressionsFresh`). Best-effort → [] on absent kv / read / parse error (never breaks caller). */
+export async function readOverridesFresh(kv?: KVNamespace): Promise<DurationOverride[]> {
+  if (!kv) return []
+  try {
+    const raw = await kv.get(OVERRIDES_KEY)
+    return raw ? normalizeOverrides(JSON.parse(raw)) : []
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
Refs #1019.

## Problem
An incident's `duration` is the provider's **paperwork** span (`resolved_at − created_at`). When a provider leaves an incident open long after the affected component recovered, that overstates real impact. Reference case — Cursor `h71m65my586h` (2026-07-14): IDE went `degraded_performance` at 19:52 UTC and was already `operational` before the formal 09:11 UTC resolve (its resolve-update `affected_components` reads `operational → operational`), yet the stored duration is **13h 20m**; the sibling `96m8j04k15r5` ("- Sol") on the same component resolved in **18 min**. That inflated duration feeds MTTR/Recovery and the monthly report's `longestIncidentMin` / `totalDowntimeMin` / `monthlyScore`.

## Change
New `worker/src/overrides.ts` — an operator duration-**override** layer mirroring the #904 suppression architecture. Suppression HIDES an incident; an override KEEPS it but PINS its duration.

- `incident:duration-overrides` KV list of `{ id, durationMin, reason }`, applied by `applyDurationOverrides` on **READ/BUILD** of the monthly accumulator — *not* by editing it, because `accumulateMonthlyIncidents`'s monotonic `if (dur > oldDur)` guard would re-inflate a raw KV edit on the next cron while the incident is still in the live feed.
- Recomputes `totalMinutes`/`longestMinutes` from the `durations` map (the `filterSuppressedFromMonthly` pattern), updates `incidents[].durationMin` (the #915 `aggregateIncidentDurations` source of truth), and — for a resolved entry — `resolvedAt = startedAt + durationMin` so the timestamp-derived surfaces (`sumGroupDuration`, the Uptime calendar span) agree.
- Wired at the three accumulator read/build sites right after suppression: `buildMonthlyArchive` (rebuild-safe), the `/api/report` current-month partial, and the weekly briefing.
- New `GET/POST /api/admin/duration-override` endpoint (auth/validation mirror `handleAdminSuppress`).
- The live `/api/status` Score is intentionally **not** overridden — MTTR is median-robust at ≥3 resolved incidents; general MTTR robustness is **Part B** (below).

## Verification
Exercised the real endpoints on a local worker with a seeded 2026-07 accumulator: override absent → `/api/report` shows 799; added via admin API → **18**; removed → 799; bad admin key → 401. Worker suite **2825 pass**, `typecheck:worker` clean, dry-run builds. Code review: 0 Critical; one Important (resolvedAt consistency) fixed + re-review confirmed converged.

## Scope / follow-up
- **Part A (this PR)** — the override mechanism + Cursor July one-off correction.
- **Part B (open on #1019, decide during impl)** — going-forward MTTR robustness: a confidence-gate or small-sample shrinkage on MTTR, vs. computing duration from AIWatch's own observed `degraded → operational` edge. Not in this PR.
- **Post-merge (production-gated)** — after worker deploy, one admin call sets `h71m65my586h`=18; the July report builds ~Aug 1 and should then read the corrected figure. Tracked as a `verify-after` on #1019.

## Docs
`status-determination.md`, `operator-tools.md`, CLAUDE.md directory map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)