### PR TITLE
chore(seo): register /reports/2026-06/ + /reports/resilience/ in sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -132,6 +132,18 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://ai-watch.dev/reports/resilience/</loc>
+    <lastmod>2026-07-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-watch.dev/reports/2026-06/</loc>
+    <lastmod>2026-07-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://ai-watch.dev/reports/2026-05/</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## What
Adds two live URLs to the hand-maintained report list in `public/sitemap.xml`:
- `https://ai-watch.dev/reports/2026-06/` — the June 2026 monthly report (published in aiwatch-reports#51)
- `https://ai-watch.dev/reports/resilience/` — the evergreen Resilience Patterns page

Both are live via the reports proxy but were missing from the sitemap, so Googlebot had no discovery path.

## Notes
- Purely additive (2 `<url>` entries, format copied from the adjacent report entries). XML well-formed (`xmllint --noout`), `npm run test:scripts` green (194/194).
- `<lastmod>` is only a committed base — the `#648` prebuild bump rewrites every `<lastmod>` to the deploy date on Vercel/CI, so the committed dates need not be exact (kept additive to avoid date churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)