### PR TITLE
test(overview): assert the filter invariant, not a named service's live status (#1034)

### DIFF
--- a/src/pages/Overview.jsx
+++ b/src/pages/Overview.jsx
@@ -119,6 +119,12 @@ function ServiceCard({ service, index, onClick, t, isRecovered, isProbed }) {
   return (
     <button
       onClick={onClick}
+      // #1034 — stable hook for the filter-tab e2e, which counts rendered cards and asserts they
+      // match the active tab's own badge count. A structural selector can't do it: ServiceCard
+      // itself contains a `grid` (the metrics row), so `div.grid > button` is ambiguous, and the
+      // section grid's responsive classes are styling, not contract. Mirrors the existing
+      // `data-testid="supply-chain-banner"` precedent below.
+      data-testid="service-card"
       className="w-full text-left bg-[var(--bg1)] border border-[var(--border)] rounded-lg
                  hover:border-t-[var(--border-hi)] hover:border-r-[var(--border-hi)] hover:border-b-[var(--border-hi)] transition-colors animate-[fade-in_0.3s_ease_both]"
       style={{

--- a/src/utils/statusDisplay.test.js
+++ b/src/utils/statusDisplay.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveStatusDisplay, sourceFlagsOf, displayStatusOf, isDisplayAffected } from './statusDisplay'
+import { resolveStatusDisplay, sourceFlagsOf, displayStatusOf, isDisplayAffected, isDisplayOperational } from './statusDisplay'
 
 // #722/#744 — the shared badge/stripe display-status resolver. Drives the StatusPill, the Overview
 // card left stripe, the sidebar dot, and (mirrored) the is-down header. Pure; never mutates the raw
@@ -84,5 +84,54 @@ describe('isDisplayAffected', () => {
 
   it('does not count a sub-threshold partial as an outage (#722 — the service is up overall)', () => {
     expect(isDisplayAffected({ status: 'operational', partialCount: 2 })).toBe(false)
+  })
+})
+
+// #1034 — `isDisplayOperational` had NO unit coverage despite #1004 calling it "the single predicate
+// behind the stat card, the tab badge AND the tab's list" (they drifted apart when only some moved).
+// The Overview filter-tab e2e asserts the tab COUNT and the rendered LIST agree, which catches that
+// drift — but both derive from THIS predicate, so a bug inside it breaks them identically and the
+// e2e still passes. That blind spot is why the predicate needs its own deterministic test.
+describe('isDisplayOperational (#1034 — the predicate the filter e2e cannot catch)', () => {
+  it('is true for a plainly operational service', () => {
+    expect(isDisplayOperational({ status: 'operational' })).toBe(true)
+  })
+
+  it('counts `partial` as operational (#722/#744 — the service IS up overall)', () => {
+    // Not a formality: this is why a partial service's is-down SEO answer stays "No".
+    expect(isDisplayOperational({ status: 'operational', partialCount: 2 })).toBe(true)
+  })
+
+  it('is false for confirmed outages', () => {
+    expect(isDisplayOperational({ status: 'degraded' })).toBe(false)
+    expect(isDisplayOperational({ status: 'down' })).toBe(false)
+  })
+
+  it('is false for an unreadable source — `unknown` is neither healthy nor affected (#1004)', () => {
+    // The bucket that makes operational + issues NOT partition the total; the Overview tabs rely on
+    // this, so an 'unknown' service must fall out of BOTH tabs rather than pad the operational one.
+    expect(isDisplayOperational({ status: 'operational', sourceDead: true })).toBe(false)
+    expect(isDisplayOperational({ status: 'degraded', sourceUnknown: true })).toBe(false)
+    expect(isDisplayAffected({ status: 'operational', sourceDead: true })).toBe(false)
+  })
+
+  it('honours the probe overrides (#689/#1004)', () => {
+    // probeConfirmed suppresses sourceDead → we know it's up despite the dead status page.
+    expect(isDisplayOperational({ status: 'operational', sourceDead: true, probeConfirmed: true })).toBe(true)
+    // probeContradicted suppresses sourceUnknown → the degraded is real, so NOT operational.
+    expect(isDisplayOperational({ status: 'degraded', sourceUnknown: true, probeContradicted: true })).toBe(false)
+  })
+
+  it('never reports a service as both operational and affected (the tabs must not double-count)', () => {
+    const cases = [
+      { status: 'operational' }, { status: 'operational', partialCount: 2 },
+      { status: 'degraded' }, { status: 'down' },
+      { status: 'operational', sourceDead: true }, { status: 'degraded', sourceUnknown: true },
+      { status: 'operational', sourceDead: true, probeConfirmed: true },
+      { status: 'degraded', sourceUnknown: true, probeContradicted: true },
+    ]
+    for (const s of cases) {
+      expect(isDisplayOperational(s) && isDisplayAffected(s), JSON.stringify(s)).toBe(false)
+    }
   })
 })

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -33,28 +33,61 @@ test.describe('Overview page', () => {
     await expect(page.locator('main').getByText('Status Calendar')).toBeVisible({ timeout: 5000 })
   })
 
-  test('filter tabs switch between All / Operational / Issues', async ({ page }) => {
+  // #1034 — asserts the filter INVARIANT ("the grid renders exactly as many cards as the active
+  // tab's own badge claims"), not the live status of a named service.
+  //
+  // The previous version asserted `Claude API` was visible under Operational, commented "always
+  // operational". That is a live-data assumption: when Claude API is genuinely degraded it is
+  // correctly filtered out and the test hard-failed, blaming the filter for working. It could
+  // only ever fail LOCALLY — CI starts no worker, so the SPA falls back to MOCK_SERVICES where
+  // `claude` is hard-coded `operational` (usePolling.js) and the assertion is vacuously true.
+  // Meanwhile CLAUDE.md makes the real local worker the DEFAULT, so the documented workflow met a
+  // failure CI could never reproduce.
+  //
+  // The count↔list agreement is also strictly better coverage: #1004 was exactly that drift — the
+  // Issues badge read 0 while the tab rendered 1 card, because the counts resolved the DISPLAY
+  // state while the filter still keyed on the raw status. This now guards it in both directions.
+  test('filter tabs switch between All / Operational / Issues (#1034)', async ({ page }) => {
     // Filter tabs are pill-style segment control (bg2 rounded container)
     const tabBar = page.locator('main .flex.bg-\\[var\\(--bg2\\)\\]')
+    const cards = page.locator('[data-testid="service-card"]')
 
-    // Click Operational tab via evaluate
-    const opTab = tabBar.getByRole('button', { name: /Operational|정상/ })
-    await opTab.evaluate((el) => el.click())
-    // Wait for filter to apply
-    await page.waitForTimeout(200)
-    // Claude API should be visible (always operational)
-    await expect(page.locator('main button').filter({ hasText: 'Claude API' })).toBeVisible()
+    // Each tab renders `<label> <count>`; read the count off the tab itself so the expectation is
+    // derived from the app's own state rather than any assumption about live data.
+    const countOnTab = async (tab) => {
+      const text = await tab.textContent()
+      const m = text.match(/(\d+)/)
+      expect(m, `tab should render a count: "${text}"`).not.toBeNull()
+      return Number(m[1])
+    }
 
-    // Click All tab to restore
-    const allTab2 = tabBar.getByRole('button').first()
-    await allTab2.evaluate((el) => el.click())
-    await page.waitForTimeout(200)
-
-    // Click All tab to restore
     const allTab = tabBar.getByRole('button').first()
+    const opTab = tabBar.getByRole('button', { name: /Operational|정상/ })
+    const issuesTab = tabBar.getByRole('button', { name: /Issues|이슈/ })
+
+    // Baseline: All shows every card in the active category.
+    const totalCount = await countOnTab(allTab)
+    expect(totalCount).toBeGreaterThan(0)
+    await expect(cards).toHaveCount(totalCount)
+
+    // Operational: the grid must match the tab's own badge.
+    const opCount = await countOnTab(opTab)
+    await opTab.evaluate((el) => el.click())
+    await expect(cards).toHaveCount(opCount)
+
+    // Issues: same invariant. Zero is a legitimate live state (everything healthy) — the tab then
+    // renders the "No Issues" empty state instead of cards, which is still 0 cards.
+    const issueCount = await countOnTab(issuesTab)
+    await issuesTab.evaluate((el) => el.click())
+    await expect(cards).toHaveCount(issueCount)
+
+    // Operational + Issues do NOT partition the total: an unreadable-source service resolves to
+    // 'unknown' and belongs to neither tab (#1004). Assert the weaker, true relation.
+    expect(opCount + issueCount).toBeLessThanOrEqual(totalCount)
+
+    // All restores the full grid.
     await allTab.evaluate((el) => el.click())
-    await page.waitForTimeout(200)
-    await expect(page.locator('main button').filter({ hasText: 'Claude API' })).toBeVisible()
+    await expect(cards).toHaveCount(totalCount)
   })
 
   test('category tabs filter the grid into per-category sections (#646)', async ({ page }) => {


### PR DESCRIPTION
## Problem

The Overview filter-tab e2e guarded the tabs by asserting one **hard-coded service** was visible under "Operational":

```js
// Claude API should be visible (always operational)
await expect(page.locator('main button').filter({ hasText: 'Claude API' })).toBeVisible()
```

"Claude API is always operational" is a live-data assumption. When Claude API is genuinely `degraded` it is correctly filtered out and the test hard-fails — **blaming the filter for working**. Hit while shipping #949.

## Why CI never caught it

**CI e2e and the documented local workflow read different data sources**, so this could only ever fail locally:

| | data source | `claude` |
|---|---|---|
| CI (`desktop`/`mobile`) | no worker started → SPA falls back to `MOCK_SERVICES` | `operational` — **hard-coded** |
| Documented local workflow | `npm run dev:worker` → **real prod data** | whatever prod actually is |

CLAUDE.md makes the real local worker the **DEFAULT** ("do NOT rely on the `MOCK_SERVICES` fallback"), so anyone following the runbook meets a failure CI cannot reproduce. The mirror image of `debugging_e2e_reuse_server_stale` ("local pass ≠ CI pass") — here it's **"local fail ≠ real fail"**.

## Fix — assert the invariant

For each tab, read the count **the tab renders on itself** and assert the grid holds exactly that many cards. No named service, no live-status assumption.

**This is strictly better coverage, not just a de-flake:**

- It guards the **#1004 drift class** — that issue's own comment records the real bug: *"the Issues badge read 0 while the tab rendered 1 card"*, because the counts resolved the display state while the filter still keyed on the raw status. Now guarded in both directions.
- **Non-vacuous in CI too**: the mock is 43 / 39 / 4, so all three expected values are distinct — a no-op, empty, or swapped filter fails.
- Covers the **Issues tab** (previously untested despite the test's title).
- Drops a **duplicated** "Click All tab" block.
- Asserts `opCount + issueCount <= totalCount` — they do **not** partition: an unreadable-source service resolves to `unknown` and belongs to neither (#1004).
- Replaces a `waitForTimeout(200)` guess with auto-retrying `toHaveCount`.

## Supporting changes

**`Overview.jsx`** — `data-testid="service-card"` on the ServiceCard root. A structural selector can't do it: ServiceCard *itself* contains a `grid` (the metrics row), so `div.grid > button` is ambiguous, and the section grid's responsive classes are styling, not contract. Mirrors the existing `data-testid="supply-chain-banner"` in the same file. Inert attribute, no visual change.

**`statusDisplay.test.js`** — unit-test `isDisplayOperational`, which had **zero coverage** despite #1004 calling it *"the single predicate behind the stat card, the tab badge AND the tab's list"*. The e2e asserts count/list **agreement**, so a wrong-but-*consistent* predicate breaks both identically and still passes — that blind spot is exactly what a unit test must cover (the #787 layering: agreement → e2e, predicate correctness → unit). Pins partial-counts-as-operational (#722/#744), the probe overrides (#689/#1004), and the disjointness property the `<=` assertion rests on.

## Verification

Both ways, at the same moment, with **Claude API degraded in live data**:

| | live worker (claude degraded) | mock (CI shape) |
|---|---|---|
| **old** assertion | ❌ `element(s) not found` | ✅ (vacuously) |
| **new** test | ✅ | ✅ |

e2e **150/150** (main was 149/150 — that one failure was this exact test) · test:src **871** (+6) · build ✅ · eslint 0 errors · filter test `--repeat-each=3` 3/3.

## Precedent

Live-data e2e flakes have recurred: #643/#644 (soften), #650/#651 (mock the route), #787/#788 (delete + unit-test — the settled doctrine). Full deletion is the wrong fit here: unlike #787's live *tie*, this test guards genuinely valuable behaviour and is deterministic under the mock. A `grep` confirms this was the **last remaining** live-status assumption in the suite.

## Out of scope

Unifying the CI/local e2e data sources (the deeper divergence). Noted in the issue.

closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)