### PR TITLE
fix(ci): clear lifecycle labels left on closed issues (refs #1037)

### DIFF
--- a/docs/reference/verify-assertions.md
+++ b/docs/reference/verify-assertions.md
@@ -102,9 +102,23 @@ Two deliberate edges, both pinned by tests:
 
 | Label | Added by | Removed by |
 |---|---|---|
-| `verify-blocked` | operator at merge (ship-issue step 10) | auto-verify, once no unchecked `verify-after` line remains |
-| `body-drift` | daily guard, when stray unchecked boxes exist | daily guard, once the body is synced (self-healing) |
-| `verify-overdue` | daily job, on every ping | daily job, once the issue is no longer due (self-healing since #966) |
+| `verify-blocked` | operator at merge (ship-issue step 10) | auto-verify, once no unchecked `verify-after` line remains; **or the closed-issue sweep (#1037)** |
+| `body-drift` | daily guard, when stray unchecked boxes exist | daily guard, once the body is synced (self-healing); **or the closed-issue sweep (#1037)** |
+| `verify-overdue` | daily job, on every ping | daily job, once the issue is no longer due (self-healing since #966); **or the closed-issue sweep (#1037)** |
+
+**Closing an issue clears all three (#1037).** Each label describes an *open* verification obligation,
+so closing is that obligation's terminal state — the daily job sweeps closed issues and strips every one
+of them, unconditionally (no date logic: closed is closed). Grouped into one edit per issue, from one
+bounded query per label. This is what makes the labels safe to filter on in triage: a hit means current
+state.
+
+> **Reopening a swept issue does not restore `verify-blocked` — re-add it by hand.** Closing is terminal
+> for the *obligation*, not for the *issue*. Only `verify-overdue` comes back on its own (the next ping;
+> that path is gated on the scanned set, not on any label). **Nothing in this job ever adds
+> `verify-blocked`** — it is applied by hand at merge. And because `isDriftCandidate` gates on
+> `verify-blocked`, `body-drift` does **not** come back either: without it the issue never enters the
+> drift scan at all, so a reopened swept issue silently loses body-drift detection until you restore
+> `verify-blocked`.
 
 `verify-overdue` was **add-only** before #966 — nothing removed it, not the auto-verify (which drops
 only `verify-blocked`) and not `gh issue close`. A verified-and-closed issue kept the label
@@ -116,9 +130,23 @@ Two properties of the self-heal worth knowing:
   weekly (`shouldFire`: due date, then every 7th day), so an issue is genuinely overdue on days it is
   not pinged. Clearing on "not pinged today" would flap the label on and off six days a week.
 - **It only reaches OPEN issues** (plus an issue closed by the auto-verify pass earlier in the same
-  run — it was still open when fetched). `fetchRepoIssues` lists `--state open`, so a `verify-overdue`
-  scar left on an issue closed by an *earlier* run is never revisited. This PR fixes forward; #857's
-  pre-existing scar was removed by hand.
+  run — it was still open when fetched, and `toClearOverdue` runs after that pass, which is #857's exact
+  path). `fetchRepoIssues` lists `--state open`, so a `verify-overdue` scar left on an issue closed by
+  an *earlier* run is never revisited. #966 fixed forward only; #857's pre-existing scar was removed by
+  hand at the time. **#1037 closed that half** with the separate closed-issue sweep above, which needs
+  no body and no dates. The two are complementary: the date-derived self-heal governs the label while
+  the issue is open; the sweep collects whatever was still on it at close. A `--dry-run` on 2026-07-16
+  planned **19** historical scars (26 labels) — all of them **human** closes (0 of the 8 `verify-overdue`
+  scars carry an `Auto-verified` comment), which is the gap's real shape: the automated close path
+  already self-heals, so what strands a label is closing by hand between runs.
+
+To reproduce the sweep locally, pass the repo explicitly — `parseScanRepos` falls back to the sibling
+repo alone when `GITHUB_REPOSITORY` is unset (as it is outside CI), so a bare run silently scans neither
+the main board nor its scars:
+
+```bash
+GITHUB_REPOSITORY=bentleypark/aiwatch node scripts/verify-reminders.mjs --dry-run
+```
 
 ## When to add an `assert:` (and when not)
 

--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -76,6 +76,78 @@ export function hasBodyDriftLabel(labels) {
   return hasLabel(labels, 'body-drift')
 }
 
+/**
+ * The labels this job applies to track an OPEN verification obligation (#1037). Each is only ever
+ * meaningful while the issue is open: `verify-blocked` = a dated check is outstanding, `verify-overdue`
+ * = that check is past due, `body-drift` = the body's boxes weren't synced at merge.
+ */
+export const LIFECYCLE_LABELS = ['verify-overdue', 'verify-blocked', 'body-drift']
+
+/** Page size for the per-label closed-issue query (#1037). A truncated page still drains over later
+ *  runs (swept issues leave the result set), but the fetch warns so it never truncates silently. */
+export const CLOSED_SCAR_LIMIT = 100
+
+/**
+ * Plan the label removals for CLOSED issues still wearing a lifecycle label (#1037) — the closed half
+ * of #966's own complaint. Every self-heal in this job is derived from an OPEN issue's body, and the
+ * scan is `--state open`, so closing an issue puts its labels permanently out of reach: the label stops
+ * describing current state and becomes a scar any triage query then misreads. #966 was filed on exactly
+ * this evidence (#857, closed and still overdue-labeled) but only fixed the open case.
+ *
+ * No date logic, deliberately: CLOSED IS the terminal state of a verification obligation, so all three
+ * labels are unconditionally meaningless once the issue is closed. Nothing to re-derive.
+ *
+ * Groups every stale label of one issue into a SINGLE edit — an issue can wear all three (#547 did), and
+ * one `gh issue edit --remove-label a --remove-label b` is one API call instead of three.
+ *
+ * Pure — no I/O. `closedIssues` = gh `--json number,labels` objects, each tagged with its `repo`.
+ */
+export function planClosedScarRemovals(closedIssues) {
+  const out = []
+  for (const iss of closedIssues || []) {
+    const stale = LIFECYCLE_LABELS.filter((l) => hasLabel(iss.labels, l))
+    if (stale.length > 0) out.push({ repo: iss.repo ?? null, number: iss.number, labels: stale })
+  }
+  return out
+}
+
+/**
+ * Merge per-label closed-issue query results into one entry per issue (#1037). The fetch runs one
+ * bounded query PER LABEL (an issue wearing two labels comes back twice), so dedup by repo+number and
+ * union the label sets before planning — otherwise one issue would get one edit per label it wears.
+ *
+ * Flattens to ANY depth on purpose: the caller nests per-repo over per-label (`repos.map(fetchClosedScars)`
+ * → repo[] of label[] of issue[]), and a fixed one-level flat silently yielded arrays instead of issues,
+ * dropping every scar while the unit tests — which passed a shallower shape than the real caller — stayed
+ * green. Caught only by a live --dry-run.
+ * Pure — no I/O.
+ */
+export function mergeClosedIssues(issueLists, warn = console.warn) {
+  const byKey = new Map()
+  for (const iss of (issueLists || []).flat(Infinity)) {
+    // WARN rather than skip quietly. A silently-dropped entry is exactly how the one-level-flat bug
+    // above stayed invisible (0 scars reads identical to a clean board), and this file's own #966
+    // silent-drop guards exist on the principle that a dropped reminder must never look like a quiet
+    // day. `gh --json number,labels` always carries `number`, so this only fires on real shape drift.
+    if (!iss || iss.number == null) {
+      warn(`[verify-reminders] closed-scar entry without a number (gh output shape drift?) — skipped: ${truncate(JSON.stringify(iss), 80)}`)
+      continue
+    }
+    const key = issueKey(iss)
+    const prev = byKey.get(key)
+    if (!prev) {
+      byKey.set(key, { ...iss, labels: [...(iss.labels || [])] })
+      continue
+    }
+    const seen = new Set(prev.labels.map((l) => (typeof l === 'string' ? l : l?.name)))
+    for (const l of iss.labels || []) {
+      const name = typeof l === 'string' ? l : l?.name
+      if (!seen.has(name)) { prev.labels.push(l); seen.add(name) }
+    }
+  }
+  return [...byKey.values()]
+}
+
 /** Stable identity for an issue across repos (the sibling scan means numbers alone collide). */
 const issueKey = (i) => `${i.repo || ''}#${i.number}`
 
@@ -262,6 +334,32 @@ function fetchRepoIssues(repo) {
   }
 }
 
+// Fetch CLOSED issues still wearing a lifecycle label, for one repo (#1037). Bounded by construction:
+// one query PER LABEL, each returning only issues that already carry it — never a full closed-issue
+// scan. Best-effort per label, mirroring fetchRepoIssues: a failure warns + contributes [] so the
+// primary reminder still runs.
+//
+// Deliberately NOT gated by the trusted-author filter: this only REMOVES a label the job itself applies,
+// so there is no abuse surface to close, and the historical scars predate any authorship bookkeeping.
+function fetchClosedScars(repo) {
+  return LIFECYCLE_LABELS.map((label) => {
+    const args = ['issue', 'list', '--state', 'closed', '--label', label, '--limit', String(CLOSED_SCAR_LIMIT), '--json', 'number,labels']
+    if (repo) args.push('--repo', repo)
+    try {
+      const parsed = JSON.parse(gh(args))
+      // A truncated page is self-correcting (swept issues leave the result set, so the backlog drains
+      // over successive days) but must not be silent — same principle as the #966 silent-drop guards.
+      if (parsed.length === CLOSED_SCAR_LIMIT) {
+        console.warn(`[verify-reminders] closed '${label}' scars hit the ${CLOSED_SCAR_LIMIT} page limit for ${repo || 'current repo'} — sweeping the first page; the rest drain on later runs.`)
+      }
+      return parsed.map((i) => ({ ...i, repo }))
+    } catch (e) {
+      console.warn(`[verify-reminders] could not list closed '${label}' issues for ${repo || 'current repo'} (skipping): ${e.message.split('\n')[0]}`)
+      return []
+    }
+  })
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run') || process.env.DRY_RUN === '1'
   const today = todayUTC()
@@ -305,6 +403,30 @@ async function main() {
       const a = ['issue', 'edit', String(iss.number), '--remove-label', 'body-drift']
       if (iss.repo) a.push('--repo', iss.repo)
       try { gh(a) } catch (e) { console.warn(`[verify-reminders] could not clear body-drift on ${displayRef(iss.repo, iss.number)}: ${e.message.split('\n')[0]}`) }
+    }
+  }
+
+  // ── Closed-issue label scars (#1037) ──────────────────────────────────────────
+  // Clear every lifecycle label left on a CLOSED issue. The rest of this job self-heals from an OPEN
+  // issue's body, and the scan is `--state open` — so a label still on at close time is stranded forever
+  // (the #857 case #966 was filed over, which its open-only fix never reached). This job even makes its
+  // own: the #873 auto-verify path closes an issue while dropping only `verify-blocked`.
+  //
+  // Placed HERE, before the due/overdue stage: that stage early-returns when there is nothing to ping,
+  // and a quiet day is exactly when a scar sweep should still run. Best-effort per issue — a label
+  // failure must never abort the reminder run.
+  const closedScars = planClosedScarRemovals(mergeClosedIssues(repos.map(fetchClosedScars)))
+  if (closedScars.length) {
+    console.log(`[verify-reminders] ${today}: ${closedScars.length} closed-issue label scar(s) → ${closedScars.map((s) => `${displayRef(s.repo, s.number)}(${s.labels.join('+')})`).join(', ')}`)
+  }
+  if (dryRun) {
+    if (closedScars.length) console.log('[verify-reminders] --dry-run: would CLEAR closed-issue labels:\n' + JSON.stringify(closedScars, null, 2))
+  } else {
+    for (const scar of closedScars) {
+      const a = ['issue', 'edit', String(scar.number)]
+      for (const l of scar.labels) a.push('--remove-label', l)
+      if (scar.repo) a.push('--repo', scar.repo)
+      try { gh(a) } catch (e) { console.warn(`[verify-reminders] could not clear ${scar.labels.join('+')} on ${displayRef(scar.repo, scar.number)}: ${e.message.split('\n')[0]}`) }
     }
   }
 

--- a/scripts/verify-reminders.test.mjs
+++ b/scripts/verify-reminders.test.mjs
@@ -3,7 +3,7 @@
 // script, not src/worker code.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseVerifyAfter, daysSinceDue, shouldFire, isValidIsoDate, parseTrustedAuthors, parseScanRepos, displayRef, findBodyDrift, isDriftCandidate, hasBodyDriftLabel, hasLabel, findStaleOverdueLabels, findInvalidVerifyAfterDates } from './verify-reminders.mjs'
+import { parseVerifyAfter, daysSinceDue, shouldFire, isValidIsoDate, parseTrustedAuthors, parseScanRepos, displayRef, findBodyDrift, isDriftCandidate, hasBodyDriftLabel, hasLabel, findStaleOverdueLabels, findInvalidVerifyAfterDates, planClosedScarRemovals, mergeClosedIssues, LIFECYCLE_LABELS, CLOSED_SCAR_LIMIT } from './verify-reminders.mjs'
 
 test('parseVerifyAfter — extracts date + note from a checklist line', () => {
   const body = '- [ ] **verify-after 2026-09-01** — check p95 after 3 months (#511)\nother text'
@@ -288,4 +288,118 @@ test('hasBodyDriftLabel — detects the self-heal label', () => {
 test('importing the module runs no side effects (main is guarded)', () => {
   // Reaching here proves importing did not invoke main() (which shells out to `gh` / posts Discord).
   assert.ok(true)
+})
+
+
+// ── #1037 — closed-issue label scars ────────────────────────────────────────────
+// The bug: every self-heal here derives from an OPEN issue's body and the scan is `--state open`, so a
+// lifecycle label still on at close time is stranded forever. #966 was filed on exactly that evidence
+// (#857) but only fixed the open case. Closed IS the terminal state → the labels are unconditionally
+// meaningless, so these assert the no-date-logic rule.
+
+test('planClosedScarRemovals — a closed issue wearing a lifecycle label is planned for removal', () => {
+  const plan = planClosedScarRemovals([{ number: 857, repo: null, labels: [{ name: 'verify-overdue' }] }])
+  assert.deepEqual(plan, [{ repo: null, number: 857, labels: ['verify-overdue'] }])
+})
+
+test('planClosedScarRemovals — groups ALL of one issue\'s stale labels into a single edit (#547 wore all three)', () => {
+  const plan = planClosedScarRemovals([
+    { number: 547, repo: null, labels: [{ name: 'verify-overdue' }, { name: 'verify-blocked' }, { name: 'body-drift' }] },
+  ])
+  assert.equal(plan.length, 1, 'one issue → one edit, not one per label')
+  assert.deepEqual(plan[0].labels, ['verify-overdue', 'verify-blocked', 'body-drift'])
+})
+
+test('planClosedScarRemovals — leaves non-lifecycle labels alone', () => {
+  const plan = planClosedScarRemovals([
+    { number: 1, repo: null, labels: [{ name: 'bug' }, { name: 'area:ops' }, { name: 'verify-blocked' }] },
+  ])
+  assert.deepEqual(plan[0].labels, ['verify-blocked'], 'only lifecycle labels are stripped')
+})
+
+test('planClosedScarRemovals — an issue with no lifecycle label is skipped entirely', () => {
+  assert.deepEqual(planClosedScarRemovals([{ number: 2, repo: null, labels: [{ name: 'bug' }] }]), [])
+  assert.deepEqual(planClosedScarRemovals([]), [])
+  assert.deepEqual(planClosedScarRemovals(null), [])
+})
+
+test('planClosedScarRemovals — carries the repo through for the sibling scan', () => {
+  const plan = planClosedScarRemovals([
+    { number: 54, repo: 'bentleypark/aiwatch-reports', labels: [{ name: 'verify-blocked' }] },
+  ])
+  assert.equal(plan[0].repo, 'bentleypark/aiwatch-reports')
+})
+
+test('planClosedScarRemovals — accepts plain string labels (hasLabel dual shape)', () => {
+  assert.deepEqual(planClosedScarRemovals([{ number: 3, repo: null, labels: ['body-drift'] }]),
+    [{ repo: null, number: 3, labels: ['body-drift'] }])
+})
+
+test('mergeClosedIssues — one issue returned by two per-label queries yields ONE entry, labels unioned', () => {
+  // The fetch runs one query per label, so an issue wearing two comes back twice. Without the merge it
+  // would get one edit per label — the exact waste the grouping exists to avoid.
+  const merged = mergeClosedIssues([
+    [{ number: 547, repo: null, labels: [{ name: 'verify-overdue' }, { name: 'body-drift' }] }],
+    [{ number: 547, repo: null, labels: [{ name: 'verify-overdue' }, { name: 'verify-blocked' }] }],
+  ])
+  assert.equal(merged.length, 1)
+  const plan = planClosedScarRemovals(merged)
+  assert.equal(plan.length, 1)
+  assert.deepEqual(plan[0].labels, ['verify-overdue', 'verify-blocked', 'body-drift'])
+})
+
+test('mergeClosedIssues — same number in DIFFERENT repos stays distinct (sibling scan collides on numbers)', () => {
+  const merged = mergeClosedIssues([
+    [{ number: 54, repo: null, labels: [{ name: 'verify-blocked' }] }],
+    [{ number: 54, repo: 'bentleypark/aiwatch-reports', labels: [{ name: 'verify-blocked' }] }],
+  ])
+  assert.equal(merged.length, 2, 'repo is part of the identity')
+})
+
+test('mergeClosedIssues — flattens the REAL caller shape: repo[] of label[] of issue[]', () => {
+  // Regression pin. The caller nests per-repo over per-label (`repos.map(fetchClosedScars)`), so the
+  // input is THREE levels deep. A one-level flat yielded arrays instead of issues and silently dropped
+  // every scar — green tests, zero effect in production. Mirror the caller's shape exactly.
+  const perRepoPerLabel = [
+    // repo A → [verify-overdue[], verify-blocked[], body-drift[]]
+    [
+      [{ number: 857, repo: null, labels: [{ name: 'verify-overdue' }] }],
+      [{ number: 547, repo: null, labels: [{ name: 'verify-blocked' }] }],
+      [],
+    ],
+    // repo B (sibling) → same shape
+    [
+      [],
+      [{ number: 41, repo: 'bentleypark/aiwatch-reports', labels: [{ name: 'verify-blocked' }] }],
+      [],
+    ],
+  ]
+  const plan = planClosedScarRemovals(mergeClosedIssues(perRepoPerLabel))
+  assert.equal(plan.length, 3, 'every scar across both repos is planned')
+  assert.deepEqual(plan.map((p) => p.number).sort((a, b) => a - b), [41, 547, 857])
+})
+
+test('mergeClosedIssues — tolerates empty input', () => {
+  assert.deepEqual(mergeClosedIssues([]), [])
+  assert.deepEqual(mergeClosedIssues(null), [])
+})
+
+test('mergeClosedIssues — WARNS on a shape-drifted entry instead of dropping it silently', () => {
+  // A silent drop is how the one-level-flat bug hid: 0 scars reads exactly like a clean board. This
+  // file's #966 guards exist on the rule that a dropped reminder must never look like a quiet day, and
+  // the sweep must honor it too.
+  const warnings = []
+  const merged = mergeClosedIssues([[null, { labels: [] }]], (m) => warnings.push(m))
+  assert.deepEqual(merged, [], 'the malformed entry is still skipped')
+  assert.equal(warnings.length, 2, 'but every skip is announced')
+  assert.match(warnings[0], /shape drift/)
+})
+
+test('LIFECYCLE_LABELS — covers exactly the three labels this job applies', () => {
+  assert.deepEqual([...LIFECYCLE_LABELS].sort(), ['body-drift', 'verify-blocked', 'verify-overdue'])
+})
+
+test('CLOSED_SCAR_LIMIT — a page size the fetch can compare against to warn on truncation', () => {
+  assert.equal(typeof CLOSED_SCAR_LIMIT, 'number')
+  assert.ok(CLOSED_SCAR_LIMIT > 0)
 })


### PR DESCRIPTION
## Problem

`verify-reminders` scans `--state open` (`verify-reminders.mjs:254`), so every lifecycle label it applies — `verify-blocked` / `verify-overdue` / `body-drift` — is stranded the moment an issue is closed. The label stops describing current state, and any triage query filtering on it reads a permanent scar.

This is the **unfinished half of #966's own complaint**, filed on exactly this evidence:

> once an issue is pinged overdue it wears the label forever — including after it is verified **and closed**. #857 was closed at 02:05 UTC and still carried `verify-overdue` hours later (removed manually while filing this).

PR #968 fixed the open case. `docs/reference/verify-assertions.md` then said the rest outright: *"a `verify-overdue` scar left on an issue closed by an *earlier* run is never revisited. This PR fixes forward; #857's pre-existing scar was removed by hand."* This is that deferred half.

**Measured on the live board — 19 issues, 26 labels:**

| Label | Count |
|---|---|
| `verify-blocked` | 17 |
| `verify-overdue` | 8 |
| `body-drift` | 1 |

## Fix

A bounded closed-sweep in the existing daily job. **No date logic**: closing IS the terminal state of a verification obligation, so the labels are unconditionally meaningless once closed — there is nothing to re-derive.

- One query per label per repo (never a full closed scan); one **grouped** edit per issue — #547 wore all three, so 26 label removals become 19 calls.
- **Best-effort throughout** — a per-label fetch failure contributes `[]`, each edit is individually guarded; a label failure can never abort the reminder run.
- **Placed before the due-stage early return** — that stage returns when there's nothing to ping, and a quiet day is exactly when a scar sweep must still run.

Chosen over an `on: issues: types:[closed]` workflow: that prevents new scars but leaves all 19 forever.

## What the investigation actually found (vs. the initial hypothesis)

The issue first claimed the #873 auto-verify pass manufactures its own scars by closing while dropping only `verify-blocked`. **That is false**, and the review caught it. `toClearOverdue` runs *after* the auto-verify pass and clears the label **same-run** (its comment names this "#857's exact path"), and **0 of the 8** `verify-overdue` scars carry an `Auto-verified` comment.

All 19 are **human** closes. The automated path already self-heals; what strands a label is **closing by hand between runs**. Both the issue body and the docs were corrected to match.

## The bug this PR nearly shipped

`mergeClosedIssues` flattens to any depth **on purpose**. A fixed one-level `.flat()` silently yielded arrays instead of issues and **dropped every scar** — while the unit tests, which passed a shallower shape than the real caller (`repos.map(fetchClosedScars)` → repo[] of label[] of issue[]), stayed **green**. Zero scars reads exactly like a clean board.

Caught only by a live `--dry-run`. Now pinned by a test mirroring the caller's nesting exactly, and confirmed by negative control: reverting `flat(Infinity)` → `.flat()` fails **only** that pin.

Per the same #966 principle that a dropped reminder must never look like a quiet day, shape-drifted entries now **warn** instead of skipping silently, and a full result page warns rather than truncating quietly.

## Verification

No browser surface (CI script) → verified by producing the real artifact, per `ship-issue`:

```
$ GITHUB_REPOSITORY=bentleypark/aiwatch node scripts/verify-reminders.mjs --dry-run
[verify-reminders] 2026-07-16: scanning 2 repo(s): bentleypark/aiwatch, bentleypark/aiwatch-reports
[verify-reminders] 2026-07-16: 19 closed-issue label scar(s) → #743(verify-overdue+verify-blocked),
  #726(verify-overdue+verify-blocked), #720(verify-overdue+verify-blocked), #575(...),
  #564(verify-overdue), #563(verify-overdue), #547(verify-overdue+verify-blocked+body-drift), ...
```

`npm run test:scripts` — **207/207 pass** (11 new). Review loop converged at **0 Critical / 0 Important** over 4 rounds.

## Docs

`docs/reference/verify-assertions.md` — label lifecycle table rows, plus two things a reader would otherwise get wrong:

- **Reopen caveat**: a reopened swept issue does **not** get `verify-blocked` back (nothing in this job ever adds it), and since `isDriftCandidate` gates on it, **`body-drift` never returns either** — only `verify-overdue` auto-restores.
- **Dry-run reproduction**: `GITHUB_REPOSITORY` must be set, or `parseScanRepos` falls back to the sibling repo alone and the run silently scans neither the main board nor its scars.

`refs #1037` — the production-gated check (the first live run actually clearing the 19) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
