### PR TITLE
docs(reference): list Kimi (Moonshot AI) in the candidate registry (#601)

### DIFF
--- a/docs/reference/service-candidates.md
+++ b/docs/reference/service-candidates.md
@@ -57,7 +57,7 @@ Three kinds of candidate, and they are not comparable:
 Best additive pick per category, all on parsers AIWatch already has: **MiniMax** (video) · **Qdrant**
 (vector — the earlier shortlist's pick; the table bolds Zilliz too, and nothing here separates them) ·
 **Ideogram** (image — #601 Phase 4 named it the optional 3rd) · **W&B or Comet** (observability —
-undifferentiated in the table; pick at Step-0) · **DeepInfra** (inference — the only row).
+undifferentiated in the table; pick at Step-0) · **DeepInfra** (inference — a generic host; **Kimi/Moonshot** #989 is the other row, richer provenance but pulls in non-English `titleMap` infra).
 The earlier shortlist also named Langfuse and FLUX; both have since shipped.
 
 ## Video — CLOSED (Runway + Luma)
@@ -138,6 +138,7 @@ coverage-additive, **not** a fallback gap. Do not let them block the gap work ab
 | Candidate | Status page | Platform | Monitorable | Note |
 |---|---|---|---|---|
 | **DeepInfra** | status.deepinfra.com | Better Stack ✅ (`/index.json`) | Yes | Serverless LLM inference. `api.deepinfra.com/v1/openai/models` → 200, probeable RTT (~1.1s). Existing BetterStack parser + probe; no new parser. Verified 2026-06-23 |
+| **Kimi (Moonshot AI)** | status.moonshot.cn | Atlassian ✅ | Yes | Step-0 verdict **RICH** (2026-07-10), fully worked in **#989**. Not a plain inference host — a Moonshot model lab (DeepSeek-class), so also a frontier-LLM add. Its incident titles are Chinese-only, so it introduces the first per-service `titleMap` (the `sanitize()` non-ASCII passthrough gap); needs `holdShortIncidents` (auto-monitor flap). `.cn` is a CNAME to Statuspage → no China-network reachability risk; `Open API` component drives badge/uptime, model components display-only (#606) |
 
 ## Declined
 


### PR DESCRIPTION
## Summary

The service-addition candidate registry (`docs/reference/service-candidates.md`, added in #1049) positions itself as the canonical "what to add next" list, but omitted **Kimi/Moonshot** — the single most-worked candidate, with a fully-detailed execution issue (**#989**) and a recorded Step-0 **RICH** verdict. That absence is exactly the scattered-state failure the registry was created to fix: a reader treating the page as canonical would never discover #989 exists.

## Changes

- **Inference section — add a Kimi row.** Placed in the `api`-category "additive, low priority" section (same class as DeepInfra — not a fallback gap). The note records what makes Kimi distinct from a plain inference sibling: a Moonshot model lab (DeepSeek-class), Chinese-only incident titles that introduce the first per-service `titleMap` (the `sanitize()` non-ASCII passthrough gap), `holdShortIncidents` for its auto-monitor flap, the `.cn`→Statuspage CNAME (no China-network reachability risk), and `Open API`-drives-badge / models-display-only (#606) scoping.
- **Pick order — fix the stale "DeepInfra — the only row" line.** Kimi is now the other inference row.

Every claim in the note is **attributed to #989**, not asserted independently — a registry row means "the page is parseable", and the verdict lives in the issue.

## Verification

- `npm run lint:okf` — 19 pages, **0 findings**.
- Docs-only reference change; no runtime/browser surface.

Refs #601, #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)