### PR TITLE
docs(strategy-review): gate-scan every slice, not just the first

### DIFF
--- a/.claude/skills/strategy-review/SKILL.md
+++ b/.claude/skills/strategy-review/SKILL.md
@@ -157,6 +157,28 @@ to connect each candidate to its rationale, then output BOTH:
   thread's next step rests on a choice with no `decision_*` page, the next step *is that decision* — say
   so, and do not dress a diligence lead-list up as a plan.
 
+  **Inputs present ≠ startable. Open the issue and read its OWN gate first.** A gate is not an input,
+  and the input vocabulary below cannot express it — so an issue can have every input resolved and
+  still be forbidden. Look for `Status: BACKLOG`, `DO NOT start`, `Build gate`, `signal-gated`,
+  `ON HOLD` in the body. If one is there, that **issue** is not the do-next no matter how ready it
+  looks. Never let an initiative page's "no blocking prerequisites" stand in for reading the issue:
+  the page states technical readiness, the issue states permission.
+
+  **A gate on ONE slice silences that slice, never the thread.** Having found a gate, walk the rest of
+  `advances::` and gate-check each — the do-next is the first UNGATED slice that serves the stated
+  bottleneck. Only if **every bottleneck-serving slice** is gated does the thread emit no action, and
+  then you must say **who fires the trigger**: a trigger nobody owns is not "waiting", it is a thread
+  that will sit `active` forever with no action, which is `parked` wearing the wrong label — say that
+  outright. (This is intra-thread slice selection; it feeds the active-first thread ordering above.)
+
+  Both rules come from the same brief, in two failed drafts (2026-07-17). First it ranked **#861**
+  first because `initiative_growth` said *"착수 가능, 막는 선행 항목 없음"* — true about inputs, while
+  the issue's first line said `Status: BACKLOG — do NOT start`; the brief never opened it (→ rule 1).
+  Corrected to "read the gate", the next draft found #861 gated and declared "Growth emits no action" —
+  never checking that **#887/#270/#346 carry no gate at all**, nor that #861's trigger can only fire
+  from the *parked* monetization thread's outreach, so nobody will (→ rule 2). Both drafts were true
+  and useless: one recommended forbidden work, the other said to wait for something nobody would cause.
+
   **Every do-next line must be executable on reading.** Before you write one, resolve its inputs —
   open the issue and list which boxes are actually unticked; look in `discovery/` before claiming a
   draft is missing; grep the code before calling a checkbox done. Then:


### PR DESCRIPTION
## Problem

The `strategy-review` skill's do-next step had no vocabulary for a **gate** (as opposed to an input), and no rule for what a gate on one slice means for the rest of the thread. Two consecutive failures in one session exposed both holes:

1. **Ranked forbidden work.** It put #861 as do-next #1 because `initiative_growth` said *"startable, no blocking prerequisites"* — while #861's issue body opens with `Status: BACKLOG — do NOT start`. The page had swallowed the issue's gate: inputs were all present, permission was not.
2. **Over-corrected into uselessness.** Told to "read the gate", the next draft found #861 gated and declared the whole thread *"emits no action"* — never checking that **#887/#270/#346 carry no gate at all**, nor that #861's trigger can only fire from a *parked* sibling thread (so nobody fires it). Both drafts were true and useless: one recommended forbidden work, the other said to wait for something nobody would cause.

## Change

Two rules added to step 4's do-next section:

- **A gate is not an input.** Open the issue and read its own `Status: BACKLOG` / `DO NOT start` / `signal-gated` / `ON HOLD` before calling anything startable. The page states technical readiness; the issue states permission.
- **A gate on one slice silences only that slice.** Walk the rest of `advances::`; the do-next is the first ungated bottleneck-serving slice. Only when **every** such slice is gated does the thread go silent — and then name **who fires the trigger** (an unowned trigger = `parked` mislabeled `active`).

Plus one merged provenance paragraph narrating both failures as the reason the rules exist.

## Why in the skill, not just memory

Memory `feedback_triage_verify_before_recommend` *already* named failure 1 as a recurring mistake — and it recurred anyway. A passively-recalled page didn't prevent it; putting the check in the procedure that runs **at the moment the do-next line is written** closes that gap. (Same rationale the skill itself gives for existing.)

## Review

Docs/runbook change — no runtime surface, so no build/test/step-3.5 gate applies. Two review rounds to 0 Critical/0 Important. Round 1 caught that the provenance paragraph had reintroduced the exact input-vs-gate conflation the rule exists to kill ("both triggers unfired" in the rule-1 clause) — fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)