### PR TITLE
test(ci): run the #1074 count lockstep on docs-only PRs (closes #1081)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -23,9 +23,10 @@ name: Docs Lint
 # `test.yml` carries the same shape via its `paths-ignore`, so this applies to its four jobs too.
 # As of 2026-07-09 `main` has NO required status checks, so the trap is latent, not live.
 # If you ever want these required, first move the path decision from the workflow trigger into the
-# job (always run the workflow; skip the lint step when no docs changed) — note that doing so
-# removes the `paths:` list that `scripts/workflow-paths-sync.test.mjs` asserts against, so that
-# guard would need rewriting too.
+# job (always run the workflow; skip each job's step when no docs changed). There are TWO jobs here
+# now — `Service Count Lockstep` is a second context that likewise never reports on a code-only PR,
+# so both need converting. Note that doing so removes the `paths:` list that
+# `scripts/workflow-paths-sync.test.mjs` asserts against, so that guard would need rewriting too.
 
 on:
   push:
@@ -36,6 +37,8 @@ on:
       - 'docs/**'
       - '.github/**/*.md'
       - 'scripts/lint-okf-bundle.mjs'      # the guard guards itself
+      - 'api/__tests__/service-count-lockstep.test.ts'   # ditto, for the count lockstep
+      - 'vitest.config.js'                 # passWithNoTests there would disarm the lockstep gate
       - '.github/workflows/docs-lint.yml'
   pull_request:
     branches: [main]
@@ -45,6 +48,8 @@ on:
       - 'docs/**'
       - '.github/**/*.md'
       - 'scripts/lint-okf-bundle.mjs'
+      - 'api/__tests__/service-count-lockstep.test.ts'
+      - 'vitest.config.js'
       - '.github/workflows/docs-lint.yml'
 
 permissions:
@@ -67,3 +72,33 @@ jobs:
       # Zero-dependency script (node: builtins only) — deliberately no `npm ci`.
       # Checks: frontmatter integrity, unquoted-`#` truncation, dangling cross-links, index.md drift.
       - run: node scripts/lint-okf-bundle.mjs
+
+  count-lockstep:
+    name: Service Count Lockstep
+    runs-on: ubuntu-latest
+    # #1081 — #1074's guard pins the service count / category breakdown / probe count / OSV package
+    # count across six files, THREE of which are README.md, README.ko.md and CLAUDE.md. It only ran
+    # inside test.yml's `Frontend Unit Tests` job, and test.yml paths-ignores exactly those files at
+    # the WORKFLOW level — so a README-only edit started no jobs and a wrong count merged green.
+    # Verified before the fix: breaking README.md's count left `lint-okf-bundle.mjs` PASSING (it reads
+    # only docs/reference/) while test.yml never started. Same shape as #877 and #961: a guard that
+    # exists but is not wired to the diffs it guards.
+    #
+    # Unlike the OKF job above this one cannot be dependency-free: the test is TypeScript run under
+    # vitest, and it renders the two Edge templates (which pull in the api/_shared subtree). The
+    # worker constants it reads — GROUP_MEMBERS / PROBE_TARGETS / OSV_PACKAGES — are NOT the reason;
+    # those three modules have zero imports between them. Reimplementing the checks as a zero-dep
+    # node:test script would mean re-declaring the counts away from those constants, which is exactly
+    # the drift #1074 exists to kill. So docs PRs pay an `npm ci`; `cache: 'npm'` blunts it.
+    #
+    # Runs ONLY the lockstep file, not `npm run test:src` — the rest of that suite is gated by
+    # test.yml on code PRs, and re-running it here would duplicate ~4s of unrelated work on every
+    # doc edit for no added coverage.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci --no-audit --fund=false
+      - run: npx vitest run --config vitest.config.js api/__tests__/service-count-lockstep.test.ts

--- a/scripts/workflow-paths-sync.test.mjs
+++ b/scripts/workflow-paths-sync.test.mjs
@@ -192,8 +192,100 @@ for (const trigger of ['push', 'pull_request']) {
   })
 }
 
-test('docs-lint.yml guards its own inputs — the lint script and itself', () => {
-  const watched = pathsUnder(wf('docs-lint.yml'), 'pull_request', 'paths')
-  assert.ok(watched.includes('scripts/lint-okf-bundle.mjs'), 'a change to the lint must re-run the lint')
-  assert.ok(watched.includes('.github/workflows/docs-lint.yml'), 'a change to the guard must re-run the guard')
+// Both triggers, not just pull_request: dropping the entry from `push` alone left the suite green,
+// so a push to main touching only the lockstep re-ran nothing that guards it. Asymmetric drift between
+// the two trigger blocks is exactly the class this file exists to pin.
+for (const trigger of ['push', 'pull_request']) {
+  test(`docs-lint.yml guards its own inputs on ${trigger} — the lint script, the count lockstep, and itself`, () => {
+    const watched = pathsUnder(wf('docs-lint.yml'), trigger, 'paths')
+    assert.ok(watched.includes('scripts/lint-okf-bundle.mjs'), 'a change to the lint must re-run the lint')
+    assert.ok(watched.includes('api/__tests__/service-count-lockstep.test.ts'), 'a change to the count lockstep must re-run it')
+    assert.ok(watched.includes('vitest.config.js'), 'the lockstep gate depends on vitest defaults — a config change must re-run it')
+    assert.ok(watched.includes('.github/workflows/docs-lint.yml'), 'a change to the guard must re-run the guard')
+  })
+}
+
+// #1081 — the paths mirror above proves a docs-only PR starts SOME workflow; it says nothing about
+// WHICH checks run. docs-lint.yml ran only the OKF bundle lint, which reads docs/reference/ and never
+// a README — so #1074's count lockstep, whose whole point is pinning README.md / README.ko.md /
+// CLAUDE.md, was unreachable from the one PR shape that edits them. Assert the job is actually wired,
+// or deleting it is silent (a guard whose default state is "pass" needs its own guard).
+test('docs-lint.yml actually RUNS the count lockstep, not just the OKF lint (#1081)', () => {
+  const yaml = wf('docs-lint.yml')
+  // ANCHORED to a step line, so a `#` in front of it breaks the match. An unanchored search matched a
+  // commented-out step and stayed green while the job ran `npm ci` and nothing else — and commenting
+  // out a step is how a red CI usually gets unblocked, in a file that is already half comment prose.
+  assert.match(yaml, /^  count-lockstep:/m, 'the count-lockstep job must exist')
+  // Scope to the job's OWN block (up to the next top-level job key or EOF). The earlier
+  // `[\s\S]*?` form was non-greedy across the WHOLE file, so it never matched an `if:` sitting
+  // immediately under this job — `if: false` passed silently.
+  // Charset covers `_` and uppercase so a later job id like `count_lockstep_v2:` still terminates the
+  // slice — otherwise that job's keys bleed in and produce a confusing red.
+  const block = yaml.split(/^  count-lockstep:$/m)[1]?.split(/^  [A-Za-z_][A-Za-z0-9_-]*:$/m)[0] ?? ''
+  assert.ok(block.length > 0, 'the count-lockstep job block must be parseable')
+
+  // Strip comments FIRST — full-line AND trailing. The ban list runs on raw text and this file's house
+  // style is heavy prose, so a comment merely containing `if:` would fail CI for no reason, which is
+  // precisely how an annoying guard gets deleted. Trailing `#` is only stripped from lines with no
+  // quote character, since a `#` inside a quoted scalar is data, not a comment.
+  const code = block
+    .split('\n')
+    .filter((l) => !/^\s*#/.test(l))
+    .map((l) => (/['"]/.test(l) ? l : l.replace(/\s+#.*$/, '')))
+    .join('\n')
+
+  // The step's TEXT existing is not the same as the step being able to FAIL THE WORKFLOW, and every
+  // escape found in review lived in that gap. Scope to the JOB BLOCK, not the file: the assertion used
+  // to read the whole yaml, so the step could satisfy it from a different (even `if: false`) job.
+  assert.match(
+    code,
+    /^\s+- run: [^\n]*vitest run[^\n]*api\/__tests__\/service-count-lockstep\.test\.ts/m,
+    'the count-lockstep job must RUN the lockstep in an uncommented step — otherwise a README-only PR can change a service count with no CI watching',
+  )
+  for (const [pattern, why] of [
+    [/\bif:/, 'a job- or step-level `if:` can skip it, and a skipped check reports green'],
+    [/\bcontinue-on-error\b/, '`continue-on-error` makes a failing step non-fatal'],
+  ]) {
+    assert.doesNotMatch(code, pattern, `count-lockstep job: ${why}`)
+  }
+  // Targeted rather than a block-wide `||` ban: a legitimate retry on the INSTALL step cannot affect
+  // gating, so banning `||` everywhere was pure false-positive risk for no added coverage.
+  assert.doesNotMatch(
+    code,
+    /vitest run[^\n]*(--passWithNoTests|\|\|)/,
+    'the vitest step must not be made non-failing (`--passWithNoTests` or a `||` fallback)',
+  )
+  // Pin the CONFIG the step uses, because the passWithNoTests assertion below hardcodes
+  // `vitest.config.js`. Without this the step could point at a sibling root config (worker/ already
+  // has one) that DOES set passWithNoTests, and the guard would keep reading the innocent file — the
+  // round-3 escape relocated one file further out.
+  assert.match(code, /vitest run[^\n]*--config vitest\.config\.js/, 'the step must use the config the passWithNoTests guard checks')
+})
+
+// The "a renamed lockstep file fails loudly" property does not live in the workflow at all — it lives
+// in vitest's default, which `vitest.config.js` can silently override. Round 3 verified it: with
+// `passWithNoTests: true` in the config and the lockstep file missing, vitest exits 0 and prints
+// "No test files found". That is the round-2 escape class relocated one file over, and it is the kind
+// of ergonomics tweak someone adds for an unrelated reason. Pin it where it actually lives.
+test('vitest.config.js does not set passWithNoTests — a missing lockstep must fail (#1081)', () => {
+  const cfg = readFileSync(new URL('../vitest.config.js', import.meta.url), 'utf-8')
+  assert.doesNotMatch(
+    cfg.split('\n').filter((l) => !/^\s*(\/\/|\*)/.test(l)).join('\n'),
+    /passWithNoTests/,
+    'passWithNoTests would make a renamed or deleted service-count-lockstep.test.ts exit 0, disarming the docs-lint gate',
+  )
+})
+
+// A cheap tripwire, not a proof: it only asserts each filename still APPEARS in the lockstep source.
+// That survives the loop-style refactor already present in that file (`read(file)` over a list), and
+// catches the case that matters — a surface dropped from coverage entirely. It cannot tell whether the
+// assertions around the name are still meaningful; only the lockstep's own mutation coverage does that.
+test('the count lockstep still names the .md surfaces test.yml ignores (#1081)', () => {
+  const lockstep = readFileSync(new URL('../api/__tests__/service-count-lockstep.test.ts', import.meta.url), 'utf-8')
+  for (const f of ['README.md', 'README.ko.md', 'CLAUDE.md']) {
+    assert.ok(
+      lockstep.includes(`'${f}'`),
+      `${f} is paths-ignored by test.yml, so docs-lint.yml is its only gate — the lockstep must still cover it`,
+    )
+  }
 })


### PR DESCRIPTION
## The gap

#1074's guard pins the service count, category breakdown, probe count and OSV package count across six files — **three of which are `README.md`, `README.ko.md` and `CLAUDE.md`**.

It only ran inside `test.yml`'s `Frontend Unit Tests` job. `test.yml` `paths-ignore`s `*.md` / `CLAUDE.md` / `docs/**` at the **workflow** level, so a README-only PR started none of its jobs. **The guard was unreachable from the one PR shape that edits the files it guards.**

Verified by breaking `README.md`'s count on a docs-only diff:

```
Docs Lint / OKF Bundle Lint  -> PASS    (lint-okf-bundle.mjs reads only docs/reference/)
test.yml                     -> never starts
```

A wrong service count merged green. Same class as #877 and #961 — a guard that exists but is not wired to the diffs it guards. The #1074 work found the README social-share badges stale at **39 vs 44**, and those badges pre-fill the text a visitor posts to X / Reddit / HN.

## The fix

`docs-lint.yml` already fires on exactly the paths `test.yml` ignores (#961), so it just needed the check — a `count-lockstep` job running the lockstep file.

Unlike the OKF job it **cannot be dependency-free**: the test is TypeScript under vitest and renders the two Edge templates. So docs PRs now pay an `npm ci`, blunted with `cache: 'npm'`. Reimplementing it as a zero-dep script would mean re-declaring the counts away from `GROUP_MEMBERS` — the drift #1074 exists to kill.

**Dropping `test.yml`'s `paths-ignore` stays rejected**: it would run the worker suite, tsc, Playwright and the bundle build on every one-line doc edit. `docs-lint.yml`'s header already documents why that filter earns its keep.

## The guard needed its own guard — four rounds deep

A job that is *present* but cannot *fail the workflow* gates nothing. Every escape found in review lived in the gap between "the step's text exists" and "the step can fail":

| Escape | Was |
|---|---|
| The step commented out | silent |
| The path dropped from `push` only | silent |
| `if: false` on the job | silent |
| `continue-on-error`, either key order | silent |
| `\|\| true` appended to the command | silent |
| `--passWithNoTests` inserted | silent |
| The step satisfied from a *different* job | silent |
| `passWithNoTests` set in **`vitest.config.js`** | silent |

The last one is the sharpest: that property is what makes a renamed lockstep exit 1, and **it does not live in the workflow at all**. The escape relocated to a file that was neither asserted nor watched.

`workflow-paths-sync.test.mjs` now slices the job's own block and bans the family, pins the `--config` the step uses (so the `passWithNoTests` assertion cannot end up reading an innocent file), and asserts `vitest.config.js` stays clean — with `vitest.config.js` added to the workflow's own `paths:`.

## Ergonomics, because a guard that cries wolf gets deleted

The ban list runs on raw text in a file that is half comment prose. Two false positives were found and fixed **in the passing direction**:

- a comment containing `if:` or `||` failed CI → comments are stripped first, full-line **and** trailing (trailing only on lines with no quote char, since `#` inside a quoted scalar is data)
- `npm ci … || npm ci …` — a legitimate retry on the **install** step, which cannot affect gating — failed the block-wide `||` ban → dropped in favour of the targeted vitest-line check

## Testing

Every assertion mutation-verified **both ways**: eight escapes made to fail, two legitimate edits confirmed still green. End-to-end, the real scenario now gates:

```
README count break on a docs-only diff -> count-lockstep job FAILS ✓
```

`test:scripts` 238 · `test:src` 979 · `lint:okf` clean · the exact CI command runs 16 tests green.

## Not safe to mark required

A workflow-level `paths:` filter means the context never reports on a non-matching PR, and **a required check that never reports blocks the merge forever**. The new job is a second such context; `docs-lint.yml`'s header comment was updated to say so.