### PR TITLE
chore(workflow): add a convergence-stall rule to the review auto-loop (closes #1097)

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -69,7 +69,22 @@ is the *procedure* — follow it top to bottom.
    - New worker logic → extract to an exported fn + unit-test it. New `src/utils/` → Vitest test.
    - **Every bug fix ships a test that would have caught the bug.**
 5. **PR review** — gate #2: `/pr-review-toolkit:review-pr`.
+   - **Track the round, and carry the prior round's finding categories into the next review prompt (#1097).**
+     The review agents are spawned fresh each round and cannot see how many rounds have run or what the
+     last round found — *you* are the only place that count lives, so make it explicit: when you re-spawn
+     a reviewer after a fix, tell it "this is round N; round N-1 flagged {categories}; check whether the
+     fix reseeded any of them." Without this the step-6 stop rule below has nothing to fire on.
 6. **Fix review findings — auto-loop** to 0 Critical/Important (Suggestions-only = converged).
+   - **A NEW finding category each round is the auto-loop working — keep going (#1052/#1049 ran several rounds each, a *different* category per round, and were legitimate). But same-category recurrence is a STOP signal (#1097).** If the same finding
+     *category* recurs for **3 rounds** — each fix reseeding the next round's finding, often a milder
+     version of the same overreach — the defect is structural, not in the sentence. STOP editing the
+     sentence and ask: **(a)** is this claim load-bearing for the point being made? If not, **delete it**
+     — an unneeded enumeration / classification / causal claim is verification debt, not content
+     (deleting a never-needed parser list ended the last-4-of-12 sub-loop in #1091 instantly). **(b)** Am I
+     holding a conclusion fixed and swapping in weaker support each round? Then weaken the *conclusion*
+     to what the evidence carries, not the wording — *milder-each-round is the tell*. This applies to
+     prose review (docs, comments, issue bodies) as much as code; a #1091 rationale rewrite took 12
+     rounds and a `/methodology` copy edit took 8, which this rule is meant to cut short.
 7. **Docs update** — update whatever the change affects: CLAUDE.md (architecture/service count/layout —
    keep it **lean, ~40k-char guideline** — check `python3 -c "print(len(open('CLAUDE.md').read()))"`,
    move detail to `docs/reference/` if near), the relevant **`docs/reference/`** file (see the

--- a/docs/reference/workflow-hooks.md
+++ b/docs/reference/workflow-hooks.md
@@ -19,6 +19,20 @@ Hook internals and operations, split out of CLAUDE.md so the always-loaded schem
 
 Every fire is logged to `.claude/hook-audit.jsonl` (gitignored). `npm run hook-audit` (= `node scripts/hook-audit-summary.mjs [--last N] [--days D]`) summarizes (by hook × decision, last-7-days, per-day trend, recent entries). **The effectiveness signal is the `Violations intercepted` tally, NOT raw `warn`/`inject` counts**: `warn` (git-mutation step-3.5 reminder) and `inject` (every-turn gate re-injection) are *preventive telemetry* that scale with workload — their trend is meaningless. A real intercepted violation is a `block` (a nag was about to ship), a step-3.5 `deny` (except `fail-closed`, which is gate-health, not an interception), or a `no_verify=1` note (`--no-verify`/`--no-gpg-sign` on a commit) — matching `isViolation` in `scripts/hook-audit-summary.mjs`. Review the **violation trend** periodically — a declining/zero count is the goal. **#657 performed the escalation** the old text anticipated: step-3.5 is now HARD-enforced by `step35-verify-gate.mjs` (a `deny` on UI/Edge commits lacking a transcript-confirmed user turn), so a step-3.5 violation is now an intercepted `deny`, not an invisible behavioral miss — correcting the earlier "the confirmation is a user message the hook never sees" claim (hooks DO receive `transcript_path`). The soft gates remain for non-UI commits + salience. **Monitoring the hard gate** (its own `🚦 step-3.5 hard gate` section in `npm run hook-audit`): because a `deny` is *ambiguous* (an intercepted skip OR a false-positive where the parser missed a real confirmation), the key signal for a HARD gate is **the false-positive rate**, not the deny count — specifically a **`commit:override` pass** (the user had to say "검증 생략" on already-verified work; the strongest proxy) and **`fail-closed`** (gate-health, should trend ~0; nonzero = the transcript read is breaking). Escalate by **tuning `CONFIRM_RE` / softening to a warn** if overrides rise, NOT by hardening further. The structural blind spot remains: a user "확인" turn proves a turn happened, not that they actually looked — so a step-3.5 *false negative* (gate passes an unverified commit) is still invisible to the log; spot-check merged UI PRs periodically.
 
+## Not hook-enforceable: the review auto-loop's own non-convergence (#1097)
+
+The PR-review auto-loop (`ship-issue` step 6, "loop until 0 Critical/Important") can fail to converge
+when the same finding *category* recurs each round because each fix reseeds it — a #1091 rationale
+rewrite ran 12 rounds and a `/methodology` copy edit ran 8, which a stop rule is meant to cut short. This is NOT
+enforceable by a hook: a `PreToolUse` hook *can* fire on the `Agent` call, but the
+convergence judgement (is this round 3 of the same category? is it 0 Critical/Important yet?) can't be
+computed from a single tool input — so the hook has nothing to decide on. So the mitigation is
+**skill-text** (`ship-issue` steps 5-6: carry prior-round categories into the next review prompt, and
+STOP editing the sentence after 3 same-category rounds to question whether the claim is load-bearing).
+Weaker than a hard gate, but it loads at the review step rather than once at session start like an
+LLM-Wiki memory page — the mode that let this session violate rules it had already recorded. The residual gap — no hard
+enforcement of loop convergence — is real and accepted; #1097 is the record.
+
 ## Related
 
 - [Reference Tooling](reference-tooling.md) — the `tooling-trigger.sh` trigger map (chub vs modern-web-guidance).


### PR DESCRIPTION
Closes #1097.

## The problem

`ship-issue` step 6 says "auto-loop until 0 Critical/Important". That is correct for *independent* findings. It has no stopping rule for the case where the **same finding category recurs** because each fix reseeds it. Two loops this session ran far past convergence that way:

- **#1091 (12 rounds):** rounds 1-9 were all one defect — an inference asserted as established — each fix a milder version (recorded-conjunction → "nothing restored it" → "routine" → "fails on the one case" → …). Rounds 9-12 were a parser enumeration, wrong four times running. The enumeration was never load-bearing; deleting it in round 12 ended that sub-loop instantly.
- **/methodology copy (8 rounds):** each round fixed the sentence pointed at and left a new inconsistency, because the card was never re-read whole.

Both share one root: a conclusion held fixed while weaker support was swapped in each round, and a claim refined round after round that was never needed by the point.

## The change

**Rule + signal, the #415 split (rule fires at the decision moment; signal makes the condition visible):**

- **`ship-issue` step 5 (signal):** carry the round number + prior-round finding categories into the next review prompt. Review agents spawn fresh and can't see the count — the operator is the only place it lives.
- **`ship-issue` step 6 (rule):** a NEW category each round is the auto-loop working (keep going). But the SAME category for 3 rounds is structural: stop editing the sentence and ask (a) is the claim load-bearing? if not, delete it; (b) am I holding a conclusion fixed and swapping in weaker support? then weaken the conclusion, not the wording.
- **`docs/reference/workflow-hooks.md`:** records why this is skill-text, not a hook — a PreToolUse hook can fire on the Agent call, but the convergence judgement can't be computed from a single tool input. The residual gap (no hard enforcement) is stated, not hidden.
- **`feedback_review_auto_loop` memory** (harness-global, not in this diff): reconciled so "don't skip rounds" and "stop after 3 same-category rounds" don't contradict — new-category = continue, same-category-milder = stop.

## Why not a hook

A review round is an `Agent` call plus operator judgement. A `PreToolUse` hook *can* intercept the Agent call, but the round count and the 0-Critical/Important judgement live in operator context, not in any single tool input — so a hook has nothing to count or decide on. Skill-text is weaker than a hard gate but loads at the review step, unlike memory (loaded once at session start — the mode that let this session violate rules it had already recorded). This limitation is the accepted residual gap, recorded on the issue.

## Dogfood

The review of this PR **converged in 3 rounds under the new rule**. Round 2 caught two instances of the exact defect #1097 documents (a counterfactual reseeded into a sibling doc; an over-specified support claim the paired edit contradicted), and the fix for the second was a **deletion** — the non-load-bearing round-count sub-claim — exactly what step 6 prescribes. Round 3 confirmed causal-overreach did not recur, so the "third strike → delete the claim" path was not needed.

## Scope / gates

Docs + skill-text only. `.claude/skills/**` is not under the #657 self-edit hard gate (that covers `.claude/hooks/**` + `.claude/settings*.json`). `lint:okf` 0 findings; the `Docs Lint` workflow gates it.

closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
