### PR TITLE
chore(triage): define Impact, and delete the archive-rollover deadline rule the code falsified (refs #1122)

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -75,8 +75,34 @@ to the now-retired `deferred` label); `tracking` stays for meta umbrellas.
 - **P1\*** — **work already shipped; only a dated production-verify remains.** NOT a do-next coding
   item — see the verify-before-recommend gate below. Keep it off the recommended-pick list. Every
   `P1*` issue carries the persistent `verify-blocked` label so the next sweep skips it by label alone.
-- **P2** — high impact + large effort (needs a scoping/design pass first), OR medium impact + `U2-later`.
+- **P2** — high impact + large effort (needs a scoping/design pass first), OR high impact + `U2-later`,
+  OR medium impact + `U2-later`.
 - **P3** — low impact / `U3-someday`.
+
+### What `Impact` means (#1122)
+
+`Impact` stays a per-sweep judgment — but an undefined factor in a formula is not a judgment, it is a
+blank. Rank by **how wrong the product is while the issue sits open**, not by how annoying it is:
+
+1. **Wrong value shown to users** — a number, badge, or claim that is confidently incorrect. The worst
+   class: nobody can tell it is wrong by looking, so it is believed. Uptime, Score, incident
+   attribution, duration.
+2. **Silent failure** — the thing simply does not happen and emits no signal (a dead alert channel, a
+   dropped incident, a guard that passes while blind). Ranks just under (1) because there is at least
+   no false claim, but it shares the property that waiting produces no evidence.
+3. **Correct but degraded** — right answer, bad experience: missing recommendation, slow, ugly, an
+   empty state where content belongs.
+4. **Internal-only** — costs us time, no user-visible surface. Tooling, docs, CI ergonomics.
+
+**1–2 = high impact, 3 = medium, 4 = low** — the vocabulary the P-tiers above already use. The scale is
+an ordinal rank, not a multiplier: `Impact × Urgency × (1 / Effort)` names the factors you weigh, it
+does not compute (lower number = worse here, same direction as `U0…U3`). `Effort` is likewise a written
+judgment, not a defined scale.
+
+Note that `U0-now` (prod break / security / data loss) is an **urgency** gloss, not this scale — an
+issue can be Impact-1 and still be `U2-later` if it fires rarely. Impact ranks a *class* — "if it
+fires, users see a wrong value" — never evidence that it fired. When that distinction decides a
+ranking, go measure before you rank, and re-rank on what you find.
 
 ### Verify-before-RECOMMEND (the most-missed; same gate as verify-before-close)
 
@@ -111,6 +137,25 @@ board is visible.
 - Produce a **triage table**: per issue → action (`close` / `re-scope` / `keep + label`) and, for the
   live ones, `area` · `urgency` · effort → derived `P`, with a one-line reason. End with per-area
   counts + the **recommended next pick** (balanced across areas).
+- **State every deadline you are trading off, with its date.** If the pick beat another issue on
+  urgency, name the loser's clock too — a deadline you did not write down is one you did not weigh
+  (#1122). An announced third-party date is the usual kind; the date is fixed, so only your slack shrinks.
+- **Cleanup cost of already-archived data is a real ranking input, but do not assert what it is from
+  memory** — the rebuild/suppression/override mechanics differ per archive field and the repo's own
+  docs are in tension about them. Read [operator-tools.md](../../../docs/reference/operator-tools.md)
+  before putting a number or a claim on it (#1122).
+- **Any derived count needs a positive and a negative control before it moves a ranking** — a script, a
+  `jq` over `/api/report`, or a hand tally alike. Pick one case you already know must be counted and one
+  you know must not, established *outside* the thing you are checking (a hand-read of the raw payload,
+  an existing issue's verified timeline), and assert both before reporting. A scoping bug fails toward
+  alarm as readily as toward "all fine", and neither looks wrong in the output — see
+  `feedback_derived_signal_needs_scoped_diagnostic` (#1122).
+- **Never print a bare issue number.** Every `#N` in the triage table, the re-ranking, or the
+  recommended pick carries a short title or a few-word gloss — `#671 (bump actions/*@v4)`, not `#671`.
+  The operator is being asked to sanction a *ranking*, and a ranking of opaque ids cannot be checked:
+  disagreeing requires knowing what the rows are, so bare numbers quietly convert review into assent.
+  The same applies to a `refs`/`supersedes` reference in an issue comment. The rule is about rows the
+  operator is ranking — a provenance citation like the `(#1122)` on this line is exempt.
 - **Act on confirmation**: closing/commenting/relabeling issues follows the same norm as the rest of
   the workflow — propose the triage, then apply the closes/labels the user confirms (issue ops are
   reversible, but the project norm is to confirm closes; see the gates in `ship-issue`).


### PR DESCRIPTION
## What

`issue-triage` derived priority as `Impact × Urgency × (1 / Effort)` but **never defined `Impact`**. A factor named in a formula and defined nowhere is a blank, not a judgment — severity entered a sweep only as unrecorded improvisation and did not reproduce between sweeps. That is structurally the same gap the skill's own `verify-before-RECOMMEND` section exists to close for a different factor.

One file: `.claude/skills/issue-triage/SKILL.md` (+46 / −1). No product code.

### Shipped

- **A four-level `Impact` rank** — wrong value shown to users > silent failure > correct-but-degraded > internal-only — bridged to the `high/medium/low` vocabulary the P-tiers already use, with an explicit note that the scale is **ordinal** (lower = worse, same direction as `U0…U3`) and that the formula names factors rather than computing them. `Effort` is flagged as likewise undefined instead of cited as a settled peer.
- **A P-tier gap the new scale exposed**: high impact + `U2-later` + *small* effort matched no tier. P2 now covers it.
- **Three Output norms**, each from a failure observed while writing this PR:
  - state every deadline you trade off, with its date — one you did not write down is one you did not weigh;
  - any derived count needs a **positive and a negative control** before it moves a ranking;
  - **never print a bare issue number** in a ranking. The operator is being asked to sanction an ordering, and a ranking of opaque ids can only be assented to, not checked. Provenance citations are exempt.

## What is deliberately NOT shipped

The issue also proposed treating the **monthly-archive rollover as a second hard-deadline class**. Three versions were written; **the code falsified every one**, each time because a narrow, correct guarantee was generalized into a board-level rule:

| # | Claim | Why it is false |
|---|---|---|
| 1 | "fixed before rollover, a deploy fixes the whole window" | `accumulateMonthlyIncidents` is go-forward with a monotonic guard (`if (dur > oldDur)`) — already-written rows survive a deploy |
| 2 | "after rollover, cleanup is manual KV surgery" | `suppression.ts`: a `rebuild-archive` of a past month drops suppressed incidents — *"rebuild-safe, no KV surgery"* |
| 3 | "the `history:` uptime path has no build-time filter" | It has two — `computeMonthlyOfficialUptime` and `resolveArchiveOfficialUptime` |

The premise also failed on its own worked example: **#965 patches `archive:monthly:2026-05`, not a `history:` key**, and its body calls it *"prophylactic data hygiene, not a live defect."*

Per the **#1097 convergence-stall rule**, the section was **deleted rather than rewritten a fourth time**. Cleanup mechanics belong to `operator-tools.md` / `status-determination.md`, and those two are themselves in tension here — `operator-tools.md` says run the rebuild after suppressing a past month; #965 and `monthly-archive.ts` say do not. A prioritization skill is the wrong place to adjudicate that. What ships instead is a **claim-free pointer**: cleanup cost is a real ranking input, read `operator-tools.md` before asserting what it is.

## Verification

**Measured before dropping it**, so the rejection rests on data and not only on review. Of the **22 incidents OpenAI published in July 2026**, our `incidents:monthly` record carries **5**, and all **17** others are correctly excluded — none of their `component_impacts` touches an openai badge component.

- **positive control** — #1104's `Images` incident intersects the badge group ✅
- **negative control** — the 07-22 file/image incident does not, matching a hand-read of the raw payload ✅

**Zero misses**, so the clock the rejected rule was built on would not have bitten, and the sweep's recommended pick was unchanged (#671, `chore(ci)`: bump `actions/*@v4`).

That measurement is itself the origin of the controls norm above: its **first cut reported all 22 incidents as mis-recorded**, because the extractor read the page's whole component directory instead of each incident's own `component_impacts`. It failed toward *alarm*, nothing in the output looked wrong, and only a contradiction with the hand-read caught it.

- Review: 3 rounds, 4 reviewer passes. Rounds 1 and 2 each found the then-current version factually wrong; round 3 returned the deletion verdict, which was verified against source before executing.
- `npm run lint:docs` ✅ 21 docs clean · `npm run lint:okf` ✅ 20 pages, 0 findings. Neither covers `.claude/skills` — every cited symbol and both relative links were checked by hand.
- No build/test scope: prose only, no product code.

`refs #1122`, not `closes` — the rejection is the issue's conclusion and wants confirmation before closing on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
