### PR TITLE
chore(skill): issue-triage detects in-flight worktrees + stale-checkout before recommending

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -18,6 +18,33 @@ skill is the periodic backstop — run it over the whole open board.
 
 ## Run the sweep
 
+0. **Freshen the checkout before reading anything.** `git fetch origin`, then
+   `git rev-list --count HEAD..origin/main` — **not** `git status -sb`, which reports the *current
+   branch's* tracking and prints no count at all from a worktree on an upstream-less feature branch,
+   i.e. exactly where this sweep tends to run. Run both commands in `aiwatch-reports` too, and report
+   both counts either way (see Output + norms): a suppressed zero is indistinguishable from never
+   having looked.
+
+   `git fetch` updates remote-tracking refs and **nothing in the working tree**, so a non-zero count
+   leaves two of this sweep's inputs stale:
+   - **the code checks** — step 3's "confirm each against the actual code" and the gate's item 1
+     `grep the symbol/file` read the working tree, so a symbol added in an unmerged commit greps as
+     absent and a finished issue reads as unshipped, which is how the sweep comes to recommend it.
+     (`git log --all --grep` is the exception: `--all` covers remote-tracking refs, so fetch alone
+     does fix that one.)
+   - **this skill file**, which lives in the repo, so the loaded copy can predate rules added by the
+     newest merges.
+
+   Prefer the rev-based reads — they have no side effects and work from any checkout. Run the code
+   checks against the fetched ref (`git grep <symbol> origin/main`, which exits 1 on no match and 128
+   on a bad rev, both with empty output — distinguish them the way item 2 does), and re-read this file
+   at `git show origin/main:.claude/skills/issue-triage/SKILL.md` **only if that revision differs from
+   the loaded one**; when your checkout is the newer one — you are editing this skill — keep what you
+   have. Fast-forwarding (`git merge --ff-only origin/main`) cures both at once, but only in the
+   checkout you actually read from, and only do it in one you own that is on `main`: another session
+   may be holding the main checkout on a branch. (`aiwatch-reports` carries no copy of this file;
+   there, only the code-check half applies.)
+
 1. **List the board**: `gh issue list --state open --limit 100 --json number,title,labels,createdAt`,
    `gh pr list --state open`, AND `gh pr list --state merged --limit 30` — question ① (shipped-not-closed)
    is about work in **merged** PRs, so the merged list is the one that catches it.
@@ -115,10 +142,51 @@ ranking, go measure before you rank, and re-rank on what you find.
 Before recommending ANY issue as do-next, verify it the **same way** you'd verify a close candidate:
 1. **Cheap shipped-check on each candidate** (1–2 issues): `git log --all --grep="#N"` + grep the
    symbol/file. If a linked PR is already **merged**, the coding is likely done.
-2. **Auto-demote to `P1*` (exclude from do-next)** if EITHER: a linked PR is merged, OR the body has a
+2. **Check what is already in flight — the committed-work checks above cannot see it.** Run this ONCE,
+   before ranking, in **both** repos. `gh pr list` and item 1's `git log --grep` read only *committed*
+   work, so a branch being actively coded on — no commit, no push, no PR — is invisible to both, and an
+   issue can be nearly finished in a sibling worktree while every check above reports it untouched.
+
+   ```bash
+   git worktree list --porcelain                         # branch ref + `detached` + `locked … (pid N)`
+   git -C <worktree> status --porcelain                  # uncommitted work
+   git -C <worktree> rev-list --count origin/main..HEAD  # commits not yet in origin/main
+   ```
+
+   Use `--porcelain`: it gives the branch as a full ref, flags `detached` entries (harness scratch
+   checkouts — skip those, no branch and no issue), and prints `locked claude session … (pid N)` for a
+   worktree an agent session is holding open. Do **not** filter by directory location: a worktree may
+   sit outside the repo tree — `aiwatch-reports` keeps one as a sibling directory — and is no less live
+   for it.
+
+   **In flight = a session lock, OR a non-empty file list, OR a non-zero count**; any one is enough.
+   Uncommitted files alone are not the test — a session that has just committed shows a clean tree, and
+   reading that as "abandoned" puts the issue back on the do-next list one commit later. The count
+   means *not yet in `origin/main`*, not "unpushed": a pushed branch counts too (an open PR is caught
+   separately by step 1's `gh pr list`). **A non-zero exit means UNKNOWN, never empty** — a worktree can
+   vanish between the list and the status, and the fatal writes nothing to stdout, so an unguarded read
+   of it is indistinguishable from "not in flight".
+
+   **This set is deliberately over-inclusive, and so does not carry the positive/negative control the
+   derived-count norm below asks for** — that norm governs a count *inferred* from data; this is a
+   direct read of one command's output whose bias is stated instead. A worktree left behind by a
+   finished session reads as in flight and costs one skipped recommendation; missing a live one costs a
+   duplicated day of work and a merge collision. When you cannot tell, treat it as in flight. **The
+   segment it cannot catch:** the issue number is read off the branch name, so a branch not following
+   `{type}/{issue#}-{desc}` maps to no issue (`docs/resilience-curation` in `aiwatch-reports` is one
+   today). Read that worktree's changed files or last commit rather than counting it as nothing
+   (`feedback_derived_signal_needs_scoped_diagnostic` — a derived signal must not fail toward "all fine").
+
+   An in-flight issue is **excluded from do-next**: recommending it duplicates work already nearly
+   done, and the collision surfaces at merge. Keep the row marked `in flight (worktree: <path>)` so the
+   exclusion is visible rather than an unexplained absence. Do **not** persist it as a label the way
+   `verify-blocked` is persisted below — a worktree is transient, so the label would go stale and then
+   suppress a genuinely available issue. (`ship-issue` runs `git worktree list` too, to decide *where to
+   branch*; here it decides *what not to recommend*. Same command, different question — not a duplicate.)
+3. **Auto-demote to `P1*` (exclude from do-next)** if EITHER: a linked PR is merged, OR the body has a
    `verify-after` line / a `## Remaining (post-deploy)` (or equiv.) section. Such issues are
    **signal-gated**, not actionable — their remaining item is a dated GA4/prod-data check, not code.
-3. **Label the gate so the next sweep sees it without re-deriving**: add `verify-blocked` to a
+4. **Label the gate so the next sweep sees it without re-deriving**: add `verify-blocked` to a
    verify-gated issue (create the label once if missing). A `verify-blocked`/`verify-overdue` issue is
    skipped from do-next by **label alone** next time — closing the gap that lets it leak back in.
    **If the remaining check is machine-checkable** (a predicate over an AIWatch JSON endpoint), also add
@@ -135,8 +203,11 @@ board is visible.
 ## Output + norms
 
 - Produce a **triage table**: per issue → action (`close` / `re-scope` / `keep + label`) and, for the
-  live ones, `area` · `urgency` · effort → derived `P`, with a one-line reason. End with per-area
-  counts + the **recommended next pick** (balanced across areas).
+  live ones, `area` · `urgency` · effort → derived `P`, with a one-line reason; an in-flight issue keeps
+  its row, marked as such in place of a `P`. End with per-area counts + the **recommended next pick**
+  (balanced across areas). Report both step-0 behind-counts and the in-flight set explicitly — they are
+  conditions the sweep ran *under*, and an unstated one reads as "clean board" when it may mean "did
+  not look".
 - **State every deadline you are trading off, with its date.** If the pick beat another issue on
   urgency, name the loser's clock too — a deadline you did not write down is one you did not weigh
   (#1122). An announced third-party date is the usual kind; the date is fixed, so only your slack shrinks.


### PR DESCRIPTION
## Problem

A triage sweep recommended **#1123** (OnlineOrNot parser) as the "do next" pick while another Claude session had it nearly finished in a sibling git worktree — 10 uncommitted files, no commit, no push, no PR. **#1119** and **#1124** were likewise in flight. The `issue-triage` skill's verify-before-RECOMMEND gate was followed, not skipped: it prescribes `gh pr list` + `git log --all --grep`, and both read only **committed** work, so an in-progress branch is structurally invisible to them.

Separately, the sweep ran from a local `main` **5 commits behind** `origin/main`, so the git-based shipped-check read a stale tree — and because this skill file lives in the repo, the copy loaded for the sweep predated rules its own newest merges had added.

## Change (`.claude/skills/issue-triage/SKILL.md` only)

- **New gate item 2** — detect in-flight work the committed-checks can't see: `git worktree list --porcelain` + per-worktree `status --porcelain` / `rev-list --count origin/main..HEAD`, across **both** repos. In-flight issues are excluded from do-next and kept in the table marked `in flight (worktree: …)`.
  - **Deliberately over-inclusive**, with the asymmetry stated: a stale worktree costs one skipped recommendation; a missed live one costs a duplicated day of work + a merge collision. So it does not carry the positive/negative control the derived-count norm asks for (that norm governs an *inferred aggregate*; this is a direct per-worktree read) — but its one silent-failure path, a branch with no issue number, is **named** per `feedback_derived_signal_needs_scoped_diagnostic` rather than left to fail toward "all fine".
  - **Not persisted as a label** (unlike `verify-blocked`) — a worktree is transient; a label would go stale and then suppress a genuinely available issue.
- **New step 0** — `git fetch` + report both repos' behind-counts; rev-based reads (`git grep <sym> origin/main`, `git show origin/main:<skill>`) so a non-zero count doesn't leave the code checks and this skill file stale. `git fetch` alone does not touch the working tree, so measuring staleness is not curing it.

## Verification

Every git-behavior claim in the new text was verified against the live worktrees in **both** repos (in-flight predicate, `locked` persistence, `--porcelain` output shape, `rev-list`/`git show` behavior from a worktree, the `aiwatch-reports` sibling-directory + numberless-branch case). `lint:docs` clean, `test:scripts` 289 pass. File is 19.4k chars (≪ 40k guideline).

Review ran **4 rounds** (code-reviewer + comment-analyzer). Each round's Critical was a real, empirically-confirmed factual error about git behavior, all fixed. The recurring "trivially-satisfiable control" finding (rounds 1–3) was resolved by **deleting** the control per the stop rule, not re-wording it a fourth time. Round 4's agent was cut off by a session limit; its two questions (norm-exemption defensibility, predicate correctness + `locked` semantics) were verified in the main loop instead.

No code change; procedure prose for the triage skill only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)