### PR TITLE
docs(marketing): require ?utm_source=reddit on Reddit outreach links (refs #270)

### DIFF
--- a/docs/marketing-playbook.md
+++ b/docs/marketing-playbook.md
@@ -159,7 +159,7 @@ Adapt to the specific thread — never copy-paste verbatim across subreddits.
 
 ```
 It's down for everyone — just pulled this from AIWatch
-(ai-watch.dev/is-claude-down):
+(ai-watch.dev/is-claude-down?utm_source=reddit):
 
 - Status: Down (confirmed [HH:MM UTC — pull from dashboard])
 - Early RTT signal: [X minutes — ONLY if the dashboard shows one] — our probe
@@ -172,6 +172,8 @@ Source is open — happy to explain how the detection works if anyone's curious.
 ```
 
 Link to the **specific service page** (`/is-claude-down`, `/is-openai-down`, etc.), **never** the homepage. The homepage link looks like spam; the service page is the contextually useful answer.
+
+**Always append `?utm_source=reddit`** to the link — it is what reliably attributes the visit to the Reddit channel in AIWatch's audience classifier (`worker/src/outage-audience.ts`); without the tag the visit may not be counted as Reddit at all. One clean `?utm_source=reddit` is all the link needs — no other UTM params are required.
 
 A genuine early-RTT signal is **rare** (most incidents are component/connector degradations that don't spike the probed endpoint's RTT, and status-page detection is structurally bounded by polling lag — #464). If the dashboard does not show one, **drop the line entirely** rather than guess or claim "ahead of official." The rest of the template still stands — confirmed outage + AI analysis + fallback recs are useful on their own. Never frame AIWatch as "faster than the official status page" as a blanket claim; the verifiable pillars are independent detection (MTTD) + RTT degradation that status pages don't report.
 
@@ -224,6 +226,7 @@ Every post, every channel, no exceptions. Run through this in order before hitti
 - [ ] All `[bracket placeholders]` in the template replaced with live values pulled from the dashboard at posting time
 - [ ] Numbers (timestamps, early-RTT signal minutes if shown, uptime %) match what ai-watch.dev shows right now — not a cached tab from 30 minutes ago
 - [ ] Link points to the specific service page (`/is-<service>-down`), not the homepage
+- [ ] **Reddit posts:** the link carries `?utm_source=reddit` — otherwise the visit may be unattributable (see Reddit § "Response template")
 - [ ] Authorship disclosed in the first line ("Author here" / "I built this")
 - [ ] Only one AIWatch URL in the body
 - [ ] No competitor named in the title


### PR DESCRIPTION
## What

The #270 Reddit outreach playbook (`docs/marketing-playbook.md`) now requires an `?utm_source=reddit` tag on the is-down link an operator posts, in three places:

1. The response-template link example (`ai-watch.dev/is-claude-down?utm_source=reddit`)
2. A short "why" under the template
3. A pre-post dry-run checklist item

## Why

Without the tag, a Reddit visit is attributed only by referrer host — verified reliable for `old.reddit.com` only; other surfaces are inference-only (`worker/src/outage-audience.ts`). So an untagged visit may not be counted as Reddit at all. The tag routes it to the `reddit` bucket regardless of surface — the point of running Reddit as a *measured* channel (`decision_reddit_over_search_channel`). `reddit.ts` already appends the same tag to links AIWatch emits (#548); this aligns manual posts with that.

## Scope note (`refs`, not `closes`)

#270's remaining acceptance criteria — a karma-history Reddit account and a monitoring-RSS subscription — are **owner actions**, not code, and are already documented as owner-action checklists in the playbook. The issue stays open until those are done.

## Review

Docs-only. `lint:docs` clean. Ran a 4-round `comment-analyzer` loop against the actual classifier code; converged at 0 Critical / 0 Important / 0 Suggestion (round 3 fired the causal stop trigger → deleted the drift-prone mechanism prose rather than re-wording it, per `feedback_no_prose_mirror_of_code_branches`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)