### PR TITLE
docs(skill): per-month Recommendations category coverage in write-monthly-report (refs aiwatch-reports#62)

### DIFF
--- a/.claude/skills/write-monthly-report/SKILL.md
+++ b/.claude/skills/write-monthly-report/SKILL.md
@@ -42,7 +42,29 @@ Heed both; they exist precisely because a prose rule gets only probabilistic com
 2. **Fill the hand-authored sections** — everything the generator leaves as a placeholder/AUTO-DRAFT:
    - **Summary** (EN bullets: Most reliable / Riskiest / High incident count / Watch out) **AND the KO
      `<details>` mirror** — keep both in lockstep.
-   - **Recommendations** table (per use-case).
+   - **Recommendations** table (per use-case). **Category coverage is data-driven per month
+     (aiwatch-reports#62)** — do NOT ship the frozen 5-row template blindly:
+     - **Always-present buyer-intent rows** (any category can win): Production-critical, Low latency /
+       cost, General purpose.
+     - **One specialized row per SPECIALIZED bucket that has ≥1 *ranked* service THIS month.** Take the
+       bucket SET — which specialized buckets exist this month — straight from THIS report's
+       `Services monitored: N — …` category-breakdown header (aiwatch-reports#98), using every bucket
+       EXCEPT the generic `LLM APIs` (feeds the buyer-intent rows) and `AI apps` (consumer end-user apps,
+       not a build-on pick). Do NOT hardcode a bucket list here — the header is the source, so the row set
+       tracks the fleet as buckets change. The header label (e.g. `voice & transcription`, `inference &
+       infra`) identifies WHICH bucket earns a row; keep the row's reader-facing Use-Case cell in the
+       established polished form (`Voice / audio`, `Inference`, `Vector / embeddings`), NOT the raw header
+       string.
+     - **"Ranked" = appears in this month's Score Rankings table** (it passed the full-month-coverage gate
+       — aiwatch#802 / aiwatch-reports#45); a mid-month-added or otherwise unranked service does **not**
+       qualify. The Rankings table has no category column, so map a ranked service to its bucket via the
+       **same service→category grouping the breakdown header is generated from** (the `group` taxonomy,
+       aiwatch#1068 / aiwatch-reports#98) — read it at authoring time; never copy a service roster into
+       this skill.
+     - **A specialized bucket with no ranked service this month is OMITTED** (or explicitly marked
+       "insufficient data this month") — **never fake a pick** from an unranked / partial-coverage service.
+     - **Roll forward only.** Apply the expanded set from the first month it ships onward; do not retrofit
+       a single past month — that creates month-to-month divergence in the immutable archive.
    - **Key Insight** — opening sentence + **3 patterns**, EN, **AND** the KO mirror.
    - **Notable Incidents** — top incidents, each with `**Affected**` + `**Duration**`.
    - **Observations**.


### PR DESCRIPTION
## What

Documents the monthly-report **Recommendations** table's per-month category-coverage rule in the `write-monthly-report` authoring skill. Previously the skill said only "Recommendations table (per use-case)", so every report shipped the frozen 5-row template (Coding Agents + Voice the only specialized tiers) — a reader choosing Image / Video / Inference / Observability got no reliability-based pick.

This is **option (a)** of `bentleypark/aiwatch-reports#62` — a skill-doc change only, no structural generator/template change.

## The rule (for the hand-filled table)

- **Always-present buyer-intent rows** (any category can win): Production-critical, Low latency / cost, General purpose.
- **One specialized row per breakdown-header bucket** (excluding the generic `LLM APIs` + consumer `AI apps`) that has **≥1 ranked service that month**. The bucket set + exact names come from THIS report's own `Services monitored: N — …` header (reports#98) — nothing hardcoded in the skill, so it tracks the fleet as buckets change.
- **"Ranked"** = appears in the Score Rankings table (passed the full-month-coverage gate, #802 / reports#45). The Rankings table has no category column, so map a ranked service to its bucket via the `group` taxonomy (#1068) at authoring time — never copy a service roster into the skill.
- An empty bucket is **omitted** (or marked "insufficient data this month") — **never fake a pick**.
- **Roll forward only** — don't retrofit a past immutable-archive month.

## Why refs, not closes

Acceptance item 3 (rule documented) is done here. Items 1–2 (covers-when-ranked / omit-not-fake) are **demonstrated when the July 2026 report is authored under this rule**, so `bentleypark/aiwatch-reports#62` stays open until that report ships.

## Review

3 rounds (pr-review-toolkit) → 0 Critical/Important. R1 fixed a taxonomy mismatch (dropped a non-existent "Vector" bucket, aligned to the report's own `group` breakdown). R2→R3: a recurring finding on a bucket-name snapshot enumeration was resolved by **deleting the enumeration** (header is the source), not re-fixing labels — eliminating the drift surface. Exclusion strings `LLM APIs` / `AI apps` verified char-for-char against the generator's `GROUP_LABELS`.

## Verification scope

Internal authoring skill (no browser surface) → step-3.5 in-browser verify N/A; no code test gates it. Cited issues (#62 / #802 / reports#45 / reports#98 / #1068) all verified real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)