### PR TITLE
fix(methodology): stop the noUptime Score formula leaking Korean onto the EN page (#974)

### DIFF
--- a/api/_methodology/__tests__/html-template.test.ts
+++ b/api/_methodology/__tests__/html-template.test.ts
@@ -98,6 +98,60 @@ describe('renderMethodologyPage', () => {
     expect(html).toMatch(/Not provided|not provided|미제공|제공.*않/)
   })
 
+  it('no .formula div leaks untranslated Korean onto the English page (#974)', () => {
+    // Defect 1 (#974): the noUptime Score formula div had no data-i18n, so setLang('en') never
+    // rewrote it and its Korean rendered on the English page. The client toggle only rewrites
+    // [data-i18n] elements, so a .formula div is leak-safe iff EITHER the div itself carries
+    // data-i18n, OR the only Korean it contains sits inside a data-i18n child span (which IS
+    // rewritten) — pure-math formula divs (language-neutral) are safe with neither.
+    const formulaDivs = [...html.matchAll(/<div class="formula"([^>]*)>([\s\S]*?)<\/div>/g)]
+    expect(formulaDivs.length).toBeGreaterThan(0)
+    for (const [, attrs, inner] of formulaDivs) {
+      if (/\bdata-i18n=/.test(attrs)) continue // whole div is translated on toggle
+      // strip translated child spans; any Korean left is direct div text that never gets rewritten
+      const bare = inner.replace(/<span[^>]*\bdata-i18n=[^>]*>[\s\S]*?<\/span>/g, '')
+      expect(/[가-힣]/.test(bare), `.formula div leaks Korean on the EN page (needs data-i18n): ${inner.slice(0, 70)}`).toBe(false)
+    }
+    // the fix's keys BOTH exist in BOTH locale blocks (ko + en). The leak scan above strips every
+    // data-i18n span unconditionally, so a key wired in only ONE locale would still pass it while
+    // leaking the other locale's text — exactly #974's bug class. Assert both keys, both locales.
+    expect((html.match(/'s4\.noUptime\.formula':/g) ?? []).length, 's4.noUptime.formula must exist in both locales').toBeGreaterThanOrEqual(2)
+    expect((html.match(/'s4\.noUptime\.formulaSub':/g) ?? []).length, 's4.noUptime.formulaSub must exist in both locales').toBeGreaterThanOrEqual(2)
+  })
+
+  it('never lists an incident.io-uptime service as "no uptime source" (#974 anti-drift)', () => {
+    // The §3 "coverage & limits" table hardcodes the no-official-uptime service names — prose that
+    // cannot derive from data, so it silently drifted: stability/elevenlabs/replicate/turbopuffer
+    // each gained an incidentIoComponentId (we now COMPUTE their uptime from incident.io
+    // component_impacts → uptimeSource 'official') but kept sitting in the table.
+    //
+    // Sound static invariant: a service with an incidentIoComponentId ALWAYS produces official
+    // uptime, so it must never appear in the limits table. This is the one direction config can
+    // pin. LIMIT: the statusComponentId / Atlassian path (deepgram vs openrouter) depends on
+    // whether the provider's HTML actually carries window.uptimeData — runtime-only, not statically
+    // derivable here — so that direction is verified against live /api/status via the issue's
+    // Tier-A verify-after assert, not this test.
+    const uptimeSection = html.slice(html.indexOf('id="uptime"'), html.indexOf('id="latency"'))
+    const limitsBlock = uptimeSection.slice(uptimeSection.indexOf('class="limits"'))
+    // first-column cells hold the ·-separated display names ("Amazon Bedrock · Azure OpenAI", …)
+    const namedNoUptime = new Set(
+      [...limitsBlock.matchAll(/<tr>\s*<td>([^<]+)<\/td>/g)]
+        .flatMap((m) => m[1].split('·').map((s) => s.trim()))
+        .filter(Boolean),
+    )
+    expect(namedNoUptime.size, 'limits-table service names should parse').toBeGreaterThan(0)
+    // Exact-name membership (NOT substring — "OpenAI" is an incident.io service whose name is a
+    // substring of the table's "Azure OpenAI", so toContain would false-positive). This assumes the
+    // table cell uses the service's config `.name` verbatim; a few no-uptime services are listed under
+    // a shortened display name (config "Gemini API"→table "Gemini", "xAI (Grok)"→"xAI"), but none of
+    // those carry an incidentIoComponentId, so the exact-name guard covers the whole incident.io set.
+    const ioNames = SERVICES.filter((s) => s.incidentIoComponentId).map((s) => s.name)
+    expect(ioNames.length).toBeGreaterThan(0)
+    for (const name of ioNames) {
+      expect(namedNoUptime.has(name), `${name} has an incidentIoComponentId (we compute its official uptime) — it must not be listed as "no uptime source"`).toBe(false)
+    }
+  })
+
   it('names every data-source platform (kept in sync with worker/src/parsers)', () => {
     // The §1 "Data sources" list must cover the real parser set — Google AI Studio (aistudio.ts,
     // #310) and Flashduty/DeepSeek (flashduty.ts, #618) were missing on first ship.

--- a/api/_methodology/html-template.ts
+++ b/api/_methodology/html-template.ts
@@ -485,7 +485,7 @@ ${consentInitScript(nonce)}
   <div class="subscore">
     <h3 data-i18n="s4.noUptime.title">Uptime 미제공 서비스</h3>
     <p data-i18n="s4.noUptime.desc">일부 서비스(Gemini·xAI·Bedrock 등)는 공식 uptime 수치가 없습니다. 가정값을 넣지 않고 uptime 컴포넌트(40점)를 제외한 뒤 나머지 가용 컴포넌트만으로 100점 환산합니다. probe가 있는 서비스(Gemini·xAI 등)는 인시던트·복구·응답성으로 점수를 산정해 랭킹에 포함합니다. probe도 없는 서비스(Bedrock·Azure)는 측정 신호가 인시던트·복구뿐이라 신뢰할 점수를 낼 수 없어, 점수를 산출·표시하지 않고 인시던트 추적만 제공합니다.</p>
-    <div class="formula">Score = (가용 컴포넌트 점수 합) / (가용 컴포넌트 max 합) × 100 <span class="fl-sub">— uptime 40점 제외</span></div>
+    <div class="formula"><span data-i18n="s4.noUptime.formula">Score = (가용 컴포넌트 점수 합) / (가용 컴포넌트 max 합) × 100</span> <span class="fl-sub" data-i18n="s4.noUptime.formulaSub">— uptime 40점 제외</span></div>
   </div>
 
   <!-- Grades -->
@@ -604,6 +604,8 @@ const i18n = {
     's4.resp.insufficient': '새로 추가된 probe 대상 서비스는 7일치 데이터가 쌓이기 전까지 5% 페널티를 적용합니다.',
     's4.noUptime.title': 'Uptime 미제공 서비스',
     's4.noUptime.desc': '일부 서비스(Gemini·xAI·Bedrock 등)는 공식 uptime 수치가 없습니다. 가정값을 넣지 않고 uptime 컴포넌트(40점)를 제외한 뒤 나머지 가용 컴포넌트만으로 100점 환산합니다. probe가 있는 서비스(Gemini·xAI 등)는 인시던트·복구·응답성으로 점수를 산정해 랭킹에 포함합니다. probe도 없는 서비스(Bedrock·Azure)는 측정 신호가 인시던트·복구뿐이라 신뢰할 점수를 낼 수 없어, 점수를 산출·표시하지 않고 인시던트 추적만 제공합니다.',
+    's4.noUptime.formula': 'Score = (가용 컴포넌트 점수 합) / (가용 컴포넌트 max 합) × 100',
+    's4.noUptime.formulaSub': '— uptime 40점 제외',
     's4.grades.title': '등급 기준',
     's5.title': '레이턴시 (Probe RTT)',
     's5.lead': '33개 AI 서비스의 엔드포인트를 Cloudflare Workers 엣지에서 5분 간격으로 직접 측정합니다. p50 / p75 / p95 분위수를 산출합니다.',
@@ -689,6 +691,8 @@ const i18n = {
     's4.resp.insufficient': 'Newly added probed services receive a 5% penalty until 7 days of probe data accumulate.',
     's4.noUptime.title': 'Services without uptime data',
     's4.noUptime.desc': 'Some services (Gemini, xAI, Bedrock, etc.) publish no official uptime. We assume no value — the 40-point uptime component is dropped and the score is rescaled over the remaining available components. Services that ARE probed (Gemini, xAI, etc.) are scored on incidents + recovery + responsiveness and included in the ranking. Services with no probe either (Bedrock, Azure OpenAI) have only incidents + recovery left as signals — too thin for a trustworthy score, so we publish no score for them and provide incident tracking only.',
+    's4.noUptime.formula': 'Score = (sum of available component scores) / (sum of their maxima) × 100',
+    's4.noUptime.formulaSub': '— uptime 40 points excluded',
     's4.grades.title': 'Grade thresholds',
     's5.title': 'Latency (Probe RTT)',
     's5.lead': 'We measure the endpoints of 33 AI services directly from the Cloudflare Workers edge every 5 minutes, producing p50 / p75 / p95 percentiles.',


### PR DESCRIPTION
Closes #974.

Three defects were filed on the public `/methodology` page. Verified each against the **current** template and **live `/api/status`** — only one was still live in code.

## 1. Korean leak on the EN page — FIXED
The "Services without uptime data" Score formula div was the only `.formula` div without `data-i18n`, so the client language toggle never rewrote it and its Korean rendered on the **English** page in both locales. Wrapped both text runs in `data-i18n` spans (`s4.noUptime.formula` + `s4.noUptime.formulaSub`) with KO+EN values — the pattern the three sibling formulas already use.

## 2. §3 "two kinds" lead — already resolved (no code change)
The issue quoted `s3.lead`: *"Uptime%는 출처에 따라 두 가지 방식으로 나뉩니다."* That sentence was removed by the #1006 rewrite; the current lead makes no "two kinds" claim, and the third state (no uptime source) is covered by the "측정 한계" table. Confirmed against the template.

## 3. Limits table "missing four services" — stale (anti-drift test instead)
The issue said 11 services had no uptime and the table listed 6, missing 4. **Live `/api/status` today shows the real no-uptime set is exactly the 6 the table already lists** (`azureopenai, bedrock, characterai, deepgram, gemini, xai`). The four it named (`elevenlabs, replicate, stability, turbopuffer`) since gained incident.io-computed **official** uptime, and `openrouter` computes it via OnlineOrNot.

Rather than re-hardcode names — the exact prose-mirrors-code drift the issue is itself an instance of (memory `feedback_no_prose_mirror_of_code_branches`, #1110) — this adds an **anti-drift unit test**: a service with an `incidentIoComponentId` always yields official uptime, so it must never appear in the limits table. That's the one direction static config can pin; the runtime direction (an Atlassian-path service that stops carrying `window.uptimeData`) is not statically derivable and is left to live verification.

> **Scope note:** the issue's literal ask for Defect 3 was "add 4 services". Since those 4 now have uptime, adding them would be wrong — the table is already correct. This PR resolves the *root* (a leaked untranslated string + drift-prone enumeration) rather than the stale symptom.

## Verification
- In-browser confirmed (operator): the formula renders **English** by default, **Korean** on the KO toggle.
- `test:src` green — 68 files / 1081 tests; methodology suite 20/20 (2 new tests: leak scan asserting no `.formula` div leaks Korean on EN + both keys wired in both locales; anti-drift invariant).
- PR review loop: round 1 = 0 Critical/Important; two Suggestions applied (`formulaSub` key parity assertion + display-name assumption comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)