### PR TITLE
fix(region): gate global-incident fallback by component-aware service status (closes #1149)

### DIFF
--- a/api/_is-down/__tests__/region-status.test.ts
+++ b/api/_is-down/__tests__/region-status.test.ts
@@ -80,3 +80,24 @@ describe('region-status.ts mirror — region-aware but not region-switchable (#9
     expect(result!.docsUrl).toBe('https://docs.pinecone.io/guides/index-data/create-an-index#cloud-regions')
   })
 })
+
+describe('region-status.ts mirror — global-incident fallback gated by service status (#1149)', () => {
+  test('operational service with region-less incident returns null (no fallback)', () => {
+    const result = regionStatusOf({
+      id: 'openai',
+      status: 'operational',
+      incidents: [{ id: 'o1', status: 'investigating', title: 'Elevated error rates' }],
+    })
+    expect(result).toBeNull()
+  })
+
+  test('degraded service with region-less incident triggers global fallback', () => {
+    const result = regionStatusOf({
+      id: 'openai',
+      status: 'degraded',
+      incidents: [{ id: 'o1', status: 'investigating', title: 'Elevated error rates' }],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.allDown).toBe(true)
+  })
+})

--- a/api/_is-down/region-status.ts
+++ b/api/_is-down/region-status.ts
@@ -194,7 +194,9 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
     if (!incMatched) hasGlobalIncident = true
   }
 
-  if (!hasRegionSpecific && ongoing.length > 0) {
+  // Gated by service status (#1149): if service.status === 'operational', do not trip
+  // the global-incident fallback for a region-less incident.
+  if (!hasRegionSpecific && ongoing.length > 0 && service.status !== 'operational') {
     const globalType = classifyIncident((ongoing[0] as IncidentLike).title)
     for (const r of regionDefs) {
       status[r.key] = { status: 'incident', type: globalType }
@@ -205,6 +207,8 @@ export function regionStatusOf(service: ServiceLike | null | undefined): RegionS
   const okRegions = regions.filter((r) => r.status === 'ok')
   const incidentRegions = regions.filter((r) => r.status === 'incident')
   const allDown = okRegions.length === 0
+
+  if (incidentRegions.length === 0 && !alwaysShow) return null
 
   return {
     regions,

--- a/api/_is-down/region-status.ts
+++ b/api/_is-down/region-status.ts
@@ -24,6 +24,7 @@ export type IncidentLike = {
 
 export type ServiceLike = {
   id?: string
+  status?: string
   incidents?: unknown[]
 }
 

--- a/src/utils/__tests__/regionStatus.test.js
+++ b/src/utils/__tests__/regionStatus.test.js
@@ -208,6 +208,24 @@ describe('regionStatusOf — global-incident fallback', () => {
     })
     expect(result.regions.every((r) => r.type === 'down')).toBe(true)
   })
+
+  test('operational service with region-less incident does NOT trigger global fallback (#1149)', () => {
+    const result = regionStatusOf({
+      id: 'openai',
+      status: 'operational',
+      incidents: [{ id: 'o1', status: 'investigating', title: 'Elevated error rates' }],
+    })
+    expect(result).toBeNull()
+
+    const degradedResult = regionStatusOf({
+      id: 'openai',
+      status: 'degraded',
+      incidents: [{ id: 'o1', status: 'investigating', title: 'Elevated error rates' }],
+    })
+    expect(degradedResult).not.toBeNull()
+    expect(degradedResult.allDown).toBe(true)
+    expect(degradedResult.regions.every((r) => r.status === 'incident')).toBe(true)
+  })
 })
 
 describe('regionStatusOf — region-aware but not region-switchable (#973)', () => {

--- a/src/utils/regionStatus.js
+++ b/src/utils/regionStatus.js
@@ -228,7 +228,13 @@ export function regionStatusOf(service, opts = {}) {
   // something IS ongoing. Mark every region with the first incident's type.
   // This is intentionally pessimistic: better to over-warn than under-warn
   // when the upstream feed gives us no region signal.
-  if (!hasRegionSpecific && ongoing.length > 0) {
+  //
+  // Gated by service status (#1149): if the component-aware service status is
+  // 'operational', component-level resolution has already determined this service's
+  // own capability is unaffected (e.g. OpenAI dropped the 'api' component from an
+  // open incident). Do not trip the pessimistic global fallback when the badge says
+  // operational.
+  if (!hasRegionSpecific && ongoing.length > 0 && service.status !== 'operational') {
     const globalType = classifyIncident(ongoing[0].title)
     for (const r of regionDefs) {
       status[r.key] = { status: 'incident', type: globalType }
@@ -239,6 +245,8 @@ export function regionStatusOf(service, opts = {}) {
   const okRegions = regions.filter((r) => r.status === 'ok')
   const incidentRegions = regions.filter((r) => r.status === 'incident')
   const allDown = okRegions.length === 0
+
+  if (incidentRegions.length === 0 && !alwaysShow) return null
 
   return {
     regions,


### PR DESCRIPTION
## Problem
On the OpenAI service-detail page, when OpenAI dropped the `api` component from an open incident, the service badge correctly read `operational`, but the Regional Availability card painted all 3 OpenAI regions 🔴 "Incident Detected".

## Cause
`regionStatusOf` (`src/utils/regionStatus.js`) re-derived region status from raw incidents without checking `service.status`. A non-resolved incident that named no region tripped the pessimistic global-incident fallback, marking all regions `incident` even when the service badge was already `operational`.

## Solution
- Gate the global-incident fallback by `service.status !== 'operational'` in both SPA (`src/utils/regionStatus.js`) and Edge SSR (`api/_is-down/region-status.ts`).
- Return `null` when `incidentRegions.length === 0` for non-`alwaysShow` services.
- Add comprehensive Vitest unit tests for both SPA and Edge mirrors.

Closes #1149

Co-Authored-By: Antigravity <antigravity@google.com>
🤖 Generated with Antigravity