### PR TITLE
feat(is-down): repurpose /is-claude-down and /is-openai-down as provider-family group pages

### DIFF
--- a/api/__tests__/is-down-group.test.ts
+++ b/api/__tests__/is-down-group.test.ts
@@ -1,0 +1,391 @@
+// #1164 — provider-family group pages (/is-claude-down, /is-openai-down after the API pages moved
+// to /is-claude-api-down, /is-openai-api-down). Mirrors is-down.test.ts's fetch-mocking pattern.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import handler from '../is-down-group'
+
+function makeReq(family: string): Request {
+  return new Request(`https://ai-watch.dev/api/is-down-group?family=${family}`, { method: 'GET' })
+}
+
+interface MockIncident {
+  id: string
+  title: string
+  status: 'investigating' | 'identified' | 'monitoring' | 'resolved'
+  startedAt: string
+  resolvedAt?: string | null
+  duration: string | null
+}
+
+function statusResponse(
+  services: Array<{ id: string; name: string; status: string; incidents?: MockIncident[] }>,
+  aiAnalysis?: Record<string, Array<{ incidentId: string; summary: string; estimatedRecovery: string }>>,
+): Response {
+  return new Response(
+    JSON.stringify({ services, ...(aiAnalysis ? { aiAnalysis } : {}) }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+describe('is-down-group.ts', () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>
+
+  afterEach(() => {
+    fetchMock?.mockRestore()
+  })
+
+  it('404s for an unknown family', async () => {
+    const res = await handler(makeReq('gemini'))
+    expect(res.status).toBe(404)
+  })
+
+  it('renders operational when every family member is operational', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=60, stale-while-revalidate=300')
+    expect(html).toContain('Is Anthropic (Claude) Down? Operational')
+    expect(html).toContain('/is-claude-api-down')
+    expect(html).toContain('/is-claude-ai-down')
+    expect(html).toContain('/is-claude-code-down')
+  })
+
+  it('worst-of headline: one member down dominates the others being operational', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'openai', name: 'OpenAI API', status: 'operational' },
+      { id: 'chatgpt', name: 'ChatGPT', status: 'down' },
+      { id: 'codex', name: 'Codex', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('openai'))
+    const html = await res.text()
+    expect(html).toContain('Is OpenAI Down? Down')
+    expect(html).toContain('/is-openai-api-down')
+    expect(html).toContain('/is-codex-down')
+  })
+
+  it('worst-of headline: degraded beats operational but loses to down', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'degraded' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(html).toContain('Is Anthropic (Claude) Down? Degraded Performance')
+  })
+
+  // #1164 review — two real bugs were caught and fixed here: (1) the headline used to render a false
+  // "🟢 Operational" when every member was unknown (STATUS_RANK tied 'unknown' with 'operational');
+  // (2) the fallback page used to render an EMPTY member list on total fetch failure, losing every
+  // outbound link exactly when they matter most. Both tests below assert the HEADLINE, not just that
+  // the word "Unknown" appears somewhere — the old bugs would still pass a mere `.toContain('Unknown')`
+  // check, since a lone member row could say "Unknown" while the headline still lied.
+  it('returns 503 + no-store, headline reads Unknown (never fabricated), and every member link still works', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new DOMException('aborted', 'AbortError'))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(res.status).toBe(503)
+    expect(res.headers.get('Cache-Control')).toMatch(/no-store/)
+    expect(html).toContain('Is Anthropic (Claude) Down? Unknown')
+    // the whole point of the group page — outbound links to every member — must survive a total
+    // Worker outage, not just the confirmed-good case.
+    expect(html).toContain('/is-claude-api-down')
+    expect(html).toContain('/is-claude-ai-down')
+    expect(html).toContain('/is-claude-code-down')
+    // #1164 review — member rows must show real display names ("claude.ai", "Claude Code"), not the
+    // raw worker ids ("claudeai", "claudecode"), even on a total fetch failure.
+    expect(html).toContain('claude.ai')
+    expect(html).toContain('Claude Code')
+    expect(html).not.toContain('>claudeai<')
+    expect(html).not.toContain('>claudecode<')
+  })
+
+  it('returns 503 + no-store when the Worker responds with a non-2xx status', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('upstream error', { status: 502 }))
+    const res = await handler(makeReq('openai'))
+    const html = await res.text()
+    expect(res.status).toBe(503)
+    expect(res.headers.get('Cache-Control')).toMatch(/no-store/)
+    expect(html).toContain('Is OpenAI Down? Unknown')
+  })
+
+  it('a member missing from the Worker response renders as unknown, not fabricated as operational', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      // claudeai / claudecode absent — e.g. a partial worker response
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(res.status).toBe(200) // the fetch itself succeeded — a missing member is not a fetch failure
+    expect(html).toContain('Unknown')
+  })
+
+  it('headline reads Unknown (not Operational) when EVERY member is missing from an otherwise-successful response', async () => {
+    // The bug this guards: STATUS_RANK used to tie 'unknown' with 'operational' at rank 0, so the
+    // reduce (seeded 'operational') never moved off it when every member came back unknown.
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(res.status).toBe(200) // fetch succeeded — an empty/mismatched roster is not a fetch failure
+    expect(html).toContain('Is Anthropic (Claude) Down? Unknown')
+    expect(html).not.toContain('Is Anthropic (Claude) Down? Operational')
+  })
+
+  it('a CONFIRMED down member still wins over an unknown sibling (unknown does not mask a real outage)', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'down' },
+      // claudeai / claudecode missing — unknown, must not outrank the confirmed 'down' above
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(html).toContain('Is Anthropic (Claude) Down? Down')
+  })
+})
+
+// #1164 round-3 — recent-incidents section added during the live design-review pass: merging a
+// shared incident id across members, incidentId-scoped AI analysis matching (+ the 2h post-resolution
+// window), ongoing-first sort, and the sibling-family "🔄 Alternative" recommendation. None of this had
+// coverage before round 3's review — each test below pins the specific bug a naive
+// simplification/regression would reintroduce (noted per case).
+describe('is-down-group.ts — recent incidents (#1164 round-3)', () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>
+
+  afterEach(() => {
+    fetchMock?.mockRestore()
+  })
+
+  const NOW = Date.parse('2026-07-26T07:00:00Z')
+
+  it('merges a shared incident id across two members into ONE row listing both', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'down', incidents: [
+        { id: 'inc-shared', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+      ] },
+      { id: 'claudeai', name: 'claude.ai', status: 'down', incidents: [
+        { id: 'inc-shared', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+      ] },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect((html.match(/class="incident-row"/g) ?? []).length).toBe(1)
+    expect(html).toContain('<a href="/is-claude-api-down">Claude API</a>')
+    expect(html).toContain('<a href="/is-claude-ai-down">claude.ai</a>')
+  })
+
+  it('does NOT merge two genuinely different incident ids — each renders its own row', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'down', incidents: [
+        { id: 'inc-a', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+      ] },
+      { id: 'claudeai', name: 'claude.ai', status: 'down', incidents: [
+        { id: 'inc-b', title: 'Login failures', status: 'investigating', startedAt: '2026-07-26T04:00:00Z', resolvedAt: null, duration: null },
+      ] },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect((html.match(/class="incident-row"/g) ?? []).length).toBe(2)
+  })
+
+  it('does NOT attach an AI analysis meant for a different, unrelated incident on the same service', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [{ id: 'claude', name: 'Claude API', status: 'down', incidents: [
+        { id: 'inc-real', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+      ] }],
+      { claude: [{ incidentId: 'inc-unrelated', summary: 'Wrong incident', estimatedRecovery: '1h' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).not.toContain('class="incident-ai">')
+    expect(html).not.toContain('Wrong incident')
+  })
+
+  // #1164 round-3 review (silent-failure-hunter + code-reviewer, independently) — the analysis for a
+  // shared incident can be filed under ANY affected member's key, not necessarily the first one in
+  // family.members order. A per-member-scoped lookup during the merge silently dropped it whenever the
+  // analysis lived under a later member. Regression test: 'claude' is first in family.members, but the
+  // analysis is filed under 'claudeai' only — it must still attach to the merged row.
+  it('finds the AI analysis even when filed under a NON-first member of a merged incident', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [
+        { id: 'claude', name: 'Claude API', status: 'down', incidents: [
+          { id: 'inc-shared', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+        ] },
+        { id: 'claudeai', name: 'claude.ai', status: 'down', incidents: [
+          { id: 'inc-shared', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+        ] },
+      ],
+      // deliberately NOT under 'claude' (family.members[0]) — only under 'claudeai'
+      { claudeai: [{ incidentId: 'inc-shared', summary: 'Filed under the second member', estimatedRecovery: '1h' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).toContain('Filed under the second member')
+  })
+
+  it('shows a RESOLVED incident\'s analysis as "Post-Incident Analysis" (no ETA) within the 2h window', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [{ id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+        { id: 'inc-recent', title: 'Brief spike', status: 'resolved', startedAt: '2026-07-26T06:00:00Z', resolvedAt: '2026-07-26T06:30:00Z', duration: '30m' },
+      ] }],
+      { claude: [{ incidentId: 'inc-recent', summary: 'Root cause explained', estimatedRecovery: '30m' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).toContain('Post-Incident Analysis')
+    expect(html).toContain('Root cause explained')
+    expect(html).not.toContain('<p class="incident-ai-eta">')
+  })
+
+  it('hides a RESOLVED incident\'s analysis once past the 2h window, but still renders the row', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [{ id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+        { id: 'inc-old', title: 'Old incident', status: 'resolved', startedAt: '2026-07-24T09:00:00Z', resolvedAt: '2026-07-24T10:30:00Z', duration: '1h 30m' },
+      ] }],
+      { claude: [{ incidentId: 'inc-old', summary: 'Stale analysis', estimatedRecovery: '15m' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).toContain('Old incident')
+    expect(html).toContain('resolved after 1h 30m')
+    expect(html).not.toContain('class="incident-ai">')
+    expect(html).not.toContain('Stale analysis')
+  })
+
+  it('never shows analysis for a resolved incident with no resolvedAt (fails closed, not open)', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [{ id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+        { id: 'inc-no-date', title: 'Unclear resolution time', status: 'resolved', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+      ] }],
+      { claude: [{ incidentId: 'inc-no-date', summary: 'Should never render', estimatedRecovery: '15m' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).not.toContain('class="incident-ai">')
+    expect(html).not.toContain('Should never render')
+  })
+
+  it('sorts an ONGOING incident above a more-recently-resolved one, regardless of startedAt', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+        { id: 'inc-resolved-recent', title: 'Just resolved', status: 'resolved', startedAt: '2026-07-26T06:00:00Z', resolvedAt: '2026-07-26T06:30:00Z', duration: '30m' },
+      ] },
+      { id: 'claudecode', name: 'Claude Code', status: 'degraded', incidents: [
+        { id: 'inc-ongoing-old', title: 'Still ongoing', status: 'monitoring', startedAt: '2026-07-20T00:00:00Z', resolvedAt: null, duration: null },
+      ] },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html.indexOf('Still ongoing')).toBeLessThan(html.indexOf('Just resolved'))
+  })
+
+  // #1164 round-3 review (silent-failure-hunter) — `new Date(inc.startedAt).getTime()` is NaN for a
+  // missing/malformed date, and the old bare `NaN < cutoff` comparison is always false, so a garbage
+  // date used to fail OPEN (never filtered, kept in the list forever) instead of failing safe.
+  it('excludes an incident with a malformed/missing startedAt instead of keeping it forever', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+        { id: 'inc-bad-date', title: 'Should be dropped', status: 'resolved', startedAt: 'not-a-date', resolvedAt: null, duration: null },
+      ] },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).not.toContain('Should be dropped')
+    expect(html).toContain('No incidents reported')
+  })
+
+  it('recommends a healthy sibling family inside an ongoing incident\'s AI card', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [
+        { id: 'claude', name: 'Claude API', status: 'down', incidents: [
+          { id: 'inc-x', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+        ] },
+        { id: 'openai', name: 'OpenAI API', status: 'operational' },
+        { id: 'chatgpt', name: 'ChatGPT', status: 'operational' },
+        { id: 'codex', name: 'Codex', status: 'operational' },
+      ],
+      { claude: [{ incidentId: 'inc-x', summary: 'Explains the outage', estimatedRecovery: '1h' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).toContain('incident-ai-alt')
+    expect(html).toContain('🔄 Alternative')
+    expect(html).toContain('href="/is-openai-down"')
+  })
+
+  it('does NOT recommend a sibling family that is itself degraded/down', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [
+        { id: 'claude', name: 'Claude API', status: 'down', incidents: [
+          { id: 'inc-x', title: 'Elevated errors', status: 'investigating', startedAt: '2026-07-26T05:00:00Z', resolvedAt: null, duration: null },
+        ] },
+        { id: 'openai', name: 'OpenAI API', status: 'operational' },
+        { id: 'chatgpt', name: 'ChatGPT', status: 'down' },
+        { id: 'codex', name: 'Codex', status: 'operational' },
+      ],
+      { claude: [{ incidentId: 'inc-x', summary: 'Explains the outage', estimatedRecovery: '1h' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).not.toContain('🔄 Alternative')
+  })
+
+  it('does NOT recommend an alternative on a RESOLVED incident\'s card, even with a healthy sibling', async () => {
+    vi.useFakeTimers().setSystemTime(NOW)
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse(
+      [
+        { id: 'claude', name: 'Claude API', status: 'operational', incidents: [
+          { id: 'inc-resolved', title: 'Brief spike', status: 'resolved', startedAt: '2026-07-26T06:00:00Z', resolvedAt: '2026-07-26T06:30:00Z', duration: '30m' },
+        ] },
+        { id: 'openai', name: 'OpenAI API', status: 'operational' },
+        { id: 'chatgpt', name: 'ChatGPT', status: 'operational' },
+        { id: 'codex', name: 'Codex', status: 'operational' },
+      ],
+      { claude: [{ incidentId: 'inc-resolved', summary: 'Root cause explained', estimatedRecovery: '30m' }] },
+    ))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    vi.useRealTimers()
+    expect(html).toContain('Post-Incident Analysis')
+    expect(html).not.toContain('🔄 Alternative')
+  })
+
+  it('shows "No incidents reported" (not an empty section) when the family has none in the window', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(html).toContain('No incidents reported for any Anthropic (Claude) service')
+  })
+})

--- a/api/__tests__/is-down-render.test.ts
+++ b/api/__tests__/is-down-render.test.ts
@@ -45,7 +45,7 @@ describe('renderDelegatedListeners integrity (#842-B)', () => {
 })
 
 describe('buildMetaDescription — recovery estimate exceeded (Mistral 2–4h on a days-long incident)', () => {
-  const seo = getSEOContent('claude')!
+  const seo = getSEOContent('claude-api')!
   const degraded = { status: 'degraded' } as unknown as Parameters<typeof buildMetaDescription>[1]
   const recent = new Date(Date.now() - 60_000).toISOString() // 1 min ago
 

--- a/api/__tests__/is-down.test.ts
+++ b/api/__tests__/is-down.test.ts
@@ -46,14 +46,14 @@ describe('is-down.ts cache-header divergence (#378)', () => {
 
   it('returns 200 + s-maxage=60 cache headers when Worker fetch succeeds', async () => {
     fetchMock.mockResolvedValueOnce(makeWorkerSuccess())
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(200)
     expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=60, stale-while-revalidate=300')
   })
 
   it('returns 503 + no-store when Worker fetch is rejected (timeout / network failure)', async () => {
     fetchMock.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'))
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(503)
     expect(res.headers.get('Cache-Control')).toMatch(/no-store/)
     expect(res.headers.get('Cache-Control')).toMatch(/must-revalidate/)
@@ -61,7 +61,7 @@ describe('is-down.ts cache-header divergence (#378)', () => {
 
   it('returns 503 + no-store when Worker returns a non-2xx HTTP status', async () => {
     fetchMock.mockResolvedValueOnce(new Response('upstream error', { status: 502 }))
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(503)
     expect(res.headers.get('Cache-Control')).toMatch(/no-store/)
   })
@@ -72,7 +72,7 @@ describe('is-down.ts cache-header divergence (#378)', () => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ services: [], aiAnalysis: {} }), {
       status: 200, headers: { 'Content-Type': 'application/json' },
     }))
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(503)
     expect(res.headers.get('Cache-Control')).toMatch(/no-store/)
   })
@@ -94,10 +94,10 @@ describe('is-down.ts cache-header divergence (#378)', () => {
 
     // Worker timeout (AbortError)
     fetchMock.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'))
-    await handler(makeReq('claude'))
+    await handler(makeReq('claude-api'))
     // Worker non-2xx
     fetchMock.mockResolvedValueOnce(new Response('upstream', { status: 502 }))
-    await handler(makeReq('openai'))
+    await handler(makeReq('openai-api'))
     // Worker 200 but slug missing from services array
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ services: [], aiAnalysis: {} }), {
       status: 200, headers: { 'Content-Type': 'application/json' },
@@ -115,7 +115,7 @@ describe('is-down.ts cache-header divergence (#378)', () => {
 
   it('does NOT cache 5xx responses anywhere on the CDN — `no-store` blocks both edge and shared caches', async () => {
     fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     const cc = res.headers.get('Cache-Control') ?? ''
     expect(cc).toContain('no-store')
     expect(cc).toContain('max-age=0')
@@ -146,7 +146,7 @@ describe('is-down.ts — #827 F4 predicted-vs-actual on a resolved card', () => 
   // page to the fallback render. Handler-level so the data-wiring (not just renderAIInsight) is covered.
   it('renders the predicted-vs-actual line (does not throw to the fallback page)', async () => {
     fetchMock.mockResolvedValueOnce(makeWorkerResolved())
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('Predicted vs actual:')
@@ -166,7 +166,7 @@ describe('is-down.ts — #827 F4 predicted-vs-actual on a resolved card', () => 
     }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     fetchMock.mockResolvedValueOnce(payload)
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const res = await handler(makeReq('claude')) // 'claude' service missing from `services`
+    const res = await handler(makeReq('claude-api')) // 'claude' service missing from `services`
     const threwParseError = errSpy.mock.calls.some(c => String(c[0]).includes('JSON parse failed'))
     errSpy.mockRestore()
     expect(threwParseError).toBe(false)   // buggy version logs this; fixed version takes the clean path
@@ -199,7 +199,7 @@ describe('is-down.ts — #827 F4 predicted-vs-actual on a resolved card', () => 
       ] },
     }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     fetchMock.mockResolvedValueOnce(payload)
-    const res = await handler(makeReq('claude'))
+    const res = await handler(makeReq('claude-api'))
     expect(res.status).toBe(200)
     const html = await res.text()
     // Both summaries present (the whole array is rendered, not just [0])…

--- a/api/_badges/__tests__/html-template.test.ts
+++ b/api/_badges/__tests__/html-template.test.ts
@@ -4,8 +4,18 @@ import { SLUG_TO_SERVICE } from '../../_is-down/slug-map'
 
 describe('badgeMarkdownFor (#805) — links to the crawlable is-down page', () => {
   it('builds markdown with the worker service id image + is-down link (slug == id)', () => {
-    expect(badgeMarkdownFor('claude')).toBe(
-      '[![Claude API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/claude)](https://ai-watch.dev/is-claude-down)',
+    expect(badgeMarkdownFor('gemini')).toBe(
+      '[![Gemini API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/gemini)](https://ai-watch.dev/is-gemini-down)',
+    )
+  })
+  // #1164 — 'claude'/'openai' moved to '-api-down' slugs when those bare URLs became
+  // provider-family group pages.
+  it('builds markdown for the renamed Claude API / OpenAI API slugs', () => {
+    expect(badgeMarkdownFor('claude-api')).toBe(
+      '[![Claude API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/claude)](https://ai-watch.dev/is-claude-api-down)',
+    )
+    expect(badgeMarkdownFor('openai-api')).toBe(
+      '[![OpenAI API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/openai)](https://ai-watch.dev/is-openai-api-down)',
     )
   })
   it('uses the worker id (not the slug) for the image when they differ', () => {

--- a/api/_intro/html-template.ts
+++ b/api/_intro/html-template.ts
@@ -902,7 +902,7 @@ ${announcementHtml}
         <div class="feature-tag">SEO PAGE</div>
         <div class="feature-icon">🔍</div>
         <div class="feature-title" data-i18n="feat.4.title">"Is X Down?" 전용 페이지</div>
-        <div class="feature-desc" data-i18n="feat.4.desc">ai-watch.dev/is-claude-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.</div>
+        <div class="feature-desc" data-i18n="feat.4.desc">ai-watch.dev/is-claude-api-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.</div>
       </div>
     </div>
   </div>
@@ -1134,7 +1134,7 @@ const i18n = {
     'feat.1.title': 'AIWatch Score', 'feat.1.desc': 'Uptime(40) + 인시던트 영향 일수(25) + 복구 시간(15) + 응답성(20)을 종합한 0~100점 신뢰도 지표입니다. 서비스마다 흩어진 공식 데이터를 통합해 한눈에 비교할 수 있게 합니다. 데이터 미제공 서비스는 업계 평균 + 패널티가 적용됩니다.',
     'feat.2.title': 'AI 장애 분석', 'feat.2.desc': '장애 발생 시 AIWatch가 패턴을 분석해 예상 복구 시간과 영향 범위를 알려줍니다. "언제쯤 복구될까?"에 빠르게 답합니다.',
     'feat.3.title': 'Fallback 추천', 'feat.3.desc': '장애 중인 서비스의 대안을 같은 카테고리 Score 상위 순으로 즉시 제안합니다. 같은 제공사 서비스는 자동 제외됩니다.',
-    'feat.4.title': '"Is X Down?" 전용 페이지', 'feat.4.desc': 'ai-watch.dev/is-claude-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.',
+    'feat.4.title': '"Is X Down?" 전용 페이지', 'feat.4.desc': 'ai-watch.dev/is-claude-api-down 같은 전용 페이지에서 실시간 상태, AI 분석, 대안 추천을 한 번에 확인합니다.',
     'how.title': '이렇게 동작합니다', 'how.sub': '각 서비스의 공식 상태 페이지 데이터를 기반으로 동작합니다',
     'compare.title': '공식 상태 페이지와 무엇이 다른가요?', 'compare.sub': '공식 페이지 데이터를 기반으로, 44개를 한 화면에서 통합합니다', 'compare.col1': '공식 상태 페이지', 'compare.r2': '장애 알림', 'compare.r2a': '제공사마다 개별 구독', 'compare.r2b': '44개를 한 곳에서 — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': '종합 점수 없음 (업타임 %만)', 'compare.r3b': 'AIWatch Score — Uptime + 영향 일수 + 복구 + 응답성', 'compare.r4': '장애 분석', 'compare.r4b': 'AI가 원인 · 복구 시간 분석', 'compare.r5': '대안 추천', 'compare.r5b': 'Fallback 서비스 즉시 제안', 'compare.r6': '월간 리포트', 'compare.r6b': '매월 리포트 공개', 'compare.r7': '비용', 'compare.r7a': '무료', 'compare.r7b': '완전 무료 · 오픈소스',
     'how.1.badge': '자동', 'how.2.badge': '장애 감지 시', 'how.3.badge': '실시간', 'how.4.badge': '매월',
@@ -1163,7 +1163,7 @@ const i18n = {
     'feat.1.title': 'AIWatch Score', 'feat.1.desc': 'A 0–100 reliability score combining Uptime (40) + Incident impact days (25) + Recovery time (15) + Responsiveness (20). Services without official data use industry averages with a penalty.',
     'feat.2.title': 'AI Incident Analysis', 'feat.2.desc': 'When an outage hits, AIWatch analyzes the pattern and tells you the estimated recovery time and impact scope. No more guessing.',
     'feat.3.title': 'Fallback Recommendations', 'feat.3.desc': 'Get instant alternative suggestions ranked by Score within the same category. Same-provider services are automatically excluded.',
-    'feat.4.title': '"Is X Down?" Dedicated Pages', 'feat.4.desc': 'Pages like ai-watch.dev/is-claude-down show real-time status, AI analysis, and fallback recommendations — all in one place.',
+    'feat.4.title': '"Is X Down?" Dedicated Pages', 'feat.4.desc': 'Pages like ai-watch.dev/is-claude-api-down show real-time status, AI analysis, and fallback recommendations — all in one place.',
     'how.title': 'How it works', 'how.sub': 'Powered by official status page data from each provider',
     'compare.title': 'How is AIWatch different?', 'compare.sub': 'Built on official status data — aggregated across 44 services in one place', 'compare.col1': 'Official Status Page', 'compare.r2': 'Alerts', 'compare.r2a': 'Subscribe per provider, separately', 'compare.r2b': 'All 44 in one — Discord · Slack · RSS', 'compare.r3': 'AIWatch Score', 'compare.r3a': 'No composite score (uptime % only)', 'compare.r3b': 'AIWatch Score — Uptime + Impact days + Recovery + Responsiveness', 'compare.r4': 'Incident analysis', 'compare.r4b': 'AI analyzes cause & recovery', 'compare.r5': 'Fallback', 'compare.r5b': 'Alternative services suggested', 'compare.r6': 'Monthly report', 'compare.r6b': 'Monthly report published', 'compare.r7': 'Cost', 'compare.r7a': 'Free', 'compare.r7b': 'Free & open source',
     'how.1.badge': 'Auto', 'how.2.badge': 'On detection', 'how.3.badge': 'Real-time', 'how.4.badge': 'Monthly',

--- a/api/_is-down/__tests__/family-groups.test.ts
+++ b/api/_is-down/__tests__/family-groups.test.ts
@@ -1,0 +1,49 @@
+// #1164 — referential integrity for FAMILY_GROUPS (provider-family group pages: /is-claude-down,
+// /is-openai-down). Nothing else in the codebase validates these invariants: a typo'd member id
+// would silently render that member as "Unknown" in production with no test failure (the group page
+// never fabricates a status, so a bad id degrades gracefully — but gracefully-wrong still ships
+// unnoticed without this check). A slug that drifts from its own map key would desync the page's
+// canonical/og:url/member-link generation (all keyed off `.slug`) from its own routing (keyed off the
+// map key) — also silent, also worth pinning.
+
+import { describe, it, expect } from 'vitest'
+import { FAMILY_GROUPS, SERVICE_ID_TO_SLUG } from '../slug-map'
+
+describe('FAMILY_GROUPS (#1164)', () => {
+  it('every member id is a real, canonical service (resolves via SERVICE_ID_TO_SLUG)', () => {
+    for (const [familyKey, family] of Object.entries(FAMILY_GROUPS)) {
+      for (const id of family.members) {
+        expect(SERVICE_ID_TO_SLUG[id], `FAMILY_GROUPS['${familyKey}'].members includes unknown id '${id}'`).toBeDefined()
+      }
+    }
+  })
+
+  it('each map key equals its own .slug — routing (keyed by map key) and rendering (keyed by .slug) must agree', () => {
+    for (const [familyKey, family] of Object.entries(FAMILY_GROUPS)) {
+      expect(family.slug, `FAMILY_GROUPS['${familyKey}'].slug should equal its own key`).toBe(familyKey)
+    }
+  })
+
+  it('every family has at least 2 members — a 1-member "family" is not a group', () => {
+    for (const [familyKey, family] of Object.entries(FAMILY_GROUPS)) {
+      expect(family.members.length, `FAMILY_GROUPS['${familyKey}'] has fewer than 2 members`).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('no service id belongs to more than one family', () => {
+    const seen = new Map<string, string>()
+    for (const [familyKey, family] of Object.entries(FAMILY_GROUPS)) {
+      for (const id of family.members) {
+        const owner = seen.get(id)
+        expect(owner, `service id '${id}' claimed by both '${owner}' and '${familyKey}'`).toBeUndefined()
+        seen.set(id, familyKey)
+      }
+    }
+  })
+
+  it('covers exactly the agreed Anthropic/OpenAI families (2 groups, 6 services)', () => {
+    expect(Object.keys(FAMILY_GROUPS).sort()).toEqual(['claude', 'openai'])
+    expect(FAMILY_GROUPS.claude.members.slice().sort()).toEqual(['claude', 'claudeai', 'claudecode'])
+    expect(FAMILY_GROUPS.openai.members.slice().sort()).toEqual(['chatgpt', 'codex', 'openai'])
+  })
+})

--- a/api/_is-down/__tests__/upstream-note.test.ts
+++ b/api/_is-down/__tests__/upstream-note.test.ts
@@ -31,7 +31,7 @@ describe('buildUpstreamNote (#1053)', () => {
         status: 'degraded',
         incidentTitle: 'Elevated errors on Sonnet 5 and Haiku 4.5',
         startedAt: '2026-07-17T06:47:54.909Z',
-        href: '/is-claude-down',
+        href: '/is-claude-api-down',
       external: false,
         leadMinutes: 29,
       }],
@@ -306,6 +306,6 @@ it('#1072 — an upstream with BOTH an is-down page and a statusUrl links INTERN
     }],
   }
   const note = buildUpstreamNote([both], 'chatgpt')!
-  expect(note.upstream[0].href).toBe('/is-claude-down')
+  expect(note.upstream[0].href).toBe('/is-claude-api-down')
   expect(note.upstream[0].external).toBe(false)
 })

--- a/api/_is-down/__tests__/upstream-wire-lockstep.test.ts
+++ b/api/_is-down/__tests__/upstream-wire-lockstep.test.ts
@@ -69,7 +69,7 @@ describe('worker UpstreamLink → Edge UpstreamLinkLike wire lockstep (#1053)', 
       status: 'degraded',
       incidentTitle: 'Elevated errors on Sonnet 5 and Haiku 4.5',
       startedAt: '2026-07-17T06:47:54.909Z',
-      href: '/is-claude-down',
+      href: '/is-claude-api-down',
       external: false, // a SERVICE upstream keeps the reader on AIWatch
       leadMinutes: 29, // derived across the boundary: worker startedAt(s) → Edge arithmetic
     }])

--- a/api/_is-down/seo-content.ts
+++ b/api/_is-down/seo-content.ts
@@ -9,7 +9,9 @@ export interface ServiceSEO {
 }
 
 const SEO_CONTENT: Record<string, ServiceSEO> = {
-  claude: {
+  // #1164 — keyed by URL slug (matches SLUG_TO_SERVICE); 'claude'/'openai' moved to
+  // 'claude-api'/'openai-api' when those slugs were repurposed as provider-family group pages.
+  'claude-api': {
     displayName: 'Claude',
     description: 'Claude is a large language model API developed by Anthropic. It powers applications ranging from chatbots to code generation tools, offering multiple model tiers for different performance and cost trade-offs.',
     insight: 'Unlike other providers, Anthropic reports incidents per model tier, resulting in higher incident counts compared to competitors. This does not necessarily indicate lower reliability — it reflects more granular reporting. When evaluating Claude API stability, focus on uptime percentage and recovery time rather than raw incident count.',
@@ -93,7 +95,7 @@ const SEO_CONTENT: Record<string, ServiceSEO> = {
       { q: 'Is claude.ai down because of Claude API?', a: 'claude.ai depends on Claude API models but can also have web-specific issues. Check the AIWatch dashboard at ai-watch.dev to see if Claude API is also experiencing issues — they often share the same incidents.' },
     ],
   },
-  openai: {
+  'openai-api': {
     displayName: 'OpenAI',
     description: 'OpenAI API provides access to OpenAI\'s language, image, and audio models used by millions of developers. It serves both the ChatGPT consumer product and enterprise API integrations.',
     insight: 'OpenAI API and ChatGPT share infrastructure but are monitored separately by AIWatch. An API outage may not affect ChatGPT and vice versa. OpenAI maintains one of the highest uptime records among AI providers, with most incidents resolved within 30 minutes.',

--- a/api/_is-down/slug-map.ts
+++ b/api/_is-down/slug-map.ts
@@ -8,13 +8,16 @@
 // check" grouping (renderFooter / FOOTER_CATEGORY_ORDER).
 export const SLUG_TO_SERVICE: Record<string, { id: string; name: string; provider: string; category: string; group: string }> = {
   // Phase A — top services
-  'claude':          { id: 'claude',     name: 'Claude API',       provider: 'Anthropic',   category: 'api', group: 'llm' },
+  // #1164 — 'claude'/'openai' used to be these single-service slugs; both URLs were repurposed as
+  // provider-family group pages (api/is-down-group.ts), so the single-service content moved to
+  // '-api' slugs. `id`/`name` are UNCHANGED — only the URL slug (this map's key) moved.
+  'claude-api':      { id: 'claude',     name: 'Claude API',       provider: 'Anthropic',   category: 'api', group: 'llm' },
   'chatgpt':         { id: 'chatgpt',    name: 'ChatGPT',          provider: 'OpenAI',      category: 'app', group: 'apps' },
   'gemini':          { id: 'gemini',     name: 'Gemini API',       provider: 'Google',      category: 'api', group: 'llm' },
   'github-copilot':  { id: 'copilot',    name: 'GitHub Copilot',   provider: 'Microsoft',   category: 'agent', group: 'agents' },
   'cursor':          { id: 'cursor',     name: 'Cursor',           provider: 'Anysphere',   category: 'agent', group: 'agents' },
   'claude-code':     { id: 'claudecode', name: 'Claude Code',      provider: 'Anthropic',   category: 'agent', group: 'agents' },
-  'openai':          { id: 'openai',     name: 'OpenAI API',       provider: 'OpenAI',      category: 'api', group: 'llm' },
+  'openai-api':      { id: 'openai',     name: 'OpenAI API',       provider: 'OpenAI',      category: 'api', group: 'llm' },
   'windsurf':        { id: 'windsurf',   name: 'Windsurf',         provider: 'Codeium',     category: 'agent', group: 'agents' },
   'claude-ai':       { id: 'claudeai',   name: 'claude.ai',        provider: 'Anthropic',   category: 'app', group: 'apps' },
   // Phase B — LLM APIs (#263)
@@ -78,31 +81,34 @@ export const SLUG_TO_SERVICE: Record<string, { id: string; name: string; provide
 }
 
 // Related services for cross-linking (SEO internal links)
+// #1164 — every 'claude'/'openai' reference below points at the specific API product
+// ('claude-api'/'openai-api'), not the provider-family group page — an "Alternatives" link should
+// land on the product being recommended, not a status aggregation page.
 export const RELATED_SLUGS: Record<string, string[]> = {
   // Phase A
-  'claude':         ['claude-ai', 'claude-code', 'openai', 'chatgpt'],
-  'claude-ai':      ['claude', 'chatgpt', 'claude-code'],
-  'claude-code':    ['claude', 'cursor', 'github-copilot', 'windsurf', 'codex', 'junie'],
-  'chatgpt':        ['claude-ai', 'openai', 'claude', 'gemini'],
-  'openai':         ['chatgpt', 'claude', 'gemini', 'mistral', 'cohere'],
-  'gemini':         ['openai', 'claude', 'chatgpt'],
+  'claude-api':     ['claude-ai', 'claude-code', 'openai-api', 'chatgpt'],
+  'claude-ai':      ['claude-api', 'chatgpt', 'claude-code'],
+  'claude-code':    ['claude-api', 'cursor', 'github-copilot', 'windsurf', 'codex', 'junie'],
+  'chatgpt':        ['claude-ai', 'openai-api', 'claude-api', 'gemini'],
+  'openai-api':     ['chatgpt', 'claude-api', 'gemini', 'mistral', 'cohere'],
+  'gemini':         ['openai-api', 'claude-api', 'chatgpt'],
   'github-copilot': ['cursor', 'windsurf', 'claude-code', 'codex', 'junie'],
   'cursor':         ['windsurf', 'github-copilot', 'claude-code', 'codex', 'junie'],
   'windsurf':       ['cursor', 'github-copilot', 'claude-code', 'codex', 'junie'],
   'codex':          ['github-copilot', 'cursor', 'windsurf', 'claude-code', 'junie'],
   'junie':          ['cursor', 'github-copilot', 'claude-code', 'codex', 'windsurf'],
   // LLM APIs — same-tier alternatives
-  'mistral':        ['cohere', 'groq', 'together', 'openai', 'claude'],
-  'cohere':         ['mistral', 'groq', 'together', 'openai'],
+  'mistral':        ['cohere', 'groq', 'together', 'openai-api', 'claude-api'],
+  'cohere':         ['mistral', 'groq', 'together', 'openai-api'],
   'groq':           ['together', 'fireworks', 'cerebras', 'mistral'],
   'together':       ['fireworks', 'groq', 'cerebras'],
   'fireworks':      ['together', 'groq', 'cerebras'],
   'cerebras':       ['groq', 'together', 'fireworks', 'mistral'],
-  'perplexity':     ['openai', 'claude', 'gemini'],
-  'xai':            ['openai', 'claude', 'gemini'],
-  'deepseek':       ['deepseek-app', 'mistral', 'groq', 'openai'],
-  'kimi':           ['deepseek', 'mistral', 'openai', 'claude'],
-  'openrouter':     ['openai', 'claude', 'mistral'],
+  'perplexity':     ['openai-api', 'claude-api', 'gemini'],
+  'xai':            ['openai-api', 'claude-api', 'gemini'],
+  'deepseek':       ['deepseek-app', 'mistral', 'groq', 'openai-api'],
+  'kimi':           ['deepseek', 'mistral', 'openai-api', 'claude-api'],
+  'openrouter':     ['openai-api', 'claude-api', 'mistral'],
   // Voice — same category
   'elevenlabs':     ['assemblyai', 'deepgram'],
   'assemblyai':     ['deepgram', 'elevenlabs'],
@@ -132,6 +138,22 @@ export const RELATED_SLUGS: Record<string, string[]> = {
 export const SERVICE_ID_TO_SLUG: Record<string, string> = Object.fromEntries(
   Object.entries(SLUG_TO_SERVICE).map(([slug, entry]) => [entry.id, slug])
 )
+
+// #1164 — provider-family group pages (api/is-down-group.ts), living at the URL slots the
+// single-service pages used to occupy (`/is-claude-down`, `/is-openai-down`) — someone searching the
+// bare product name is more likely asking about the product broadly than one specific surface.
+// `members` are worker service ids (NOT slugs); the group page worst-of's their live status and
+// links out to each member's own (now `-api`-suffixed, for the API member) is-down page.
+export interface ServiceFamily {
+  slug: string
+  name: string
+  members: string[]
+}
+
+export const FAMILY_GROUPS: Record<string, ServiceFamily> = {
+  claude: { slug: 'claude', name: 'Anthropic (Claude)', members: ['claude', 'claudeai', 'claudecode'] },
+  openai: { slug: 'openai', name: 'OpenAI', members: ['openai', 'chatgpt', 'codex'] },
+}
 
 // #842 — outbound referral wedge. Product/homepage URL per service that can be RECOMMENDED as a
 // fallback on the is-down page, so an outage-moment visitor can ACT on the (Score-ranked, UNPAID)

--- a/api/is-down-group.ts
+++ b/api/is-down-group.ts
@@ -1,0 +1,445 @@
+// #1164 — Vercel Edge Function for the provider-family group pages that now live at
+// /is-claude-down and /is-openai-down (the single-service content that used to be there moved to
+// /is-claude-api-down and /is-openai-api-down, api/is-down.ts). Someone searching the bare product
+// name ("is claude down") is more likely asking about the product broadly than one specific surface
+// — this page worst-of's the family's live status and links out to each member's own page.
+//
+// Deliberately LIGHT still: no FAQ/Alternatives/embed-badge/region-status sections — those stay
+// individual-page-only. But the page carries real content beyond the live status snapshot: recent
+// incidents (7d, across every member) with their AI analysis when one exists, a share affordance, and
+// cross-links to sibling family pages — real-review feedback that a bare status list read as too
+// empty, especially on the (common) all-operational day.
+
+import { FAMILY_GROUPS, SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE } from './_is-down/slug-map'
+import { cspForHtml } from './_shared/csp-hash'
+import { EXTENSION_STORE_URL, renderExtInstallCta } from './_shared/extension-cta'
+
+export const config = { runtime: 'edge' }
+
+const WORKER_API = 'https://aiwatch-worker.p2c2kbf.workers.dev'
+
+interface MemberStatus {
+  id: string
+  name: string
+  slug: string
+  status: 'operational' | 'degraded' | 'down' | 'unknown'
+}
+
+interface FamilyIncident {
+  /** #1164 — a shared multi-surface incident (one incident id across e.g. Claude API + claude.ai, the
+   *  same model the worker's alert/tweet-draft svcIds resolution already relies on) carries every
+   *  affected member here instead of being split into one row per member. Almost always length 1. */
+  members: Array<{ name: string; slug: string }>
+  title: string
+  status: 'investigating' | 'identified' | 'monitoring' | 'resolved'
+  startedAt: string
+  resolvedAt?: string | null
+  duration: string | null
+  /** AI-generated summary for this SPECIFIC incident, when the worker's analysis pipeline has one
+   *  (matched by incidentId — the worker can hold analyses for other, unrelated incidents on the
+   *  same member). Absent is normal (no incident, or not yet analyzed), not an error. */
+  aiSummary?: string
+  aiEstimatedRecovery?: string
+}
+
+// Recent-incidents window + cap — mirrors the single-service page's "Last 7 days" framing, capped to
+// a handful so a busy family doesn't turn the group page into a full incident log (that's what each
+// member's own is-down page is for).
+const RECENT_INCIDENTS_DAYS = 7
+const RECENT_INCIDENTS_MAX = 5
+// A resolved incident's analysis is only shown for a short window after recovery — the reply-tweet
+// use case ("is X down [was]?") happens shortly after the fact, not days later. Past this window the
+// row still renders (with the plain "resolved after X" meta line), just without the analysis card.
+//
+// 2h, not a guess: matches worker/src/recovery-mark.ts's RESOLVED_TTL_S (7200s) — the single constant
+// that already governs how long BOTH the `recovered:{svcId}:{incId}` marker and the resolved
+// `ai:analysis:*` value live in KV. Past that TTL, `/api/status/cached`'s aiAnalysis simply stops
+// carrying the entry at all (worker/src/index.ts's recoveryCutoff there is a 3h READ-side query margin
+// for clock/cron skew, not the actual data lifetime — the KV key itself is gone by 2h regardless), so
+// this local gate is redundant with the upstream cutoff today. Kept anyway as defense-in-depth (same
+// posture as STATUS_RANK's unknown-outranks-operational gate above) rather than trusting the upstream
+// contract to never change or lag — hand-copied, not imported, since worker/ and api/ are different
+// deploy targets (no established import path in that direction yet, unlike slug-map.ts → worker).
+const RESOLVED_ANALYSIS_WINDOW_MS = 2 * 60 * 60 * 1000
+
+// #1164 review — 'unknown' MUST outrank 'operational': it means AIWatch couldn't confirm that
+// member's status (missing from the Worker response, or the whole fetch failed), not that it's
+// healthy. Ranking it alongside 'operational' (both 0) let a family where every member is unknown
+// render a false "🟢 Operational" headline — the worst failure mode for a status page. 'unknown'
+// still loses to a CONFIRMED 'degraded'/'down', since an actual known problem is worse than an
+// unconfirmed one.
+const STATUS_RANK: Record<MemberStatus['status'], number> = { operational: 0, unknown: 1, degraded: 2, down: 3 }
+const STATUS_EMOJI: Record<MemberStatus['status'], string> = { operational: '🟢', degraded: '🟡', down: '🔴', unknown: '⚪' }
+const STATUS_LABEL: Record<MemberStatus['status'], string> = {
+  operational: 'Operational', degraded: 'Degraded Performance', down: 'Down', unknown: 'Unknown',
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/** Narrows an arbitrary Worker status string to the 4 values this page renders — anything else
+ *  (a typo, a future status value the Worker adds) collapses to 'unknown' rather than being trusted. */
+function normalizeStatus(raw: string | undefined): MemberStatus['status'] {
+  return raw === 'operational' || raw === 'degraded' || raw === 'down' ? raw : 'unknown'
+}
+
+/** Worst-of across a set of statuses: down > degraded > unknown > operational — an unconfirmed member
+ *  must never be silently masked by a confirmed-operational one (see STATUS_RANK). Empty input →
+ *  'unknown' as defense-in-depth; in practice `members` always has `family.members.length` entries
+ *  (never fabricate a status when the fetch failed — same posture as is-down.ts's fallback). Takes just
+ *  `{ status }` (not the full MemberStatus) so it also serves the other-family alternative-recommendation
+ *  check below, which has no per-member name/slug to construct. */
+function worstStatus(members: Array<{ status: MemberStatus['status'] }>): MemberStatus['status'] {
+  if (members.length === 0) return 'unknown'
+  return members.reduce((worst, m) => (STATUS_RANK[m.status] > STATUS_RANK[worst] ? m.status : worst), 'operational' as MemberStatus['status'])
+}
+
+/** Formats an incident row's date, resolved-duration text (if applicable). Pure/side-effect-free. */
+function incidentMeta(inc: FamilyIncident): string {
+  const started = new Date(inc.startedAt)
+  const dateStr = Number.isNaN(started.getTime()) ? '' : started.toISOString().slice(0, 10)
+  if (inc.status === 'resolved') return inc.duration ? `${dateStr} · resolved after ${inc.duration}` : `${dateStr} · resolved`
+  return `${dateStr} · ongoing`
+}
+
+function renderGroupPage(family: { slug: string; name: string }, members: MemberStatus[], incidents: FamilyIncident[], otherFamilies: Array<{ slug: string; name: string; status: MemberStatus['status'] }>): string {
+  const headline = worstStatus(members)
+  const title = `Is ${family.name} Down? ${STATUS_LABEL[headline]} | AIWatch`
+  const desc = headline === 'operational'
+    ? `No — every ${family.name} service AIWatch monitors is currently operational.`
+    : `${STATUS_LABEL[headline]} — see which ${family.name} service is affected and its live status.`
+  const canonical = `https://ai-watch.dev/is-${family.slug}-down`
+  const ogImage = 'https://ai-watch.dev/og-intro.png'
+
+  const rows = members.map((m) => `
+    <li class="member-row">
+      <a href="/is-${esc(m.slug)}-down">
+        <span class="member-emoji">${STATUS_EMOJI[m.status]}</span>
+        <span class="member-name">${esc(m.name)}</span>
+        <span class="member-status">${STATUS_LABEL[m.status]}</span>
+      </a>
+    </li>`).join('')
+
+  // #1164 review — a lightweight alternative-service nudge for an ONGOING incident's AI card: not the
+  // individual is-down page's tiered fallback engine (~150 lines, worker/src/fallback.ts-synced, keyed
+  // per-service capability/tier) — deliberately not duplicated a third time here, and out of scope for
+  // a "worst-of across N surfaces of ONE provider" page anyway. A group page only has sibling FAMILIES
+  // to recommend, so the question is simply "is the other whole provider healthy right now?". Never
+  // recommends a family that's itself degraded/down/unknown — that isn't an alternative.
+  const healthyOtherFamily = otherFamilies.find((f) => f.status === 'operational')
+  const altRecommendation = healthyOtherFamily
+    ? `<p class="incident-ai-alt">🔄 Alternative: <a href="/is-${esc(healthyOtherFamily.slug)}-down">${esc(healthyOtherFamily.name)}</a> is operational right now.</p>`
+    : ''
+
+  // #1164 review — recent incidents give the "everything's operational" case actual content instead
+  // of reading as empty (a clean status still has a history worth showing), and give a currently-bad
+  // headline supporting evidence beyond the bare status word.
+  const incidentSection = incidents.length > 0
+    ? `<h2>Recent Incidents <span class="incidents-window">(last ${RECENT_INCIDENTS_DAYS} days)</span></h2>
+<ul class="incident-list">${incidents.map((inc) => `
+    <li class="incident-row">
+      <div class="incident-header">
+        <span class="incident-service">${inc.members.map((m) => `<a href="/is-${esc(m.slug)}-down">${esc(m.name)}</a>`).join(', ')}</span>
+        <span class="incident-title">${esc(inc.title)}</span>
+        <span class="incident-meta">${esc(incidentMeta(inc))}</span>
+      </div>${inc.aiSummary ? `
+      <div class="incident-ai">
+        <span class="incident-ai-badge">${inc.status === 'resolved' ? '🤖 Post-Incident Analysis' : '🤖 AI Analysis'}</span>
+        <p>${esc(inc.aiSummary)}</p>
+        ${inc.status === 'resolved'
+          ? '' /* #1164 review — a live "Estimated recovery" figure is stale once resolved (incidentMeta
+                 above already states "resolved after {duration}"); the summary text alone is what an
+                 operator needs for a post-hoc reply tweet explaining WHAT happened. An alternative is
+                 also moot post-recovery, so altRecommendation is withheld here too, not just the ETA. */
+          : `${inc.aiEstimatedRecovery ? `<p class="incident-ai-eta">Estimated recovery: ${esc(inc.aiEstimatedRecovery)}</p>` : ''}${altRecommendation}`}
+      </div>` : ''}
+    </li>`).join('')}</ul>`
+    : `<h2>Recent Incidents <span class="incidents-window">(last ${RECENT_INCIDENTS_DAYS} days)</span></h2>
+<p class="no-incidents">No incidents reported for any ${esc(family.name)} service in the last ${RECENT_INCIDENTS_DAYS} days.</p>`
+
+  // #1164 review — same "set up alerts" entry point the individual pages' secondary CTA links to
+  // (https://ai-watch.dev/#settings?focus=alerts). No per-family feed exists (RSS/Slack subscribe is
+  // per-service, /feed/{slug}), so this points at the central settings screen rather than inventing
+  // one — the user can enable alerts for any/all of this family's members there.
+  const alertSection = `<p class="alert-cta"><a href="https://ai-watch.dev/#settings?focus=alerts" data-ga="click_cta_alerts" data-ga-loc="is_down_group_page">🔔 Get notified when ${esc(family.name)} status changes</a></p>`
+
+  // #1164 review — a share affordance, matching the individual is-down pages (X + copy link). Kept
+  // deliberately simple (no Threads/Kakao) for the v1 group page.
+  const shareText = `${STATUS_EMOJI[headline]} Is ${family.name} down? ${STATUS_LABEL[headline]}. Live status → ${canonical}`
+  const shareSection = `<div class="share-row">
+  <a class="share-btn share-x" href="https://x.com/intent/tweet?text=${encodeURIComponent(shareText)}" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> Post</a>
+  <button class="share-btn share-copy" data-url="${esc(canonical)}" data-action="copy-link">🔗 Copy link</button>
+</div>`
+
+  // #1164 review — cross-links to the OTHER provider-family pages. Someone checking one provider is
+  // plausibly curious about the other too (both are common AI-stack dependencies), and this doubles
+  // as internal linking between the two highest-value SEO pages on the site. Shares one footer line
+  // with the dashboard home link (below) rather than its own stacked paragraph — two one-line "here's
+  // somewhere else to go" links didn't need two separate rows.
+  const otherFamiliesLinks = otherFamilies.length > 0
+    ? `Also check: ${otherFamilies.map((f) => `<a href="/is-${esc(f.slug)}-down">${esc(f.name)}</a>`).join(' · ')} · `
+    : ''
+  const otherFamiliesSection = `<p class="also-check">${otherFamiliesLinks}<a class="home" href="/">All AI services on AIWatch</a></p>`
+
+  // #837/#888 — the Chrome extension is Claude-ONLY, so it's gated to the Anthropic family page only
+  // (an install CTA on /is-openai-down would be a mismatch — mirrors isClaudeSurface's gate on the
+  // individual is-down pages). Empty EXTENSION_STORE_URL → renderExtInstallCta returns '' (pre-CWS-
+  // approval), same fail-closed default as the individual pages.
+  const extCtaSection = family.slug === 'claude'
+    ? renderExtInstallCta(EXTENSION_STORE_URL, { loc: 'is_down_group_page', variant: 'is-down' })
+    : ''
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: title,
+    url: canonical,
+    description: desc,
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${esc(title)}</title>
+<meta name="description" content="${esc(desc)}">
+<link rel="canonical" href="${canonical}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${canonical}">
+<meta property="og:title" content="${esc(title)}">
+<meta property="og:description" content="${esc(desc)}">
+<meta property="og:image" content="${ogImage}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${esc(title)}">
+<meta name="twitter:description" content="${esc(desc)}">
+<meta name="twitter:image" content="${ogImage}">
+<link rel="icon" type="image/png" href="/favicon.png">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<style>
+  body { background:#080c10; color:#e6edf3; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; max-width:640px; margin:0 auto; padding:32px 20px; }
+  h1 { font-size:1.5rem; text-align:center; }
+  h2 { font-size:1.05rem; margin:28px 0 12px; }
+  .incidents-window { color:#9ca3af; font-weight:400; font-size:0.85rem; }
+  .headline { font-size:1.1rem; margin-bottom:24px; }
+  ul.member-list, ul.incident-list { list-style:none; padding:0; margin:0; }
+  .member-row a { display:flex; align-items:center; gap:10px; padding:14px 16px; border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; text-decoration:none; color:inherit; }
+  .member-name { flex:1; font-weight:600; }
+  .member-status { color:#9ca3af; font-size:0.9rem; }
+  .incident-row { border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; overflow:hidden; }
+  .incident-header { display:flex; flex-wrap:wrap; align-items:center; gap:10px; padding:14px 16px; }
+  .incident-service { font-weight:600; }
+  .incident-service a { color:#58a6ff; text-decoration:none; }
+  .incident-service a:hover { text-decoration:underline; }
+  .incident-title { flex:1; }
+  .incident-meta { color:#9ca3af; font-size:0.85rem; width:100%; }
+  .no-incidents { color:#9ca3af; }
+  .incident-ai { padding:12px 16px; border-top:1px solid #1f2937; background:#0d1420; }
+  .incident-ai-badge { font-size:0.8rem; color:#9ca3af; }
+  .incident-ai p { margin:6px 0 0; font-size:0.9rem; }
+  .incident-ai-eta { color:#9ca3af; font-size:0.85rem; }
+  .incident-ai-alt { color:#9ca3af; font-size:0.85rem; }
+  .incident-ai-alt a { color:#58a6ff; text-decoration:none; }
+  .incident-ai-alt a:hover { text-decoration:underline; }
+  .also-check { margin-top:16px; color:#9ca3af; }
+  .also-check a { color:#58a6ff; }
+  .alert-cta { margin-top:20px; padding:12px 16px; border:1px solid #1f2937; border-radius:8px; background:#161b22; text-align:center; }
+  .alert-cta a { color:#58a6ff; text-decoration:none; }
+  .ext-strip { margin:20px 0 0; padding:9px 14px; border:1px solid #21262d; border-radius:8px; background:#0d1117; text-align:center; font-size:13px; line-height:1.45; }
+  .ext-strip a { color:#8b949e; text-decoration:none; }
+  .ext-strip a:hover { color:#c9d1d9; }
+  .ext-strip strong { color:#58a6ff; font-weight:600; }
+  .share-row { display:flex; gap:10px; margin-top:24px; }
+  .share-btn { flex:1; display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:10px; border:1px solid #1f2937; border-radius:8px; background:#161b22; color:#e6edf3; text-decoration:none; cursor:pointer; font-size:0.9rem; }
+  .share-x { background:#000; color:#fff; border-color:#333; }
+  a.home { color:#58a6ff; }
+</style>
+</head>
+<body>
+<h1>${STATUS_EMOJI[headline]} Is ${esc(family.name)} Down?</h1>
+<p class="headline">${esc(desc)}</p>
+<ul class="member-list">${rows}</ul>
+${alertSection}
+${extCtaSection}
+${incidentSection}
+${shareSection}
+${otherFamiliesSection}
+<script>
+document.querySelector('[data-action="copy-link"]')?.addEventListener('click', function(e){
+  navigator.clipboard.writeText(e.currentTarget.dataset.url).then(function(){
+    e.currentTarget.textContent = '✓ Copied'
+    setTimeout(function(){ e.currentTarget.textContent = '🔗 Copy link' }, 2000)
+  })
+})
+// #482-style delegated GA4 hook — CSP-clean (no inline handlers). Mirrors the individual is-down
+// pages' [data-ga] listener, minimal subset (location only) since this page has no gtag script of its
+// own yet; a no-op until GA4 is wired here (typeof gtag guard, same as the individual pages).
+document.addEventListener('click', function(e){
+  var g = e.target.closest('[data-ga]')
+  if (g && typeof gtag === 'function') gtag('event', g.dataset.ga, { location: g.dataset.gaLoc })
+})
+</script>
+</body>
+</html>`
+}
+
+export default async function handler(req: Request) {
+  try {
+    const url = new URL(req.url)
+    const familyKey = url.searchParams.get('family') ?? ''
+    const family = FAMILY_GROUPS[familyKey]
+    if (!family) return new Response('Not Found', { status: 404 })
+    // #1164 review — cross-links to every OTHER family (currently just the one sibling, but this
+    // scales automatically if a third family is ever added to FAMILY_GROUPS). Starts 'unknown' like
+    // `members` below — the fetch-success block overwrites with a real worst-of status, used both for
+    // the "Also check" cross-link and the ongoing-incident "🔄 Alternative" recommendation (which must
+    // never recommend a sibling family whose own status couldn't be confirmed).
+    let otherFamilies: Array<{ slug: string; name: string; status: MemberStatus['status'] }> =
+      Object.values(FAMILY_GROUPS)
+        .filter((f) => f.slug !== family.slug)
+        .map((f) => ({ slug: f.slug, name: f.name, status: 'unknown' as const }))
+
+    // #1164 review — every member starts 'unknown' (name/slug BOTH resolved from the canonical
+    // SLUG_TO_SERVICE/SERVICE_ID_TO_SLUG maps, so the row reads with a real display name — "claude.ai",
+    // not the raw id "claudeai" — and its is-down link works even when nothing is confirmed). A
+    // successful fetch OVERWRITES this per member below; on total fetch failure it's what actually
+    // renders — so the fallback page keeps every member's real name + outbound link instead of an
+    // empty list of raw ids.
+    const resolvedName = (id: string, slug: string) => SLUG_TO_SERVICE[slug]?.name ?? id
+    let members: MemberStatus[] = family.members.map((id) => {
+      const slug = SERVICE_ID_TO_SLUG[id] ?? id
+      return { id, name: resolvedName(id, slug), slug, status: 'unknown' as const }
+    })
+    let incidents: FamilyIncident[] = []
+    let isFallback = true
+    try {
+      const res = await fetch(`${WORKER_API}/api/status/cached`, { signal: AbortSignal.timeout(5000) })
+      if (res.ok) {
+        const data = await res.json() as {
+          services: Array<{
+            id: string; name: string; status: string
+            incidents?: Array<{
+              id: string; title: string; status: 'investigating' | 'identified' | 'monitoring' | 'resolved'
+              startedAt: string; resolvedAt?: string | null; duration: string | null
+            }>
+          }>
+          // #926 — one entry per active incident, keyed by service id (same shape is-down.ts reads).
+          aiAnalysis?: Record<string, Array<{ incidentId: string; summary: string; estimatedRecovery: string }>>
+        }
+        const byId = new Map(data.services.map((s) => [s.id, s]))
+        members = family.members.map((id) => {
+          const s = byId.get(id)
+          const slug = SERVICE_ID_TO_SLUG[id] ?? id
+          if (!s) return { id, name: resolvedName(id, slug), slug, status: 'unknown' as const }
+          return { id, name: s.name, slug, status: normalizeStatus(s.status) }
+        })
+        // #1164 review — same /api/status/cached payload already carries EVERY monitored service (not
+        // just this family's), so the sibling family's worst-of status is derived from the same `byId`
+        // map with zero extra fetches — see the "🔄 Alternative" recommendation in renderGroupPage.
+        otherFamilies = otherFamilies.map((f) => ({
+          ...f,
+          status: worstStatus(FAMILY_GROUPS[f.slug].members.map((id) => ({ status: normalizeStatus(byId.get(id)?.status) }))),
+        }))
+        // #1164 review — recent incidents across every family member, newest first, capped. Gives the
+        // page real content even in the common "everything's operational right now" case, and backs
+        // up a bad headline with the actual incident, not just the bare status word. Each incident is
+        // cross-matched to the worker's AI analysis (by incidentId, NOT just service id — a service can
+        // hold an analysis for a different, unrelated incident) when one exists.
+        //
+        // A same-family incident that hits multiple surfaces at once (e.g. Claude API + claude.ai) is
+        // carried under the SAME incident id on each affected member's own `incidents` array — the same
+        // sharing the worker's alert/tweet-draft svcIds resolution already relies on (worker/src/alerts.ts
+        // FAMILY_OF_SERVICE / buildGroupTweetDraft). Group by id across members here so it renders as ONE
+        // row listing every affected member, not one duplicate row per member.
+        //
+        // #1164 round-3 review (code-reviewer + silent-failure-hunter, independently) — the Worker
+        // stores an incident's analysis under exactly ONE service key (the alert's primary surface),
+        // not every affected member's, and the cross-member sibling-copy in worker/src/ai-analysis.ts
+        // only runs for ACTIVE incidents on a later cron cycle (never backfills a resolved one). A
+        // per-member-scoped lookup during the merge loop below would only ever check whichever member
+        // happens to be iterated first for a given incident id — silently dropping a real analysis
+        // filed under a different member. Build one incidentId → analysis map across EVERY member's
+        // bucket up front instead, so the lookup is independent of which member is "first".
+        const analysisByIncidentId = new Map<string, { summary: string; estimatedRecovery: string }>()
+        for (const id of family.members) {
+          for (const a of data.aiAnalysis?.[id] ?? []) {
+            if (!analysisByIncidentId.has(a.incidentId)) analysisByIncidentId.set(a.incidentId, a)
+          }
+        }
+        const cutoff = Date.now() - RECENT_INCIDENTS_DAYS * 86_400_000
+        const byIncidentId = new Map<string, FamilyIncident>()
+        for (const id of family.members) {
+          const s = byId.get(id)
+          const slug = SERVICE_ID_TO_SLUG[id] ?? id
+          const memberName = s ? s.name : resolvedName(id, slug)
+          for (const inc of s?.incidents ?? []) {
+            // #1164 round-3 review (silent-failure-hunter) — `new Date(inc.startedAt).getTime()` is
+            // NaN for a missing/malformed date, and `NaN < cutoff` is always false — the old bare
+            // inequality let a garbage-dated incident fail OPEN (never filtered, kept forever) instead
+            // of failing safe. Reject NaN explicitly, same posture as the resolved-analysis window below.
+            const startedMs = new Date(inc.startedAt).getTime()
+            if (Number.isNaN(startedMs) || startedMs < cutoff) continue
+            const existing = byIncidentId.get(inc.id)
+            if (existing) {
+              existing.members.push({ name: memberName, slug })
+              continue
+            }
+            // #1164 review — a RESOLVED incident's analysis is shown too (mirrors the individual is-down
+            // page's "Post-Incident Analysis" card, html-template.ts renderAIInsight): an operator
+            // replying to an "is X down" tweet shortly after recovery needs the same root-cause
+            // explanation, not just a bare "resolved after 1h 30m". But NOT unconditionally — past
+            // RESOLVED_ANALYSIS_WINDOW_MS since resolvedAt, the analysis is stale/no-longer-actionable
+            // and is dropped (row still renders, just without the card). Never shown for a resolved
+            // incident with no resolvedAt (can't establish recency, so fail closed).
+            const recoveredRecently = inc.status === 'resolved'
+              ? !!inc.resolvedAt && Date.now() - new Date(inc.resolvedAt).getTime() <= RESOLVED_ANALYSIS_WINDOW_MS
+              : true
+            const analysis = recoveredRecently ? analysisByIncidentId.get(inc.id) : undefined
+            byIncidentId.set(inc.id, {
+              members: [{ name: memberName, slug }], title: inc.title, status: inc.status,
+              startedAt: inc.startedAt, resolvedAt: inc.resolvedAt, duration: inc.duration,
+              aiSummary: analysis?.summary, aiEstimatedRecovery: analysis?.estimatedRecovery,
+            })
+          }
+        }
+        // Ongoing incidents (any non-'resolved' status) always rank above resolved ones, regardless of
+        // startedAt — a currently-active incident is the thing a visitor most needs to see, even if a
+        // shorter incident on another member resolved more recently. Newest-first within each group.
+        incidents = Array.from(byIncidentId.values())
+          .sort((a, b) => {
+            const aOngoing = a.status === 'resolved' ? 0 : 1
+            const bOngoing = b.status === 'resolved' ? 0 : 1
+            if (aOngoing !== bOngoing) return bOngoing - aOngoing
+            return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+          })
+          .slice(0, RECENT_INCIDENTS_MAX)
+        isFallback = false
+      }
+    } catch (err) {
+      console.warn(`[is-down-group/${familyKey}] status fetch failed:`, err instanceof Error ? err.message : err)
+    }
+
+    const html = renderGroupPage(family, members, incidents, otherFamilies)
+    const csp = await cspForHtml(html, { enforce: true })
+    // Mirrors is-down.ts's fallback semantics: a fetch failure renders "unknown" for every member
+    // (never a fabricated status), and the 503 + no-store tells caches/crawlers not to trust or cache
+    // that render, exactly like the single-service page.
+    return new Response(html, {
+      status: isFallback ? 503 : 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': isFallback
+          ? 'no-store, max-age=0, must-revalidate'
+          : 'public, s-maxage=60, stale-while-revalidate=300',
+        [csp.key]: csp.value,
+      },
+    })
+  } catch (err) {
+    console.error('[is-down-group] Unhandled error:', err instanceof Error ? err.stack : err)
+    return new Response(
+      '<!DOCTYPE html><html><head><title>AIWatch - Temporarily Unavailable</title></head><body style="background:#080c10;color:#e6edf3;font-family:sans-serif;text-align:center;padding:60px"><h1>Something went wrong</h1><p>Please try again or visit <a href="https://ai-watch.dev" style="color:#58a6ff">AIWatch</a>.</p></body></html>',
+      { status: 500, headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' } },
+    )
+  }
+}

--- a/extension/lib/render-slug-sync.test.js
+++ b/extension/lib/render-slug-sync.test.js
@@ -1,0 +1,20 @@
+// #1164 — pins render.js's hand-copied IS_DOWN_SLUG map to the canonical source
+// (api/_is-down/slug-map.ts's SERVICE_ID_TO_SLUG). The extension bundle can't import from api/ at
+// RUNTIME (it ships as static files, no build step pulling from this repo's api/ directory), but a
+// Vitest test can import it directly — same reasoning worker/src/__tests__/feed-slug-sync.test.ts and
+// src/utils/__tests__/feed-slug.test.js already use for their own hand-copies of this same mapping.
+// Without this, a future slug-map.ts rename (like #1164's own claude→claude-api) could silently
+// desync the extension's popup deep-links with no CI signal — exactly the drift class #1164's review
+// flagged this map as missing a guard for.
+
+import { describe, it, expect } from 'vitest'
+import { isDownPath } from './render.js'
+import { SERVICE_ID_TO_SLUG } from '../../api/_is-down/slug-map'
+
+describe('IS_DOWN_SLUG ↔ api/is-down slug-map sync (#1164)', () => {
+  it('every id the extension deep-links matches the canonical SERVICE_ID_TO_SLUG', () => {
+    for (const id of ['claude', 'claudeai', 'claudecode']) {
+      expect(isDownPath(id), `isDownPath('${id}')`).toBe(`/is-${SERVICE_ID_TO_SLUG[id]}-down`)
+    }
+  })
+})

--- a/extension/lib/render.js
+++ b/extension/lib/render.js
@@ -99,8 +99,12 @@ export function shouldShowFallback(status) {
 
 // Per-surface "Is X Down?" page path. Each Anthropic surface has its own SEO page
 // (verified against api/_is-down/slug-map.ts + vercel.json), so a card deep-links to
-// the RIGHT one instead of everything pointing at /is-claude-down. Unknown id → null.
-const IS_DOWN_SLUG = { claude: 'claude', claudeai: 'claude-ai', claudecode: 'claude-code' }
+// the RIGHT one instead of everything pointing at the same page. Unknown id → null.
+// #1164 — 'claude' moved from 'claude' to 'claude-api' when /is-claude-down was repurposed as the
+// Anthropic-family group page. NOTE: an already-installed extension keeps its OLD copy of this map
+// until the user updates — its Claude API card will deep-link to the (still valid, just repurposed)
+// group page until then, not a broken link.
+const IS_DOWN_SLUG = { claude: 'claude-api', claudeai: 'claude-ai', claudecode: 'claude-code' }
 export function isDownPath(id) {
   const slug = IS_DOWN_SLUG[id]
   return slug ? `/is-${slug}-down` : null

--- a/extension/lib/render.test.js
+++ b/extension/lib/render.test.js
@@ -128,7 +128,7 @@ describe('shouldShowFallback (status-gated, mirrors dashboard)', () => {
 
 describe('isDownPath (per-surface deep link)', () => {
   it('maps each Anthropic surface to its OWN is-down page', () => {
-    expect(isDownPath('claude')).toBe('/is-claude-down')
+    expect(isDownPath('claude')).toBe('/is-claude-api-down')
     expect(isDownPath('claudeai')).toBe('/is-claude-ai-down')
     expect(isDownPath('claudecode')).toBe('/is-claude-code-down')
   })

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,4 +15,9 @@
 ## "Is X down?" pages (one per service)
 Answer-first pages stating whether a given service is currently down, with live status, 30-day uptime, incident history, and recommended alternatives.
 - Pattern: `https://ai-watch.dev/is-{service}-down`
-- Examples: [/is-claude-down](https://ai-watch.dev/is-claude-down), [/is-chatgpt-down](https://ai-watch.dev/is-chatgpt-down), [/is-gemini-down](https://ai-watch.dev/is-gemini-down), [/is-cursor-down](https://ai-watch.dev/is-cursor-down), [/is-pinecone-down](https://ai-watch.dev/is-pinecone-down)
+- Examples: [/is-claude-api-down](https://ai-watch.dev/is-claude-api-down), [/is-chatgpt-down](https://ai-watch.dev/is-chatgpt-down), [/is-gemini-down](https://ai-watch.dev/is-gemini-down), [/is-cursor-down](https://ai-watch.dev/is-cursor-down), [/is-pinecone-down](https://ai-watch.dev/is-pinecone-down)
+
+## "Is X down?" provider-family pages
+Lighter pages answering the same question for a whole provider (worst-of status across every surface they ship, with links to each surface's own page above) — for when the question is about the provider broadly, not one specific product surface.
+- [/is-claude-down](https://ai-watch.dev/is-claude-down): Anthropic (Claude API, claude.ai, Claude Code).
+- [/is-openai-down](https://ai-watch.dev/is-openai-down): OpenAI (OpenAI API, ChatGPT, Codex).

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,9 +9,17 @@
   </url>
 
   <!-- Is X Down? SEO pages (Edge SSR) -->
+  <!-- #1164 — /is-claude-down is now the Anthropic-family group page; the single-service
+       Claude API page moved to /is-claude-api-down. -->
   <url>
     <loc>https://ai-watch.dev/is-claude-down</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://ai-watch.dev/is-claude-api-down</loc>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -46,9 +54,17 @@
     <priority>0.9</priority>
   </url>
 
+  <!-- #1164 — /is-openai-down is now the OpenAI-family group page; the single-service
+       OpenAI API page moved to /is-openai-api-down. -->
   <url>
     <loc>https://ai-watch.dev/is-openai-down</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://ai-watch.dev/is-openai-api-down</loc>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/src/utils/__tests__/badge.test.js
+++ b/src/utils/__tests__/badge.test.js
@@ -4,7 +4,7 @@ import { SERVICE_ID_TO_SLUG } from '../../../api/_is-down/slug-map'
 
 describe('buildBadgeLinkTarget — #805 backlinks must hit the crawlable is-down page', () => {
   it('links to the is-down page when slug == id', () => {
-    expect(buildBadgeLinkTarget('claude')).toBe('https://ai-watch.dev/is-claude-down')
+    expect(buildBadgeLinkTarget('gemini')).toBe('https://ai-watch.dev/is-gemini-down')
   })
 
   it('uses the slug override when id != slug (claudeai → claude-ai)', () => {
@@ -17,6 +17,11 @@ describe('buildBadgeLinkTarget — #805 backlinks must hit the crawlable is-down
     ['langsmith', 'langchain'],
     ['bfl', 'flux'],
     ['characterai', 'character-ai'],
+    // #1164 — 'claude'/'openai' moved to '-api-down' slugs when those bare URLs became
+    // provider-family group pages; the badge (a single-service embed) must still target the
+    // service's OWN page, not the group.
+    ['claude', 'claude-api'],
+    ['openai', 'openai-api'],
   ])('resolves the override slug for %s → is-%s-down', (id, slug) => {
     expect(buildBadgeLinkTarget(id)).toBe(`https://ai-watch.dev/is-${slug}-down`)
   })
@@ -36,7 +41,7 @@ describe('buildBadgeLinkTarget — #805 backlinks must hit the crawlable is-down
 describe('buildBadgeMarkdown', () => {
   it('embeds the badge image and links it to the is-down page', () => {
     expect(buildBadgeMarkdown('claude', 'Claude API')).toBe(
-      '[![Claude API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/claude)](https://ai-watch.dev/is-claude-down)',
+      '[![Claude API](https://aiwatch-worker.p2c2kbf.workers.dev/badge/claude)](https://ai-watch.dev/is-claude-api-down)',
     )
   })
 })

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -157,6 +157,10 @@ const FEED_SLUG_OVERRIDE = {
   langsmith:   'langchain',
   deepseekapp: 'deepseek-app',
   bfl:         'flux', // #756 — SEO-friendly "is flux down" slug
+  // #1164 — /is-claude-down and /is-openai-down became provider-family group pages; the
+  // single-service pages moved to '-api' slugs.
+  claude:      'claude-api',
+  openai:      'openai-api',
 }
 
 // Services with no /is-{slug}-down page and therefore no RSS feed — estimate-only

--- a/tests/consent.spec.js
+++ b/tests/consent.spec.js
@@ -26,8 +26,11 @@ async function getGaCookies(page) {
   return cookies.filter((c) => c.name.startsWith('_ga') || c.name.startsWith('_gid') || c.name.startsWith('_gcl_au'))
 }
 
+// #1164 — /is-claude-down became the Anthropic family group page (no GA4/consent-banner script of
+// its own yet); the single-service consent/GA4 apparatus this spec exercises moved with the rest of
+// the single-service content to /is-claude-api-down.
 const SURFACES = [
-  { name: '/is-claude-down', path: '/is-claude-down' },
+  { name: '/is-claude-api-down', path: '/is-claude-api-down' },
   { name: '/intro', path: '/intro' },
 ]
 
@@ -112,7 +115,7 @@ for (const surface of SURFACES) {
 
 test.describe('Consent banner DOM (#352)', () => {
   test('banner is visible on first visit (no consent key)', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     const banner = page.locator('#aiwatch-cookie-banner')
     await expect(banner).toBeVisible()
   })
@@ -121,13 +124,13 @@ test.describe('Consent banner DOM (#352)', () => {
     await page.addInitScript(() => {
       try { localStorage.setItem('aiwatch-cookie-consent', 'granted') } catch {}
     })
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     const banner = page.locator('#aiwatch-cookie-banner')
     await expect(banner).toBeHidden()
   })
 
   test('clicking "Essential Only" writes "denied" and hides the banner', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     await page.locator('[data-aiwatch-cb="essential"]').click()
     const stored = await page.evaluate(() => localStorage.getItem('aiwatch-cookie-consent'))
     expect(stored).toBe('denied')
@@ -135,7 +138,7 @@ test.describe('Consent banner DOM (#352)', () => {
   })
 
   test('clicking "Accept All" writes "granted" and hides the banner', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     await page.locator('[data-aiwatch-cb="accept"]').click()
     const stored = await page.evaluate(() => localStorage.getItem('aiwatch-cookie-consent'))
     expect(stored).toBe('granted')
@@ -175,7 +178,7 @@ test.describe('Consent banner DOM (#352)', () => {
         }
       }, 5)
     })
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     await page.locator('[data-aiwatch-cb="accept"]').click()
     // Banner must remain visible — user re-prompted next interaction since choice didn't persist.
     await expect(page.locator('#aiwatch-cookie-banner')).toBeVisible()

--- a/tests/is-down.spec.js
+++ b/tests/is-down.spec.js
@@ -14,7 +14,10 @@ const MAX_RANKED = ALL_SERVICE_IDS.length
 
 const PAGES = [
   // Phase A — original 6 services
-  { slug: 'claude', title: 'Is Claude Down?', displayName: 'Claude' },
+  // #1164 — 'claude' moved to 'claude-api' when /is-claude-down became the Anthropic-family group
+  // page (a deliberately light page with none of the FAQ/About/CTA content this suite checks below —
+  // see the separate 'Provider-family group pages' describe block near the bottom of this file).
+  { slug: 'claude-api', title: 'Is Claude Down?', displayName: 'Claude' },
   { slug: 'chatgpt', title: 'Is ChatGPT Down?', displayName: 'ChatGPT' },
   { slug: 'gemini', title: 'Is Gemini Down?', displayName: 'Gemini' },
   { slug: 'github-copilot', title: 'Is GitHub Copilot Down?', displayName: 'GitHub Copilot' },
@@ -134,7 +137,7 @@ test.describe('Is X Down? SSR pages', () => {
   })
 
   test('meta description contains dynamic status', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     const desc = page.locator('meta[name="description"]')
     // #566: answer-first — leads with No/Yes/Issues + the plain-language status phrase.
     await expect(desc).toHaveAttribute('content', /(No|Yes|Issues) — Claude (is operational|is down right now|is having problems right now)/)
@@ -142,7 +145,7 @@ test.describe('Is X Down? SSR pages', () => {
 
   // #321 — 30-day incident window + grouping on SSR page for SEO depth.
   test('Recent Incidents heading says "Last 7 days"', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     // #incident-history-collapse — the incident-history window aligned 30d → 7d. Claude reliably
     // has incidents in any recent 7-day window, so the heading is rendered.
     const heading = page.locator('h2', { hasText: 'Recent Incidents' })
@@ -154,7 +157,7 @@ test.describe('Is X Down? SSR pages', () => {
     // Use a service that tends to have incidents tracked in the 30-day window.
     // If operational AND >0 incidents, description should surface "N incidents tracked (30d)".
     // When status is non-operational, AI Analysis copy replaces this — assertion is skipped.
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     const desc = await page.locator('meta[name="description"]').getAttribute('content')
     const isOperational = /No — Claude is operational/i.test(desc ?? '')
     if (!isOperational) {
@@ -184,23 +187,23 @@ test.describe('Is X Down? SSR pages', () => {
   })
 
   test('footer has internal cross-links to other service pages', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     await expect(page.locator('a[href="/is-chatgpt-down"]').first()).toBeAttached()
     await expect(page.locator('a[href="/is-gemini-down"]').first()).toBeAttached()
     await expect(page.locator('a[href="/is-cursor-down"]').first()).toBeAttached()
   })
 
   test('OG meta tags point to dynamic OG image', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /Is Claude Down/)
-    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', 'https://ai-watch.dev/is-claude-down')
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', 'https://ai-watch.dev/is-claude-api-down')
     // Dynamic OG image URL should contain /api/og with service param
     await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /\/api\/og\?service=Claude/)
     await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute('content', /\/api\/og\?service=Claude/)
   })
 
   test('share buttons are present', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     // X (Twitter) share link
     await expect(page.locator('a.share-x')).toHaveAttribute('href', /x\.com\/intent\/tweet/)
     // Threads share link
@@ -212,7 +215,7 @@ test.describe('Is X Down? SSR pages', () => {
   })
 
   test('share text includes AIWatch branding', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     // Copy button data-text should mention AIWatch
     const copyText = await page.locator('button.share-copy').getAttribute('data-text')
     expect(copyText).toContain('AIWatch')
@@ -222,14 +225,14 @@ test.describe('Is X Down? SSR pages', () => {
   })
 
   test('related cross-links are present in footer', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     // Claude page should cross-link to Claude Code and OpenAI
     await expect(page.locator('a[href="/is-claude-code-down"]').first()).toBeAttached()
-    await expect(page.locator('a[href="/is-openai-down"]').first()).toBeAttached()
+    await expect(page.locator('a[href="/is-openai-api-down"]').first()).toBeAttached()
   })
 
   test('AI Insight card shows when analysis available', async ({ page }) => {
-    await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+    await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
     // AI Insight card is conditional — only shows when Worker has analysis data
     const aiCard = page.locator('text=AI Analysis').or(page.locator('text=Post-Incident Analysis'))
     if (await aiCard.isVisible({ timeout: 3000 }).catch(() => false)) {
@@ -310,7 +313,7 @@ test.describe('Is X Down? SSR pages', () => {
       // Regression guard: the alert subscription prompt must sit directly below
       // the status header, ahead of AI Analysis, so it catches peak intent.
       // Reverting the order would silently tank conversion on real outage traffic.
-      await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+      await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
       const cta = page.locator('.cta').first()
       await expect(cta).toBeVisible()
 
@@ -334,7 +337,7 @@ test.describe('Is X Down? SSR pages', () => {
     })
 
     test('primary CTA is the Slack-feed button; RSS secondary; Discord demoted to a text link (#547/#696)', async ({ page }) => {
-      await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+      await page.goto('/is-claude-api-down', { waitUntil: 'domcontentloaded' })
       // #696 Primary = zero-config Slack /feed button → copy_slack_feed (success proxy).
       // #482: the click fires from the delegated [data-action] dispatcher (no inline onclick).
       const primary = page.locator('.cta button.btn-primary[data-slack]')
@@ -370,6 +373,36 @@ test.describe('Is X Down? SSR pages', () => {
       // #696: the primary button is the zero-config Slack-feed button (both states).
       const btnText = (await page.locator('.cta button.btn-primary').textContent()) || ''
       expect(btnText).toMatch(/Get alerts in Slack/i)
+    })
+  })
+
+  // #1164 — /is-claude-down and /is-openai-down are now provider-family GROUP pages (a deliberately
+  // light template — headline + member list + links, none of the FAQ/CTA/AI-analysis content the
+  // parametrized suite above checks for the single-service pages).
+  test.describe('Provider-family group pages', () => {
+    test('/is-claude-down renders the Anthropic family headline + links to every member page', async ({ page }) => {
+      await page.goto('/is-claude-down', { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveTitle(/Is Anthropic \(Claude\) Down\?/)
+      const canonical = page.locator('link[rel="canonical"]')
+      await expect(canonical).toHaveAttribute('href', 'https://ai-watch.dev/is-claude-down')
+      await expect(page.locator('a[href="/is-claude-api-down"]').first()).toBeAttached()
+      await expect(page.locator('a[href="/is-claude-ai-down"]').first()).toBeAttached()
+      await expect(page.locator('a[href="/is-claude-code-down"]').first()).toBeAttached()
+    })
+
+    test('/is-openai-down renders the OpenAI family headline + links to every member page', async ({ page }) => {
+      await page.goto('/is-openai-down', { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveTitle(/Is OpenAI Down\?/)
+      const canonical = page.locator('link[rel="canonical"]')
+      await expect(canonical).toHaveAttribute('href', 'https://ai-watch.dev/is-openai-down')
+      await expect(page.locator('a[href="/is-openai-api-down"]').first()).toBeAttached()
+      await expect(page.locator('a[href="/is-chatgpt-down"]').first()).toBeAttached()
+      await expect(page.locator('a[href="/is-codex-down"]').first()).toBeAttached()
+    })
+
+    test('an unknown family 404s', async ({ page }) => {
+      const res = await page.request.get('/api/is-down-group?family=gemini')
+      expect(res.status()).toBe(404)
     })
   })
 })

--- a/tests/service-details.spec.js
+++ b/tests/service-details.spec.js
@@ -673,7 +673,9 @@ test.describe('ServiceDetails RSS feed link (#432)', () => {
     await rssBtn.click()
     // Success-path feedback proves writeText resolved
     await expect(page.locator('main').getByText(/Copied ✓|복사됨 ✓/)).toBeVisible()
-    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('https://ai-watch.dev/feed/claude')
+    // #1164 — /is-claude-down became the Anthropic family group page; the single-service Claude API
+    // page (and its feed slug) moved to '-api'. FEED_SLUG_OVERRIDE.claude -> 'claude-api'.
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('https://ai-watch.dev/feed/claude-api')
   })
 
   test('Claude Code feed URL uses the is-down slug, not the service ID', async ({ page, context }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -24,13 +24,15 @@
     }
   ],
   "rewrites": [
-    { "source": "/is-claude-down", "destination": "/api/is-down?slug=claude" },
+    { "source": "/is-claude-down", "destination": "/api/is-down-group?family=claude" },
+    { "source": "/is-claude-api-down", "destination": "/api/is-down?slug=claude-api" },
     { "source": "/is-chatgpt-down", "destination": "/api/is-down?slug=chatgpt" },
     { "source": "/is-gemini-down", "destination": "/api/is-down?slug=gemini" },
     { "source": "/is-github-copilot-down", "destination": "/api/is-down?slug=github-copilot" },
     { "source": "/is-cursor-down", "destination": "/api/is-down?slug=cursor" },
     { "source": "/is-claude-code-down", "destination": "/api/is-down?slug=claude-code" },
-    { "source": "/is-openai-down", "destination": "/api/is-down?slug=openai" },
+    { "source": "/is-openai-down", "destination": "/api/is-down-group?family=openai" },
+    { "source": "/is-openai-api-down", "destination": "/api/is-down?slug=openai-api" },
     { "source": "/is-windsurf-down", "destination": "/api/is-down?slug=windsurf" },
     { "source": "/is-claude-ai-down", "destination": "/api/is-down?slug=claude-ai" },
     { "source": "/is-mistral-down", "destination": "/api/is-down?slug=mistral" },

--- a/worker/src/__tests__/indexnow.test.ts
+++ b/worker/src/__tests__/indexnow.test.ts
@@ -3,29 +3,29 @@ import { buildIndexNowBody, indexNowUrlsFor, pingIndexNow, INDEXNOW_KEY } from '
 
 describe('buildIndexNowBody', () => {
   it('builds the IndexNow payload with host, key, and keyLocation', () => {
-    const body = buildIndexNowBody(['https://ai-watch.dev/is-claude-down'])
+    const body = buildIndexNowBody(['https://ai-watch.dev/is-claude-api-down'])
     expect(body).toEqual({
       host: 'ai-watch.dev',
       key: INDEXNOW_KEY,
       keyLocation: `https://ai-watch.dev/${INDEXNOW_KEY}.txt`,
-      urlList: ['https://ai-watch.dev/is-claude-down'],
+      urlList: ['https://ai-watch.dev/is-claude-api-down'],
     })
   })
 })
 
 describe('indexNowUrlsFor', () => {
   it('maps service ids to canonical is-down URLs', () => {
-    expect(indexNowUrlsFor(['claude'])).toEqual(['https://ai-watch.dev/is-claude-down'])
+    expect(indexNowUrlsFor(['claude'])).toEqual(['https://ai-watch.dev/is-claude-api-down'])
   })
   it('uses the feed-slug override (claudecode → is-claude-code-down)', () => {
     expect(indexNowUrlsFor(['claudecode'])).toEqual(['https://ai-watch.dev/is-claude-code-down'])
   })
   it('dedups repeated ids', () => {
-    expect(indexNowUrlsFor(['claude', 'claude'])).toEqual(['https://ai-watch.dev/is-claude-down'])
+    expect(indexNowUrlsFor(['claude', 'claude'])).toEqual(['https://ai-watch.dev/is-claude-api-down'])
   })
   it('excludes no-is-down-page services (bedrock → dashboard hash, dropped)', () => {
     expect(indexNowUrlsFor(['bedrock'])).toEqual([])
-    expect(indexNowUrlsFor(['claude', 'bedrock'])).toEqual(['https://ai-watch.dev/is-claude-down'])
+    expect(indexNowUrlsFor(['claude', 'bedrock'])).toEqual(['https://ai-watch.dev/is-claude-api-down'])
   })
 })
 
@@ -39,7 +39,7 @@ describe('pingIndexNow', () => {
     expect(url).toBe('https://api.indexnow.org/IndexNow')
     expect(init.method).toBe('POST')
     const sent = JSON.parse(init.body as string)
-    expect(sent.urlList).toEqual(['https://ai-watch.dev/is-claude-down'])
+    expect(sent.urlList).toEqual(['https://ai-watch.dev/is-claude-api-down'])
     expect(sent.keyLocation).toBe(`https://ai-watch.dev/${INDEXNOW_KEY}.txt`)
   })
 

--- a/worker/src/__tests__/reddit.test.ts
+++ b/worker/src/__tests__/reddit.test.ts
@@ -277,7 +277,7 @@ describe('formatRedditAlert', () => {
     const formatted = formatRedditAlert(alert)
     expect(formatted.title).toBe('📢 Reddit: r/ClaudeAI [🎯 PROMOTE]')
     expect(formatted.description).toContain('Is Claude down?')
-    expect(formatted.description).toContain('ai-watch.dev/is-claude-down')
+    expect(formatted.description).toContain('ai-watch.dev/is-claude-api-down')
     // #548 — the promote share link carries the Reddit-channel utm (after the #539 ?e=reddit hint).
     expect(formatted.description).toContain('?e=reddit&utm_source=reddit&utm_medium=social&utm_campaign=outage')
     expect(formatted.description).not.toContain('Suggested reply')
@@ -304,7 +304,7 @@ describe('formatRedditAlert', () => {
     const formatted = formatRedditAlert(alert)
     expect(formatted.description).toContain('claude ai is down again') // brand defused
     expect(formatted.description).not.toContain('claude.ai')
-    expect(formatted.description).toContain('ai-watch.dev/is-claude-down?e=reddit') // source-namespaced share link
+    expect(formatted.description).toContain('ai-watch.dev/is-claude-api-down?e=reddit') // source-namespaced share link
   })
 
   it('omits Is X Down link for unknown subreddit', () => {

--- a/worker/src/__tests__/rss.test.ts
+++ b/worker/src/__tests__/rss.test.ts
@@ -107,7 +107,7 @@ describe('buildRssFeed — service scope', () => {
     expect(xml).toContain('<title>AIWatch — OpenAI Incidents</title>')
     expect(xml).toContain('OpenAI issue')
     expect(xml).not.toContain('Claude issue')
-    expect(xml).toContain('href="https://ai-watch.dev/feed/openai"')
+    expect(xml).toContain('href="https://ai-watch.dev/feed/openai-api"')
   })
 
   it('uses the is-down slug in the self link for dash-dropped IDs', () => {
@@ -384,7 +384,8 @@ describe('feed slug resolution', () => {
   ]
 
   it('feedSlug matches the is-down page slug', () => {
-    expect(feedSlug('claude')).toBe('claude')
+    // #1164 — 'claude' stopped being an identity slug when /is-claude-down became the group page.
+    expect(feedSlug('claude')).toBe('claude-api')
     expect(feedSlug('claudecode')).toBe('claude-code')
     expect(feedSlug('characterai')).toBe('character-ai')
     expect(feedSlug('bedrock')).toBe('bedrock')
@@ -425,9 +426,11 @@ describe('isValidFeedSegment', () => {
 
 describe('buildRssFeed — item link', () => {
   it('links to the /is-{id}-down SEO page for identity-slug services', () => {
-    const xml = buildRssFeed([service({ id: 'openai', incidents: [incident()] })], { scope: 'all' }, NOW)
+    // #1164 — 'openai' stopped being an identity slug when /is-openai-api-down was repurposed as the
+    // provider-family group page; 'gemini' still demonstrates the identity-slug case.
+    const xml = buildRssFeed([service({ id: 'gemini', incidents: [incident()] })], { scope: 'all' }, NOW)
     // #539 status hint (?e=) + #548 utm (&amp; XML-escaped). The link <link>s through escapeXml.
-    expect(xml).toContain('<link>https://ai-watch.dev/is-openai-down?e=active&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
+    expect(xml).toContain('<link>https://ai-watch.dev/is-gemini-down?e=active&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
   })
 
   it('applies the slug override for dash-dropped service IDs', () => {
@@ -453,14 +456,14 @@ describe('buildRssFeed — item link', () => {
   // maps `active → operational`). operational (monitoring / green badge) still ships `active`.
   it('pins the ?e= hint to the live severity for an active outage item', () => {
     const degraded = buildRssFeed([service({ id: 'openai', status: 'degraded', incidents: [incident()] })], { scope: 'all' }, NOW)
-    expect(degraded).toContain('<link>https://ai-watch.dev/is-openai-down?e=degraded&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
+    expect(degraded).toContain('<link>https://ai-watch.dev/is-openai-api-down?e=degraded&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
 
     const down = buildRssFeed([service({ id: 'openai', status: 'down', incidents: [incident()] })], { scope: 'all' }, NOW)
-    expect(down).toContain('<link>https://ai-watch.dev/is-openai-down?e=down&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
+    expect(down).toContain('<link>https://ai-watch.dev/is-openai-api-down?e=down&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
 
     // operational service (e.g. an incident in `monitoring`, badge already green) keeps `?e=active`.
     const operational = buildRssFeed([service({ id: 'openai', status: 'operational', incidents: [incident({ status: 'monitoring' })] })], { scope: 'all' }, NOW)
-    expect(operational).toContain('is-openai-down?e=active&amp;')
+    expect(operational).toContain('is-openai-api-down?e=active&amp;')
   })
 
   it('keeps ?e=resolved on a resolved item regardless of live status (#539 cache-bust)', () => {
@@ -469,7 +472,7 @@ describe('buildRssFeed — item link', () => {
       { scope: 'all' },
       NOW,
     )
-    expect(xml).toContain('<link>https://ai-watch.dev/is-openai-down?e=resolved&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
+    expect(xml).toContain('<link>https://ai-watch.dev/is-openai-api-down?e=resolved&amp;utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
   })
 })
 

--- a/worker/src/__tests__/tweet-draft.test.ts
+++ b/worker/src/__tests__/tweet-draft.test.ts
@@ -41,7 +41,7 @@ describe('buildTweetDraft', () => {
     })
     const draft = buildTweetDraft(alert(), [svc])
     expect(draft).not.toBeNull()
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: API returning 500s. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: API returning 500s. Live status → https://ai-watch.dev/is-claude-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
     expect(draft!.intentUrl).toBe(X_INTENT + encodeURIComponent(draft!.text))
   })
 
@@ -57,7 +57,7 @@ describe('buildTweetDraft', () => {
   it('falls back to status phrasing for a status-only down alert (no incident)', () => {
     const svc = mockService({ id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'down' })
     const draft = buildTweetDraft(alert({ key: 'alerted:down:openai', title: '🔴 OpenAI API — Service Down' }), [svc])
-    expect(draft!.text).toBe('🔴 OpenAI API is reporting an outage. Live status → https://ai-watch.dev/is-openai-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(draft!.text).toBe('🔴 OpenAI API is reporting an outage. Live status → https://ai-watch.dev/is-openai-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('uses "degraded performance" for a degraded status alert', () => {
@@ -72,7 +72,7 @@ describe('buildTweetDraft', () => {
       incidents: [{ id: 'inc1', title: 'Slow responses', status: 'investigating', startedAt: new Date().toISOString(), impact: 'minor' } as any],
     })
     const draft = buildTweetDraft(alert(), [svc])
-    expect(draft!.text).toBe('🔴 Claude API is reporting degraded performance: Slow responses. Live status → https://ai-watch.dev/is-claude-down?e=degraded&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
+    expect(draft!.text).toBe('🔴 Claude API is reporting degraded performance: Slow responses. Live status → https://ai-watch.dev/is-claude-api-down?e=degraded&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
   })
 
   it('builds a recovery draft with duration parsed from the resolved title (claude.ai slug)', () => {
@@ -87,13 +87,13 @@ describe('buildTweetDraft', () => {
   it('builds a recovery draft from a service-recovered status alert', () => {
     const svc = mockService({ status: 'operational' })
     const draft = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered (45m)' }), [svc])
-    expect(draft!.text).toBe('🟢 Claude API recovered after 45m. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(draft!.text).toBe('🟢 Claude API recovered after 45m. Live status → https://ai-watch.dev/is-claude-api-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('omits duration when the recovery title has none', () => {
     const svc = mockService({ status: 'operational' })
     const draft = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered' }), [svc])
-    expect(draft!.text).toBe('🟢 Claude API has recovered. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(draft!.text).toBe('🟢 Claude API has recovered. Live status → https://ai-watch.dev/is-claude-api-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
   })
 
   it('resolves the claudecode → claude-code slug and maps critical impact to "a major outage"', () => {
@@ -112,7 +112,7 @@ describe('buildTweetDraft', () => {
     const gemini = mockService({ id: 'gemini', name: 'Gemini API', provider: 'Google', status: 'down', incidents: [inc] })
     const claude = mockService({ status: 'down', incidents: [inc] })
     const draft = buildTweetDraft(alert(), [gemini, claude])
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Shared multi-provider outage. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Shared multi-provider outage. Live status → https://ai-watch.dev/is-claude-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=inc1')
   })
 
   it('consults _mergedKeys when resolving the covered service', () => {
@@ -123,7 +123,7 @@ describe('buildTweetDraft', () => {
     })
     const draft = buildTweetDraft(alert({ key: 'alerted:new:incA', _mergedKeys: ['alerted:new:incA', 'alerted:new:incB'] }), [svc])
     // #804 — token derives from the representative alert.key (incA), not the merged tail
-    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Merged incident. Live status → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=incA')
+    expect(draft!.text).toBe('🔴 Claude API is reporting a major outage: Merged incident. Live status → https://ai-watch.dev/is-claude-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&i=incA')
   })
 
   it('returns null for a non-target service', () => {
@@ -145,7 +145,7 @@ describe('buildTweetDraft', () => {
     const draft = buildTweetDraft(alert(), [svc])
     expect(draft!.text.length).toBeLessThanOrEqual(270)
     expect(draft!.text).toContain('…')
-    expect(draft!.text).toContain('https://ai-watch.dev/is-claude-down')
+    expect(draft!.text).toContain('https://ai-watch.dev/is-claude-api-down')
   })
 
   it('collapses newlines/backticks in the incident title', () => {
@@ -171,13 +171,64 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
 
   it('returns one draft per affected in-scope surface, each with its OWN name + is-down url', () => {
     const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)
-    expect(drafts.map((d) => d.serviceId)).toEqual(['claude', 'claudeai', 'claudecode'])
-    expect(drafts[0].text).toContain('Claude API')
-    expect(drafts[0].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-down'))
-    expect(drafts[1].text).toContain('claude ai') // #539: brand defused in tweet text
-    expect(drafts[1].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-ai-down'))
-    expect(drafts[2].text).toContain('Claude Code')
-    expect(drafts[2].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-code-down'))
+    // #1164 — a group draft (family:claude) is prepended ahead of the 3 per-service ones, since all
+    // 3 in-scope Anthropic surfaces are covered by this alert.
+    expect(drafts.map((d) => d.serviceId)).toEqual(['family:claude', 'claude', 'claudeai', 'claudecode'])
+    expect(drafts[1].text).toContain('Claude API')
+    expect(drafts[1].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-api-down'))
+    expect(drafts[2].text).toContain('claude ai') // #539: brand defused in tweet text
+    expect(drafts[2].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-ai-down'))
+    expect(drafts[3].text).toContain('Claude Code')
+    expect(drafts[3].intentUrl).toContain(encodeURIComponent('https://ai-watch.dev/is-claude-code-down'))
+  })
+
+  // #1164 — the group draft itself: text + link shape, distinct from the per-service ones above.
+  it('the group draft points at the family is-down page and names every affected member', () => {
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)
+    const group = drafts[0]
+    expect(group.serviceId).toBe('family:claude')
+    expect(group.serviceName).toBe('Anthropic (Claude)')
+    expect(group.text).toBe('🔴 Multiple Anthropic (Claude) services are affected (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(group.intentUrl).toBe(X_INTENT + encodeURIComponent(group.text))
+  })
+
+  // #1164 review — the bucketing Map must keep two DIFFERENT families' member lists separate, not
+  // conflate them into one draft. Both an Anthropic and an OpenAI surface pair are covered by one
+  // alert's svcIds (a real scenario: a shared upstream provider outage spanning both families).
+  it('two different families covered by one alert each get their OWN separate group draft', () => {
+    const both = [
+      mockService({ id: 'claude', name: 'Claude API', status: 'down', incidents: [sharedInc('multi')] }),
+      mockService({ id: 'claudeai', name: 'claude.ai', status: 'down', incidents: [sharedInc('multi')] }),
+      mockService({ id: 'openai', name: 'OpenAI API', status: 'down', incidents: [sharedInc('multi')] }),
+      mockService({ id: 'chatgpt', name: 'ChatGPT', status: 'down', incidents: [sharedInc('multi')] }),
+    ]
+    const drafts = buildTweetDrafts(alert({ key: 'alerted:new:multi' }), both)
+    const groupDrafts = drafts.filter((d) => d.serviceId.startsWith('family:'))
+    expect(groupDrafts.map((d) => d.serviceId).sort()).toEqual(['family:claude', 'family:openai'])
+    const claudeGroup = groupDrafts.find((d) => d.serviceId === 'family:claude')!
+    const openaiGroup = groupDrafts.find((d) => d.serviceId === 'family:openai')!
+    // Each family's group draft names ONLY its own members — never conflated with the other family.
+    expect(claudeGroup.text).toContain('Claude API, claude ai')
+    expect(claudeGroup.text).not.toContain('OpenAI')
+    expect(claudeGroup.text).not.toContain('ChatGPT')
+    expect(openaiGroup.text).toContain('OpenAI API, ChatGPT')
+    expect(openaiGroup.text).not.toContain('Claude')
+    // 4 per-service drafts + 2 group drafts.
+    expect(drafts).toHaveLength(6)
+  })
+
+  // #1164 review — svcIds can scope an alert to a SUBSET of a family (e.g. one surface already fired
+  // in an earlier alert, #545). The group draft's member list must reflect only what THIS alert
+  // actually covers, not the full family roster present in `services`.
+  it('group draft names only the in-scope subset when svcIds excludes a family member', () => {
+    const drafts = buildTweetDrafts(
+      alert({ key: 'alerted:new:opus47', svcIds: ['claude', 'claudeai'] }), // claudecode excluded
+      anthropic,
+    )
+    const group = drafts.find((d) => d.serviceId === 'family:claude')!
+    expect(group.text).toContain('Claude API, claude ai')
+    expect(group.text).not.toContain('Claude Code')
+    expect(drafts.map((d) => d.serviceId)).toEqual(['family:claude', 'claude', 'claudeai']) // no claudecode draft either
   })
 
   it('filters out non-in-scope services in the group (e.g. Gemini)', () => {
@@ -186,10 +237,10 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
       ...anthropic,
     ]
     const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), withGemini)
-    expect(drafts.map((d) => d.serviceId)).toEqual(['claude', 'claudeai', 'claudecode']) // gemini excluded
+    expect(drafts.map((d) => d.serviceId)).toEqual(['family:claude', 'claude', 'claudeai', 'claudecode']) // gemini excluded
   })
 
-  it('single-surface incident yields exactly one draft (matches buildTweetDraft)', () => {
+  it('single-surface incident yields exactly one draft (matches buildTweetDraft) — no group draft for a lone surface', () => {
     const svc = mockService({ id: 'openai', name: 'OpenAI API', provider: 'OpenAI', status: 'down', incidents: [sharedInc('solo')] })
     const drafts = buildTweetDrafts(alert({ key: 'alerted:new:solo' }), [svc])
     expect(drafts).toHaveLength(1)
@@ -201,20 +252,22 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
     expect(buildTweetDrafts(alert({ key: 'alerted:new:g1' }), [svc])).toEqual([])
   })
 
-  it('builds recovery drafts per surface for a resolved multi-surface incident', () => {
+  it('builds recovery drafts per surface for a resolved multi-surface incident, group draft first', () => {
     const drafts = buildTweetDrafts(alert({ key: 'alerted:res:opus47', title: '🟢 Claude API — Incident Resolved (34m)' }), anthropic)
-    expect(drafts).toHaveLength(3)
-    expect(drafts[0].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage&i=opus47')
-    expect(drafts[1].text).toContain('🟢 claude ai recovered after 34m') // #539: brand defused
+    expect(drafts).toHaveLength(4)
+    expect(drafts[0].text).toBe('🟢 Anthropic (Claude) services have recovered (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(drafts[1].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-api-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage&i=opus47')
+    expect(drafts[2].text).toContain('🟢 claude ai recovered after 34m') // #539: brand defused
   })
 
   it('#545 — scopes drafts to alert.svcIds (the joiner), not every service sharing the incidentId', () => {
     // The alert represents only the late joiner (claudecode); the other two surfaces already fired.
-    // Without the alert.svcIds preference, all three would be re-drafted (the #545 bug).
+    // Without the alert.svcIds preference, all three would be re-drafted (the #545 bug). A single
+    // joiner is also too few for a group draft (needs 2+ in-scope members covered by THIS alert).
     const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47', svcIds: ['claudecode'] }), anthropic)
     expect(drafts.map((d) => d.serviceId)).toEqual(['claudecode'])
-    // Sanity: without svcIds the same alert+services would draft all three.
-    expect(buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)).toHaveLength(3)
+    // Sanity: without svcIds the same alert+services would draft the group + all three surfaces.
+    expect(buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)).toHaveLength(4)
   })
 })
 
@@ -223,7 +276,7 @@ describe('appendTweetDraftSection (#521 — Discord 4096 length guard)', () => {
   const draft = (serviceId: string, serviceName: string, text: string): TweetDraft =>
     ({ serviceId, serviceName, text, intentUrl: 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(text) })
   const three = [
-    draft('claude', 'Claude API', '🔴 Claude API is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-down'),
+    draft('claude', 'Claude API', '🔴 Claude API is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-api-down'),
     draft('claudeai', 'claude.ai', '🔴 claude.ai is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-ai-down'),
     draft('claudecode', 'Claude Code', '🔴 Claude Code is reporting degraded performance: Opus 4.7 elevated errors. Live status → https://ai-watch.dev/is-claude-code-down'),
   ]
@@ -370,11 +423,11 @@ describe('buildTweetForService brand defuse + status hint (#539)', () => {
   it('appends ?e=resolved on recovery and ?e=<status> on outage (distinct URLs)', () => {
     const recSvc = mockService({ status: 'operational' })
     const rec = buildTweetDraft(alert({ key: 'alerted:recovered:claude', title: '🟢 Claude API — Service Recovered (45m)' }), [recSvc])!
-    expect(rec.text).toContain('is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(rec.text).toContain('is-claude-api-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage')
 
     const downSvc = mockService({ status: 'down', incidents: [{ id: 'inc1', title: 'down', status: 'investigating', startedAt: new Date().toISOString(), impact: 'major' } as any] })
     const down = buildTweetDraft(alert(), [downSvc])!
-    expect(down.text).toContain('is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(down.text).toContain('is-claude-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage')
     // the two transitions yield different URLs → fresh unfurl
     expect(rec.text).not.toBe(down.text)
   })

--- a/worker/src/__tests__/tweet-search.test.ts
+++ b/worker/src/__tests__/tweet-search.test.ts
@@ -104,7 +104,7 @@ describe('buildReplyDraft', () => {
     expect(reply).not.toBeNull()
     expect(reply!.serviceId).toBe('claude')
     expect(reply!.text).toBe(
-      '🔴 yes — Claude API is down right now. live status, affected components & recovery ETA → https://ai-watch.dev/is-claude-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&utm_content=reply&i=inc1',
+      '🔴 yes — Claude API is down right now. live status, affected components & recovery ETA → https://ai-watch.dev/is-claude-api-down?e=down&utm_source=x&utm_medium=social&utm_campaign=outage&utm_content=reply&i=inc1',
     )
   })
 
@@ -144,6 +144,29 @@ describe('buildReplyDraft', () => {
       mockService({ id: 'claudecode', name: 'Claude Code' }),
     ])
     expect(reply!.serviceId).toBe('claude')
+  })
+
+  // #1164 — a grouped same-family incident (2+ TWEET_DRAFT_SERVICES-scoped members covered by the
+  // alert) replies with the family's GROUP is-down page, not the single primary surface: the reply
+  // targets "is claude down" searches — the bare product-name query — so once more than one surface is
+  // affected, the group page is the better answer than a single-surface one.
+  it('links + names the family group page for a grouped same-family incident (2+ members covered)', () => {
+    const a = alert({ svcIds: ['claude', 'claudeai', 'claudecode'] })
+    const reply = buildReplyDraft(a, [
+      mockService({ id: 'claude', name: 'Claude API' }),
+      mockService({ id: 'claudeai', name: 'claude.ai' }),
+      mockService({ id: 'claudecode', name: 'Claude Code' }),
+    ])
+    expect(reply!.text).toContain('https://ai-watch.dev/is-claude-down?')
+    expect(reply!.text).not.toContain('is-claude-api-down')
+    expect(reply!.text).toContain('Anthropic (Claude) is down right now')
+  })
+
+  it('still links the single surface when only ONE family member is covered by the alert', () => {
+    const a = alert({ svcIds: ['claude'] })
+    const reply = buildReplyDraft(a, [mockService({ id: 'claude', name: 'Claude API' })])
+    expect(reply!.text).toContain('https://ai-watch.dev/is-claude-api-down?')
+    expect(reply!.text).not.toContain('is-claude-down')
   })
 
   it('defuses a bare claude.ai brand in the reply text (operator pastes into X)', () => {

--- a/worker/src/__tests__/webhook-subscriptions.test.ts
+++ b/worker/src/__tests__/webhook-subscriptions.test.ts
@@ -323,7 +323,7 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
 
   it('rewrites the operator dashboard link to the tagged is-down page', () => {
     const out = toPerUserEntry(feedEntry({ svcIds: ['claude'], embed: { title: 't', description: desc(opLink('claude')), color: 1 } }))
-    expect(out.embed.description).toContain(`[View on AIWatch](https://ai-watch.dev/is-claude-down?${UTM})`)
+    expect(out.embed.description).toContain(`[View on AIWatch](https://ai-watch.dev/is-claude-api-down?${UTM})`)
     expect(out.embed.description).not.toContain('ai-watch.dev/?' + UTM + '#claude')
   })
 
@@ -334,7 +334,7 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
 
   it('also tolerates a BARE (untagged) dashboard link — regex robustness', () => {
     const out = toPerUserEntry(feedEntry({ svcIds: ['claude'], embed: { title: 't', description: desc('https://ai-watch.dev/#claude'), color: 1 } }))
-    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-down?${UTM}`)
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
   })
 
   it('keeps a tagged DASHBOARD link for a no-is-down-page service (azureopenai) — no-op, same entry ref', () => {
@@ -358,15 +358,15 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
   it('rewrites the exact tagged "[View on AIWatch](…)" markup the operator embed emits (format pin)', () => {
     const operatorLink = `[View on AIWatch](${opLink('openai')})`
     const out = toPerUserEntry(feedEntry({ svcIds: ['openai'], embed: { title: 't', description: `🔴 Down\n${operatorLink}`, color: 1 } }))
-    expect(out.embed.description).toContain(`[View on AIWatch](https://ai-watch.dev/is-openai-down?${UTM})`)
+    expect(out.embed.description).toContain(`[View on AIWatch](https://ai-watch.dev/is-openai-api-down?${UTM})`)
     expect(out.embed.description).not.toContain(operatorLink)
   })
 
   // The `/g` flag is load-bearing: a future description section could add a second dashboard link.
   it('rewrites EVERY dashboard link (global), each to its own tagged is-down page', () => {
     const out = toPerUserEntry(feedEntry({ svcIds: ['claude', 'openai'], embed: { title: 't', description: `${desc(opLink('claude'))}\nalso [b](${opLink('openai')})`, color: 1 } }))
-    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-down?${UTM}`)
-    expect(out.embed.description).toContain(`https://ai-watch.dev/is-openai-down?${UTM}`)
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-openai-api-down?${UTM}`)
     expect(out.embed.description).not.toContain('#claude')
     expect(out.embed.description).not.toContain('#openai')
   })
@@ -374,7 +374,7 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
   // Mixed eligibility in one description: the per-link isDownUrl branch diverges within a single pass.
   it('rewrites an is-down-eligible service but leaves a tagged dashboard link for a no-page service', () => {
     const out = toPerUserEntry(feedEntry({ svcIds: ['claude', 'bedrock'], embed: { title: 't', description: `${desc(opLink('claude'))}\nalso [b](${opLink('bedrock')})`, color: 1 } }))
-    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-down?${UTM}`)
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
     expect(out.embed.description).toContain(`https://ai-watch.dev/?${UTM}#bedrock`) // no is-down page → tagged dashboard hash kept
     expect(out.embed.description).not.toContain('#claude')
   })
@@ -383,7 +383,7 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
     const once = toPerUserEntry(feedEntry({ svcIds: ['claude'], embed: { title: 't', description: desc(opLink('claude')), color: 1 } }))
     const twice = toPerUserEntry(once)
     expect(twice).toBe(once)
-    expect(twice.embed.description).toContain(`https://ai-watch.dev/is-claude-down?${UTM}`)
+    expect(twice.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
   })
 
   it('does not mutate the input entry (returns a copy)', () => {
@@ -420,7 +420,7 @@ describe('deliverToSubscribers', () => {
     let sentDesc = ''
     const post = vi.fn(async (_url: string, entry: AlertFeedEntry) => { sentDesc = entry.embed.description; return 204 })
     await deliverToSubscribers(kv, KEY, feed, post, 1)
-    expect(sentDesc).toContain('https://ai-watch.dev/is-claude-down')
+    expect(sentDesc).toContain('https://ai-watch.dev/is-claude-api-down')
     expect(sentDesc).not.toContain('ai-watch.dev/#claude')
   })
 

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -24,7 +24,9 @@ import { regionStatusOf } from '../../api/_is-down/region-status'
 // #777 — is-down slug for the copyable reply draft's live-status link. SERVICE_ID_TO_SLUG is pure data
 // (no @vercel/edge deps, same module the tweet-draft-slug-sync test imports) and covers gemini, which
 // TWEET_DRAFT_SERVICES does not. Same cross-dir-import trade-off as regionStatusOf above (#422).
-import { SERVICE_ID_TO_SLUG } from '../../api/_is-down/slug-map'
+// #1164 — FAMILY_GROUPS imported the same way (pure data, zero drift risk) rather than hand-copied —
+// see FAMILY_OF_SERVICE below, derived from it once at module load.
+import { SERVICE_ID_TO_SLUG, FAMILY_GROUPS } from '../../api/_is-down/slug-map'
 import type { ServiceStatus } from './services'
 import type { Incident } from './types'
 import { withdrawalHold, liveIncidentIds, type WithdrawalHold, type WithdrawnIncident } from './withdrawn'
@@ -927,13 +929,23 @@ export function buildServiceAlerts(
 //
 // id → is-down slug. Slugs MUST match api/_is-down/slug-map.ts — pinned by tweet-draft-slug-sync.test.ts.
 export const TWEET_DRAFT_SERVICES: Record<string, string> = {
-  claude: 'claude',
-  openai: 'openai',
+  // #1164 — /is-claude-down and /is-openai-down were repurposed as provider-family group pages; the
+  // single-service pages moved to '-api' slugs.
+  claude: 'claude-api',
+  openai: 'openai-api',
   claudeai: 'claude-ai',
   chatgpt: 'chatgpt',
   claudecode: 'claude-code',
   codex: 'codex',
 }
+
+// #1164 — provider family → group is-down page slug + display name, for the ADDITIONAL group draft
+// (see buildTweetDrafts) when 2+ in-scope services from the SAME family are covered by one alert.
+// DERIVED from FAMILY_GROUPS (imported above, not hand-copied) — inverts {slug: {members}} into
+// {memberId: {slug, name}} once at module load, so there is nothing here to drift out of sync.
+const FAMILY_OF_SERVICE: Record<string, { slug: string; name: string }> = Object.fromEntries(
+  Object.values(FAMILY_GROUPS).flatMap((family) => family.members.map((id) => [id, { slug: family.slug, name: family.name }])),
+)
 
 // Headroom under X's 280-char limit. Literal .length is conservative: X counts any URL as 23 chars
 // (t.co) regardless of its literal length, so a cap on the literal string can never under-count.
@@ -1058,12 +1070,32 @@ export interface TweetDraft {
   intentUrl: string
 }
 
+/** #1164 — the ADDITIONAL draft for a multi-surface same-family incident, pointing at the family's
+ *  group is-down page so one share reflects the whole blast radius instead of a single surface.
+ *  Never replaces the per-service drafts below — the operator still picks whichever fits. */
+function buildGroupTweetDraft(
+  family: { slug: string; name: string },
+  members: ScoredService[],
+  kind: AlertKind,
+): { text: string; intentUrl: string } {
+  const isRecovery = kind === 'resolved' || kind === 'recovered'
+  const names = members.map((s) => defuseAutolinkDomain(s.name)).join(', ')
+  const url = `https://ai-watch.dev/is-${family.slug}-down?${X_UTM}`
+  const text = isRecovery
+    ? `🟢 ${family.name} services have recovered (${names}). Live status → ${url}`
+    : `🔴 Multiple ${family.name} services are affected (${names}). Live status → ${url}`
+  return { text, intentUrl: X_INTENT_BASE + encodeURIComponent(text) }
+}
+
 /**
  * Build a tweet draft per in-scope (Claude/OpenAI-family) service the alert covers (#521). A grouped
  * multi-surface incident (one incidentId across Claude API / claude.ai / Claude Code) yields one draft
  * per affected surface, in svcIds order, so the operator PICKS which surface to tweet about instead of
  * being locked to a single auto-chosen "primary". Empty when the alert covers no in-scope service.
  * Operator-only (the caller appends these after the per-user feed entry — never relayed, #475).
+ *
+ * #1164 — when 2+ in-scope services share a family (Anthropic or OpenAI), ONE group draft is
+ * prepended ahead of the per-service ones, pointing at the family's group is-down page.
  */
 export function buildTweetDrafts(
   alert: AlertCandidate,
@@ -1080,9 +1112,30 @@ export function buildTweetDrafts(
   // resolve the key tail (svcId/incId) the legacy way.
   const keys = alert._mergedKeys ?? [alert.key]
   const svcIds = alert.svcIds ?? svcIdsForAlert(keys, kind, services)
+  const inScopeIds = svcIds.filter((id) => TWEET_DRAFT_SERVICES[id])
+
   const drafts: TweetDraft[] = []
-  for (const id of svcIds) {
-    if (!TWEET_DRAFT_SERVICES[id]) continue // not a Claude/OpenAI-family service in scope
+
+  // #1164 — group draft(s) first: bucket in-scope ids by family, one group draft per family with 2+
+  // members covered by THIS alert (a single-member "family" is just the normal per-service draft below).
+  const byFamily = new Map<string, string[]>()
+  for (const id of inScopeIds) {
+    const family = FAMILY_OF_SERVICE[id]
+    if (!family) continue
+    const bucket = byFamily.get(family.slug) ?? []
+    bucket.push(id)
+    byFamily.set(family.slug, bucket)
+  }
+  for (const ids of byFamily.values()) {
+    if (ids.length < 2) continue
+    const members = ids.map((id) => services.find((s) => s.id === id)).filter((s): s is ScoredService => !!s)
+    if (members.length < 2) continue
+    const family = FAMILY_OF_SERVICE[ids[0]]
+    const { text, intentUrl } = buildGroupTweetDraft(family, members, kind)
+    drafts.push({ serviceId: `family:${family.slug}`, serviceName: family.name, text, intentUrl })
+  }
+
+  for (const id of inScopeIds) {
     const svc = services.find((s) => s.id === id)
     if (!svc) continue
     const { text, intentUrl } = buildTweetForService(svc, kind, alert, services)
@@ -1232,10 +1285,16 @@ export interface ReplyDraft {
  * 🐦 TWEET DRAFT compose link can't pre-fill a *reply* to someone else's viral "is X down" tweet — the
  * operator has to paste text — so this provides that text, rendered in a Discord code block (one-click
  * copy on desktop) right above the 🔎 search links. Conversational tone so it blends into the reply thread
- * (not a press release). Primary = the first service in svcIds order that's in search scope (one reply per
- * alert: a grouped Anthropic incident → reply to "claude down" tweets with the Claude API surface). The
+ * (not a press release). Primary = the first service in svcIds order that's in search scope. The
  * live-status link reuses the same `?e=` hint + X UTM as the tweet draft, and the service name is defused
  * (`claude.ai` → `claude ai`) since the operator pastes this into X where a bare domain auto-links (#539).
+ *
+ * #1164 — when the primary service's family has 2+ TWEET_DRAFT_SERVICES-scoped members covered by THIS
+ * alert (the same threshold buildTweetDrafts uses for its group draft), the reply links + names the
+ * family's group is-down page instead of the single surface: the reply targets "is claude down" searches
+ * (TWEET_SEARCH_TERMS' bare product-name query), which is exactly the group page's audience once more
+ * than one surface is affected — a grouped Anthropic incident now replies with the Claude group page, not
+ * just the Claude API surface.
  */
 export function buildReplyDraft(alert: AlertCandidate, services: ScoredService[]): ReplyDraft | null {
   const kind = kindFromKey(alert.key)
@@ -1257,8 +1316,14 @@ export function buildReplyDraft(alert: AlertCandidate, services: ScoredService[]
   const hint = isRecovery ? 'resolved' : svc.status === 'operational' ? 'active' : svc.status
   // #804 — per-incident token (incident alerts only) → distinct og:url per outage, fresh card on re-share.
   const token = incidentTokenForAlert(alert)
-  const url = `${appendStatusHint(`https://ai-watch.dev/is-${slug}-down`, hint)}&${X_REPLY_UTM}${token ? `&i=${encodeURIComponent(token)}` : ''}`
-  const name = defuseAutolinkDomain(svc.name)
+  const family = FAMILY_OF_SERVICE[id]
+  const familyMemberCount = family
+    ? svcIds.filter((s) => TWEET_DRAFT_SERVICES[s] && FAMILY_OF_SERVICE[s]?.slug === family.slug).length
+    : 0
+  const isGroup = !!family && familyMemberCount >= 2
+  const linkSlug = isGroup ? family!.slug : slug
+  const url = `${appendStatusHint(`https://ai-watch.dev/is-${linkSlug}-down`, hint)}&${X_REPLY_UTM}${token ? `&i=${encodeURIComponent(token)}` : ''}`
+  const name = isGroup ? family!.name : defuseAutolinkDomain(svc.name)
   // #936 — lead with a status circle (🔴 down / 🟠 degraded / 🟢 recovered) so the pasted tweet reply
   // shows severity at a glance in the thread. Mirrors the dashboard/feed dot convention.
   const circle = isRecovery ? '🟢' : svc.status === 'degraded' ? '🟠' : '🔴'

--- a/worker/src/reddit.ts
+++ b/worker/src/reddit.ts
@@ -245,9 +245,13 @@ export async function detectRedditPosts(
 }
 
 // Subreddit → Is X Down slug mapping for share links
+// #1164 — ClaudeAI/OpenAI point at the '-api' slugs (Claude API / OpenAI API), matching every other
+// slug map this migration touched (TWEET_DRAFT_SERVICES, RSS/SPA feed overrides, RELATED_SLUGS, the
+// extension). A Reddit promote share is about the specific product a subreddit discusses, not the
+// provider broadly — same reasoning "Alternatives" links point at a product, not a family group page.
 const SUBREDDIT_SLUG: Record<string, string> = {
-  ClaudeAI: 'claude', ClaudeCode: 'claude-code',
-  ChatGPT: 'chatgpt', OpenAI: 'openai',
+  ClaudeAI: 'claude-api', ClaudeCode: 'claude-code',
+  ChatGPT: 'chatgpt', OpenAI: 'openai-api',
   cursor: 'cursor', windsurf: 'windsurf', Codeium: 'windsurf',
 }
 

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -164,6 +164,10 @@ export const IS_DOWN_SLUG_OVERRIDE: Record<string, string> = {
   langsmith: 'langchain',
   deepseekapp: 'deepseek-app',
   bfl: 'flux', // #756
+  // #1164 — /is-claude-down and /is-openai-down were repurposed as provider-family group pages; the
+  // single-service pages moved to '-api' slugs, so the per-service feed URL follows (/feed/claude-api).
+  claude: 'claude-api',
+  openai: 'openai-api',
 }
 
 // Services with no /is-{slug}-down page — estimate-only, excluded per #263.


### PR DESCRIPTION
## Summary
Closes #1164.

- `/is-claude-down` and `/is-openai-down` now render provider-family GROUP pages (worst-of status across every member surface + links to each) instead of single-service content — someone searching the bare product name is more likely asking about the product broadly. The prior single-service content moved to `/is-claude-api-down` and `/is-openai-api-down`.
- New `api/is-down-group.ts`, driven entirely by `FAMILY_GROUPS` in `api/_is-down/slug-map.ts` (a third family needs no new page code). Carries: recent incidents (7d, incidents sharing an id across members merged into one row, AI-analysis matched by incidentId with a 2h post-resolution window), a lightweight sibling-family "Alternative" recommendation, share/alert-CTA/Chrome-extension-install sections, cross-links between the two family pages.
- `worker/src/alerts.ts`: `buildTweetDrafts` gains a group draft ahead of per-service drafts when an alert spans 2+ same-family services; `buildReplyDraft` now links the family page under the same threshold.
- Slug rename (`claude`/`openai` → `claude-api`/`openai-api`) propagated through every hand-copied slug map this codebase maintains, plus their sync tests, sitemap.xml, llms.txt.

Went through 3 full review rounds + a live design-review pass. Two real bugs caught and fixed in round 3: the incident-merge loop only checked the first-iterated member's AI analysis bucket (analysis is stored under one primary service key upstream, and cross-member backfill never runs for resolved incidents — so a real analysis could be silently dropped depending on member order); and a malformed/missing incident `startedAt` failed OPEN on the 7-day recency filter instead of being excluded. 22 tests in `api/__tests__/is-down-group.test.ts` (13 new).

## Test plan
- [x] Full worker suite (3749 tests) green
- [x] api/src/extension suite (1115 tests) green
- [x] Playwright e2e (138 tests incl. new group-page coverage) green against local `vercel dev`
- [x] Typecheck clean
- [x] Doc-symbol lint clean
- [x] `wrangler deploy --dry-run` clean
- [x] User's own in-browser confirmation of the local render (multiple iterations during live design review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>