### PR TITLE
fix(is-down): wire GA4/consent + live og:image into the provider-family group pages

### DIFF
--- a/api/__tests__/is-down-group.test.ts
+++ b/api/__tests__/is-down-group.test.ts
@@ -39,6 +39,40 @@ describe('is-down-group.ts', () => {
     expect(res.status).toBe(404)
   })
 
+  // #1164 follow-up — the group page originally shipped with NO gtag.js/consent-init/cookie-banner
+  // (the [data-ga] listener was a dead no-op), unlike every individual is-down page. Regression guard
+  // for the fix: both shared modules must actually render, not just be imported.
+  it('wires GA4 (consent-init) + the cookie consent banner, same as the individual is-down pages', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('claude'))
+    const html = await res.text()
+    expect(html).toContain('googletagmanager.com/gtag/js')
+    expect(html).toContain("gtag('consent','default'")
+    expect(html).toContain('id="aiwatch-cookie-banner"')
+    expect(html).toContain('data-aiwatch-cb="accept"')
+  })
+
+  // #1164 follow-up — the group page originally hardcoded the static site-wide og-intro.png for every
+  // share, unlike the individual is-down pages' live status card. Regression guard: og:image must be
+  // the dynamic worker endpoint, carrying the family name + CURRENT worst-of status (not a fixed image
+  // that never reflects an outage) — plus a `v` cache-buster (#1103: a static og:image query string
+  // behind a static og:url can make a social crawler unfurl with NO image at all, not just a stale one).
+  it('uses the dynamic /api/og live-status card for og:image, reflecting the worst-of headline + cache-busted', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'openai', name: 'OpenAI API', status: 'operational' },
+      { id: 'chatgpt', name: 'ChatGPT', status: 'down' },
+      { id: 'codex', name: 'Codex', status: 'operational' },
+    ]))
+    const res = await handler(makeReq('openai'))
+    const html = await res.text()
+    expect(html).toContain('og:image" content="https://aiwatch-worker.p2c2kbf.workers.dev/api/og?service=OpenAI&amp;status=down&amp;v=')
+    expect(html).not.toContain('og-intro.png')
+  })
+
   it('renders operational when every family member is operational', async () => {
     fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
       { id: 'claude', name: 'Claude API', status: 'operational' },

--- a/api/is-down-group.ts
+++ b/api/is-down-group.ts
@@ -13,6 +13,8 @@
 import { FAMILY_GROUPS, SERVICE_ID_TO_SLUG, SLUG_TO_SERVICE } from './_is-down/slug-map'
 import { cspForHtml } from './_shared/csp-hash'
 import { EXTENSION_STORE_URL, renderExtInstallCta } from './_shared/extension-cta'
+import { CONSENT_INIT_COMMENT, consentInitScript } from './_shared/consent-init'
+import { cookieBannerHtml } from './_shared/cookie-banner'
 
 export const config = { runtime: 'edge' }
 
@@ -110,7 +112,19 @@ function renderGroupPage(family: { slug: string; name: string }, members: Member
     ? `No — every ${family.name} service AIWatch monitors is currently operational.`
     : `${STATUS_LABEL[headline]} — see which ${family.name} service is affected and its live status.`
   const canonical = `https://ai-watch.dev/is-${family.slug}-down`
-  const ogImage = 'https://ai-watch.dev/og-intro.png'
+  // #1164 follow-up — the group page originally used the static site-wide og-intro.png, unlike every
+  // individual is-down page (which draws a live status card via the worker's /api/og). Reuses that
+  // SAME endpoint: `service`/`status` alone render a full card (STATUS_STYLE covers 'unknown' too —
+  // worker/src/og.ts), `score`/`uptime` are optional and simply omitted since there's no
+  // family-level analog for either.
+  //
+  // #1103 (diagnosed on the individual pages, applies identically here) — og:url ("canonical" below)
+  // never changes for this page (no `?e=`/`?i=` pin like a per-incident share), so a static og:image
+  // query string lets a social platform's crawler cache the URL indefinitely against a card that can
+  // go stale OR — #1103's actual observed failure — unfurl with NO image at all once the crawler
+  // decides the (unchanged) URL doesn't need a re-fetch. `v`, a 10-min bucket, forces periodic
+  // re-fetch on the LIVE page the same way the individual pages' unpinned share does.
+  const ogImage = `https://aiwatch-worker.p2c2kbf.workers.dev/api/og?${new URLSearchParams({ service: family.name, status: headline, v: String(Math.floor(Date.now() / 600_000)) }).toString()}`
 
   const rows = members.map((m) => `
     <li class="member-row">
@@ -210,13 +224,15 @@ function renderGroupPage(family: { slug: string; name: string }, members: Member
 <meta property="og:url" content="${canonical}">
 <meta property="og:title" content="${esc(title)}">
 <meta property="og:description" content="${esc(desc)}">
-<meta property="og:image" content="${ogImage}">
+<meta property="og:image" content="${esc(ogImage)}">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="${esc(title)}">
 <meta name="twitter:description" content="${esc(desc)}">
-<meta name="twitter:image" content="${ogImage}">
+<meta name="twitter:image" content="${esc(ogImage)}">
 <link rel="icon" type="image/png" href="/favicon.png">
 <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+${CONSENT_INIT_COMMENT}
+${consentInitScript()}
 <style>
   body { background:#080c10; color:#e6edf3; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; max-width:640px; margin:0 auto; padding:32px 20px; }
   h1 { font-size:1.5rem; text-align:center; }
@@ -273,13 +289,15 @@ document.querySelector('[data-action="copy-link"]')?.addEventListener('click', f
   })
 })
 // #482-style delegated GA4 hook — CSP-clean (no inline handlers). Mirrors the individual is-down
-// pages' [data-ga] listener, minimal subset (location only) since this page has no gtag script of its
-// own yet; a no-op until GA4 is wired here (typeof gtag guard, same as the individual pages).
+// pages' [data-ga] listener, minimal subset (location only) — every CTA on this page (alerts,
+// extension install, share, cross-links) already carries data-ga/data-ga-loc attributes from the
+// section builders above, so this listener now actually fires once gtag exists (below).
 document.addEventListener('click', function(e){
   var g = e.target.closest('[data-ga]')
   if (g && typeof gtag === 'function') gtag('event', g.dataset.ga, { location: g.dataset.gaLoc })
 })
 </script>
+${cookieBannerHtml()}
 </body>
 </html>`
 }


### PR DESCRIPTION
## Summary
Refs #1164 (the group pages themselves already shipped/merged in #1166 — this closes a gap discovered right after merge, via the user's own manual checks).

- The group pages (`/is-claude-down`, `/is-openai-down`) had NO GA4/Consent Mode init and NO cookie-consent banner — unlike every individual is-down page. The `[data-ga]` click listener was a dead no-op since `gtag` never existed on the page.
- `og:image` was a static site-wide `og-intro.png` instead of a live status card. Now uses the same `/api/og` worker endpoint the individual pages use, carrying `service`(family name)/`status`(worst-of headline) — score/uptime intentionally omitted (no family-level analog).
- Added the `#1103` cache-buster (`v`, 10-min bucket): the group page's `og:url` never changes (no per-share pin), so without a buster the og:image query string is static too — reproducing the exact #1103 failure mode (a social crawler unfurling with no image at all). Reproduced live on an X compose preview before this fix.

## Test plan
- [x] Full api/src/extension suite (1117 tests) green
- [x] Playwright `is-down` + `consent` projects (151 tests) green against local `vercel dev`
- [x] Typecheck, eslint, doc-symbol lint clean
- [x] User's own in-browser confirmation of the GA4/consent-banner Accept flow
- [x] Fetched both `operational` and `down` OG card variants directly from the live `/api/og` endpoint to confirm score/uptime stays correctly omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>