### PR TITLE
feat(alerts): link the family group is-down page for shared multi-surface incidents in Discord + Slack

### DIFF
--- a/worker/src/__tests__/rss.test.ts
+++ b/worker/src/__tests__/rss.test.ts
@@ -610,6 +610,22 @@ describe('buildRssFeed — shared incident (per-surface providers)', () => {
     expect(xml).not.toContain('Also affecting')
   })
 
+  // #1164 — a shared multi-surface incident's <link> now points at the family GROUP is-down page
+  // instead of the (arbitrary) primary surface's own page, matching the item's own provider-grouped
+  // title ("Anthropic (Claude API, claude.ai, Claude Code): …") — a subscriber reading THAT title
+  // and clicking through used to land on the narrower Claude API page alone.
+  it('points the collapsed multi-surface item\'s <link> at the family GROUP is-down page', () => {
+    const xml = buildRssFeed(anthropic, { scope: 'all' }, NOW)
+    expect(xml).toContain('<link>https://ai-watch.dev/is-claude-down?utm_source=rss&amp;utm_medium=feed&amp;utm_campaign=outage</link>')
+    expect(xml).not.toContain('is-claude-api-down')
+  })
+
+  it('a single-surface incident still links its OWN is-down page, not a group page', () => {
+    const xml = buildRssFeed([service({ incidents: [incident({ id: 'solo' })] })], { scope: 'all' }, NOW)
+    expect(xml).toMatch(/<link>https:\/\/ai-watch\.dev\/is-[a-z-]+-down\?/)
+    expect(xml).not.toMatch(/<link>https:\/\/ai-watch\.dev\/is-claude-down/)
+  })
+
   it('uses a per-incident guid for the collapsed item (no Slack re-post churn)', () => {
     const xml = buildRssFeed(anthropic, { scope: 'all' }, NOW)
     expect((xml.match(/aiwatch:claude:shared/g) ?? []).length).toBe(1)

--- a/worker/src/__tests__/webhook-subscriptions.test.ts
+++ b/worker/src/__tests__/webhook-subscriptions.test.ts
@@ -391,6 +391,34 @@ describe('toPerUserEntry — per-user is-down link rewrite (#726, #936 UTM)', ()
     toPerUserEntry(entry)
     expect(entry.embed.description).toContain(`?${UTM}#claude`) // original untouched
   })
+
+  // #1164 — a shared multi-surface incident (2+ of entry.svcIds in the SAME family) points general
+  // subscribers at the family GROUP is-down page instead of one arbitrary surface, matching the
+  // embed's own provider-grouped title ("Anthropic (Claude API, claude.ai) — New Incident").
+  it('rewrites to the family GROUP is-down page when svcIds spans 2+ same-family members', () => {
+    const out = toPerUserEntry(feedEntry({
+      svcIds: ['claude', 'claudeai'],
+      embed: { title: 'Anthropic (Claude API, claude.ai) — New Incident', description: `${desc(opLink('claude'))}\nalso [b](${opLink('claudeai')})`, color: 1 },
+    }))
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-down?${UTM}`)
+    expect(out.embed.description).not.toContain('is-claude-api-down')
+    expect(out.embed.description).not.toContain('is-claude-ai-down')
+  })
+
+  it('still uses the single-surface page when only ONE member of a family is in svcIds', () => {
+    const out = toPerUserEntry(feedEntry({ svcIds: ['claude'], embed: { title: 't', description: desc(opLink('claude')), color: 1 } }))
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
+    expect(out.embed.description).not.toContain('is-claude-down')
+  })
+
+  it('does NOT group across different families — claude + openai stay on their own single-surface pages', () => {
+    const out = toPerUserEntry(feedEntry({
+      svcIds: ['claude', 'openai'],
+      embed: { title: 't', description: `${desc(opLink('claude'))}\nalso [b](${opLink('openai')})`, color: 1 },
+    }))
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-claude-api-down?${UTM}`)
+    expect(out.embed.description).toContain(`https://ai-watch.dev/is-openai-api-down?${UTM}`)
+  })
 })
 
 describe('deliverToSubscribers', () => {

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -943,7 +943,9 @@ export const TWEET_DRAFT_SERVICES: Record<string, string> = {
 // (see buildTweetDrafts) when 2+ in-scope services from the SAME family are covered by one alert.
 // DERIVED from FAMILY_GROUPS (imported above, not hand-copied) — inverts {slug: {members}} into
 // {memberId: {slug, name}} once at module load, so there is nothing here to drift out of sync.
-const FAMILY_OF_SERVICE: Record<string, { slug: string; name: string }> = Object.fromEntries(
+// Exported — webhook-subscriptions.ts's toPerUserEntry (#726 general-subscriber relay) reuses this
+// SAME map so its own group-vs-single-surface link decision can't drift from the tweet-draft one.
+export const FAMILY_OF_SERVICE: Record<string, { slug: string; name: string }> = Object.fromEntries(
   Object.values(FAMILY_GROUPS).flatMap((family) => family.members.map((id) => [id, { slug: family.slug, name: family.name }])),
 )
 

--- a/worker/src/rss.ts
+++ b/worker/src/rss.ts
@@ -5,7 +5,7 @@
 import type { ServiceStatus, Incident } from './types'
 import { escapeXml } from './badge'
 import { getGroupedFallbacks } from './fallback'
-import { defuseAutolinkDomain, WITHDRAWN_NOTE } from './alerts'
+import { defuseAutolinkDomain, WITHDRAWN_NOTE, FAMILY_OF_SERVICE } from './alerts'
 import { formatRecoveryDisplay } from './ai-analysis'
 import { appendStatusHint, appendUtm, isNonReliabilityAdvisory } from './utils'
 import { durationMinOf, predictedVsActualText, resolvedAtOf, scoringBaselineHours } from './incident-history'
@@ -229,7 +229,14 @@ export function isDownUrl(serviceId: string): string {
 // mis-pinned the Slack unfurl to a green Operational card. Mirror the alerts.ts derivation: operational
 // (monitoring / green badge) → `active`, otherwise the live status → `degraded`/`down`. `resolved` is
 // unchanged (recovery cache-bust, #539).
-function serviceLink(serviceId: string, kind: ItemKind, status: ServiceStatus['status']): string {
+// #1164 — `groupUrl`, when given, wins outright: a shared multi-surface incident (2+ of the SAME
+// family carrying this incident id — see itemXml's `familyMemberCount` check) points general
+// subscribers at the family group is-down page instead of one arbitrarily-"first" surface, matching
+// the #724 provider-grouped TITLE this item already renders ("Anthropic (Claude API, claude.ai): …").
+// No `?e=` hint on the group URL — is-down-group.ts computes its own live worst-of headline and
+// never reads the query param, unlike the single-surface page's OG-pinning use of it.
+function serviceLink(serviceId: string, kind: ItemKind, status: ServiceStatus['status'], groupUrl?: string): string {
+  if (groupUrl) return appendUtm(groupUrl, 'rss')
   // NO_IS_DOWN_PAGE services fall back to the dashboard hash (no OG page) → no hint and no utm.
   if (NO_IS_DOWN_PAGE.has(serviceId)) return isDownUrl(serviceId)
   // #1106 — a withdrawal gets its OWN `?e=` token rather than reusing 'resolved' (which would pin a
@@ -271,15 +278,17 @@ function rfc822(iso: string): string {
 // A subscriber whose 🔴 read "Anthropic (Claude API, claude.ai, Claude Code)" must not get a ⚪ that
 // looks like it is about one of them. The roster remembers the sibling svcIds; this maps them back
 // to names via `services` (a tombstone for a service we no longer carry contributes nothing).
-function buildIncidentServiceMap(services: ServiceStatus[], withdrawn?: WithdrawnIncident[]): Map<string, string[]> {
-  const map = new Map<string, string[]>()
-  const add = (incId: string, name: string) => {
-    const names = map.get(incId) ?? []
-    if (!names.includes(name)) names.push(name)
-    map.set(incId, names)
+// #1164 — carries `id` alongside `name` (not just name) so a caller can decide whether the
+// co-affected set shares a FAMILY_OF_SERVICE family (group is-down link), not just render a name list.
+function buildIncidentServiceMap(services: ServiceStatus[], withdrawn?: WithdrawnIncident[]): Map<string, Array<{ id: string; name: string }>> {
+  const map = new Map<string, Array<{ id: string; name: string }>>()
+  const add = (incId: string, id: string, name: string) => {
+    const entries = map.get(incId) ?? []
+    if (!entries.some((e) => e.id === id)) entries.push({ id, name })
+    map.set(incId, entries)
   }
   for (const svc of services) {
-    for (const inc of svc.incidents ?? []) add(inc.id, svc.name)
+    for (const inc of svc.incidents ?? []) add(inc.id, svc.id, svc.name)
   }
   // Snapshot the LIVE ids before folding, so the check below can't be satisfied by a sibling
   // tombstone this same loop just added (a multi-surface withdrawal must still group).
@@ -290,8 +299,8 @@ function buildIncidentServiceMap(services: ServiceStatus[], withdrawn?: Withdraw
     // adding its name here would inject a surface into the LIVE item's provider-grouped title,
     // naming a service that no longer carries the incident. Only genuinely-gone ids may contribute.
     if (liveIds.has(w.incId)) continue
-    const name = services.find((s) => s.id === w.svcId)?.name
-    if (name) add(w.incId, name)
+    const svc = services.find((s) => s.id === w.svcId)
+    if (svc) add(w.incId, svc.id, svc.name)
   }
   return map
 }
@@ -452,12 +461,20 @@ function descHtml(
 function itemXml(
   service: ServiceStatus,
   inc: Incident,
-  incidentServices: Map<string, string[]>,
+  incidentServices: Map<string, Array<{ id: string; name: string }>>,
   opts: { kind: ItemKind; pubDate: string; fallbackText?: string; analysis?: RssAiAnalysis },
 ): string {
   const isResolved = opts.kind === 'resolved'
   const isWithdrawn = opts.kind === 'withdrawn'
-  const coAffected = (incidentServices.get(inc.id) ?? []).filter((n) => n !== service.name)
+  const coAffectedEntries = (incidentServices.get(inc.id) ?? []).filter((e) => e.id !== service.id)
+  const coAffected = coAffectedEntries.map((e) => e.name)
+  // #1164 — 2+ members of the SAME family carrying this incident id → group is-down link (see
+  // serviceLink's `groupUrl` param). Threshold matches buildTweetDrafts/buildReplyDraft/
+  // toPerUserEntry (worker/src/alerts.ts, worker/src/webhook-subscriptions.ts) — one incident, one
+  // rule for "does this count as a family-wide event" across every subscriber-facing surface.
+  const family = FAMILY_OF_SERVICE[service.id]
+  const familyMemberCount = family ? 1 + coAffectedEntries.filter((e) => FAMILY_OF_SERVICE[e.id]?.slug === family.slug).length : 0
+  const groupUrl = family && familyMemberCount >= 2 ? `${SITE}/is-${family.slug}-down` : undefined
   const emoji = severityEmoji(service, inc, opts.kind)
   // #724 — provider-grouped header for a multi-surface (shared) incident, mirroring the Discord
   // embed ("Anthropic (Claude API, claude.ai, Claude Code) — …") instead of an API-centric
@@ -478,7 +495,7 @@ function itemXml(
 
   return `    <item>
       <title>${xml(title)}</title>
-      <link>${xml(serviceLink(service.id, opts.kind, service.status))}</link>
+      <link>${xml(serviceLink(service.id, opts.kind, service.status, groupUrl))}</link>
       <guid isPermaLink="false">${xml(guid)}</guid>
       <pubDate>${rfc822(opts.pubDate)}</pubDate>${inc.impact ? `\n      <category>${xml(inc.impact)}</category>` : ''}
       <description><![CDATA[${descHtml(service, inc, opts)}]]></description>

--- a/worker/src/webhook-subscriptions.ts
+++ b/worker/src/webhook-subscriptions.ts
@@ -18,6 +18,7 @@
 
 import { kvPut, kvDel, isAllowedAlertWebhook, appendUtm } from './utils'
 import { isDownUrl } from './rss'
+import { FAMILY_OF_SERVICE } from './alerts'
 import type { AlertFeedEntry, AlertKind } from './alert-feed'
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -441,9 +442,20 @@ const DASHBOARD_HASH_LINK_RE = /https:\/\/ai-watch\.dev\/(?:\?[^#\s)]*)?#([a-z0-
 export function toPerUserEntry(entry: AlertFeedEntry): AlertFeedEntry {
   const desc = entry.embed.description
   if (!desc) return entry
-  // Rewrite to the is-down page AND re-tag it (discord/notification) so per-user clicks attribute the
-  // same as the operator's — isDownUrl() drops the operator's query, appendUtm re-adds ours.
-  const rewritten = desc.replace(DASHBOARD_HASH_LINK_RE, (_m, id) => appendUtm(isDownUrl(id), 'discord'))
+  // #1164 — a shared multi-surface incident (2+ of `entry.svcIds` in the SAME family — the exact
+  // roster this alert covers, so no scope guess) points general subscribers at the family's GROUP
+  // is-down page instead of one arbitrarily-first surface: the embed's own title already reads
+  // "Anthropic (Claude API, claude.ai, Claude Code)", so a single-surface link under it is a mismatch.
+  // Mirrors the same threshold buildTweetDrafts/buildReplyDraft use (worker/src/alerts.ts).
+  const linkFor = (id: string): string => {
+    const family = FAMILY_OF_SERVICE[id]
+    const familyMemberCount = family ? entry.svcIds.filter((s) => FAMILY_OF_SERVICE[s]?.slug === family.slug).length : 0
+    return family && familyMemberCount >= 2 ? `https://ai-watch.dev/is-${family.slug}-down` : isDownUrl(id)
+  }
+  // Rewrite to the is-down (or group) page AND re-tag it (discord/notification) so per-user clicks
+  // attribute the same as the operator's — linkFor()/isDownUrl() drop the operator's query, appendUtm
+  // re-adds ours.
+  const rewritten = desc.replace(DASHBOARD_HASH_LINK_RE, (_m, id) => appendUtm(linkFor(id), 'discord'))
   return rewritten === desc ? entry : { ...entry, embed: { ...entry.embed, description: rewritten } }
 }
 


### PR DESCRIPTION
## Summary
Refs #1164.

Discord's per-user webhook relay and the Slack `/feed` RSS feed both already collapse a shared multi-surface incident (e.g. an Anthropic outage touching Claude API + claude.ai) into ONE alert/item with a provider-grouped title ("Anthropic (Claude API, claude.ai) — New Incident"). But the clickable link under that title still pointed at a single, arbitrarily-first surface's own page.

Both surfaces now use the same "2+ svcIds in the same family" threshold `buildTweetDrafts`/`buildReplyDraft` already established, pointing at the family's group is-down page instead:

- `worker/src/webhook-subscriptions.ts` — `toPerUserEntry`'s dashboard-hash-link rewrite checks `entry.svcIds` before falling back to the single-surface `isDownUrl`.
- `worker/src/rss.ts` — `itemXml`'s `serviceLink` gained an optional `groupUrl` param; `buildIncidentServiceMap` now tracks `{id, name}` pairs (was name-only) so the family check has ids to work with.
- `worker/src/alerts.ts` — exported the existing `FAMILY_OF_SERVICE` map so every surface shares one source.

A single-surface incident, or one spanning services from different families, is unaffected.

## Test plan
- [x] 5 new tests (3 webhook-subscriptions, 2 rss) covering grouped/ungrouped/cross-family cases
- [x] Full worker suite (3754 tests) green
- [x] Typecheck, eslint, doc-symbol lint clean
- [x] `wrangler deploy --dry-run` clean
- [x] UI-less backend change — verified against the real generated RSS item XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>