### PR TITLE
fix(share): group-page tweet draft + og:url never got the #1063/#804 status pin

### DIFF
--- a/api/__tests__/is-down-group.test.ts
+++ b/api/__tests__/is-down-group.test.ts
@@ -4,8 +4,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import handler from '../is-down-group'
 
-function makeReq(family: string): Request {
-  return new Request(`https://ai-watch.dev/api/is-down-group?family=${family}`, { method: 'GET' })
+function makeReq(family: string, extraParams?: Record<string, string>): Request {
+  const params = new URLSearchParams({ family, ...extraParams })
+  return new Request(`https://ai-watch.dev/api/is-down-group?${params.toString()}`, { method: 'GET' })
 }
 
 interface MockIncident {
@@ -178,6 +179,77 @@ describe('is-down-group.ts', () => {
     const res = await handler(makeReq('claude'))
     const html = await res.text()
     expect(html).toContain('Is Anthropic (Claude) Down? Down')
+  })
+})
+
+// <NEW> — this page never got the #1063/#804 og:url pin the individual is-down pages (api/is-down.ts)
+// and buildTweetForService got: og:url was ALWAYS the bare canonical, so a social platform's
+// og:url-keyed card cache reused whatever it first fetched no matter how many real outages were
+// shared afterward. Reproduced live 2026-08-02 via the operator's "Anthropic (Claude)" group tweet
+// draft option (worker/src/alerts.ts buildGroupTweetDraft), which was ALSO never pinned. Both are
+// fixed together — the worker now appends `?e=`/`&i=` to the group draft link, and this page now reads
+// + reflects them.
+describe('is-down-group.ts — og:url pin (#1063/#804 parity, group page)', () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>
+  afterEach(() => { fetchMock?.mockRestore() })
+
+  it('with no ?e=/&i=, og:url is the bare canonical (unpinned — unchanged legacy behavior)', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const html = await (await handler(makeReq('claude'))).text()
+    expect(html).toContain('og:url" content="https://ai-watch.dev/is-claude-down">')
+  })
+
+  it('with ?e=degraded&i=<token>, og:url carries BOTH — a distinct, per-incident card identity', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' }, // live status is IRRELEVANT once pinned
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const html = await (await handler(makeReq('claude', { e: 'degraded', i: 'opus47' }))).text()
+    expect(html).toContain('og:url" content="https://ai-watch.dev/is-claude-down?e=degraded&amp;i=opus47">')
+    // The og:image reflects the PINNED status, not the live 'operational' data above.
+    expect(html).toContain('og:image" content="https://aiwatch-worker.p2c2kbf.workers.dev/api/og?service=Anthropic+%28Claude%29&amp;status=degraded">')
+    // og:title pins too — otherwise the card reads "Operational" over a "Degraded" image.
+    expect(html).toContain('og:title" content="Is Anthropic (Claude) Down? Degraded Performance | AIWatch">')
+    // The page <title> stays LIVE (unpinned) — only the social card pins.
+    expect(html).toContain('<title>Is Anthropic (Claude) Down? Operational | AIWatch</title>')
+  })
+
+  it('a pinned share drops the 10-min cache-buster (the image must not move after the share moment)', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'openai', name: 'OpenAI API', status: 'operational' },
+      { id: 'chatgpt', name: 'ChatGPT', status: 'operational' },
+      { id: 'codex', name: 'Codex', status: 'operational' },
+    ]))
+    const html = await (await handler(makeReq('openai', { e: 'down', i: 'inc1' }))).text()
+    expect(html).toContain('og:image" content="https://aiwatch-worker.p2c2kbf.workers.dev/api/og?service=OpenAI&amp;status=down">')
+    expect(html).not.toContain('&amp;v=')
+  })
+
+  it('an unrecognized ?e= value is ignored (falls back to unpinned live behavior)', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'down' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const html = await (await handler(makeReq('claude', { e: '__proto__' }))).text()
+    expect(html).toContain('og:url" content="https://ai-watch.dev/is-claude-down">')
+    expect(html).toContain('og:image" content="https://aiwatch-worker.p2c2kbf.workers.dev/api/og?service=Anthropic+%28Claude%29&amp;status=down&amp;v=')
+  })
+
+  it('?i= alone (no ?e=) still pins the og:url — an incident-token-only share is just as frozen', async () => {
+    fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(statusResponse([
+      { id: 'claude', name: 'Claude API', status: 'operational' },
+      { id: 'claudeai', name: 'claude.ai', status: 'operational' },
+      { id: 'claudecode', name: 'Claude Code', status: 'operational' },
+    ]))
+    const html = await (await handler(makeReq('claude', { i: 'opus47' }))).text()
+    expect(html).toContain('og:url" content="https://ai-watch.dev/is-claude-down?i=opus47">')
+    expect(html).not.toContain('&amp;v=')
   })
 })
 

--- a/api/is-down-group.ts
+++ b/api/is-down-group.ts
@@ -105,7 +105,22 @@ function incidentMeta(inc: FamilyIncident): string {
   return `${dateStr} · ongoing`
 }
 
-function renderGroupPage(family: { slug: string; name: string }, members: MemberStatus[], incidents: FamilyIncident[], otherFamilies: Array<{ slug: string; name: string; status: MemberStatus['status'] }>): string {
+// Same vocabulary + mapping as api/_is-down/html-template.ts's HINT_TO_OG_STATUS — kept as a hand-copied
+// mirror (api/is-down.ts and api/is-down-group.ts are the same Vercel Edge deploy target but different
+// files with no established shared-import path yet, matching this file's existing hand-copy posture for
+// RESOLVED_ANALYSIS_WINDOW_MS above). 'active' means "we know there's a live incident but the computed
+// status hasn't caught up to non-operational yet" (mirrors worker/src/alerts.ts buildTweetForService's
+// hint fallback) — maps to 'operational' since that's the literal current value in that edge case.
+const HINT_TO_OG_STATUS: Record<string, MemberStatus['status']> = { down: 'down', degraded: 'degraded', active: 'operational', resolved: 'operational', withdrawn: 'unknown' }
+
+function renderGroupPage(
+  family: { slug: string; name: string },
+  members: MemberStatus[],
+  incidents: FamilyIncident[],
+  otherFamilies: Array<{ slug: string; name: string; status: MemberStatus['status'] }>,
+  ogStatusHint?: string | null,
+  ogIncidentToken?: string | null,
+): string {
   const headline = worstStatus(members)
   const title = `Is ${family.name} Down? ${STATUS_LABEL[headline]} | AIWatch`
   const desc = headline === 'operational'
@@ -118,13 +133,30 @@ function renderGroupPage(family: { slug: string; name: string }, members: Member
   // worker/src/og.ts), `score`/`uptime` are optional and simply omitted since there's no
   // family-level analog for either.
   //
-  // #1103 (diagnosed on the individual pages, applies identically here) — og:url ("canonical" below)
-  // never changes for this page (no `?e=`/`?i=` pin like a per-incident share), so a static og:image
-  // query string lets a social platform's crawler cache the URL indefinitely against a card that can
-  // go stale OR — #1103's actual observed failure — unfurl with NO image at all once the crawler
-  // decides the (unchanged) URL doesn't need a re-fetch. `v`, a 10-min bucket, forces periodic
-  // re-fetch on the LIVE page the same way the individual pages' unpinned share does.
-  const ogImage = `https://aiwatch-worker.p2c2kbf.workers.dev/api/og?${new URLSearchParams({ service: family.name, status: headline, v: String(Math.floor(Date.now() / 600_000)) }).toString()}`
+  // #1103 (diagnosed on the individual pages) / <NEW> (this file never got the fix) — og:url
+  // ("canonical" below) used to NEVER change for this page (no `?e=`/`?i=` pin like the individual
+  // pages and buildTweetForService got in #1063/#804), so a social platform's og:url-keyed card cache
+  // reused whatever it first fetched — usually the routine "operational" card — no matter how many
+  // real outages were shared afterward. `pinnedHint`/`ogUrlPinned` below port the SAME fix #1063/#804
+  // shipped for api/is-down.ts: when the share carries `?e=`/`&i=` (worker/src/alerts.ts's
+  // buildGroupTweetDraft appends both), the OG tags (not the live page body) freeze to the share-moment
+  // status and the og:url becomes a per-incident-unique identity instead of the bare canonical.
+  const pinnedHint = ogStatusHint && Object.prototype.hasOwnProperty.call(HINT_TO_OG_STATUS, ogStatusHint) ? ogStatusHint : null
+  const ogStatus = pinnedHint ? HINT_TO_OG_STATUS[pinnedHint] : headline
+  const ogUrlPinned = Boolean(pinnedHint || ogIncidentToken)
+  const ogQuery = new URLSearchParams()
+  if (pinnedHint) ogQuery.set('e', pinnedHint)
+  if (ogIncidentToken) ogQuery.set('i', ogIncidentToken)
+  const ogUrl = [...ogQuery.keys()].length ? `${canonical}?${ogQuery.toString()}` : canonical
+  const ogParams = new URLSearchParams({ service: family.name, status: ogStatus })
+  // The `v` 10-min cache-buster is for the LIVE (unpinned) card only — a PIN exists to make the card
+  // represent the SHARE MOMENT, so its image must not keep moving afterward (#1103's same reasoning).
+  if (!ogUrlPinned) ogParams.set('v', String(Math.floor(Date.now() / 600_000)))
+  const ogImage = `https://aiwatch-worker.p2c2kbf.workers.dev/api/og?${ogParams.toString()}`
+  // og:title pins to the hint too so the card headline matches the pinned IMAGE — otherwise the card
+  // reads "Operational" (live) over a "Degraded" image. The page <title>/body/JSON-LD stay LIVE; only
+  // the social card pins.
+  const ogTitle = pinnedHint ? `Is ${family.name} Down? ${STATUS_LABEL[ogStatus]} | AIWatch` : title
 
   const rows = members.map((m) => `
     <li class="member-row">
@@ -221,12 +253,12 @@ function renderGroupPage(family: { slug: string; name: string }, members: Member
 <meta name="description" content="${esc(desc)}">
 <link rel="canonical" href="${canonical}">
 <meta property="og:type" content="website">
-<meta property="og:url" content="${canonical}">
-<meta property="og:title" content="${esc(title)}">
+<meta property="og:url" content="${esc(ogUrl)}">
+<meta property="og:title" content="${esc(ogTitle)}">
 <meta property="og:description" content="${esc(desc)}">
 <meta property="og:image" content="${esc(ogImage)}">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="${esc(title)}">
+<meta name="twitter:title" content="${esc(ogTitle)}">
 <meta name="twitter:description" content="${esc(desc)}">
 <meta name="twitter:image" content="${esc(ogImage)}">
 <link rel="icon" type="image/png" href="/favicon.png">
@@ -306,6 +338,13 @@ export default async function handler(req: Request) {
   try {
     const url = new URL(req.url)
     const familyKey = url.searchParams.get('family') ?? ''
+    // #1063/#804 parity, mirroring api/is-down.ts exactly (same sanitization — id-safe chars + a
+    // length cap, since the token only namespaces a cache key, not an id we look anything up by).
+    const ogStatusHint = url.searchParams.get('e')
+    const rawIncidentToken = url.searchParams.get('i')
+    const ogIncidentToken = rawIncidentToken
+      ? rawIncidentToken.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64) || null
+      : null
     const family = FAMILY_GROUPS[familyKey]
     if (!family) return new Response('Not Found', { status: 404 })
     // #1164 review — cross-links to every OTHER family (currently just the one sibling, but this
@@ -438,7 +477,7 @@ export default async function handler(req: Request) {
       console.warn(`[is-down-group/${familyKey}] status fetch failed:`, err instanceof Error ? err.message : err)
     }
 
-    const html = renderGroupPage(family, members, incidents, otherFamilies)
+    const html = renderGroupPage(family, members, incidents, otherFamilies, ogStatusHint, ogIncidentToken)
     const csp = await cspForHtml(html, { enforce: true })
     // Mirrors is-down.ts's fallback semantics: a fetch failure renders "unknown" for every member
     // (never a fabricated status), and the 503 + no-store tells caches/crawlers not to trust or cache

--- a/worker/src/__tests__/tweet-draft.test.ts
+++ b/worker/src/__tests__/tweet-draft.test.ts
@@ -207,12 +207,17 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
   })
 
   // #1164 — the group draft itself: text + link shape, distinct from the per-service ones above.
-  it('the group draft points at the family is-down page and names every affected member', () => {
+  // <NEW> — also carries the #1063/#804 og:url pin (status hint + per-incident token), same as every
+  // other tweet-draft link; this group draft never had it before, so a real share of it reused
+  // whatever card a social platform had cached for the bare `is-claude-down` URL regardless of the
+  // actual outage (reproduced live 2026-08-02).
+  it('the group draft points at the family is-down page (pinned) and names every affected member', () => {
     const drafts = buildTweetDrafts(alert({ key: 'alerted:new:opus47' }), anthropic)
     const group = drafts[0]
     expect(group.serviceId).toBe('family:claude')
     expect(group.serviceName).toBe('Anthropic (Claude)')
-    expect(group.text).toBe('🔴 Multiple Anthropic (Claude) services are affected (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?utm_source=x&utm_medium=social&utm_campaign=outage')
+    // worst-of the 3 'degraded' members → ?e=degraded; alert's incident id → &i=opus47.
+    expect(group.text).toBe('🔴 Multiple Anthropic (Claude) services are affected (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?e=degraded&utm_source=x&utm_medium=social&utm_campaign=outage&i=opus47')
     expect(group.intentUrl).toBe(X_INTENT + encodeURIComponent(group.text))
   })
 
@@ -279,7 +284,7 @@ describe('buildTweetDrafts (#521 — operator picks the surface)', () => {
   it('builds recovery drafts per surface for a resolved multi-surface incident, group draft first', () => {
     const drafts = buildTweetDrafts(alert({ key: 'alerted:res:opus47', title: '🟢 Claude API — Incident Resolved (34m)' }), anthropic)
     expect(drafts).toHaveLength(4)
-    expect(drafts[0].text).toBe('🟢 Anthropic (Claude) services have recovered (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?utm_source=x&utm_medium=social&utm_campaign=outage')
+    expect(drafts[0].text).toBe('🟢 Anthropic (Claude) services have recovered (Claude API, claude ai, Claude Code). Live status → https://ai-watch.dev/is-claude-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage&i=opus47')
     expect(drafts[1].text).toBe('🟢 Claude API recovered after 34m. Live status → https://ai-watch.dev/is-claude-api-down?e=resolved&utm_source=x&utm_medium=social&utm_campaign=outage&i=opus47')
     expect(drafts[2].text).toContain('🟢 claude ai recovered after 34m') // #539: brand defused
   })

--- a/worker/src/alerts.ts
+++ b/worker/src/alerts.ts
@@ -1093,15 +1093,33 @@ export interface TweetDraft {
 
 /** #1164 — the ADDITIONAL draft for a multi-surface same-family incident, pointing at the family's
  *  group is-down page so one share reflects the whole blast radius instead of a single surface.
- *  Never replaces the per-service drafts below — the operator still picks whichever fits. */
+ *  Never replaces the per-service drafts below — the operator still picks whichever fits.
+ *
+ *  <NEW> — this never got the #1063/#804 og:url pin `buildTweetForService` (below) has: the URL used
+ *  to be byte-identical across every share of this family (only `X_UTM`, no `?e=`/`&i=`), so a social
+ *  platform's og:url-keyed card cache reused whatever it first fetched no matter how many real outages
+ *  were shared afterward — reproduced live via the operator's "Anthropic (Claude)" group tweet draft
+ *  option on 2026-08-02, still showing a stale operational card during a real Claude incident. Fixed
+ *  the same way: a status hint (worst-of the affected members, since there's no single `svc.status`
+ *  here) + the per-incident token, both read by api/is-down-group.ts's matching fix. */
 function buildGroupTweetDraft(
   family: { slug: string; name: string },
   members: ScoredService[],
   kind: AlertKind,
+  alert: AlertCandidate,
 ): { text: string; intentUrl: string } {
   const isRecovery = kind === 'resolved' || kind === 'recovered'
   const names = members.map((s) => defuseAutolinkDomain(s.name)).join(', ')
-  const url = `https://ai-watch.dev/is-${family.slug}-down?${X_UTM}`
+  // Worst-of across the affected members — mirrors api/is-down-group.ts's own STATUS_RANK/worstStatus,
+  // hand-copied for the same reason (no shared-import path between worker/ and api/ for this shape).
+  const STATUS_RANK: Record<string, number> = { operational: 0, degraded: 1, down: 2 }
+  const worst = members.reduce((w, s) => ((STATUS_RANK[s.status] ?? 0) > (STATUS_RANK[w] ?? 0) ? s.status : w), 'operational')
+  // Hint vocab mirrors buildTweetForService below: 'active' is the fallback for "known live incident,
+  // but the worst member status hasn't flipped off 'operational' yet" — never emit ?e=operational on
+  // an outage share.
+  const hint = isRecovery ? 'resolved' : worst === 'operational' ? 'active' : worst
+  const token = incidentTokenForAlert(alert)
+  const url = `${appendStatusHint(`https://ai-watch.dev/is-${family.slug}-down`, hint)}&${X_UTM}${token ? `&i=${encodeURIComponent(token)}` : ''}`
   const text = isRecovery
     ? `🟢 ${family.name} services have recovered (${names}). Live status → ${url}`
     : `🔴 Multiple ${family.name} services are affected (${names}). Live status → ${url}`
@@ -1152,7 +1170,7 @@ export function buildTweetDrafts(
     const members = ids.map((id) => services.find((s) => s.id === id)).filter((s): s is ScoredService => !!s)
     if (members.length < 2) continue
     const family = FAMILY_OF_SERVICE[ids[0]]
-    const { text, intentUrl } = buildGroupTweetDraft(family, members, kind)
+    const { text, intentUrl } = buildGroupTweetDraft(family, members, kind, alert)
     drafts.push({ serviceId: `family:${family.slug}`, serviceName: family.name, text, intentUrl })
   }
 


### PR DESCRIPTION
## Summary

- #1063/#804 pinned `api/is-down.ts`'s (individual is-down page) `og:url` with `?e=<status>&i=<incidentToken>` so a social platform doesn't reuse a stale cached card across different outage shares. That fix never reached the provider-family GROUP pages (`api/is-down-group.ts`, `/is-claude-down` etc.) or the operator's group tweet draft (`worker/src/alerts.ts`'s `buildGroupTweetDraft`, added by #1164 — after #1063 shipped, and never given the same treatment).
- `is-down-group.ts`'s `og:url` was **always** the bare canonical — no `?e=`/`?i=` support at all.
- `buildGroupTweetDraft`'s link carried only UTM tags — no status hint or incident token, unlike its sibling `buildTweetForService` which correctly appends both.
- Reproduced live 2026-08-02: the operator posted via the "Anthropic (Claude)" group tweet-draft option during a real active Claude incident; X unfurled the stale pre-outage "Operational" card — the exact #1063 symptom, on the one path that was never patched.

## Fix

Ported the #1063/#804 pin mechanism to both pieces:
- `worker/src/alerts.ts` `buildGroupTweetDraft` now computes a worst-of status hint across the affected members + the alert's incident token, appended the same way `buildTweetForService` does.
- `api/is-down-group.ts` now reads `?e=`/`&i=` (same sanitization as `is-down.ts`), pins `og:url`/`og:image`/`og:title` to the share-moment status when present, and drops the 10-min cache-buster on a pinned share (a pin exists precisely so the card doesn't keep moving after the share moment — same reasoning `is-down.ts` already uses). The page `<title>`/body/JSON-LD stay live, unpinned — only the social card pins.

closes #1194

## Verification

- New tests: `worker/src/__tests__/tweet-draft.test.ts` (group draft now asserts the pinned URL shape), `api/__tests__/is-down-group.test.ts` (5 new cases — unpinned bare canonical, pinned og:url/og:image/og:title, cache-buster dropped when pinned, an unrecognized `?e=` falls back safely, `?i=`-only still pins).
- Full worker (4004) + frontend/api (1153) suites green, `typecheck:worker`, eslint, build all clean.
- Local-verified against a real `vercel dev` server: `?e=degraded&i=test123` on `/is-claude-down` renders a unique, pinned `og:url`/`og:title`("Degraded Performance")/`og:image`(status=degraded), while the page's own `<title>` correctly stays live ("Operational", the actual current status) — confirming only the social card pins, not the page body.

## Test plan

- [x] Unpinned share: `og:url` is the bare canonical (unchanged legacy behavior)
- [x] Pinned share (`?e=`/`&i=`): `og:url`/`og:image`/`og:title` all reflect the share-moment status, distinct per incident
- [x] Pinned share drops the 10-min cache-buster (image must not move after the share moment)
- [x] Unrecognized `?e=` value falls back to unpinned live behavior (no crash, no silent misrender)
- [x] `?i=`-only share (no `?e=`) still pins `og:url`
- [x] Group tweet draft link carries the same pin, worst-of status across affected members
- [x] Full worker + frontend/api suites, typecheck, lint, build all green
- [x] Local `vercel dev` real-request verification (see Verification above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)