### PR TITLE
fix(og): support HEAD requests on /api/og

### DIFF
--- a/worker/src/__tests__/og.test.ts
+++ b/worker/src/__tests__/og.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { generateOgSvg } from '../og'
+import workerModule from '../index'
 
 describe('generateOgSvg', () => {
   it('generates valid SVG with service name and status', () => {
@@ -56,5 +57,40 @@ describe('generateOgSvg', () => {
     // generateOgSvg slices to 50 chars
     expect(svg).toContain('A'.repeat(50))
     expect(svg).not.toContain('A'.repeat(51))
+  })
+})
+
+// #1196 — /api/og used to match GET only, so a HEAD request fell through to the router's generic
+// 404 handler (found live: `curl -I` against production returned 404 with a mismatched
+// content-type/body, while the identical GET succeeded). Not confirmed as the root cause of the
+// unfurl report that surfaced it (that turned out to be a transient X-side retry), but a real,
+// independently-worth-fixing gap: some link-preview crawlers/validators probe with HEAD before a GET.
+describe('GET/HEAD /api/og route (worker/src/index.ts)', () => {
+  const env = {} as unknown as Parameters<typeof workerModule.fetch>[1]
+  const ctx = {} as ExecutionContext
+
+  it('GET returns an image (PNG, or the SVG fallback if the WASM renderer is unavailable in this env) with a real body', async () => {
+    const res = await workerModule.fetch(new Request('https://ai-watch.dev/api/og?service=Claude&status=degraded'), env, ctx)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toMatch(/^image\/(png|svg\+xml)$/)
+    const body = await res.arrayBuffer()
+    expect(body.byteLength).toBeGreaterThan(0)
+  })
+
+  it('HEAD returns the SAME headers as GET, but an empty body', async () => {
+    const [getRes, headRes] = await Promise.all([
+      workerModule.fetch(new Request('https://ai-watch.dev/api/og?service=Claude&status=degraded'), env, ctx),
+      workerModule.fetch(new Request('https://ai-watch.dev/api/og?service=Claude&status=degraded', { method: 'HEAD' }), env, ctx),
+    ])
+    expect(headRes.status).toBe(200)
+    expect(headRes.headers.get('Content-Type')).toBe(getRes.headers.get('Content-Type'))
+    expect(headRes.headers.get('Cache-Control')).toBe(getRes.headers.get('Cache-Control'))
+    const headBody = await headRes.arrayBuffer()
+    expect(headBody.byteLength).toBe(0)
+  })
+
+  it('a non-GET/HEAD method still 404s (no over-widening to POST/PUT/etc.)', async () => {
+    const res = await workerModule.fetch(new Request('https://ai-watch.dev/api/og?service=Claude', { method: 'POST' }), env, ctx)
+    expect(res.status).not.toBe(200)
   })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3933,8 +3933,17 @@ export default {
     // was removed with the browser relay — active-webhook counts now come from confirmed
     // subscriptions (webhook:sub:*, counted via listConfirmedHashes in the daily summary).
 
-    // GET /api/og — dynamic OG image (PNG) for social share previews
-    if (request.method === 'GET' && url.pathname === '/api/og') {
+    // GET/HEAD /api/og — dynamic OG image (PNG) for social share previews.
+    // #1196 — HEAD support: this route used to match GET only, so a HEAD request fell through to
+    // the generic router-level 404 — a real gap found while diagnosing a "card didn't unfurl" report
+    // tied to #1063/#1194's og:url pin (the actual cause there turned out to be a transient X-side
+    // retry, not this, but a link-unfurling endpoint with no HEAD handling is a latent risk
+    // regardless — some crawlers/validators probe with HEAD before committing to a GET). Same body-
+    // generation path as GET; HEAD strips the body before responding (the standard HEAD contract:
+    // identical headers, no body) rather than skipping the render — simpler and avoids a
+    // Content-Length that could disagree with a real GET.
+    if ((request.method === 'GET' || request.method === 'HEAD') && url.pathname === '/api/og') {
+      const isHead = request.method === 'HEAD'
       const service = (url.searchParams.get('service') || 'Unknown').slice(0, 50)
       const status = url.searchParams.get('status') || 'operational'
       const score = (url.searchParams.get('score') || '').slice(0, 5)
@@ -3943,7 +3952,7 @@ export default {
       try {
         const { renderPng } = await import('./og-render')
         const png = await renderPng(svg)
-        return new Response(png, {
+        return new Response(isHead ? null : png, {
           headers: {
             'Content-Type': 'image/png',
             'Cache-Control': 'public, max-age=600, s-maxage=600',
@@ -3952,7 +3961,7 @@ export default {
         })
       } catch (err) {
         console.error('[og] PNG render failed, falling back to SVG:', err instanceof Error ? err.message : err)
-        return new Response(svg, {
+        return new Response(isHead ? null : svg, {
           headers: {
             'Content-Type': 'image/svg+xml',
             'Cache-Control': 'public, max-age=60, s-maxage=60',


### PR DESCRIPTION
## Summary

`/api/og` (the dynamic OG image endpoint for social share previews) only matched `request.method === 'GET'`, so a HEAD request fell through to the router's generic 404 handler — returning an internally inconsistent response (404 status, `content-type: application/json`, but a body that could still be a leftover image from Cloudflare's edge cache). Found live via `curl -I` returning 404 against production while the identical GET succeeded.

Discovered while diagnosing a "X card doesn't show an image" report tied to #1063/#1194's og:url pin. Not confirmed as the root cause there — a live `wrangler tail` capture showed a retry succeeding cleanly on the second attempt (matching #1103's documented "sometimes resolves on retry" pattern for this same endpoint) — but a link-unfurling image endpoint with no HEAD support is a real, independently-worth-fixing gap: some crawlers/link-preview validators probe with HEAD before a GET.

closes #1196

## Fix

`/api/og` now matches `GET` or `HEAD`. HEAD runs the identical body-generation path as GET (same PNG/SVG-fallback logic) and strips the body before responding — the standard HEAD contract (same headers, no body) — rather than trying to skip rendering, which risks a `Content-Length`/headers mismatch against what a real GET would return.

## Verification

- New tests in `worker/src/__tests__/og.test.ts`: GET returns an image (PNG, or the SVG fallback when the WASM renderer is unavailable in the test env) with a real body; HEAD returns headers identical to GET with an empty body; a non-GET/HEAD method (POST) still fails, confirming the route wasn't over-widened.
- Full worker suite (4007) green, `typecheck:worker` clean.

## Test plan

- [x] GET still returns a full image body (PNG or SVG fallback)
- [x] HEAD returns identical `Content-Type`/`Cache-Control` headers to GET, with an empty body
- [x] POST (and other non-GET/HEAD methods) still 404s — route wasn't over-widened
- [x] Full worker suite + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)