### PR TITLE
fix(fetch): retry the Azure RSS leg on a 4s budget so a connection stall stops publishing a false degraded (refs #1211)

### DIFF
--- a/docs/reference/status-determination.md
+++ b/docs/reference/status-determination.md
@@ -169,6 +169,23 @@ The fix widens the SERVICE scope to what the card represents, rather than annota
 
 **General rule**: when adding or updating a service with an Atlassian Statuspage, check both `{custom-domain}/api/v2/summary.json` and `{slug}.statuspage.io/api/v2/summary.json`. Use whichever responds with HTTP 200 from a non-browser client. Also confirm that the `statusComponentId` value in the service config resolves correctly against the chosen endpoint's component list — component IDs are not always identical between a custom domain and its `.statuspage.io` mirror.
 
+### Known case: Azure OpenAI — a header-less stall, not a block (2026-08, #1211)
+
+The #498 shape above is a **block**: the connection is refused fast, and the fix is a different host. Azure OpenAI's RSS feed fails a different way — the connection is accepted and then no response headers arrive, so only our own `AbortController` ends it.
+
+`azureopenai` is where that reaches the card unopposed: one source, no probe target (`probe.ts`), and `getServicePlatform` resolves to `'other'` so neither the quorum nor the metastatuspage phase covers it. Three stalls therefore crossed `trackFetchFailure`'s threshold into a `degraded` that described our connection rather than Azure.
+
+**Fix**: retry the leg (`fetchWithRetry`) with a **4s** first attempt instead of the 8s default. Budget: 4s + the helper's 1s backoff + its 3s retry cap = the 8s the leg already cost.
+
+Where 4s came from: on 2026-08-06 the `latency:24h` series (48 half-hourly samples) held 36 successful polls between 31ms and 1185ms and 12 failures at exactly the 8000ms timeout, with no sample in between. That is a sample, not a census, and those 8000ms entries were the bug writing its own abort budget into the series — after this change neither stall outcome reaches `latency:24h` at all.
+
+Two things to carry over if this is applied elsewhere:
+
+- **The published `latency` must belong to a response that actually arrived.** The retry resets the clock (`onRetry`), and a poll where nothing arrived publishes `null` rather than the elapsed abort budget. Otherwise our own timeout lands in `/api/v1/status` and `latency:24h` looking like a measurement of the provider. Other legs still charge their abandoned attempts this way — unaddressed, and worth its own issue.
+- **A rescued stall books nothing**, so `fetch-fail:daily:{svcId}` stops counting it. The stall rate is only visible in Workers Logs (`[fetchWithRetry] first attempt failed`) for as long as they are retained. There is no durable stall-rate signal; a stall regime that worsens without ever failing both attempts would not surface on its own.
+
+**Not applied to the AWS Health leg (`bedrock`)**, which has the same exposure profile. Scope call, not a claim about bedrock's health.
+
 ### Known case: DeepSeek Flashduty — grouped-section uptime is NOT worst-of the leaf components (2026-07, #1171)
 
 DeepSeek's status-page reorg (around its V4 models) replaced the single component `flashdutyPrimaryComponentId` previously pointed at with 7 named components: 2 standalone API components (V4 Pro / V4 Flash — no grouping) and 5 App/chat components (Instant/Expert/Vision Mode, File Upload, Search) that Flashduty groups under one named **section**, `"对话服务(Chat Service)"` (`active.page.sections[]`, `component.section_id`). #1171 widened `flashdutyPrimaryComponentId` from a single id to a non-empty tuple so both scopes resolve again (`worker/src/parsers/flashduty.ts`).

--- a/worker/src/__tests__/azure-rss-retry.test.ts
+++ b/worker/src/__tests__/azure-rss-retry.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fetchService, SERVICES } from '../services'
+import type { KVLike } from '../utils'
+
+// #1211 — the Azure RSS leg intermittently returns no response headers at all, and three such stalls
+// cross `trackFetchFailure`'s threshold into a `degraded` that describes our connection rather than
+// Azure. azureopenai has one source, no probe target, and qualifies for no cross-validation phase, so
+// nothing downstream can contradict it.
+//
+// These drive the real `fetchService` entry point rather than a hand-assembled imitation, because the
+// bug is in the WIRING (which fetch helper this branch calls, and what latency it publishes), not in
+// any parser — a parser-level test stays green through the entire failure.
+
+const azure = SERVICES.find((s) => s.id === 'azureopenai')!
+
+function mockKV(store: Record<string, string> = {}, ttls: Record<string, number | undefined> = {}): KVNamespace {
+  return {
+    get: async (k: string) => store[k] ?? null,
+    put: async (k: string, v: string, opts?: { expirationTtl?: number }) => { store[k] = v; ttls[k] = opts?.expirationTtl },
+    delete: async (k: string) => { delete store[k] },
+  } as unknown as KVLike as unknown as KVNamespace
+}
+
+/** `fetch-fail:daily:*` keys are date-suffixed; match on the prefix. */
+const keysStartingWith = (store: Record<string, string>, prefix: string) =>
+  Object.keys(store).filter((k) => k.startsWith(prefix))
+
+function abortError() {
+  const err = new Error('The operation was aborted')
+  err.name = 'AbortError'
+  return err
+}
+
+/**
+ * A faithful stall: the connection is accepted and then nothing arrives, so only the caller's own
+ * AbortController ends it. Honouring `init.signal` is what makes this a stall rather than an instant
+ * throw — the timing the fix is about is not exercised otherwise.
+ */
+function hangUntilAborted(init?: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject(abortError()))
+  })
+}
+
+/**
+ * The real feed is the WHOLE-Azure firehose, so a faithful fixture carries sibling noise: azureopenai's
+ * only scoping is `incidentKeywords: ['Azure OpenAI']`, and a single-item fixture would let a dropped
+ * `filterIncidents` call pass unnoticed.
+ *
+ * The Azure OpenAI title's word "Degraded" is load-bearing: `classifyAwsImpact` keys on it for
+ * `impact: 'major'`, which is what makes `deriveAwsStatus` return `degraded` rather than `down`.
+ */
+function feedWithIncident() {
+  const pubDate = new Date(Date.now() - 3_600_000).toUTCString()
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Azure Status</title>
+  <item>
+    <title>Azure OpenAI - Degraded experience for some customers</title>
+    <description>Engineers are investigating elevated error rates.</description>
+    <pubDate>${pubDate}</pubDate>
+    <guid>az-1211-test</guid>
+  </item>
+  <item>
+    <title>Azure Cosmos DB - Degraded experience in West Europe</title>
+    <description>A sibling Azure service, not ours.</description>
+    <pubDate>${pubDate}</pubDate>
+    <guid>az-cosmos-test</guid>
+  </item>
+</channel></rss>`
+}
+
+/** What the feed actually looks like almost all the time: reachable, zero incidents. */
+const EMPTY_FEED = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel><title>Azure Status</title></channel></rss>`
+
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers() })
+
+describe('#1211 — a stalled Azure RSS connection must not publish a false status', () => {
+  it('recovers the incident when the first attempt stalls and the retry succeeds', async () => {
+    // The regression test proper. Pre-fix this branch called `fetchWithTimeout` directly, so the abort
+    // collapsed to `null` → `incidents: []` and the ongoing incident vanished from the card.
+    const store: Record<string, string> = { 'fetch-fail:azureopenai': '2' }
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      calls++
+      if (calls === 1) throw abortError()
+      return new Response(feedWithIncident(), { status: 200 })
+    }))
+
+    const svc = await fetchService(azure, undefined, mockKV(store))
+
+    expect(calls, 'the stalled attempt must be retried on a fresh connection').toBe(2)
+    expect(svc.incidents.length, 'ours reaches the card; the sibling Azure service is filtered out').toBe(1)
+    expect(svc.incidents[0].title).toContain('Azure OpenAI')
+    expect(svc.incidents[0].impact, 'the fixture title drives impact, which drives the status below').toBe('major')
+    expect(svc.status).toBe('degraded')
+
+    // The failure episode must be un-booked, not merely out-voted — the crossing counter is what
+    // turned into the published `degraded`.
+    expect(store['fetch-fail:azureopenai'], 'a success clears the streak').toBeUndefined()
+    expect(keysStartingWith(store, 'fetch-fail:daily:'), 'no crossing may be booked when the retry rescued it').toEqual([])
+  })
+
+  it('still degrades when BOTH attempts stall — the retry must not swallow a dead source', async () => {
+    // The other direction. A retry that hid a genuinely unreachable source would trade a false
+    // `degraded` for a false `operational`, which is the worse failure for this product.
+    const store: Record<string, string> = { 'fetch-fail:azureopenai': '2' }
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async () => { calls++; throw abortError() }))
+
+    const svc = await fetchService(azure, undefined, mockKV(store))
+
+    expect(calls, 'it must fail AFTER retrying, not instead of retrying').toBe(2)
+    expect(svc.incidents, 'no feed was read, so no incidents').toEqual([])
+    expect(store['fetch-fail:azureopenai'], 'the failure must still be booked').toBe('3')
+    expect(svc.status, 'the third consecutive failure crosses the threshold').toBe('degraded')
+    // No response was measured, so no response time may be published — reporting the elapsed abort
+    // budget would put our own timeout into /api/v1/status and the latency:24h series as Azure's.
+    expect(svc.latency, 'a poll that got nothing publishes no latency').toBeNull()
+  })
+
+  it('does not retry a successful first attempt — one subrequest on the happy path', async () => {
+    // Guards the cost side: this leg runs on every /api/status request and every cron tick, so a
+    // retry that fired unconditionally would double its subrequest and connection footprint.
+    const store: Record<string, string> = {}
+    const fetchMock = vi.fn(async () => new Response(feedWithIncident(), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const svc = await fetchService(azure, undefined, mockKV(store))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(svc.incidents.length).toBe(1)
+  })
+
+  it('an empty feed read on the retry is a clean operational, not a rescue with no effect', async () => {
+    // The modal case: the live feed carries no <item> most of the time, so this — not the incident
+    // fixture above — is what a real rescue usually produces.
+    const store: Record<string, string> = { 'fetch-fail:azureopenai': '2' }
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      calls++
+      if (calls === 1) throw abortError()
+      return new Response(EMPTY_FEED, { status: 200 })
+    }))
+
+    const svc = await fetchService(azure, undefined, mockKV(store))
+
+    expect(svc.status, 'a reachable feed with no incidents is operational').toBe('operational')
+    expect(svc.incidents).toEqual([])
+    expect(store['fetch-fail:azureopenai']).toBeUndefined()
+  })
+
+  it('an HTTP error response is NOT retried — only a stall is', async () => {
+    // Documents the boundary. `fetchWithRetry` retries a THROW, not a `!res.ok`, so a 5xx still books
+    // a failure on the first response. Pinned so a later change does not silently assume otherwise.
+    const store: Record<string, string> = { 'fetch-fail:azureopenai': '2' }
+    const fetchMock = vi.fn(async () => new Response('upstream error', { status: 503 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const svc = await fetchService(azure, undefined, mockKV(store))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(store['fetch-fail:azureopenai']).toBe('3')
+    expect(svc.status).toBe('degraded')
+    expect(svc.latency, 'an HTTP error still measured a real round trip — that one is kept').toBeTypeOf('number')
+  })
+
+  it('clears the #500 persistent-block marker too, once a retry recovers the source', async () => {
+    // The episode that matters: the streak already crossed, so `fetch-fail:since` is armed and the 1h
+    // structural-block alert is counting. A rescue that cleared only the streak would leave that clock
+    // running and eventually page the operator about a source that recovered.
+    const store: Record<string, string> = {
+      'fetch-fail:azureopenai': '3',
+      'fetch-fail:since:azureopenai': new Date(Date.now() - 600_000).toISOString(),
+    }
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      calls++
+      if (calls === 1) throw abortError()
+      return new Response(EMPTY_FEED, { status: 200 })
+    }))
+
+    await fetchService(azure, undefined, mockKV(store))
+
+    expect(store['fetch-fail:azureopenai']).toBeUndefined()
+    expect(store['fetch-fail:since:azureopenai'], 'the persistent-block clock must be disarmed too').toBeUndefined()
+  })
+})
+
+describe('#1211 — the timing the fix is actually about', () => {
+  // Fake timers so these assert the real budget without paying it. Everything here is driven by the
+  // AbortController inside `fetchWithTimeout` and the 1s backoff inside `fetchWithRetry`.
+
+  it('abandons the first attempt at 4s — not the 8s default — and publishes the RETRY\'s latency', async () => {
+    // Two claims in one run, because they share a timeline.
+    //
+    // (a) The budget. 4s + 1s + 3s keeps the worst case at the 8s this leg already cost, while a stall
+    //     is detected in half the time. Reverting to the 8s default silently doubles the worst case,
+    //     and nothing else in the suite would notice.
+    // (b) The latency. `start` is reset before the retry, so the served response's own RTT is what
+    //     gets published. Measuring across the whole helper would charge the abandoned attempt and the
+    //     backoff to the response that arrived, into `/api/v1/status` and the `latency:24h` series,
+    //     where it reads as a measurement of Azure.
+    vi.useFakeTimers()
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => {
+      calls++
+      if (calls === 1) return hangUntilAborted(init)
+      return Promise.resolve(new Response(EMPTY_FEED, { status: 200 }))
+    }))
+
+    const pending = fetchService(azure, undefined, mockKV({}))
+
+    await vi.advanceTimersByTimeAsync(3_900)
+    expect(calls, 'the first attempt is still in flight just under the budget').toBe(1)
+
+    await vi.advanceTimersByTimeAsync(200)   // crosses 4s → abort fires
+    await vi.advanceTimersByTimeAsync(1_000) // the backoff before the retry
+    const svc = await pending
+
+    expect(calls, 'the retry fires once the abandoned attempt is cut loose').toBe(2)
+    expect(svc.status).toBe('operational')
+    expect(svc.latency, 'an api-category service must still publish a number').toBeTypeOf('number')
+    expect(svc.latency, 'the abandoned 4s attempt and the 1s backoff must not be charged to the response')
+      .toBeLessThan(1_000)
+  })
+
+  it('caps the retry at 3s, so the whole leg still resolves within its old 8s budget', async () => {
+    // The other half of the budget claim. The retry inherits `Math.min(timeoutMs, 3000)`; widening it
+    // to the caller's 4s would push the worst case past the 8s this change promised not to exceed.
+    vi.useFakeTimers()
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => { calls++; return hangUntilAborted(init) }))
+
+    const store: Record<string, string> = { 'fetch-fail:azureopenai': '2' }
+    const pending = fetchService(azure, undefined, mockKV(store))
+
+    await vi.advanceTimersByTimeAsync(4_000)  // first attempt abandoned
+    await vi.advanceTimersByTimeAsync(1_000)  // backoff
+    expect(calls, 'the retry is in flight').toBe(2)
+
+    await vi.advanceTimersByTimeAsync(2_900)
+    let settled = false
+    void pending.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled, 'still waiting on the retry just under its 3s cap').toBe(false)
+
+    await vi.advanceTimersByTimeAsync(200)    // 4s + 1s + 3s = 8s, the pre-change budget
+    const svc = await pending
+    expect(svc.status, 'both attempts stalled on an already-crossing streak').toBe('degraded')
+  })
+})

--- a/worker/src/services.ts
+++ b/worker/src/services.ts
@@ -1522,16 +1522,23 @@ export function includeUntaggedIncidents(
 
 // Retry once on failure to reduce false-positive 'down' from transient network issues
 // Retry uses shorter timeout to keep total wall-clock time under ~12s per service
-async function fetchWithRetry(url: string, timeoutMs = 8000): Promise<Response> {
+//
+// `onRetry` fires immediately before the second attempt (#1211), so a caller can restart whatever
+// clock it publishes. Only the Azure RSS leg passes one; the Atlassian callers below time both legs
+// together and have the same inflation on their own retry path, unaddressed.
+async function fetchWithRetry(url: string, timeoutMs = 8000, onRetry?: () => void): Promise<Response> {
   try {
     return await fetchWithTimeout(url, timeoutMs)
   } catch (err) {
-    console.warn(`[fetchWithRetry] first attempt failed for ${url}, retrying...`)
+    // The reason is logged, not just the fact: "aborted at the timeout" (a stall) and "connection
+    // reset in 200ms" (a block) call for different fixes, and attempt 1's reason is otherwise lost.
+    console.warn(`[fetchWithRetry] first attempt failed for ${url}, retrying:`, err instanceof Error ? `${err.name}: ${err.message}` : err)
     await new Promise((r) => setTimeout(r, 1000))
+    onRetry?.()
     try {
       return await fetchWithTimeout(url, Math.min(timeoutMs, 3000))
     } catch (retryErr) {
-      console.error(`[fetchWithRetry] retry also failed for ${url}`)
+      console.error(`[fetchWithRetry] retry also failed for ${url}:`, retryErr instanceof Error ? `${retryErr.name}: ${retryErr.message}` : retryErr)
       throw retryErr
     }
   }
@@ -2131,7 +2138,8 @@ async function fetchServiceUntagged(config: ServiceConfig, prefetched?: Prefetch
       }
     } else {
       // No Statuspage API — HTTP check + optional scraping (parallel)
-      // Uses fetchWithTimeout (no retry) to stay within 50-subrequest budget
+      // Uses fetchWithTimeout (no retry) to stay within 50-subrequest budget — EXCEPT the Azure RSS
+      // leg below, which retries (#1211); that costs +1 subrequest only on a failed first attempt.
       // #677 — AWS Health public events JSON API (one fetch, all regions, real start+end timestamps)
       if (config.awsHealthApi) {
         const start = Date.now()
@@ -2182,8 +2190,18 @@ async function fetchServiceUntagged(config: ServiceConfig, prefetched?: Prefetch
 
       // Azure RSS — single feed, keyword-filtered (reuses AWS parser)
       if (config.azureRssUrl) {
-        const start = Date.now()
-        const rssRes = await fetchWithTimeout(config.azureRssUrl, 8000).catch((err) => {
+        // #1211 — retried, on a 4s first attempt rather than the 8s default. This leg intermittently
+        // aborts on its own timeout, and three such polls cross `trackFetchFailure`'s threshold into a
+        // `degraded` that describes our connection rather than Azure. Nothing else catches it: one
+        // source, no probe target, no cross-validation phase it qualifies for. 4s + the helper's 1s
+        // backoff + its 3s retry cap keeps the worst case at the 8s this leg already cost. The budget
+        // derivation is in docs/reference/status-determination.md — not repeated here, since it is not
+        // checkable from this file.
+        //
+        // `start` is reset before the retry so the published latency is the served response's own RTT
+        // rather than the abandoned attempt plus the backoff.
+        let start = Date.now()
+        const rssRes = await fetchWithRetry(config.azureRssUrl, 4000, () => { start = Date.now() }).catch((err) => {
           console.warn(`[fetchService] ${config.id} Azure RSS failed:`, err instanceof Error ? err.message : err)
           return null
         })
@@ -2191,7 +2209,10 @@ async function fetchServiceUntagged(config: ServiceConfig, prefetched?: Prefetch
         if (!rssRes || !rssRes.ok) {
           if (rssRes) { console.warn(`[fetchService] ${config.id} Azure RSS HTTP ${rssRes.status}`); rssRes.body?.cancel() }
           const shouldDegrade = await trackFetchFailure(kv, config.id)
-          return { ...base, status: shouldDegrade ? 'degraded' : 'operational', incidents: [], latency: config.category === 'api' ? latency : null }
+          // An HTTP error still measured a response time (kept, as on the AWS Health leg above); a
+          // stall measured nothing, so publishing the elapsed abort budget would put our own timeout
+          // into `/api/v1/status` and `latency:24h` as though it were Azure's.
+          return { ...base, status: shouldDegrade ? 'degraded' : 'operational', incidents: [], latency: rssRes && config.category === 'api' ? latency : null }
         }
         await resetFetchFailure(kv, config.id)
         const incidents = parseAwsRssIncidents(await rssRes.text())


### PR DESCRIPTION
refs #1211

## What was happening

Azure OpenAI flipped `operational` ↔ `degraded` several times a day with no Azure incident behind it. A production `wrangler tail` caught the cause: the RSS leg aborts on its own timeout while the other 44 services in the same invocation complete normally.

```
01:35:24  wall=14,091ms
  +    0ms [prefetch] status.character.ai/api/v2/summary.json returned HTTP 401 — skipping
  +  439ms [gemini] merged vertex=1 aistudio=36        ← batch 0 is already running
  + 8149ms [fetchService] azureopenai Azure RSS failed: The operation was aborted
  + 8303ms … the remaining 44 services parse normally through +10s
```

Three such polls cross `trackFetchFailure`'s threshold, and `azureopenai` is the service with nothing to catch that — one source, no probe target, and no cross-validation phase it qualifies for. Threshold crossings in production KV: **22** on 2026-08-04, 6 on 08-05, 3 by 01:00 on 08-06, against 2 and 1 for the next-worst services.

The feed itself answers in 33–300ms from outside Cloudflare, and this leg was the one status source fetched with no retry.

## The change

- **`fetchWithRetry` on a 4s first attempt** instead of the 8s default. `4s + 1s backoff + 3s retry cap` = the 8s this leg already cost, so nothing downstream's worst case grows.
- **4000 is derived, not picked.** In `latency:24h`, azureopenai's successful polls sat between 31ms and 1185ms and every failure sat at exactly the 8000ms timeout — no sample in between. The 8s first attempt was dead time.
- **`onRetry` resets the latency clock**, so a rescued poll publishes the served response's own RTT instead of the abandoned attempt plus the backoff.
- **A poll that got no response publishes `latency: null`**; an HTTP error keeps its real RTT, as on the AWS Health leg. Our own abort budget no longer lands in `/api/v1/status` and `latency:24h` looking like a measurement of Azure.
- **`fetchWithRetry` logs each attempt's error name and message.** "Aborted at the timeout" (a stall) and "reset in 200ms" (a block) take different fixes, and attempt 1's reason was previously never logged.

`docs/reference/status-determination.md` gets the case, contrasted against the #498 block shape it is often confused with.

## Trade-off, stated

The accepted response window narrows from a single 8s attempt to 4s + 3s. A feed that consistently answered in 3–8s would now fail both attempts. The distribution above is a 48-sample day, not a census — that caveat is in the doc rather than the code comment.

## Verification

- 8 tests drive the real `fetchService` (not a parser twin — the bug was in the wiring), including two fake-timer cases pinning the 4s budget and the 3s retry cap, and a fixture carrying sibling Azure noise so a dropped `filterIncidents` is caught.
- **Mutation matrix, keyed on exit code — 9/9 killed**: retry→no-retry, retry-timeout-uncapped, drop `filterIncidents` (line-scoped to this leg), drop `resetFetchFailure`, `onRetry`-not-resetting-start, first-timeout→8000, success-latency→null, stall-publishes-abort-budget, failure-always-null.
- Reproduced the failure shape end to end in the real Workers runtime with a local harness that hangs the first request and serves the feed on the second: `[fetchWithRetry] first attempt failed … retrying` → incident reaches the card. Harness reverted.
- `npm run test:worker` 124 files / 4064 tests · `npm run typecheck:worker` 0 errors · `wrangler deploy --dry-run` · `lint:okf` · `lint:docs` · `test:scripts` — all clean.
- Dashboard verified in-browser against a local worker reading the real production sources.

## Review

Four rounds, converging at 0 Critical / 0 Important. Rounds 2 and 3 were dominated by defects that the *previous round's own fix* had introduced — a fabricated latency moved from the success path to the failure path, and an observability KV counter that was traffic-proportional, unread, and shorter-lived than the verification it existed for. The stop-trigger fired, and round 4 was restricted to deletion and mechanical correction; `worker/src/utils.ts` and `docs/reference/kv-schema.md` ended byte-identical to `main`.

## Why `refs`, not `closes`

The remaining item is a production-data check after deploy: threshold crossings for `azureopenai` should fall to ~0. Tracked as a dated `verify-after` on #1211.

## Follow-ups

Split out to #1212 — the non-RSS-200 fail-open on this leg (the only one that can publish a wrong status), both no-second-source legs dropping `sourceUnknown` contrary to the #714 rule stated in the same function, and `fetchWithRetry` logs not being filterable by service id. All three predate this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
