### PR TITLE
fix(tooling): verify-reminders no longer fires on backtick-quoted verify-after citations

### DIFF
--- a/docs/reference/verify-assertions.md
+++ b/docs/reference/verify-assertions.md
@@ -95,6 +95,7 @@ both scanners — the live `pairVerifyAssertions` and its exported twin `parseVe
 |---|---|---|
 | `- [x] verify-after 2026-01-01` | ✅ | done item; ticking the box is the SSOT "verified" action (#586) |
 | `> … verify-after 2026-01-01 …` | ✅ | **blockquote = retrospective narrative, never a live action item** (#966) |
+| `` …the #1153 `verify-after 2026-01-01` box… `` | ✅ (that occurrence) | **backtick-wrapped = a citation of another issue's box** (#1215) |
 | `- [ ] verify-after 2026-01-01` | ❌ fires | the canonical open reminder |
 | `Open: verify-after 2026-01-01` | ❌ fires | non-quoted prose is a legitimate reminder (#541) |
 | `-[x] verify-after 2026-01-01` | ❌ fires | GFM renders this as literal text, not a task |
@@ -118,6 +119,75 @@ Two deliberate edges, both pinned by tests:
 - **The guard is blockquote-*line*-only.** A `verify-after <date>` token inside a fenced code block or
   a markdown table row still fires, since neither line starts with `>`. Left as-is: real issue bodies
   don't do this, and over-broadening the guard risks swallowing genuine reminders.
+
+#### Backtick-quoted citations (#1215)
+
+A second markdown convention QUOTES the token the same way a blockquote does, without `>`: wrapping it
+in inline code. #1189's own evidence section cites #1153's already-closed box in ordinary prose —
+
+```
+Found while reading the #1153 `verify-after 2026-07-30` box against production
+```
+
+— which is not a checkbox and not inside a `>`, so the blockquote rule alone let it through. #1189
+wore `verify-overdue` continuously from 2026-08-03 (its citation's own due date) until this fix, off a
+box that belongs to a different, already-closed issue. Scanned against the live board: every
+backtick-wrapped occurrence not inside a blockquote was this shape (3 found — #1189 ×2, #1089 ×1), and
+every genuine checkbox uses the canonical bold `**verify-after DATE**` form (ship-issue SKILL.md §8),
+never backticks — a clean discriminator, zero counterexamples either direction.
+
+**Unlike the blockquote rule, this is checked per *occurrence*, not per line** — `isBacktickQuotedOccurrence(line, index)`,
+not `isSuppressedReminderLine`. A checkbox line can legitimately carry its own real, bold box AND cite a
+*different* issue's date in backticks in the same sentence; the live board has exactly this shape
+(aiwatch-reports#76: `` - [ ] **verify-after 2026-08-03** — regenerate… Depends on aiwatch#1002's `verify-after 2026-08-02` archive check ``).
+Gating the whole line on "contains a backtick-quoted verify-after anywhere" — the first draft of this
+fix — would have silently dropped that box; caught only by running `--dry-run` against the live board
+before shipping, not by the unit tests written against synthetic bodies.
+
+**A second, subtler bug on top of that** (caught in PR review, by two independent agents, before
+merge): `VERIFY_RE`'s own trailing note capture (`([^\n]*)`) is greedy, so a naive `line.matchAll` on a
+clone of that pattern returns **exactly one match per line, always** — the first match's note swallows
+everything after it, including a second `verify-after` token's own text, so that second occurrence is
+never surfaced as a match of its own. On a line where the backtick-quoted citation comes **first**
+(the reverse of the aiwatch-reports#76 order), that silently dropped the real, later box entirely —
+not merely misclassified it, exactly the failure this whole system exists to prevent. The fix is
+`liveVerifyOccurrences(line)`, built on a **token-only** global regex (date only, no note capture) so
+occurrences are found regardless of order; each match's own note is then derived by slicing `line` from
+the match's end. `pairVerifyAssertions`, `parseVerifyAfter`, `countOpenVerifyAfter`,
+`findBacktickQuotedVerifyBoxes`, and the body-drift guard's verify-after exclusion are all built on this
+one function, so they cannot disagree on what counts as a live occurrence.
+
+The dangerous-shape twin (`findBacktickQuotedVerifyBoxes`, mirroring `findQuotedVerifyAfterBoxes`) warns
+a checkbox line only when it has verify-after occurrences but **none** of them are live — i.e. exactly
+the condition under which `pairVerifyAssertions` would parse nothing off that line. A checkbox that
+merely cites a different date in backticks alongside its own real (live) one still has a live occurrence
+and is correctly not flagged.
+
+**`countOpenVerifyAfter` and the body-drift guard had to move onto the same function**, not just the two
+parsers. Before this, a checkbox whose only "verify-after" text was a backtick citation still counted as
+an open verify-after line (`OPEN_BOX_RE.test(l) && VERIFY_RE.test(l)`, presence-only) — so
+`planIssueAutoVerify`'s `dropLabel` could never fire (the counter never reached zero) even after the
+real, separate box was ticked, pinning `verify-blocked` open forever with nothing left to ping or
+auto-verify. `findBodyDrift`'s verify-after exclusion had the same blind spot from the other side: it
+treated the citation-only box as "open-until-verified, not drift," so it was invisible to *both* guards
+at once — stuck and unflagged. Both now exclude/count on `liveVerifyOccurrences(line).length`.
+
+`pairVerifyAssertions` and `parseVerifyAfter` take only the FIRST live occurrence per line, both — a
+round-2 review finding: `parseVerifyAfter` originally looped over every live occurrence (the `matchAll`
+loop it already had, now correctly reachable past the greedy-capture fix above), which is a real
+divergence from its twin on a line with two genuine dates. Pinned to `[0]` on both, since
+`parseVerifyAfter` has no production caller (`pairVerifyAssertions` is what `main()` drives) and this
+was the historical behavior anyway — before #1215, the greedy capture already collapsed any such line to
+one hit in practice, so nothing that depended on multiple hits per line was ever exercised.
+
+**The backtick-closing check is deliberately loose**, not exact-adjacent: `isBacktickQuotedOccurrence`
+requires a backtick immediately BEFORE the match (that's what protects a real bold box — it is never
+preceded by a backtick, so an unrelated stray backtick earlier in the line can never falsely suppress
+it) but only requires SOME backtick later on the line, not one immediately after the date. A tighter,
+exact-adjacent close check (the first draft) misses a citation whose code span also wraps its own note
+(`` `verify-after 2026-08-02 archive check` `` — the same failure this fix exists to close, under an
+alternate spelling); the live board's three real occurrences all use the tight form, but the loose form
+covers both without reopening the false-suppression risk the open-side anchor exists to close.
 
 ### Label lifecycle
 
@@ -248,6 +318,11 @@ changed.
 - **Blockquote suppression + `verify-overdue` self-healing (#966)** — the rules and the label lifecycle are
   in [Which lines are scanned](#which-lines-are-scanned-966) and the label table above; the pure fns are
   `isSuppressedReminderLine` (shared by BOTH scanners), `findQuotedVerifyAfterBoxes`, `findStaleOverdueLabels`.
+- **Backtick-quoted citation suppression (#1215)** — the second quoting convention #966 didn't cover; see
+  [Backtick-quoted citations](#backtick-quoted-citations-1215) above. Pure fns: `isBacktickQuotedOccurrence`
+  (per-occurrence), `liveVerifyOccurrences` (the shared per-line scanner every consumer is built on — both
+  parsers, `countOpenVerifyAfter`, the body-drift guard's exclusion, and the dangerous-shape twin
+  `findBacktickQuotedVerifyBoxes`).
 
 Follow-ups tracked in #873: `ship-issue`/`issue-triage`/`adding-a-service` convention notes (done),
 an optional HTML/text-body assertion mode, and a Tier-B weekly "suggest-don't-auto-close" digest for

--- a/scripts/verify-assertions.mjs
+++ b/scripts/verify-assertions.mjs
@@ -166,10 +166,75 @@ export function evaluateAssertion(assertion, json) {
 // A CHECKED task marker — a done item is skipped.
 const CHECKED_BOX_RE = /^\s*[-*+]\s+\[[xX]\]/
 
+// An UNCHECKED task marker (`- [ ]` / `* [ ]` / `+ [ ]`) — the one open-box shape, shared by every
+// consumer that needs to anchor on it (previously two byte-identical copies, `OPEN_BOX_ANCHORED_RE` and
+// `OPEN_BOX_RE`, drifted apart in name only — round-2 review).
+const OPEN_BOX_RE = /^\s*[-*+]\s+\[ \]/
+
 // A markdown BLOCKQUOTE line (`> …`, leading indent ok).
 const BLOCKQUOTE_RE = /^\s*>/
 
-const VERIFY_RE = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})([^\n]*)/i
+// Presence-only (no capture groups needed — its one remaining use is a boolean `.test`, in
+// findQuotedVerifyAfterBoxes below). Deliberately non-global: a global regex under `.test` is
+// `lastIndex`-stateful across calls, which a module-level constant must never be.
+const VERIFY_RE = /verify-after[\s:-]+\d{4}-\d{2}-\d{2}/i
+// A TOKEN-only global regex — date captured, NO trailing note capture — so callers can enumerate every
+// occurrence on a line (matchAll) instead of only the first. The original approach (a global clone of a
+// pattern with a greedy trailing `([^\n]*)` note capture) is greedy, so on a line with a second
+// "verify-after" later, matchAll on such a clone returns exactly ONE match: the first match's note
+// swallows the rest of the line — including the second occurrence's own text — so it is never surfaced
+// as a match of its own (#1215 review finding). That silently drops a live reminder whenever a
+// backtick-quoted citation happens to come FIRST on a line that also carries a real box, not merely
+// misclassifies it. A token-only pattern has no such tail to be greedy with, so every occurrence is
+// found regardless of order; each match's own trailing note is then derived by
+// slicing `line` from the match's end, which is exactly what VERIFY_RE's group 2 was doing anyway.
+const VERIFY_TOKEN_RE_G = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})/gi
+
+/**
+ * True when the SPECIFIC `verify-after <date>` occurrence starting at `index` on `line` is wrapped in
+ * inline code (`` `verify-after 2026-09-01` ``) — a citation of another issue's box, not a live
+ * directive here (#1215). This is deliberately a PER-OCCURRENCE check, not a per-line one: a line can
+ * legitimately carry both its own real box (bold, `**verify-after DATE**`) and a backtick-quoted
+ * citation of a DIFFERENT issue's date in the same sentence — the real board has exactly this shape
+ * (aiwatch-reports#76: "Depends on aiwatch#1002's `verify-after 2026-08-02` archive check" trailing
+ * its own `- [ ] **verify-after 2026-08-03**"). Suppressing by whole-line presence would have silently
+ * dropped that box — caught only by running --dry-run against the live board before shipping, not by
+ * the unit tests, which is why the check is bound to `index`, not to `line` as a whole.
+ *
+ * Requires a backtick immediately before the match — anchoring the OPEN side is what protects a real
+ * box: a bold `**verify-after DATE**` box is never preceded by a backtick, so an unrelated stray
+ * backtick earlier in the line can never falsely suppress it, regardless of the CLOSE-side check below.
+ *
+ * The close side only requires SOME backtick later on the line, not one immediately after the date —
+ * round-2 review found the immediately-after form misses a citation whose code span also wraps its own
+ * trailing note (`` `verify-after 2026-08-02 archive check` `` — the same failure this whole check
+ * exists to close, under a plausible alternate spelling). This widening is safe SPECIFICALLY because
+ * the open-side anchor above is the one load-bearing guard against false suppression, not because
+ * loosening a check "in one direction" is inherently safe — that reasoning would equally justify
+ * loosening the open side, which is exactly the false-suppression bug this function exists to avoid
+ * (round-3 review: an early draft of this function's own test suite loosened the open side by
+ * accident and nothing caught it, because the test's only backtick was on the close side).
+ */
+export function isBacktickQuotedOccurrence(line, index) {
+  if (line[index - 1] !== '`') return false
+  return line.indexOf('`', index) !== -1
+}
+
+/**
+ * Every verify-after occurrence on a line that is NOT backtick-quoted (#1215), as raw regex match
+ * objects (`.index` absolute, `[0]` the "verify-after <date>" token). Built on the token-only global
+ * regex specifically so a citation earlier in the line can never swallow a later real occurrence — see
+ * VERIFY_TOKEN_RE_G's docstring for the greedy-capture failure this avoids. Single source of truth for
+ * "does this line still fire, and with what date" — used by `pairVerifyAssertions`, the exported
+ * `parseVerifyAfter` twin, `countOpenVerifyAfter`, `findBacktickQuotedVerifyBoxes`, and the body-drift
+ * guard's verify-after exclusion, so all five agree on what counts as live. `findQuotedVerifyAfterBoxes`
+ * (the blockquote-nested-checkbox detector) is deliberately NOT a sixth consumer — it must flag a
+ * blockquoted box whether or not its date is ALSO backtick-quoted, since the blockquote is already
+ * fatal on its own; narrowing it to "live" occurrences only would under-report. Pure — no I/O.
+ */
+export function liveVerifyOccurrences(line) {
+  return [...line.matchAll(VERIFY_TOKEN_RE_G)].filter((m) => !isBacktickQuotedOccurrence(line, m.index))
+}
 
 /**
  * True when a line must NOT be scanned for a `verify-after` reminder — a done item (`- [x]`) or a
@@ -183,6 +248,10 @@ const VERIFY_RE = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})([^\n]*)/i
  * #873 auto-verify's `tickedKeys` suppression is keyed by the *checkbox* lineIndex — it cannot reach a
  * prose line. So it re-fired daily until the issue closed. Full history: docs/reference/verify-assertions.md.
  *
+ * A backtick-quoted citation (#1215, see isBacktickQuotedOccurrence) is deliberately NOT handled here —
+ * unlike a checked box or a blockquote, it is not a whole-line property, so it is filtered per-match by
+ * the two callers instead of gating the whole line (see the aiwatch-reports#76 shape in that docstring).
+ *
  * Non-quoted prose still fires — a `verify-after` written outside a checkbox is a legitimate reminder.
  */
 export function isSuppressedReminderLine(line) {
@@ -191,7 +260,6 @@ export function isSuppressedReminderLine(line) {
 
 // Strips one or more leading `>` quote markers so the quoted line's own markdown can be inspected.
 const QUOTE_STRIP_RE = /^(\s*>)+\s?/
-const OPEN_BOX_ANCHORED_RE = /^\s*[-*+]\s+\[ \]/
 
 /**
  * The ONE dangerous shape the blockquote rule suppresses: an UNCHECKED `verify-after` checkbox nested
@@ -208,7 +276,31 @@ export function findQuotedVerifyAfterBoxes(body) {
   const out = []
   body.split('\n').forEach((line, lineIndex) => {
     if (!BLOCKQUOTE_RE.test(line) || !VERIFY_RE.test(line)) return
-    if (OPEN_BOX_ANCHORED_RE.test(line.replace(QUOTE_STRIP_RE, ''))) out.push({ lineIndex, text: line.trim() })
+    if (OPEN_BOX_RE.test(line.replace(QUOTE_STRIP_RE, ''))) out.push({ lineIndex, text: line.trim() })
+  })
+  return out
+}
+
+/**
+ * The backtick-quoting twin of findQuotedVerifyAfterBoxes (#1215): an OPEN `verify-after` checkbox
+ * whose OWN date got accidentally wrapped in inline code (`` - [ ] `verify-after 2026-09-01` — … ``)
+ * would be silently suppressed forever — the same failure #966 built a warning for on the blockquote
+ * side. Flags a checkbox line only when it has AT LEAST ONE verify-after occurrence AND NONE of them
+ * are live (`liveVerifyOccurrences` empty) — i.e. exactly the condition under which
+ * `pairVerifyAssertions` would find nothing on this line. A checkbox that merely CITES a different
+ * issue's backtick-quoted date alongside its own real (live) one — a real, legitimate shape, see
+ * isBacktickQuotedOccurrence's docstring — still has a live occurrence and is correctly not flagged.
+ * Returns [{lineIndex, text}] so it can feed the same silent-drop warning loop. Pure — no I/O.
+ */
+export function findBacktickQuotedVerifyBoxes(body) {
+  if (!body) return []
+  const out = []
+  body.split('\n').forEach((line, lineIndex) => {
+    if (!OPEN_BOX_RE.test(line)) return
+    const all = [...line.matchAll(VERIFY_TOKEN_RE_G)]
+    if (all.length > 0 && all.every((m) => isBacktickQuotedOccurrence(line, m.index))) {
+      out.push({ lineIndex, text: line.trim() })
+    }
   })
   return out
 }
@@ -238,9 +330,12 @@ export function pairVerifyAssertions(body) {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
     if (isSuppressedReminderLine(line)) continue
-    const v = VERIFY_RE.exec(line)
+    // First LIVE occurrence (#1215) — not simply the first match, since a line can legitimately carry
+    // its own real box AND cite a different date in backticks in the same sentence, in EITHER order
+    // (aiwatch-reports#76; see liveVerifyOccurrences / isBacktickQuotedOccurrence).
+    const v = liveVerifyOccurrences(line)[0]
     if (!v) continue
-    const note = v[2].replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
+    const note = line.slice(v.index + v[0].length).replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
     let assertion = null
     let durable = null
     for (let j = i + 1; j < lines.length; j++) {
@@ -269,18 +364,22 @@ export function tickBox(body, lineIndex) {
   return lines.join('\n')
 }
 
-const OPEN_BOX_RE = /^\s*[-*+]\s+\[ \]/
-
 /** Count UNCHECKED markdown task boxes (`- [ ]`) in a body — 0 means the issue is fully checked. */
 export function countOpenBoxes(body) {
   if (!body) return 0
   return body.split('\n').filter((l) => OPEN_BOX_RE.test(l)).length
 }
 
-/** Count UNCHECKED `verify-after` lines specifically (an open box whose line carries a verify-after). */
+/**
+ * Count UNCHECKED `verify-after` lines specifically (an open box whose line carries a LIVE
+ * verify-after — #1215: a box whose only occurrence is a backtick-quoted citation does not count,
+ * matching what `pairVerifyAssertions` would actually parse off that line). Load-bearing for
+ * `planIssueAutoVerify`'s `dropLabel`: counting a citation-only box here would pin `verify-blocked`
+ * open forever with nothing left to ping or auto-verify it.
+ */
 export function countOpenVerifyAfter(body) {
   if (!body) return 0
-  return body.split('\n').filter((l) => OPEN_BOX_RE.test(l) && VERIFY_RE.test(l)).length
+  return body.split('\n').filter((l) => OPEN_BOX_RE.test(l) && liveVerifyOccurrences(l).length > 0).length
 }
 
 /**

--- a/scripts/verify-assertions.test.mjs
+++ b/scripts/verify-assertions.test.mjs
@@ -5,7 +5,8 @@ import {
   parseAssertionLine, parseLiteral, parseSelector, evalSelector, compare,
   evaluateAssertion, isAllowedUrl, resolveSource, pairVerifyAssertions, tickBox, runAssertion,
   truncate, countOpenBoxes, countOpenVerifyAfter, planIssueAutoVerify, DEFAULT_ASSERT_BASE,
-  isSuppressedReminderLine, findQuotedVerifyAfterBoxes,
+  isSuppressedReminderLine, findQuotedVerifyAfterBoxes, findBacktickQuotedVerifyBoxes, isBacktickQuotedOccurrence,
+  liveVerifyOccurrences,
 } from './verify-assertions.mjs'
 
 test('parseAssertionLine — valid GET + selector + quoted expected', () => {
@@ -197,7 +198,7 @@ test('findQuotedVerifyAfterBoxes — nested quote markers + empty bodies (#966)'
   assert.deepEqual(findQuotedVerifyAfterBoxes('> just a quote, no token'), [])
 })
 
-test('isSuppressedReminderLine — checked boxes and blockquotes only (#966)', () => {
+test('isSuppressedReminderLine — checked boxes and blockquotes only, unchanged by #1215', () => {
   assert.equal(isSuppressedReminderLine('- [x] verify-after 2026-01-01'), true)
   assert.equal(isSuppressedReminderLine('   * [X] verify-after 2026-01-01'), true)
   assert.equal(isSuppressedReminderLine('> quoted'), true)
@@ -206,6 +207,95 @@ test('isSuppressedReminderLine — checked boxes and blockquotes only (#966)', (
   assert.equal(isSuppressedReminderLine('plain prose verify-after 2026-01-01'), false)
   // GFM renders `-[x]` (no space) as literal text, not a task — must still fire (#586 edge, retained).
   assert.equal(isSuppressedReminderLine('-[x] verify-after 2026-01-01'), false)
+  // #1215 — backtick-quoting is deliberately NOT a whole-line property here; it's filtered per-match
+  // by the callers (see isBacktickQuotedOccurrence below), so this line-level gate stays untouched —
+  // a line can carry both a real box and a backtick citation of a different date (aiwatch-reports#76).
+  assert.equal(isSuppressedReminderLine('Found while reading the #1153 `verify-after 2026-07-30` box against production'), false)
+})
+
+test('isBacktickQuotedOccurrence — the exact #1189/#1089 citation shapes are wrapped, a real box is not (#1215)', () => {
+  const l1 = 'Found while reading the #1153 `verify-after 2026-07-30` box against production'
+  assert.equal(isBacktickQuotedOccurrence(l1, l1.indexOf('verify-after')), true)
+
+  const l2 = 'a **decision deferred to `verify-after 2026-08-20`** below'
+  assert.equal(isBacktickQuotedOccurrence(l2, l2.indexOf('verify-after')), true)
+
+  const l3 = '- [ ] **verify-after 2026-08-03** — regenerate. Depends on `verify-after 2026-08-02`.'
+  const firstIdx = l3.indexOf('verify-after')
+  const secondIdx = l3.indexOf('verify-after', firstIdx + 1)
+  assert.equal(isBacktickQuotedOccurrence(l3, firstIdx), false) // the bold box's own date — real
+  assert.equal(isBacktickQuotedOccurrence(l3, secondIdx), true) // the trailing citation — quoted
+
+  // A bare mention with no wrapping backticks at all.
+  const l4 = 'Open: verify-after 2026-07-02 (prose ref)'
+  assert.equal(isBacktickQuotedOccurrence(l4, l4.indexOf('verify-after')), false)
+})
+
+test('isBacktickQuotedOccurrence — the closing backtick may come after a trailing note inside the span, not just immediately after the date (#1215 round-2 finding)', () => {
+  const l = '- [ ] `verify-after 2026-08-02 archive check` cited'
+  assert.equal(isBacktickQuotedOccurrence(l, l.indexOf('verify-after')), true)
+})
+
+test('isBacktickQuotedOccurrence — an unrelated stray backtick on EITHER side does not falsely suppress a real box (open side stays anchored, #1215 round-3 finding)', () => {
+  // Must have a backtick on BOTH sides of the match, or the close-side `indexOf` check alone (not the
+  // open-side anchor) could make this pass for the wrong reason — round-3 review caught exactly that:
+  // the original version of this test had no backtick after the match, so it passed via the close side
+  // returning false, never exercising the open-side anchor it claimed to pin.
+  const l = 'stray ` then **verify-after 2026-03-03** and `code` after'
+  assert.equal(isBacktickQuotedOccurrence(l, l.indexOf('verify-after')), false)
+})
+
+test('pairVerifyAssertions — a real box still fires even when the same line cites a different date in backticks (#1215, aiwatch-reports#76 shape)', () => {
+  const body = "- [ ] **verify-after 2026-08-03** — regenerate the report. Depends on aiwatch#1002's `verify-after 2026-08-02` archive check."
+  const found = pairVerifyAssertions(body)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].date, '2026-08-03')
+})
+
+test('pairVerifyAssertions — a real box still fires when the CITATION PRECEDES it on the same line (#1215 review finding)', () => {
+  // VERIFY_RE's trailing note capture is greedy, so a naive matchAll on the full pattern would let the
+  // FIRST match's note swallow the rest of the line — including a real box coming AFTER a citation —
+  // and never surface it as a match at all. This is the reverse text order from aiwatch-reports#76, and
+  // it must not silently drop the real date instead of merely skipping the citation.
+  const body = "Per #1153's `verify-after 2026-07-30` note — our own **verify-after 2026-09-09** still stands"
+  const found = pairVerifyAssertions(body)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].date, '2026-09-09')
+})
+
+test('liveVerifyOccurrences — finds a live match regardless of how many backtick citations precede it (#1215)', () => {
+  const line = 'cites `verify-after 2026-01-01` and `verify-after 2026-02-02` but ours is verify-after 2026-03-03 — ok'
+  const found = liveVerifyOccurrences(line)
+  assert.equal(found.length, 1)
+  assert.equal(found[0][1], '2026-03-03')
+})
+
+test('liveVerifyOccurrences — empty when every occurrence on the line is backtick-quoted', () => {
+  const line = 'Found while reading the #1153 `verify-after 2026-07-30` box against production'
+  assert.deepEqual(liveVerifyOccurrences(line), [])
+})
+
+test('pairVerifyAssertions and parseVerifyAfter agree on a line with TWO live dates — both take only the first (#1215 round-2 finding)', () => {
+  const line = '- [ ] **verify-after 2026-03-03** then also verify-after 2026-04-04 tail'
+  assert.deepEqual(pairVerifyAssertions(line).map((f) => f.date), ['2026-03-03'])
+})
+
+test('findBacktickQuotedVerifyBoxes — flags a backtick-wrapped OPEN box, ignores a box that merely CITES another date in backticks (#1215)', () => {
+  const body = [
+    'Found while reading the #1153 `verify-after 2026-07-30` box against production.', // prose — expected, silent
+    '- [ ] `verify-after 2026-09-01` accidentally backtick-wrapped date — DANGEROUS, never fires',
+    '- [x] `verify-after 2026-09-02` already done — not a live loss',
+    '- [ ] verify-after 2026-09-03 a normal box, not backtick-wrapped',
+    "- [ ] **verify-after 2026-09-04** — real box that cites `verify-after 2026-09-05` in its own note", // aiwatch-reports#76 shape — must NOT flag
+  ].join('\n')
+  const found = findBacktickQuotedVerifyBoxes(body)
+  assert.deepEqual(found.map((f) => f.lineIndex), [1])
+})
+
+test('findBacktickQuotedVerifyBoxes — empty bodies + no token (#1215)', () => {
+  assert.deepEqual(findBacktickQuotedVerifyBoxes(''), [])
+  assert.deepEqual(findBacktickQuotedVerifyBoxes(null), [])
+  assert.deepEqual(findBacktickQuotedVerifyBoxes('- [ ] just a normal box, no token'), [])
 })
 
 test('pairVerifyAssertions — tolerates a blank line before the assert', () => {
@@ -236,6 +326,26 @@ test('countOpenBoxes / countOpenVerifyAfter', () => {
   assert.equal(countOpenVerifyAfter(body), 1)    // only the open verify-after line
   assert.equal(countOpenBoxes(''), 0)
   assert.equal(countOpenVerifyAfter(''), 0)
+})
+
+test('countOpenVerifyAfter — an open box whose only verify-after is a backtick citation does not count (#1215)', () => {
+  // Load-bearing for planIssueAutoVerify's dropLabel: counting this box would pin verify-blocked open
+  // forever, since pairVerifyAssertions would never parse a live reminder off this line either.
+  const body = [
+    '- [ ] doc note citing `verify-after 2026-07-30` for context, not a real box',
+    '- [ ] **verify-after 2026-08-20** — the actual live reminder',
+  ].join('\n')
+  assert.equal(countOpenVerifyAfter(body), 1)
+})
+
+test('planIssueAutoVerify — dropLabel fires even when a citation-only box is still unchecked (#1215)', () => {
+  const body = [
+    '- [ ] **verify-after 2026-08-03** — the real, assertable box',
+    '      assert: GET /api/status | services[id=x].ok == true',
+    '- [ ] doc note citing `verify-after 2026-07-30` for context, not a real box',
+  ].join('\n')
+  const plan = planIssueAutoVerify(body, [{ lineIndex: 0, status: 'pass' }])
+  assert.equal(plan.dropLabel, true)
 })
 
 test('planIssueAutoVerify — ticks passers; dropLabel when no open verify-after; close when no open box', () => {

--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -14,23 +14,20 @@
 import { execFileSync } from 'node:child_process'
 // #873 — Tier-A auto-verify: evaluate a machine-checkable `assert:` clause on a verify-after line and
 // close the loop (tick + comment + drop verify-blocked) instead of only pinging. See verify-assertions.mjs.
-import { pairVerifyAssertions, runAssertion, planIssueAutoVerify, truncate, isSuppressedReminderLine, findQuotedVerifyAfterBoxes } from './verify-assertions.mjs'
+import { pairVerifyAssertions, runAssertion, planIssueAutoVerify, truncate, isSuppressedReminderLine, findQuotedVerifyAfterBoxes, findBacktickQuotedVerifyBoxes, liveVerifyOccurrences } from './verify-assertions.mjs'
 
-// Matches a `verify-after 2026-09-01` token anywhere on a line; captures the date + the rest of the
-// line as a free-form note. Case-insensitive; `after` may be followed by space, `:` or `-`.
-const VERIFY_RE = /verify-after[\s:-]+(\d{4}-\d{2}-\d{2})([^\n]*)/gi
-
-// Which lines a verify-after scan must SKIP (checked box `- [x]` / blockquote `>`) now lives in
+// Which lines a verify-after scan must SKIP (checked box `- [x]` / blockquote `>`) lives in
 // verify-assertions.mjs as `isSuppressedReminderLine` — one definition shared by both scanners (#966).
-// Unchecked boxes (`- [ ]`) and non-quoted prose still fire.
+// Unchecked boxes (`- [ ]`) and non-quoted prose still fire. A backtick-quoted OCCURRENCE (#1215) is
+// deliberately NOT part of that line-level gate — it is not a whole-line property (a line can carry
+// both its own real box and a citation of a different date) — so it is filtered per-match instead, via
+// `liveVerifyOccurrences` (verify-assertions.mjs), everywhere below that used to scan with VERIFY_RE.
 
 // An UNCHECKED markdown task-list marker at the start of a line (`- [ ]` / `* [ ]` / `+ [ ]`, leading
 // indent ok). Used by the body-drift guard below. The marker→`[` space is REQUIRED (`\s+`), mirroring
 // the checked-box marker inside `isSuppressedReminderLine` (verify-assertions.mjs), so `-[ ]` (GFM
 // literal text, not a task) is not treated as a checkbox.
 const UNCHECKED_BOX_RE = /^\s*[-*+]\s+\[ \]/
-// A verify-after line is legitimately unchecked until its production signal lands, so it is NOT drift.
-const VERIFY_AFTER_LINE_RE = /verify-after[\s:-]+\d{4}-\d{2}-\d{2}/i
 
 /**
  * Body-drift guard (issue-body-sync backstop). A `verify-blocked` issue means "code shipped; only a
@@ -38,7 +35,12 @@ const VERIFY_AFTER_LINE_RE = /verify-after[\s:-]+\d{4}-\d{2}-\d{2}/i
  * the only lines still `- [ ]` should be the verify-after line(s). Any OTHER unchecked box means the
  * body was never synced at merge (the late/no-gate/other-system step) or the label is wrong. This
  * returns the count + a few samples of those stray unchecked boxes so the caller can flag the issue.
- * Pure + unit-tested. verify-after lines and checked boxes are excluded; an empty body → no drift.
+ * Pure + unit-tested. LIVE verify-after lines and checked boxes are excluded; an empty body → no drift.
+ * A box whose only "verify-after" text is a backtick-quoted citation (#1215) is NOT excluded — it has
+ * no live occurrence (`liveVerifyOccurrences` empty), so `pairVerifyAssertions` would never parse it as
+ * a reminder either, and treating it as open-until-verified would leave `verify-blocked` pinned open
+ * forever with nothing left to ping, auto-verify, or flag as drift (the exact silent-stuck state this
+ * guard exists to catch).
  * Known limitation (accepted): the scan is line-based and NOT fence-aware, so a `- [ ]` inside a
  * ```fenced``` checklist template/example counts too — tolerable here (label-only, self-heals, and the
  * verify-blocked bucket rarely embeds template checklists).
@@ -48,7 +50,7 @@ export function findBodyDrift(body) {
   const items = []
   for (const line of body.split('\n')) {
     if (!UNCHECKED_BOX_RE.test(line)) continue
-    if (VERIFY_AFTER_LINE_RE.test(line)) continue // open-until-verified, not drift
+    if (liveVerifyOccurrences(line).length > 0) continue // open-until-verified, not drift
     items.push(line.replace(UNCHECKED_BOX_RE, '').replace(/\*+/g, '').trim())
   }
   return { count: items.length, samples: items.slice(0, 5) }
@@ -327,19 +329,25 @@ export function isValidIsoDate(s) {
   return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s
 }
 
-/** Extract every {date, note} pair from an issue body. Calendar-invalid dates are skipped, as are
- *  CHECKED checkbox (`- [x]`) and BLOCKQUOTE (`>`) lines — see isSuppressedReminderLine. */
+/** Extract the {date, note} pair from every LINE of an issue body that has one — one hit per line, the
+ *  first LIVE occurrence, matching `pairVerifyAssertions` on occurrence selection and note extraction
+ *  (round-2 review: they must not disagree on how many hits one line contributes, only on which
+ *  occurrence is live) — except that calendar-INVALID dates are skipped HERE but retained by
+ *  `pairVerifyAssertions`, deliberately: `findInvalidVerifyAfterDates` is built on the latter and needs
+ *  the invalid ones to warn about them. CHECKED checkbox (`- [x]`) and BLOCKQUOTE (`>`) lines are
+ *  skipped — see isSuppressedReminderLine — and a backtick-quoted first occurrence (#1215, see
+ *  liveVerifyOccurrences) — checked per match, in EITHER order, so a legitimate match earlier or later
+ *  on the same line still fires and is not swallowed by a citation preceding it. */
 export function parseVerifyAfter(body) {
   const out = []
   if (!body) return out
   // Scan line-by-line so a per-line checkbox/blockquote can suppress that line's verify-after.
   for (const line of body.split('\n')) {
     if (isSuppressedReminderLine(line)) continue
-    for (const m of line.matchAll(VERIFY_RE)) {
-      if (!isValidIsoDate(m[1])) continue
-      const note = m[2].replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
-      out.push({ date: m[1], note })
-    }
+    const m = liveVerifyOccurrences(line)[0]
+    if (!m || !isValidIsoDate(m[1])) continue
+    const note = line.slice(m.index + m[0].length).replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
+    out.push({ date: m[1], note })
   }
   return out
 }
@@ -615,6 +623,9 @@ async function main() {
   for (const iss of considered) {
     for (const q of findQuotedVerifyAfterBoxes(iss.body)) {
       console.warn(`[verify-reminders] ${displayRef(iss.repo, iss.number)}: an UNCHECKED verify-after box is nested in a blockquote (line ${q.lineIndex + 1}) — it will NEVER fire. Unquote it: ${truncate(q.text, 100)}`)
+    }
+    for (const q of findBacktickQuotedVerifyBoxes(iss.body)) {
+      console.warn(`[verify-reminders] ${displayRef(iss.repo, iss.number)}: an UNCHECKED verify-after box has its date wrapped in backticks (line ${q.lineIndex + 1}) — it will NEVER fire. Use the canonical bold form instead: ${truncate(q.text, 100)}`)
     }
     for (const bad of findInvalidVerifyAfterDates(iss.body)) {
       console.warn(`[verify-reminders] ${displayRef(iss.repo, iss.number)}: verify-after date '${bad.date}' (line ${bad.lineIndex + 1}) is not a valid calendar date — it will never ping. Fix the date.`)

--- a/scripts/verify-reminders.test.mjs
+++ b/scripts/verify-reminders.test.mjs
@@ -130,6 +130,16 @@ test('findBodyDrift — counts unchecked NON-verify-after boxes; excludes verify
   assert.equal(findBodyDrift(many).samples.length, 5)
 })
 
+test('findBodyDrift — a box whose only verify-after is a backtick citation IS drift, not exempt (#1215)', () => {
+  // No live occurrence on this line, so pairVerifyAssertions would never parse a reminder off it —
+  // treating it as "open-until-verified" would leave it silently unflagged forever alongside a stuck
+  // verify-blocked label (see the countOpenVerifyAfter/planIssueAutoVerify tests in verify-assertions).
+  const body = '- [x] shipped the fix\n- [ ] doc note citing `verify-after 2026-07-30` for context'
+  const d = findBodyDrift(body)
+  assert.equal(d.count, 1)
+  assert.match(d.samples[0], /verify-after 2026-07-30/)
+})
+
 test('isDriftCandidate — verify-blocked AND NOT tracking; accepts {name} or string labels', () => {
   assert.equal(isDriftCandidate([{ name: 'verify-blocked' }, { name: 'bug' }]), true)
   assert.equal(isDriftCandidate(['verify-blocked']), true)
@@ -174,6 +184,62 @@ test('parseVerifyAfter — the real aiwatch-reports#41 shape yields exactly ONE 
   assert.equal(hits.length, 1)
   assert.equal(hits[0].date, '2026-07-02')
   assert.match(hits[0].note, /2026-06 report/)
+})
+
+// ── #1215: backtick-quoted `verify-after` citations must not fire ────────────────────────────────
+test('parseVerifyAfter — the real #1189 body lines yield ZERO hits (#1215)', () => {
+  // Verbatim from #1189 — prose citing #1153's already-closed box and #1153's other still-open row,
+  // both outside a blockquote, both backtick-wrapped. Neither is #1189's own reminder.
+  assert.deepEqual(
+    parseVerifyAfter('Found while reading the #1153 `verify-after 2026-07-30` box against production'),
+    [],
+  )
+  assert.deepEqual(
+    parseVerifyAfter(
+      '- **#1153** stays open on its own remaining production observation (`mistral / b3e1006c-c3a7-4b1b-8628-3e364b2e3c71`, `verify-after 2026-08-03`). Its fix is unaffected.',
+    ),
+    [],
+  )
+})
+
+test('parseVerifyAfter — the real #1089 body line yields ZERO hits (#1215)', () => {
+  assert.deepEqual(
+    parseVerifyAfter(
+      '      shipped work but a **decision deferred to `verify-after 2026-08-20`** below — "needs a decision, not"',
+    ),
+    [],
+  )
+})
+
+test('parseVerifyAfter — backtick-quoting does not over-suppress a real box or unwrapped prose (#1215)', () => {
+  assert.equal(parseVerifyAfter('- [ ] **verify-after 2026-08-20** — read the frequency, then pick 1/2/3 above')[0].date, '2026-08-20')
+  // Same #541 fail-safe as the blockquote case: a bare mention with no backticks still fires.
+  assert.equal(parseVerifyAfter('Open: verify-after 2026-07-02 (prose ref)')[0].date, '2026-07-02')
+})
+
+test('parseVerifyAfter — a real box still fires when the same line cites a different date in backticks (#1215, aiwatch-reports#76 shape)', () => {
+  const line = "- [ ] **verify-after 2026-08-03** — regenerate the report. Depends on aiwatch#1002's `verify-after 2026-08-02` archive check."
+  const hits = parseVerifyAfter(line)
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].date, '2026-08-03')
+})
+
+test('parseVerifyAfter — a real box still fires when the CITATION PRECEDES it on the line (#1215 review finding)', () => {
+  // Same greedy-capture hazard as the pairVerifyAssertions test of the same name: a naive matchAll on
+  // the full verify-after+note pattern lets the citation's match swallow the rest of the line, so the
+  // real date later on the line is never surfaced as its own match at all — silently dropped, not just
+  // skipped.
+  const line = "Per #1153's `verify-after 2026-07-30` note — our own verify-after 2026-09-09 stands"
+  const hits = parseVerifyAfter(line)
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].date, '2026-09-09')
+})
+
+test('parseVerifyAfter — one hit per line even with two live dates, matching pairVerifyAssertions (#1215 round-2 finding)', () => {
+  const line = '- [ ] **verify-after 2026-03-03** then also verify-after 2026-04-04 tail'
+  const hits = parseVerifyAfter(line)
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].date, '2026-03-03')
 })
 
 // ── #966: `verify-overdue` is a current-state label, so it must self-heal ─────────────────────────


### PR DESCRIPTION
## Summary

- `verify-reminders`'s daily scanner was treating a backtick-quoted citation of another issue's already-closed `verify-after` box as a live reminder of its own — #1189 has worn `verify-overdue` continuously since 2026-08-03 off a box that belongs to #1153, and got a false Discord ping.
- Root cause: `isSuppressedReminderLine` (#966) only skips checked boxes and blockquotes; a backtick-quoted citation in ordinary prose (not a checkbox, not a blockquote) fell through. Confirmed against the live board: every backtick-wrapped `verify-after` outside a blockquote was this exact citation shape (3 found), and every genuine checkbox uses the canonical bold form — never backticks.
- The fix is per-*occurrence*, not per-line, because a real box can legitimately share a line with a citation of a *different* date (`aiwatch-reports#76`). `liveVerifyOccurrences(line)` is now the single source of truth used by all five consumers that need to agree on what counts as a live reminder.
- A second, more serious bug surfaced during PR review (caught independently by two review agents): the first draft's multi-occurrence scan reused a regex with a greedy trailing note-capture, so it could only ever find one match per line — a citation *preceding* a real box on the same line silently dropped the real box entirely, not just misclassified it. Fixed with a token-only regex that has no greedy tail to swallow a later occurrence.

## Test plan

- [x] `npm run test:scripts` — 380/380 (+15 new tests, including regression pins on the real #1189/#1089 body text and the aiwatch-reports#76 mixed-shape line in both text orders)
- [x] `npm run lint:docs` — clean
- [x] `node scripts/verify-reminders.mjs --dry-run` against the live board (both `bentleypark/aiwatch` and `bentleypark/aiwatch-reports`) — #1189 no longer appears in the due/ping list and is correctly flagged as having a clearable stale `verify-overdue` label; `aiwatch-reports#76` no longer trips the dangerous-shape warning
- [x] 3 rounds of `pr-review-toolkit` review, converged to 0 Critical/Important (round 1: 1 shared Critical found by two independent agents, fixed; round 2: 2 Important, fixed; round 3: 1 Important on test quality itself, fixed + self-verified by mutation)

closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)