### PR TITLE
fix(footer): prevent overlap of the report button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -152,7 +152,7 @@ function AppInner() {
             {t('footer.copyright')}
           </span>
         </div>
-        <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-3 flex-wrap">
           <button
             onClick={() => { setModal('privacy'); trackEvent('open_legal', { type: 'privacy' }) }}
             className="mono text-[11px] text-[var(--text2)] hover:text-[var(--text0)] transition-colors cursor-pointer"

--- a/src/index.css
+++ b/src/index.css
@@ -166,11 +166,12 @@ pre,
 
 .site-footer {
   margin: 20px 24px 20px;
-  padding: 16px 24px;
+  padding: 16px 220px 16px 24px;
 }
 @media (max-width: 767px) {
-  .site-footer { margin: 14px; padding: 14px; }
+  .site-footer { margin: 14px; padding: 14px 14px 60px; }
 }
+
 
 /* ─── Scrollbar ─────────────────────────────────────────── */
 * {


### PR DESCRIPTION
## Summary
- Prevented the "Report an issue" button from overlapping footer content
- Added some bottom and right side padding for the '.site-footer' in 'index.css'
- Verified the fix on desktop and iPad layouts

## Related Issue
Closes #1221 

## Changes
- updated '.site-footer' spacing in in `src/index.css`
- increased the gap from 2 to 3 for the footer links and buttons in `src/App.jsx`

## Screenshots

### Before: 
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/a5e6096f-542e-4be6-8b9b-a372992296ce" />


### After: 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f3177a0a-441c-442d-b69c-c8995d474b35" />

