### PR TITLE
docs(review): write down how to invoke pr-review-toolkit and read what it returns (refs #1245)

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -68,7 +68,10 @@ is the *procedure* — follow it top to bottom.
    - Worker (`worker/`): `npx wrangler deploy --config worker/wrangler.toml --dry-run` + `npm run test:worker`.
    - New worker logic → extract to an exported fn + unit-test it. New `src/utils/` → Vitest test.
    - **Every bug fix ships a test that would have caught the bug.**
-5. **PR review** — gate #2: `/pr-review-toolkit:review-pr`.
+5. **PR review** — gate #2: `/pr-review-toolkit:review-pr`. **How to invoke it and how to read what it
+   returns** — which agent by domain, why only `code-reviewer` carries a severity floor, and why the
+   suggested rewrites in a report are not to be adopted — is
+   [docs/reference/code-review-policy.md](../../../docs/reference/code-review-policy.md) (#1245).
    - **Carry the round number, the RUNNING Critical total, and the prior round's findings into the next
      review prompt (#1097/#1124).** The review agents are spawned fresh each round and cannot see how many
      rounds have run or what the last one found — *you* are the only place that history lives, so state it:

--- a/docs/reference/code-review-policy.md
+++ b/docs/reference/code-review-policy.md
@@ -1,0 +1,106 @@
+---
+type: reference
+title: "Code-review policy (#1245) — how to invoke pr-review-toolkit and read what it returns"
+description: "Which review agent to spawn, how to re-judge its severity labels, and what to take from a report and what to discard."
+tags: [workflow, review, tooling]
+---
+
+# Code-review policy (#1245)
+
+`ship-issue` steps 5-6 say *when* to review and when to stop looping. This page is the other half —
+**how to invoke `/pr-review-toolkit:review-pr` and how to read what comes back**. It existed nowhere
+until #1245; the three interventions on the review loop before it (#1097 → #1124 → #1150) all targeted
+the stop condition, and none targeted the call.
+
+The plugin is not ours to edit — it is installed from the official marketplace under
+`~/.claude/plugins/` — so this page is the local discipline around it.
+
+## What the plugin actually is
+
+`review-pr` is a **command** that selects among **six agents** by what the diff touches. The agents,
+and the two facts about them that matter most here:
+
+| Agent | Domain | Notes |
+|---|---|---|
+| `code-reviewer` | CLAUDE.md compliance + real bugs | **the only agent with a reporting floor** |
+| `comment-analyzer` | **code comments**, cross-referenced against the code they describe | advisory-only by its own spec |
+| `pr-test-analyzer` | behavioural coverage | |
+| `silent-failure-hunter` | catch blocks, fallbacks, swallowed errors | operates on "non-negotiable rules"; no floor |
+| `type-design-analyzer` | type invariants | |
+| `code-simplifier` | post-review cleanup | the one agent that **acts on** code rather than reporting |
+
+## Pick by domain, not by how important the change feels
+
+A standalone markdown page is **not** `comment-analyzer`'s domain. Its first task is *"Cross-reference
+every claim in the comment against the actual code implementation"* — with no implementation to
+cross-reference it has no anchor, which is what it was given on #1244.
+
+For a docs-only diff, `code-reviewer` is the better match, with one thing said plainly: its file scopes
+it to *"review code against project guidelines in CLAUDE.md"*, so CLAUDE.md compliance is in scope
+and the factual accuracy of prose is a judgement you are asking it to make outside its spec. Name the
+diff and what you want checked in the prompt rather than relying on the agent's defaults.
+
+**Say which aspect you want.** A bare `/pr-review-toolkit:review-pr` lets the command route by file
+type, and its own step 4 sends `comment-analyzer` when docs changed — the shape above. The command
+takes aspect arguments (`code`, `tests`, `errors`, `types`, `comments`, `simplify`), so
+`/pr-review-toolkit:review-pr code` is what selects `code-reviewer` alone.
+
+## Re-judge severity; do not take the labels at face value
+
+Only `code-reviewer` states a bar:
+
+> Rate each issue from 0-100 … **91-100**: Critical bug or explicit CLAUDE.md violation …
+> **Only report issues with confidence ≥ 80**
+
+The other five have no floor. Their `CRITICAL` is not that scale, and on a diff outside an agent's
+domain it is not anchored to anything. Before treating a finding as blocking, ask the `code-reviewer`
+question of it: *is this a bug, or an explicit CLAUDE.md violation?* If neither, it is a Suggestion
+however it was labelled.
+
+## Take the finding, not the remedy
+
+`comment-analyzer`'s fifth task is *"**Suggest Improvements**: … Rewrite suggestions for unclear or
+inaccurate portions"* — handing back replacement prose is its spec, not a malfunction. That prose is
+unverified by anyone. Adopting it inserts a new claim into the artifact, which the next round then
+flags; on #1244 that path produced one of round 2's Criticals.
+
+Take the **finding** ("this claim outruns its evidence") and discard the **remedy** ("write this
+instead"). Where the finding names a deletion, apply the deletion.
+
+## Verify a finding before acting on it
+
+Every Critical is a claim about the record, and the record is one command away — `gh pr view`,
+`gh issue view`, `git log`, `grep`. It matters most where a finding would make you *delete* something:
+#1245 Part 1's round 1 claimed the whole feature was inert in production, and confirming that against
+the real audit log is what made the fix the right one rather than a rewrite of working code.
+
+## Do not edit a file while an agent is reading it
+
+Both directions are recorded in the memory page `debugging_review_agent_clobbers_concurrent_edits`: an
+agent's write clobbered concurrent edits (#1032), and a live mutation battery run during a review came
+close to being reported as a Critical in the diff (#1224 — the agent was reading its own rsync
+snapshot, so its conclusion held, and it flagged the anomaly with a timestamp). Run mutation batteries
+on a copy, and when several agents are in flight, collect all reports before applying anything.
+
+## Agent count is not the lever on loop depth
+
+A second agent in the same domain adds report volume — on #1244 two agents on a docs diff returned
+**opposing** recommendations rather than coverage. But it does not follow that fewer agents means
+fewer rounds: #1245 Parts 1 and 2 each ran exactly one agent per round and still took five and four
+rounds. Pick one agent per domain because a second adds nothing there, not because it will shorten the
+loop.
+
+## No lint checks whether a claim is true
+
+`scripts/check-doc-symbols.mjs` (#1100) reads `CLAUDE.md` and `docs/reference/*.md` for citations, and
+it checks one thing: that a backticked identifier exists somewhere in source. **A false claim in prose
+is not an identifier**, so no lint sees it — in a doc or in a comment. #1245 Part 1 wrote a code comment
+citing "CLAUDE.md's no-silent-caps rule", which does not exist; `npm run lint:docs` was green
+throughout, and the review loop is what caught it, before merge. Claims of this kind carry no
+automated check at all — they are review's job, and this page's job to say so.
+
+## Related
+
+- CLAUDE.md "Development Workflow" — the step outline; `ship-issue` is the runbook.
+- [Workflow-gate hooks](workflow-hooks.md) — `review-loop-gate.mjs` records what each loop did, per
+  branch since #1245 Part 1, and why the loop is not hook-enforced.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -29,6 +29,7 @@ Read this index first, then load only the pages you need.
 - [GA4 CLI access (#998)](ga4-cli-access.md) — querying GA4 reports from the command line via a service account + the Data API, what's provisioned, what's UI-only.
 - [Content-Security-Policy (CSP) — #482](reference-csp.md) — per-surface enforcement (nonce vs content-hash) + SPA policy.
 - [Workflow-gate hooks (#415/#657)](workflow-hooks.md) — the seven workflow hooks, hard vs soft, the audit log + how to tune the step-3.5 hard gate.
+- [Code-review policy (#1245)](code-review-policy.md) — which review agent to spawn, how to re-judge its severity labels, and what to take from a report.
 - [Reference Tooling](reference-tooling.md) — chub vs modern-web-guidance trigger map + the PreToolUse backstop.
 - [Tier-A `verify-after` assertions (#873)](verify-assertions.md) — machine-checkable assert-clause grammar.
 - [Directory map](directory-map.md) — every module's purpose + the #-issue history behind it (CLAUDE.md keeps only the map).


### PR DESCRIPTION
Part 3 of #1245 — the last of the three. A new `docs/reference/code-review-policy.md`, one index line, and a pointer on `ship-issue` step 5.

## Why

Steps 5-6 of `ship-issue` say **when** to review and when to stop looping. Nothing anywhere said **how to invoke** the tool or **how to read what comes back**. That gap is the reason the three interventions before #1245 — #1097 → #1124 → #1150 — all targeted the stop condition and none targeted the call. The plugin itself is installed from the official marketplace under `~/.claude/plugins/` and is not ours to edit, so this page is the local discipline around it.

## What it carries

Each item is sourced from the plugin's own files, not from experience:

- **Pick by domain, and say which aspect.** A bare `/pr-review-toolkit:review-pr` routes by file type, and its step 4 sends `comment-analyzer` at a docs diff — the agent whose first task is *"Cross-reference every claim in the comment against the actual code implementation"*, which a standalone page gives no anchor for. `/pr-review-toolkit:review-pr code` selects `code-reviewer` alone.
- **Re-judge severity.** Only `code-reviewer` carries a reporting floor (`Only report issues with confidence ≥ 80`) and a defined band (`91-100 = Critical bug or explicit CLAUDE.md violation`). The other five have none, so their `CRITICAL` is not that scale.
- **Take the finding, not the remedy.** Returning rewrite prose is `comment-analyzer`'s spec, and that prose is unverified by anyone.
- **Verify a finding before acting on it**, especially where it would make you delete something.
- **Do not edit a file while an agent is reading it** — both directions are recorded in memory.
- **No lint checks whether a claim is TRUE.** `check-doc-symbols.mjs` (#1100) checks that a backticked identifier exists; a false claim in prose is not an identifier, so nothing sees it — in a doc or in a comment.

## Re-grounded, not copied from the checklist

- **"One agent per domain" is kept, but its promise is cut.** Two agents on a docs diff did return opposing recommendations. But Parts 1 and 2 each ran *exactly one agent per round* and still took five and four rounds — verified from the telemetry, not the PR bodies — so agent count is not the lever on loop depth, and the page says so rather than implying a benefit it cannot deliver.
- **#1245's own `check-doc-symbols` scope claim is wrong.** `SOURCE_DIRS` includes `scripts` and `.claude/*`; what is limited to `CLAUDE.md` + `docs/reference/*.md` is the *citing* side. The page states the mechanism instead of the scope, which is also the stronger claim: a false prose claim is invisible to that guard even in an in-scope file.

## Review

Four rounds, 2 Critical / 11 Important, ending **0/0** — and the last round was asked for that observation explicitly, because "the reviewer thinks it is converged" is a forecast and this loop's record argued for checking.

Round 1's two Criticals both **inverted the record**: I wrote that a fabricated citation had *shipped* (`git log --all -S "no-silent-caps"` finds no commit — it was caught before merge, which is the opposite of the section's point), and I had the `check-doc-symbols` scope backwards. Rounds 2 and 3 were transcription fidelity — a quote that transposed its source, editorial bold the sources do not carry, a round number no record pins — all resolved by deletion.

Two below-bar items were **dropped rather than reworded**. Neither arrived with a reproduction, a failing check, or a mutation that goes red, which is exactly the disposition step 6 prescribes as of #1247 — this PR applying the rule its own sibling shipped.

`npm run lint:okf` 22 pages / 0 findings · `npm run lint:docs` 23 docs clean · `npm run test:scripts` 538/538 · CLAUDE.md untouched.

## At merge

The Part 3 checklist in #1245 does not match what shipped (the scope claim above is wrong in the issue, "one agent per domain" was re-grounded, and two items are new). Sync the body rather than ticking it, per `feedback_sync_issue_body_at_merge` — the same handling Part 2 got.

`refs #1245`, not `closes` — the 2026-09-19 measurement is what closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
