### PR TITLE
fix(tooling): a verify-after's own sub-lines were unreachable once its note wrapped (refs #1206)

### DIFF
--- a/docs/reference/verify-assertions.md
+++ b/docs/reference/verify-assertions.md
@@ -28,9 +28,16 @@ integration is in `scripts/verify-reminders.mjs`. Both are unit-tested by
 
 ## Grammar
 
-Indented sub-lines **directly under** a `verify-after` checkbox — `assert:` (machine-decidable) and
-`durable:` (#1206, human-decidable). Either order, and a line may carry both; the sub-block ends at the
-first non-blank line that is neither.
+Indented sub-lines under a `verify-after` checkbox — `assert:` (machine-decidable) and `durable:`
+(#1206, human-decidable). Either order, and a line may carry both.
+
+The sub-block is the checkbox's **own list item**: every line indented past the `- [ ]` marker, up to the
+next CHECKBOX or the next line at or below that indent (a plain nested bullet does not end it). So the note may wrap across several lines and the
+sub-lines still attach. It used to end at the first non-blank line that was neither marker, which meant a
+two-line note pushed a correctly-written `durable:` out of reach — the line was right and the machine
+reported "no durable trace", so the issue was labelled `verify-undecidable` for naming an artifact eight
+lines down. Two open issues were in that state when it was found (#1245, #1224). Fenced code inside the
+item is skipped, so an `assert:` shown as an EXAMPLE is not read as a live one.
 
 ```
 - [ ] verify-after 2026-07-09 — turbopuffer probe warmed
@@ -323,6 +330,13 @@ changed.
   (per-occurrence), `liveVerifyOccurrences` (the shared per-line scanner every consumer is built on — both
   parsers, `countOpenVerifyAfter`, the body-drift guard's exclusion, and the dangerous-shape twin
   `findBacktickQuotedVerifyBoxes`).
+
+- **Unparseable-`assert:` warning (#1206 follow-up)** — the only way a line can go dark that leaves no trace
+  at all. A clause that does not parse is simply not attached, so the auto-verify the author believed
+  they wrote never runs; and once a `durable:` sits beside it the item reads as decidable, so not even
+  `verify-undecidable` fires. `findMalformedAssertLines` reports it in the warn-only silent-drop loop
+  beside its siblings. It shares `itemSubLines` with `pairVerifyAssertions` — the boundary is one function, so
+  the two cannot drift and the boundary tests cover both. Warn-only: it never changes what is attached.
 
 Follow-ups tracked in #873: `ship-issue`/`issue-triage`/`adding-a-service` convention notes (done),
 an optional HTML/text-body assertion mode, and a Tier-B weekly "suggest-don't-auto-close" digest for

--- a/scripts/verify-assertions.mjs
+++ b/scripts/verify-assertions.mjs
@@ -311,17 +311,27 @@ export function findBacktickQuotedVerifyBoxes(body) {
  * verify-after lines are skipped — see isSuppressedReminderLine. This is the scanner `main()`
  * actually drives (#541 reminders + #873 auto-verify); `parseVerifyAfter` is the exported twin.
  *
- * The sub-block is the run of consecutive non-blank `assert:` / `durable:` lines under the
- * verify-after, in EITHER order; the first non-blank line that is neither ends it. Order-independence
- * is load-bearing, not a nicety (#1206): the original scan stopped at the first non-blank line, so a
- * `durable:` written above an `assert:` would have silently disabled that issue's auto-verify — the
- * job would fall back to pinging forever and nothing would say why.
+ * The sub-block is the verify-after's own list item: every line indented past the `- [ ]` marker, up to
+ * the next CHECKBOX or the next line at or below the marker's indent. A plain nested bullet does not end
+ * it; an ordered box (`1. [ ]`) is outside this grammar, as it is for `OPEN_BOX_RE` and `tickBox`. `assert:` / `durable:` are collected
+ * anywhere inside it, in either order.
  *
- * First of each marker wins, and a REPEAT does not end the block — a second `durable:` must not strand
- * an `assert:` below it, which is the same silent-auto-verify-loss the ordering fix exists to prevent.
- * A malformed `assert:` is not a marker (it parses to null) and so does end the block, deliberately:
- * that is the pre-existing behaviour, and treating a broken clause as a sub-line would let it swallow
- * the real content underneath.
+ * It used to be the run of consecutive `assert:`/`durable:` lines, ending at the first non-blank line
+ * that was neither — which meant a verify-after whose NOTE wrapped to a second line pushed its own
+ * sub-lines out of reach. The line was written correctly and the machine could not see it, so the issue
+ * was labelled `verify-undecidable` for having no durable trace while naming one eight lines down. Two
+ * open issues were in that state when this was found (#1245, #1224), and the failure is silent in the
+ * worst direction: the label says "you did not write one", never "I could not reach it".
+ * Order-independence within the block is load-bearing for the same reason (#1206) — a `durable:` above
+ * an `assert:` must not disable auto-verify.
+ *
+ * First of each marker wins, and a REPEAT does not end the block. A malformed `assert:` is simply not a
+ * marker (it parses to null); it no longer ends the block either, because ending on it is what the item
+ * boundary is for.
+ *
+ * Fenced code inside the item is skipped, so an `assert:` quoted as an EXAMPLE — which the docs page and
+ * several issue bodies do — is not mistaken for a live one. That was not reachable before, since a fence
+ * line ended the scan.
  */
 export function pairVerifyAssertions(body) {
   const out = []
@@ -338,15 +348,71 @@ export function pairVerifyAssertions(body) {
     const note = line.slice(v.index + v[0].length).replace(/^[\s—–:*_)·-]+/, '').replace(/\*+$/, '').trim()
     let assertion = null
     let durable = null
-    for (let j = i + 1; j < lines.length; j++) {
-      if (lines[j].trim() === '') continue
-      const a = parseAssertionLine(lines[j])
+    for (const [, raw] of itemSubLines(lines, i)) {
+      const a = parseAssertionLine(raw)
       if (a) { assertion ??= a; continue }
-      const d = parseDurableLine(lines[j])
+      const d = parseDurableLine(raw)
       if (d) { durable ??= d; continue }
-      break
     }
     out.push({ date: v[1], note, lineIndex: i, assertion, durable })
+  }
+  return out
+}
+
+/**
+ * The sub-lines of ONE verify-after item: every line indented past its `- [ ]` marker, up to the next
+ * checkbox or the next line at or below that indent. Blank lines pass through; fenced code is skipped.
+ *
+ * Extracted because there are two callers (#1206 follow-up). They were byte-identical copies for about
+ * an hour, and only one of them had the four boundary tests — so all three of the detector's boundary
+ * conditions could be deleted with CI green. `feedback_shared_primitive_over_parallel_copies`: the
+ * second copy is the extraction point, and the asymmetry in coverage is what makes it a drift risk
+ * rather than harmless duplication.
+ *
+ * The checkbox test is `\[[ xX]\]`, not a bare `\[`: a markdown LINK bullet (`- [label](url)`) is a
+ * plain nested bullet, and both the docstring below and the reference page say a plain nested bullet
+ * does not end the item. `tickBox` can only act on `[ ]` anyway.
+ */
+function* itemSubLines(lines, markerIndex) {
+  const markerIndent = (/^\s*/.exec(lines[markerIndex]) ?? [''])[0].length
+  let inFence = false
+  for (let j = markerIndex + 1; j < lines.length; j++) {
+    const raw = lines[j]
+    if (raw.trim() === '') continue
+    const indent = (/^\s*/.exec(raw) ?? [''])[0].length
+    if (indent <= markerIndent || /^\s*[-*+]\s+\[[ xX]\]/.test(raw)) return
+    if (/^\s*(```|~~~)/.test(raw)) { inFence = !inFence; continue }
+    if (inFence) continue
+    yield [j, raw]
+  }
+}
+
+/**
+ * #1206 follow-up — lines inside a verify-after item that LOOK like `assert:` but do not parse.
+ *
+ * The only way a line can go dark that leaves no trace at all. A malformed clause used to
+ * end the sub-block, which also swallowed any `durable:` below it — so both came back null and the
+ * `verify-undecidable` label fired. Misleading message, but a non-zero signal on the board. Now the
+ * `durable:` survives, the item reads as decidable, and the auto-verify the author believed they wrote
+ * simply never runs, with nothing anywhere saying why.
+ *
+ * Warn-only, like the other silent-drop guards it sits beside in `verify-reminders.mjs`: this reports,
+ * it does not change what `pairVerifyAssertions` attaches.
+ *
+ * Returns [{ lineIndex, text }] — deliberately not the reason it failed to parse. `parseAssertionLine`
+ * returns a bare null for a bad source, a bad clause, a bad operator and a bad selector alike, so
+ * naming one would be a guess; the line itself is what the author has to look at.
+ */
+export function findMalformedAssertLines(body) {
+  const out = []
+  if (!body) return out
+  const lines = body.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    if (isSuppressedReminderLine(lines[i])) continue
+    if (!liveVerifyOccurrences(lines[i])[0]) continue
+    for (const [j, raw] of itemSubLines(lines, i)) {
+      if (/^\s*assert:/i.test(raw) && !parseAssertionLine(raw)) out.push({ lineIndex: j, text: raw.trim() })
+    }
   }
   return out
 }

--- a/scripts/verify-assertions.test.mjs
+++ b/scripts/verify-assertions.test.mjs
@@ -3,7 +3,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   parseAssertionLine, parseLiteral, parseSelector, evalSelector, compare,
-  evaluateAssertion, isAllowedUrl, resolveSource, pairVerifyAssertions, tickBox, runAssertion,
+  evaluateAssertion, isAllowedUrl, resolveSource, pairVerifyAssertions, tickBox, runAssertion, findMalformedAssertLines,
   truncate, countOpenBoxes, countOpenVerifyAfter, planIssueAutoVerify, DEFAULT_ASSERT_BASE,
   isSuppressedReminderLine, findQuotedVerifyAfterBoxes, findBacktickQuotedVerifyBoxes, isBacktickQuotedOccurrence,
   liveVerifyOccurrences,
@@ -142,6 +142,144 @@ test('pairVerifyAssertions — pairs verify-after with following assert, skips c
   assert.equal(items[0].lineIndex, 0)
   assert.equal(items[1].date, '2026-08-05')
   assert.equal(items[1].assertion, null) // no following assert line
+})
+
+// #1206 follow-up — the sub-block is the verify-after's LIST ITEM, not the run of lines immediately
+// under it. The old scan broke at the first line that was neither `assert:` nor `durable:`, so a note
+// that wrapped to a second line pushed its own sub-lines out of reach. Two open issues were in that
+// state (#1245, #1224): the line was written correctly and the machine reported "no durable trace".
+// The failure direction is what makes it worth pinning — the label says "you did not write one", never
+// "I could not reach it".
+test('pairVerifyAssertions — a wrapped NOTE does not strand the sub-lines (#1206)', () => {
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — read the telemetry and compare against the baseline.',
+    '      **The baseline is the PRE-#1246 log: 4 sessions at maxRound >= 7.** Compare shapes,',
+    '      not like for like: how many BRANCHES reach maxRound >= 7, out of how many.',
+    '      durable: `.claude/hook-audit.jsonl` (local-only, append-only, no rotation)',
+  ].join('\n')
+  const items = pairVerifyAssertions(body)
+  assert.equal(items.length, 1)
+  assert.ok(items[0].durable, 'the durable line is eight lines from the box, still inside the item')
+  assert.match(items[0].durable, /hook-audit\.jsonl/)
+})
+
+test('pairVerifyAssertions — a wrapped note does not strand an assert: either (#1206)', () => {
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — confirm the field ships on the public contract.',
+    '      Context that wraps across a line, because that is how these get written.',
+    '      assert: GET /api/v1/status | services[id=characterai].incidentSourceStale == true',
+  ].join('\n')
+  const [item] = pairVerifyAssertions(body)
+  assert.ok(item.assertion, 'assert: must survive a wrapped note')
+  assert.equal(item.assertion.selector, 'services[id=characterai].incidentSourceStale')
+})
+
+test('pairVerifyAssertions — the NEXT item does not inherit this one\'s sub-lines (#1206)', () => {
+  // The boundary the item-scan has to respect: widening the scan must not let one box\'s durable
+  // satisfy the box below it, which would hide exactly the undecidable lines #1206 exists to catch.
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — first, with a wrapped note.',
+    '      more note text here.',
+    '      durable: artifact-A (90d)',
+    '- [ ] **verify-after 2026-09-20** — second, with nothing of its own.',
+  ].join('\n')
+  const items = pairVerifyAssertions(body)
+  assert.equal(items.length, 2)
+  assert.equal(items[0].durable, 'artifact-A (90d)')
+  assert.equal(items[1].durable, null, 'the second box names no artifact and must stay undecidable')
+})
+
+test('pairVerifyAssertions — a NESTED checkbox keeps its assert to itself (#1206)', () => {
+  // The clause that stops the scan at the next checkbox had NO test: deleting it left the whole suite
+  // green while both boxes took the nested assertion. The failure direction is the worst one available
+  // here — `planIssueAutoVerify` ticks every passing item's lineIndex, so the OUTER box would be
+  // auto-ticked on evidence belonging to a different verification, and close fires if it was the last
+  // open box. The three sibling-box cases all sit at indent 0, where the indent break already fires, so
+  // they cover the other half twice and this half not at all. An assert:, not a durable:, because only
+  // the assertion reaches the auto-tick path.
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — OUTER box, note wraps here',
+    '      and continues onto a second line',
+    '  - [ ] **verify-after 2026-09-20** — NESTED box',
+    '        assert: GET /api/status | services[id=claude].status == "operational"',
+  ].join('\n')
+  const items = pairVerifyAssertions(body)
+  assert.equal(items.length, 2)
+  assert.equal(items[0].assertion, null, 'the outer box must not inherit the nested assertion')
+  assert.ok(items[1].assertion, 'the nested box keeps its own')
+  assert.equal(items[1].assertion.selector, 'services[id=claude].status')
+})
+
+test('pairVerifyAssertions — a markdown LINK bullet is a plain bullet, not a checkbox (#1206)', () => {
+  // The break regex was a bare `\\[`, so `- [label](url)` ended the item and took the durable: with it —
+  // which contradicted both the docstring and the reference page, each of which say a plain nested
+  // bullet does not end it. `tickBox` can only act on `[ ]`, so `\\[[ xX]\\]` is the honest test.
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — note',
+    '  - [the dashboard](https://example.com) is where to look',
+    '      durable: artifact-A',
+  ].join('\n')
+  const [item] = pairVerifyAssertions(body)
+  assert.equal(item.durable, 'artifact-A', 'a link bullet must not end the item')
+})
+
+test('findMalformedAssertLines — an assert: that does not parse is reported, not swallowed (#1206)', () => {
+  // The silent path this fix would otherwise have created: the durable: now survives a broken clause,
+  // so the item reads as decidable, no `verify-undecidable` fires, and the auto-verify the author
+  // believed they wrote never runs. Warn-only — it must not change what pairVerifyAssertions attaches.
+  const body = [
+    '- [ ] **verify-after 2026-12-01** — a future check whose clause has a typo',
+    '      assert: GET /api/status | services[id=claude].status = "operational"',
+    '      durable: archive:monthly:2026-11 (no TTL)',
+  ].join('\n')
+  const bad = findMalformedAssertLines(body)
+  assert.equal(bad.length, 1)
+  assert.equal(bad[0].lineIndex, 1)
+  assert.match(bad[0].text, /^assert:/)
+  const [item] = pairVerifyAssertions(body)
+  assert.equal(item.assertion, null, 'still not an assertion')
+  assert.equal(item.durable, 'archive:monthly:2026-11 (no TTL)', 'and the durable is still honoured')
+})
+
+test('findMalformedAssertLines — a well-formed clause, and an EXAMPLE in a fence, are not reported', () => {
+  const good = [
+    '- [ ] **verify-after 2026-12-01** — fine',
+    '      assert: GET /api/status | services[id=claude].status == "operational"',
+  ].join('\n')
+  assert.deepEqual(findMalformedAssertLines(good), [])
+  const fenced = [
+    '- [ ] **verify-after 2026-12-01** — shows the grammar',
+    '      ```',
+    '      assert: nonsense with no pipe',
+    '      ```',
+  ].join('\n')
+  assert.deepEqual(findMalformedAssertLines(fenced), [], 'an example is not a live clause')
+})
+
+test('pairVerifyAssertions — an unindented line ends the item (#1206)', () => {
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — a box whose item ends at the heading below.',
+    '',
+    '## Some heading',
+    'durable: not-mine',
+  ].join('\n')
+  const [item] = pairVerifyAssertions(body)
+  assert.equal(item.durable, null, 'a top-level line is outside the item')
+})
+
+test('pairVerifyAssertions — a FENCED example assert: is not taken as live (#1206)', () => {
+  // Newly reachable: before the item-scan, a fence line ended the block, so a quoted example could
+  // never be read. The docs page and several issue bodies show the grammar this way.
+  const body = [
+    '- [ ] **verify-after 2026-09-19** — shows the grammar, then names its real artifact.',
+    '      ```',
+    '      assert: GET /api/status | services[id=x].y == "z"',
+    '      ```',
+    '      durable: artifact-B',
+  ].join('\n')
+  const [item] = pairVerifyAssertions(body)
+  assert.equal(item.assertion, null, 'an example inside a fence is not an assertion')
+  assert.equal(item.durable, 'artifact-B')
 })
 
 // #966 — pairVerifyAssertions is the scanner main() actually drives (parseVerifyAfter is its twin),
@@ -443,15 +581,19 @@ test('pairVerifyAssertions — durable: above assert: must not hide the assert (
   assert.equal(dup.durable, 'archive:monthly:2026-08 (no TTL)', 'first of each marker wins')
 })
 
-test('pairVerifyAssertions — the sub-block ends at the first line that is neither marker', () => {
+test('pairVerifyAssertions — the sub-block ends at the ITEM boundary, not at the first non-marker', () => {
   const VA = '- [ ] **verify-after 2026-09-01** — check it'
   const A = '      assert: GET /api/status | services[id=claude].status == "operational"'
+  // Unindented prose is OUTSIDE the item, so an assert: beyond it still is not this line's.
   const [it] = pairVerifyAssertions(`${VA}\nplain prose\n${A}`)
-  assert.equal(it.assertion, null, "an assert: below unrelated prose is not this line's")
+  assert.equal(it.assertion, null, "an assert: below unrelated top-level prose is not this line's")
   assert.equal(it.durable, null)
-  // A MALFORMED assert: is not a marker, so it ends the block (pre-existing behaviour, kept on
-  // purpose: a broken clause must not swallow the real content underneath it).
+  // #1206 follow-up — CHANGED deliberately. A malformed `assert:` used to END the block, which meant a
+  // typo in the clause silently discarded a perfectly good `durable:` under it: one author error
+  // compounded into a second, and the issue was then labelled `verify-undecidable` while naming its
+  // artifact two lines down. The malformed line is still not an assertion; it just no longer takes the
+  // rest of the item with it. The typo itself is surfaced by `findMalformedAssertLines`, tested above.
   const [bad] = pairVerifyAssertions(`${VA}\n      assert: nonsense with no pipe\n      durable: x`)
-  assert.equal(bad.assertion, null)
-  assert.equal(bad.durable, null)
+  assert.equal(bad.assertion, null, 'a broken clause is still not an assertion')
+  assert.equal(bad.durable, 'x', 'but it no longer strands the durable: below it')
 })

--- a/scripts/verify-reminders.mjs
+++ b/scripts/verify-reminders.mjs
@@ -14,7 +14,7 @@
 import { execFileSync } from 'node:child_process'
 // #873 — Tier-A auto-verify: evaluate a machine-checkable `assert:` clause on a verify-after line and
 // close the loop (tick + comment + drop verify-blocked) instead of only pinging. See verify-assertions.mjs.
-import { pairVerifyAssertions, runAssertion, planIssueAutoVerify, truncate, isSuppressedReminderLine, findQuotedVerifyAfterBoxes, findBacktickQuotedVerifyBoxes, liveVerifyOccurrences } from './verify-assertions.mjs'
+import { pairVerifyAssertions, runAssertion, planIssueAutoVerify, truncate, isSuppressedReminderLine, findQuotedVerifyAfterBoxes, findBacktickQuotedVerifyBoxes, liveVerifyOccurrences, findMalformedAssertLines } from './verify-assertions.mjs'
 
 // Which lines a verify-after scan must SKIP (checked box `- [x]` / blockquote `>`) lives in
 // verify-assertions.mjs as `isSuppressedReminderLine` — one definition shared by both scanners (#966).
@@ -617,7 +617,7 @@ async function main() {
   }
 
   // ── Silent-drop guards (#966) ─────────────────────────────────────────────────
-  // This system exists so a verification is never forgotten, so both ways a line can go dark must be
+  // This system exists so a verification is never forgotten, so every way a line can go dark must be
   // observable. Warn-only (never mutating, never fatal) — a run that drops a real reminder must not
   // look identical to a run with nothing to do.
   for (const iss of considered) {
@@ -629,6 +629,12 @@ async function main() {
     }
     for (const bad of findInvalidVerifyAfterDates(iss.body)) {
       console.warn(`[verify-reminders] ${displayRef(iss.repo, iss.number)}: verify-after date '${bad.date}' (line ${bad.lineIndex + 1}) is not a valid calendar date — it will never ping. Fix the date.`)
+    }
+    // The only FULLY silent one (#1206 follow-up): an `assert:` that does not parse
+    // is simply not attached, so the auto-verify never runs and the line degrades to a human ping with
+    // nothing saying why. It does not even reach `verify-undecidable` when a `durable:` sits beside it.
+    for (const bad of findMalformedAssertLines(iss.body)) {
+      console.warn(`[verify-reminders] ${displayRef(iss.repo, iss.number)}: an assert: clause on line ${bad.lineIndex + 1} does not parse — it will NEVER auto-verify, silently. Check the source/selector/operator: ${truncate(bad.text, 100)}`)
     }
   }
 


### PR DESCRIPTION
A `verify-after` line whose note wrapped to a second line could not reach its own `assert:` / `durable:` sub-lines.

## The failure

`pairVerifyAssertions`' scan broke at the first non-blank line that was neither marker. So this reads as having no durable trace:

```
- [ ] **verify-after 2026-09-19** — read the telemetry and compare against the baseline.
      **The baseline is the PRE-#1246 log: 4 sessions at maxRound >= 7.** Compare shapes,
      not like for like: how many BRANCHES reach maxRound >= 7, out of how many.
      durable: `.claude/hook-audit.jsonl` (local-only, append-only, no rotation)
```

`verify-undecidable` (#1206) then asserts the line "names no artifact that will exist on its date" — when the author named one four lines down and the machine could not reach it. **The label says "you did not write one", never "I could not read it."** That is the direction that makes it worth fixing: the author has no way to tell the difference, and the fix looks like it was already applied.

Measured with the real parser over the open board: **two issues were in that state — #1245 and #1224.** A third (#827) reports the same way and genuinely has no sub-line, so its label is correct.

## The fix

The sub-block is the checkbox's own **list item**: lines indented past the `- [ ]` marker, up to the next checkbox or the next line at or below that indent. Fenced code inside the item is skipped, so an `assert:` shown as an example is not read as live — newly reachable, since a fence line used to end the scan.

Two consequences, neither incidental:

- **A malformed `assert:` no longer ends the block.** It used to, which meant a typo in the clause also discarded a good `durable:` below it — one author error compounding into a second. But removing that also removed the only signal the state had: the item then reads as decidable, `verify-undecidable` does not fire, and the auto-verify the author believed they wrote silently never runs. So `findMalformedAssertLines` reports the unparseable clause in the warn-only silent-drop loop beside its siblings. It changes nothing about what gets attached.
- **The item boundary is one function.** `itemSubLines`, consumed by both callers. It was two byte-identical copies for about an hour, and only one had the boundary tests — all three of the detector's boundary conditions could be deleted with CI green. Extracted, so the existing tests cover both.

The checkbox test is `\[[ xX]\]` rather than a bare `\[`: a markdown link bullet (`- [label](url)`) is a plain nested bullet, which both the docstring and the reference page say does not end the item.

## Verification

- **504 issue bodies** across both repos, open and closed, HEAD vs this tree: exactly **two** outputs change, both the intended ones, and **no `assertion` field changes on any body** — the widening adds zero new auto-tick input, which is the direction that could have hurt.
- The new warning fires **zero** times on that corpus, including the ten closed issues that carry a real `assert:`.
- Mutation, on the shared boundary: drop the indent break → 2 red; drop the next-checkbox clause → 1 red; drop fence handling → 2 red; revert `\[[ xX]\]` → 1 red; stub the detector to `return []` → 1 red. Before the extraction, the detector's copy scored 0 on the first three.
- Real checkbox forms on the board: 886 `- [ ]`, 861 `- [x]`, zero ordered boxes, zero tab-indented. The old and new regexes differ on 4 lines out of 1751, and none of the 4 is a checkbox.
- `npm run test:scripts` 578 pass / 0 fail. `lint:docs`, `lint:okf` clean. CI-gated by the `Test` workflow.

Three review rounds, one agent each, scoped by domain: 0 Critical / 3 Important, all worked, round 3 clean. No UI or Edge surface is touched and no worker deploy is needed.

Once merged, the daily Action self-heals `verify-undecidable` off #1245 and #1224; #827 keeps it, correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
