### PR TITLE
fix: give the all-services feed the same three states a per-service feed gets (#1273)

### DIFF
--- a/worker/src/__tests__/api-traffic.test.ts
+++ b/worker/src/__tests__/api-traffic.test.ts
@@ -565,20 +565,20 @@ describe('subscriberFeeds (#1273)', () => {
       claude: { slack: 72 },
       __all__: { slack: 77 },
       mistral: { reader: 30 },
-    })).toEqual({ perService: ['claude', 'mistral'], allFeed: true, belowFloor: 0 })
+    })).toEqual({ perService: ['claude', 'mistral'], allFeed: 'subscribed', belowFloor: 0 })
   })
 
   it('EXCLUDES a crawler-only feed — the whole reason the map is nested', () => {
     // A crawler sweeping every feed would add ~46 keys to a FLAT byFeed and read as 46 new
     // subscribers. This is the assertion that fails if the nesting is ever flattened back.
     expect(subscriberFeeds({ claude: { slack: 72 }, huggingface: { bot: 400 }, mistral: { bot: 4 } }))
-      .toEqual({ perService: ['claude'], allFeed: false, belowFloor: 0 })
+      .toEqual({ perService: ['claude'], allFeed: 'none', belowFloor: 0 })
   })
 
   it('EXCLUDES browser and other — a one-off human hit and an unrecognised UA are not subscriptions', () => {
     // Documented bias: an unrecognised reader lands in `browser` (Mozilla envelope) or `other`, and
     // either way is undercounted. Accepted — admitting them would let any scraper count as a subscriber.
-    expect(subscriberFeeds({ a: { browser: 90 }, b: { other: 90 } })).toEqual({ perService: [], allFeed: false, belowFloor: 0 })
+    expect(subscriberFeeds({ a: { browser: 90 }, b: { other: 90 } })).toEqual({ perService: [], allFeed: 'none', belowFloor: 0 })
   })
 
   it('counts a feed polled by BOTH a subscriber and a crawler', () => {
@@ -607,9 +607,30 @@ describe('subscriberFeeds (#1273)', () => {
     expect(subscriberFeeds({ [FEED_UNKNOWN_TARGET]: { slack: 1 } }).belowFloor).toBe(0)
   })
 
+  it('gives the all-feed the same three states a per-service feed gets', () => {
+    // Observed on the first production window after the #1273 deploy: `__all__` carried one Slack
+    // poll and `subscriberFeeds` reported it identically to no traffic at all, because the value was
+    // a boolean and the `__all__` branch `continue`d above the `belowFloor` increment. Staying out of
+    // `belowFloor` is right — that integer is a per-service count — but it left no way to say
+    // "polled, suppressed" about the one subscription the operator actually holds.
+    const state = (n: number) => subscriberFeeds({ [FEED_ALL_TARGET]: { slack: n } }).allFeed
+    expect(state(0)).toBe('none')
+    expect(state(1)).toBe('below-floor')
+    // Literals, not `MIN_SUBSCRIBER_REQUESTS ± 1`, for the reason on the per-service floor test
+    // above. `state(3)` is what catches the floor moving UP; the `mixed` assertion below already
+    // caught it moving down.
+    expect(state(2)).toBe('below-floor')
+    expect(state(3)).toBe('subscribed')
+    // Non-subscriber traffic never moves it off `none`, in either direction.
+    expect(subscriberFeeds({ [FEED_ALL_TARGET]: { bot: 900, browser: 900 } }).allFeed).toBe('none')
+    // And it still stays out of both per-service tallies.
+    const mixed = subscriberFeeds({ [FEED_ALL_TARGET]: { slack: 2 }, claude: { slack: 5 } })
+    expect(mixed).toEqual({ perService: ['claude'], allFeed: 'below-floor', belowFloor: 0 })
+  })
+
   it('EXCLUDES the __unknown__ sentinel — a 404 URL is not a subscribable feed', () => {
     expect(subscriberFeeds({ [FEED_UNKNOWN_TARGET]: { slack: 90 }, claude: { slack: 72 } }))
-      .toEqual({ perService: ['claude'], allFeed: false, belowFloor: 0 })
+      .toEqual({ perService: ['claude'], allFeed: 'none', belowFloor: 0 })
   })
 
   it('orders by COUNT desc, not alphabetically — the cap names the top six, not the first six', () => {
@@ -619,7 +640,7 @@ describe('subscriberFeeds (#1273)', () => {
   })
 
   it('is empty for an empty map', () => {
-    expect(subscriberFeeds({})).toEqual({ perService: [], allFeed: false, belowFloor: 0 })
+    expect(subscriberFeeds({})).toEqual({ perService: [], allFeed: 'none', belowFloor: 0 })
   })
 })
 

--- a/worker/src/__tests__/daily-summary.test.ts
+++ b/worker/src/__tests__/daily-summary.test.ts
@@ -559,6 +559,33 @@ describe('formatFeedClientLine (#1273)', () => {
 })
 
 describe('formatSubscribedFeedsLine (#1273)', () => {
+  it('says the all-feed is suppressed rather than rendering it as absence', () => {
+    // `allFeed` was a boolean, so one poll and zero polls rendered identically — on the ONE feed the
+    // operator actually subscribes to. `#860` recorded Slack's poller backing off on exactly this
+    // feed, so a quiet window here is the expected state, not an exotic one.
+    expect(formatSubscribedFeedsLine({ __all__: { slack: 1 } }))
+      .toBe('\n   Feeds: 0 per-service subscribed (all-feed below subscriber floor)')
+    expect(formatSubscribedFeedsLine({ __all__: { slack: 9 } }))
+      .toBe('\n   Feeds: 0 per-service subscribed (all-feed active)')
+  })
+
+  it('keeps the all-feed term and the per-service tally readable side by side', () => {
+    // The live 2026-08-24 post-deploy window, verbatim: `__all__` and seven per-service feeds at one
+    // Slack poll each, all under the floor.
+    const live = {
+      __all__: { slack: 1, bot: 1 }, claude: { slack: 1, bot: 1 }, claudecode: { slack: 1 },
+      chatgpt: { slack: 1 }, openai: { slack: 1 }, codex: { slack: 1 }, gemini: { slack: 1 },
+      cursor: { slack: 1 },
+    }
+    expect(formatSubscribedFeedsLine(live))
+      .toBe('\n   Feeds: 0 per-service subscribed (all-feed below subscriber floor) · 7 per-service below floor')
+    // The shape any such window takes the moment a feed clears the floor — the event this
+    // instrumentation exists to detect. Both terms render here, and nothing rendered both before, so
+    // swapping their order stayed green.
+    expect(formatSubscribedFeedsLine({ __all__: { slack: 2 }, claude: { slack: 5 }, mistral: { slack: 2 } }))
+      .toBe('\n   Feeds: 1 per-service subscribed (claude) · all-feed below subscriber floor · 1 per-service below floor')
+  })
+
   // Direct tests: this function is exported but was reached only through formatFeedTrafficSection,
   // and every render fixture there had belowFloor === 0 — so six independent mutations of the
   // below-floor term passed the whole suite. The signal was computed right and rendered by
@@ -567,7 +594,7 @@ describe('formatSubscribedFeedsLine (#1273)', () => {
 
   it('names suppressed feeds so "0 per-service" cannot read as a quiet window', () => {
     expect(formatSubscribedFeedsLine({ claude: slack(2), chatgpt: slack(1) }))
-      .toBe('\n   Feeds: 0 per-service subscribed · 2 below floor')
+      .toBe('\n   Feeds: 0 per-service subscribed · 2 per-service below floor')
   })
 
   it('renders nothing at all when nothing QUALIFIED', () => {
@@ -577,17 +604,18 @@ describe('formatSubscribedFeedsLine (#1273)', () => {
 
   it('carries the note alongside a non-empty per-service list', () => {
     expect(formatSubscribedFeedsLine({ claude: slack(72), mistral: slack(2) }))
-      .toBe('\n   Feeds: 1 per-service subscribed (claude) · 1 below floor')
+      .toBe('\n   Feeds: 1 per-service subscribed (claude) · 1 per-service below floor')
   })
 
   it('never prints a zero note', () => {
     expect(formatSubscribedFeedsLine({ claude: slack(72) })).toBe('\n   Feeds: 1 per-service subscribed (claude)')
   })
 
-  it('keeps the all-feed OUT of both the count and the floor note', () => {
-    // The operator holds exactly one subscription and it is this one. Counting it below the floor
-    // re-merges the split the separation exists to keep.
-    expect(formatSubscribedFeedsLine({ __all__: slack(2) })).toBe('')
+  it('keeps the all-feed OUT of the per-service count and the floor INTEGER', () => {
+    // The operator holds exactly one subscription and it is this one. Counting it inside either
+    // number re-merges the split the separation exists to keep — but it still gets its own term.
+    expect(formatSubscribedFeedsLine({ __all__: slack(2), claude: slack(72) }))
+      .toBe('\n   Feeds: 1 per-service subscribed (claude) · all-feed below subscriber floor')
     expect(formatSubscribedFeedsLine({ __all__: slack(77), claude: slack(72) }))
       .toBe('\n   Feeds: 1 per-service subscribed (claude) · all-feed active')
   })

--- a/worker/src/api-traffic.ts
+++ b/worker/src/api-traffic.ts
@@ -408,6 +408,30 @@ export function rollupByClient(byFeed: FeedPollsByTarget): Record<string, number
   return Object.fromEntries(out)
 }
 
+/** Whether the all-services feed had subscriber-class traffic, and whether it cleared the floor.
+ *  Three states, matching what a per-service feed gets — `boolean` could not express "polled, but
+ *  under the floor", so that case rendered identically to no traffic at all. */
+export type AllFeedState = 'subscribed' | 'below-floor' | 'none'
+
+export interface SubscriberFeeds {
+  readonly perService: readonly string[]
+  readonly allFeed: AllFeedState
+  /** PER-SERVICE feeds only. The all-feed's own suppression is `allFeed`, deliberately not folded in
+   *  here: beside "N per-service subscribed" an incremented integer reads as another per-service
+   *  feed. */
+  readonly belowFloor: number
+}
+
+/**
+ * Where one feed's subscriber-class count sits relative to the floor. ONE spelling of the rule,
+ * which the two populations previously spelled separately, so changing the floor meant finding every
+ * site. They differ only in how they AGGREGATE this, which is the honest asymmetry: per-service feeds
+ * are attributable and get a list plus a count, the all-feed is not and gets a state. Pure.
+ */
+function floorState(n: number): AllFeedState {
+  return n >= MIN_SUBSCRIBER_REQUESTS ? 'subscribed' : n > 0 ? 'below-floor' : 'none'
+}
+
 /**
  * The feeds a SUBSCRIBER-class client polled, split into per-service feeds and the all-services feed.
  *
@@ -416,7 +440,7 @@ export function rollupByClient(byFeed: FeedPollsByTarget): Record<string, number
  * `MIN_SUBSCRIBER_REQUESTS` — neither sentinel enters it. The split
  * lives HERE rather than in the renderer so every consumer gets it: as of 2026-08-21 the operator
  * holds one subscription and it is the all-feed, so folding it into a per-service count publishes an
- * adoption figure that is +1 by construction. `allFeed` is a flag, not a count — `__all__` aggregates
+ * adoption figure that is +1 by construction. `allFeed` is a STATE, not a count — `__all__` aggregates
  * every /feed.xml poller and cannot be attributed to anyone.
  *
  * Limits, all pointing the same way:
@@ -425,29 +449,32 @@ export function rollupByClient(byFeed: FeedPollsByTarget): Record<string, number
  *     sit below the floor and stay invisible;
  *   - `other`/`browser` are excluded, and an unrecognised reader shipping a Mozilla envelope lands in
  *     `browser`, so it is excluded too;
- *   - the all-feed is a flag, and it carries no `belowFloor` note — an all-feed that polls 1-2 times
- *     in a window disappears from the report entirely rather than showing as suppressed.
+ *   - the all-feed is unattributable, so `below-floor` says only THAT it was suppressed, never by how
+ *     many clients.
  * Treat `perService.length` as a lower bound: it can show growth happened, never that it didn't.
  *
  * `__unknown__` is excluded — a URL we answered 404 to is not a subscribable feed.
  */
-export function subscriberFeeds(byFeed: FeedPollsByTarget): { perService: string[]; allFeed: boolean; belowFloor: number } {
+export function subscriberFeeds(byFeed: FeedPollsByTarget): SubscriberFeeds {
   const totals: Array<[string, number]> = []
-  let allFeed = false
+  let allFeed: AllFeedState = 'none'
   let belowFloor = 0
   for (const [feed, perClient] of Object.entries(byFeed)) {
     if (feed === FEED_UNKNOWN_TARGET) continue
     const n = SUBSCRIBER_CLIENTS.reduce((acc, cls) => acc + (perClient[cls] ?? 0), 0)
+    const state = floorState(n)
     if (feed === FEED_ALL_TARGET) {
-      // The operator's own: reported as a flag, never inside a per-service count and never inside
-      // `belowFloor` — folding it back in is the +1-by-construction this split exists to prevent.
-      if (n >= MIN_SUBSCRIBER_REQUESTS) allFeed = true
+      // Never inside the per-service count and never inside `belowFloor` — folding it back into
+      // either is the +1-by-construction this split exists to prevent. But it gets the SAME three
+      // states they do: excluding it from `belowFloor` on the attribution argument left it unable to
+      // say "suppressed", so the one subscription the operator actually holds rendered as absence.
+      allFeed = state
       continue
     }
     // Counted, not just skipped: a FIRST appearance is by construction low-volume, so the floor is
     // quietest exactly where the signal lives.
-    if (n > 0 && n < MIN_SUBSCRIBER_REQUESTS) belowFloor++
-    if (n < MIN_SUBSCRIBER_REQUESTS) continue
+    if (state === 'below-floor') belowFloor++
+    if (state !== 'subscribed') continue
     totals.push([feed, n])
   }
   // Count desc, then name asc — a stable order, so the rendered line changes only when the data does.

--- a/worker/src/daily-summary.ts
+++ b/worker/src/daily-summary.ts
@@ -12,7 +12,7 @@ import type { SourceHealthRead } from './reddit'
 import type { AiUsageCounters } from './ai-analysis'
 import { AUDIENCE_SOURCES, type AudienceCounts, type AudienceSource } from './outage-audience'
 import type { StatuslineTrafficCounts, StatuslineTrafficDelta, BadgeTrafficCounts, FeedTrafficCounts, FeedPollsByTarget } from './api-traffic'
-import { BADGE_UNKNOWN_SERVICE, FEED_UNKNOWN_TARGET, rollupByClient, subscriberFeeds } from './api-traffic'
+import { BADGE_UNKNOWN_SERVICE, FEED_UNKNOWN_TARGET, rollupByClient, subscriberFeeds, type AllFeedState } from './api-traffic'
 
 // #679 — the "detection lead" (faster-than-official) metric was removed (structurally null — status-page
 // polling is always later than the official publish; #464 already retired the framing). The RTT-degradation
@@ -515,6 +515,25 @@ export function formatFeedClientLine(byClient: Record<string, number>, total: nu
 const SUBSCRIBED_FEEDS_SHOWN = 6
 
 /**
+ * The phrase each all-feed state contributes to the `Feeds:` line; `''` contributes no term.
+ *
+ * A `Record` keyed by the union, not a ternary chain — the same shape `AUDIENCE_LABEL` above uses for
+ * its own union, and for the reason `api-traffic.ts`'s `FEED_CLIENT_IS_SUBSCRIBER` writes down in
+ * full. A fourth `AllFeedState` added to a chain falls through to `''` and its term goes silent,
+ * which is the regression `AllFeedState` was introduced to repair; as a `Record` it is a compile
+ * error instead. It also single-sources a phrase the two call sites below used to spell separately.
+ *
+ * `subscriber floor` says whose polls the floor counts: the headline two lines up reports the
+ * all-feed's traffic across EVERY client class, so without that word a crawler-heavy window reads as
+ * a large poll count sitting below a small floor.
+ */
+const ALL_FEED_LABEL: Record<AllFeedState, string> = {
+  subscribed: 'all-feed active',
+  'below-floor': 'all-feed below subscriber floor',
+  none: '',
+}
+
+/**
  * Render the feeds a SUBSCRIBER-class client polled (#1273):
  * `Feeds: 2 per-service subscribed (claude, chatgpt) · all-feed active`.
  *
@@ -524,14 +543,21 @@ const SUBSCRIBED_FEEDS_SHOWN = 6
  */
 export function formatSubscribedFeedsLine(byFeed: FeedPollsByTarget): string {
   const { perService, allFeed, belowFloor } = subscriberFeeds(byFeed)
-  const floorNote = belowFloor > 0 ? ` · ${belowFloor} below floor` : ''
-  if (perService.length === 0) return allFeed || belowFloor > 0 ? `\n   Feeds: 0 per-service subscribed${allFeed ? ' (all-feed active)' : ''}${floorNote}` : ''
+  // The integer names its POPULATION: `below-floor` gives the all-feed a term sharing these words for
+  // the first time, and unqualified the two read as one tally — which puts the all-feed back inside a
+  // per-service count, the +1-by-construction the split exists to prevent, from the other side.
+  const floorNote = belowFloor > 0 ? ` · ${belowFloor} per-service below floor` : ''
+  const label = ALL_FEED_LABEL[allFeed]
+  if (perService.length === 0) {
+    if (!label && !floorNote) return ''
+    return `\n   Feeds: 0 per-service subscribed${label ? ` (${label})` : ''}${floorNote}`
+  }
   // Count-desc order comes from `subscriberFeeds`; the cap means a newly-subscribed low-volume feed
   // is the first name truncated into `+N more`, while still being counted.
   const shown = perService.slice(0, SUBSCRIBED_FEEDS_SHOWN)
   const more = perService.length - shown.length
   return `\n   Feeds: ${perService.length} per-service subscribed (${shown.join(', ')}${more > 0 ? `, +${more} more` : ''})` +
-    (allFeed ? ' · all-feed active' : '') + floorNote
+    (label ? ` · ${label}` : '') + floorNote
 }
 
 /**


### PR DESCRIPTION
## The defect, found in production

#1273's instrumentation deployed **2026-08-24 12:16 UTC**. Querying the first window through the real production pipeline:

```
📡 Feed Polls (RSS/Slack)
   Last 24h: 590 polls (all-feed 79 · per-service ~511)
   Clients: slack 8 · bot 2 · 580 unclassified
   Feeds: 0 per-service subscribed · 7 below floor
```

`__all__` carried a Slack poll. The `Feeds:` line says nothing about it — not `active`, not `below floor`. Silence.

A per-service feed had **three** outcomes (listed / counted in `belowFloor` / absent). The all-feed had **two**, because `allFeed` was a `boolean` and its branch `continue`d above the `belowFloor++` line. **The operator's only real subscription is the all-feed**, so the single most consequential observation this instrumentation can make was the one it could not report.

## Why the asymmetry existed, and what was actually wrong

#1273's round 6 was **right** to keep `__all__` out of `belowFloor`: that integer is a per-service count, `__all__` aggregates every `/feed.xml` poller and is unattributable, and folding it in publishes an adoption figure that is `+1` by construction. That separation stays.

What was wrong is that excluding it from `belowFloor` also removed its only way to say *suppressed*. Round 5 added `belowFloor` (per-service: 2 states → 3); round 6 excluded `__all__` from it (all-feed: still 2). **The asymmetry was manufactured by that review, not inherited.**

## Changes

| | |
|---|---|
| `AllFeedState = 'subscribed' \| 'below-floor' \| 'none'` | Its own term. Still out of `perService` and out of the `belowFloor` integer. |
| `ALL_FEED_LABEL: Record<AllFeedState, string>` | Replaces two hand-written ternary chains. A fourth member added to a chain fell through to `''` and shipped as **silence** — the exact regression this PR repairs. As a `Record` it is `TS2741`. |
| `floorState(n)` | One spelling of the floor rule. The two populations share the predicate and differ only in aggregation — the honest asymmetry. |
| Copy | `· N per-service below floor` and `all-feed below subscriber floor`. Unqualified the two shared the words "below floor" and read as one tally, putting the all-feed back inside a per-service count from the other side. |

Rendered, on the live window:

```
Feeds: 0 per-service subscribed (all-feed below subscriber floor) · 7 per-service below floor
```

## A test was pinning the defect

```js
expect(formatSubscribedFeedsLine({ __all__: slack(2) })).toBe('')   // #1273
```

Green, and therefore invisible. Replaced by an assertion of what should render.

## Verification

Mutation batteries in parity-verified sandboxes (139 files / 4621 tests, matching the repo), each led by a CONTROL that must go red. All red, including the two a review proved were **green before**: swapping the two terms' order, and adding a fourth `AllFeedState` member (now a compile error).

Five review rounds, 0 Critical, 11 Important — all fixed. Rounds 2-5 each surfaced exactly one defect of a single shape: **a comment stating a number or a quotation about what the code does, written by reasoning instead of by running it** (a cross-file line subtraction; a mis-derived threshold; a spliced "render" that no line emits). From round 3 those were fixed by deletion rather than rewording, which is what ended the loop — measured comment delta vs `main`: **+4,518 → +3,683**.

`refs #1273` — the row-content check stays open (`verify-after 2026-08-28`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)