### PR TITLE
test(ci): pin the cron test's event clock so it stops failing for ten minutes a day

### DIFF
--- a/worker/src/__tests__/cache-reseed-wiring.test.ts
+++ b/worker/src/__tests__/cache-reseed-wiring.test.ts
@@ -82,7 +82,20 @@ describe('behavior — the real scheduled() handler re-seeds only on a genuine m
   afterEach(() => { vi.restoreAllMocks() })
 
   const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext
-  const event = { scheduledTime: Date.now(), cron: '*/5 * * * *' } as ScheduledEvent
+  // The EVENT time is pinned; the cache fixtures below are deliberately NOT. `scheduled()` derives its
+  // `scheduledNow` from `event.scheduledTime`, and the daily-summary block fires when that lands in
+  // `isInSummaryWindow` (09:00–09:05 and 10:00–10:05 UTC) — so with `Date.now()` these tests ran the
+  // whole summary path, including unmocked Analytics Engine reads, for ten minutes every day, failing
+  // as a 5s TIMEOUT rather than a legible assertion. Mid-month and off the hour, so no monthly or
+  // hourly cron branch is entangled either.
+  //
+  // The fixtures stay wall-clock-relative because `cronAlertCheck` calls `isCacheStale(raw, threshold)`
+  // with TWO arguments — its `now` defaults to `Date.now()` and the scheduled time never reaches it.
+  // Pinning `cachedAt` to this constant therefore does not make a snapshot look fresh; it makes it
+  // weeks stale, which silently moved the "fresh and unchanged" case onto the stale path and left the
+  // not-stale branch covered by nothing. Both fixtures are relative to the same clock `isCacheStale`
+  // reads, so they are deterministic without being pinned.
+  const event = { scheduledTime: Date.parse('2026-08-12T12:07:00.000Z'), cron: '*/5 * * * *' } as ScheduledEvent
 
   // All-operational, exactly the real roster — matching ids avoids the #221 service-count-drop alert,
   // and matching status against whatever's "cached" below avoids an incidental status-edge (#488)


### PR DESCRIPTION
## Problem

`worker/src/__tests__/cache-reseed-wiring.test.ts` drives the real `scheduled()` handler and passed `scheduledTime: Date.now()`.

`scheduled()` derives `scheduledNow` from `event.scheduledTime`, and the daily-summary block fires when that lands in `isInSummaryWindow` — **UTC 09:00–09:05 and 10:00–10:05**. Inside those windows the test ran the whole summary path, including unmocked Analytics Engine reads, and failed as a **5s timeout** rather than a legible assertion.

Intermittent and clock-shaped, so it reads as "my change broke this" — it cost a debugging detour in the session that found it.

**Reproduction** — the unchanged file, either side of the boundary:

| wall clock | result |
|---|---|
| 09:04 UTC | 3 failed (5s timeouts) |
| 09:05 UTC | 8 passed |

## Fix

Pins the **event time only**, mid-month and off the hour so no monthly or hourly cron branch is entangled.

The `cachedAt` fixtures deliberately stay wall-clock-relative. `cronAlertCheck` calls `isCacheStale(raw, threshold)` with **two** arguments, so its `now` defaults to `Date.now()` and the scheduled time never reaches it. Pinning `cachedAt` to the same constant makes the "fresh" snapshot weeks stale, which silently moves that test onto the stale path and leaves the not-stale branch covered by nothing — verified: 18.9 days old against a 10-minute threshold.

## Known limit

**This fix cannot pin itself.** Reverting it is green outside the two windows, because the defect is wall-clock-dependent by nature. The reproduction window is recorded in the test's comment instead of as an assertion.

## Scope

Test-only, one file. Split out of the #1293 branch deliberately — it is CI infrastructure, not measurement, and it unblocks any PR that runs during those windows.

A sibling bomb in `onlineornot.test.ts` (a fixture aged past a 90-day cutoff on 2026-08-30) was found in the same sweep but is **already fixed on main** by #1294 — no change needed here.

## Verification

- Full worker suite: **4939 passed**
- `npm run typecheck:worker`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU