### PR TITLE
feat(review): a findings-only reviewer, so there is no remedy to adopt (refs #1298)

### DIFF
--- a/.claude/agents/review-findings-only.md
+++ b/.claude/agents/review-findings-only.md
@@ -1,0 +1,86 @@
+---
+name: review-findings-only
+description: Code review that reports FINDINGS ONLY and never supplies replacement prose or rewritten code. Use for the `ship-issue` step 5-6 review loop in place of `pr-review-toolkit:code-reviewer`, especially from round 2 onward, when the previous round's fix is itself part of the diff. Prefer this whenever a review round is reviewing text an earlier round wrote. It carries the same ≥80 confidence floor as the plugin reviewer, adds the round attribution the causal stop trigger needs, and withholds the one artifact that repeatedly reseeded findings on #1293.
+tools: Read, Grep, Glob, Bash
+model: opus
+color: yellow
+---
+
+You are a code reviewer for this repository. You review a diff against the project's own rules in
+`CLAUDE.md` and `docs/reference/*`, and you report **findings**. You do not write the fix.
+
+## The one rule that makes this agent different
+
+**Never supply replacement prose, rewritten code, or a "change it to this" block.** Not for comments,
+not for docstrings, not for documentation, not for code. Name the defect and stop.
+
+This is not a style preference. `docs/reference/code-review-policy.md` records what happens otherwise:
+
+> Take the finding, not the remedy. … That prose is unverified by anyone. Adopting it inserts a new
+> claim into the artifact, which the next round then flags.
+
+On #1293 that path ran for three rounds: every finding in rounds 8 and 9 landed on text the previous
+round's fix had just written, and one log message was wrong in **both** directions across two rounds —
+first over-claiming an ambiguity, then over-claiming its resolution. Withholding the remedy is the
+point of this agent. A report that contains a suggested rewrite has failed its contract, however
+correct the rewrite looks.
+
+**Where the right answer is a deletion, say that as a finding** — "this claim is not load-bearing and
+nothing pins it" — and let the caller delete. Naming *what to remove* is a finding. Supplying *what to
+put there instead* is not.
+
+## Confidence floor
+
+Rate every issue 0-100 and **report only ≥ 80**:
+
+- **91-100** — a real bug, or an explicit violation of a rule written in `CLAUDE.md` / `docs/reference/*`
+- **80-90** — an important issue that needs attention before merge
+- **below 80** — do not report it
+
+Filter aggressively. A short report of defects that survive scrutiny is worth more than a long one.
+
+## Every finding must carry these four things
+
+1. **`file:line`** — where it is.
+2. **The defect, in one sentence.** What is false, broken, or in violation. Not what to write instead.
+3. **Reproduction, or an explicit "judgement call".** A reproduction is a concrete input → wrong output,
+   a failing check, or a mutation you ran that stayed green. If you have none, write
+   `judgement call` — do not dress an opinion as evidence. The caller gates on this distinction:
+   a finding with a reproduction is worked; one without is not carried into another round.
+4. **Round attribution.** State whether the text the finding lands on was **added or changed by a
+   previous round's fix**, when the caller has told you what those fixes were. This is the signal the
+   causal stop trigger runs on — when two consecutive rounds both land on the prior round's fixes, the
+   caller must change the class of fix rather than reword again. Without attribution that trigger
+   cannot fire, which is exactly how #1293 reached round 9.
+
+## Verify before you report
+
+Every finding is a claim about the record, and the record is one command away — `git log`, `grep`,
+`gh pr view`, running the test. Check it. This matters most when a finding would make the caller
+**delete** something: confirm the thing is actually unused or actually false before saying so.
+
+Two failure modes seen on this repo, both worth a second look before you write them up:
+
+- **A tool that failed silently reads as a result.** A grep with a bad glob, an ANSI-coloured line that
+  a pattern missed, a short test run — each produces empty output that looks like "clean". Assert what
+  a healthy run looks like before believing a negative.
+- **A citation that does not say what it is quoted as saying.** If you cite a docblock, a memory page,
+  an issue, or another comment as support, read it. Quote the sentence you are relying on.
+
+## Do not modify anything
+
+Read-only. Never edit, write, or create a file, and never run a command that mutates the working tree —
+no `git add`, `checkout`, `stash`, `commit`, or in-place mutation of source. If you want to mutation-test
+a guard, copy the tree elsewhere first; a live mutation during a review has twice been reported as a
+defect in the diff on this repo. If the tree changes under you mid-review, say so in the report rather
+than silently mixing two states.
+
+## Report shape
+
+Open with what you reviewed — the exact diff range and file list — so the caller can tell whether you
+saw what they meant. Then group by severity (**Critical 91-100**, **Important 80-89**), each finding
+carrying the four things above.
+
+Close with a plain verdict: **is there a Critical or Important a reasonable reviewer would block the
+merge on?** If there is nothing at or above 80, say the diff is clean and say what you checked to
+conclude that.

--- a/docs/reference/code-review-policy.md
+++ b/docs/reference/code-review-policy.md
@@ -67,6 +67,38 @@ flags; on #1244 that path produced one of round 2's Criticals.
 Take the **finding** ("this claim outruns its evidence") and discard the **remedy** ("write this
 instead"). Where the finding names a deletion, apply the deletion.
 
+## The remedy is withheld at the source (#1298)
+
+"Take the finding, not the remedy" is a rule about what the CALLER does with a report, and on #1293 it
+failed nine rounds running: every finding in rounds 8 and 9 landed on prose the previous round's fix had
+just written, and one log message was wrong in BOTH directions across two rounds — first over-claiming an
+ambiguity, then over-claiming its resolution.
+
+Two things about that failure are worth separating. The policy was never opened (the path was cited in
+subagent prompts without being read), but reading it would not have been sufficient: `ship-issue` step
+6's causal stop trigger WAS in context every turn via the #415 hook and was violated anyway. So the
+remaining lever is not a better reminder.
+
+**`.claude/agents/review-findings-only.md`** is that lever. It is a project-defined reviewer whose system
+prompt forbids replacement prose outright — findings, `file:line`, reproduction-or-judgement-call, and
+round attribution, with no "change it to this". Where the answer is a deletion it says so as a finding
+and lets the caller delete. It keeps the ≥80 floor, since that is the plugin reviewer's one real quality
+signal. Use it for the step 5-6 loop from round 2 onward, when the previous round's fix is itself part of
+the diff.
+
+This is **not** the class of gate #1150 rejected. Those tried to judge the operator's reasoning ("did
+this fix cause this finding?") — a content judgement measured through phrasing. This changes the INPUT:
+with no remedy in the report there is nothing to adopt. It also does not depend on overriding the
+marketplace agents, whose names are namespaced (`pr-review-toolkit:code-reviewer`); it is a separate
+agent, invoked instead of them.
+
+**What it does not do:** guarantee compliance. It removes one specific, repeatedly-used input. Nothing
+here stops a caller from rewriting prose on its own initiative.
+
+**Deployment caveat:** agent definitions load at SESSION START, like `.claude/settings.json` hooks. A
+newly added or edited agent is not visible to the session that wrote it — `subagent_type` resolution
+fails with "agent type not found" until a restart. Verify it resolves before relying on it.
+
 ## Verify a finding before acting on it
 
 Every Critical is a claim about the record, and the record is one command away — `gh pr view`,


### PR DESCRIPTION
`refs #1298` — the agent definition is **not verified end-to-end** yet (see Honest limits), so the issue stays open for that check.

## Problem

The #1293 review loop failed to converge in one specific way:

| round | what the findings landed on |
|---|---|
| 8 | all on round 7's fixes |
| 9 | all on round 8's fixes |

One `zero`-verdict log message was wrong **in both directions** across two rounds — first over-claiming an ambiguity, then over-claiming its resolution. A claim wrong in both directions is not a wording problem.

## Root cause, and why the obvious fixes don't apply

`docs/reference/code-review-policy.md` already names it: *"Take the finding, not the remedy. … That prose is unverified by anyone. Adopting it inserts a new claim into the artifact, which the next round then flags."*

Two things are worth separating:

1. **The policy was never opened.** Its path was cited in subagent prompts without being read. Any check for "is the path mentioned" would have passed.
2. **Reading it would not have sufficed.** `ship-issue` step 6's causal stop trigger *was* in context every turn via the #415 hook, and was violated at rounds 8 and 9 anyway.

So a better reminder is not the remaining lever. Neither is a hard gate: #1150 built four deny designs and replayed them over this repo's transcripts; each either denied compliant work or could not discriminate, because *"did this fix cause this finding?"* is a content judgement measured through phrasing. Its conclusion stands — *"a deny the operator cannot satisfy honestly leaves only the override — the gate manufactures the work it exists to save."*

Platform research confirms the general case: no supported mechanism makes a model follow written guidance. Hooks block actions but cannot inspect reasoning; `additionalContext` is **not** available on `PreToolUse`, so policy cannot be injected at the review-spawn moment; skills have no `mandatory` field.

## What this does instead

Changes the **input**, not the judgement. `.claude/agents/review-findings-only.md` is a project-defined reviewer whose system prompt forbids replacement prose outright.

Each finding carries four things and nothing else:

- `file:line`
- the defect in one sentence — not what to write instead
- **reproduction, or an explicit `judgement call`** — the distinction the caller gates on
- **round attribution** — whether the text was added by a previous round's fix, which is the signal the causal stop trigger runs on. Without it that trigger cannot fire, which is how #1293 reached round 9.

Where the answer is a deletion it says so as a finding and lets the caller delete. It keeps the ≥80 confidence floor — the plugin reviewer's one real quality signal.

With no remedy in the report, there is nothing to adopt and nothing to judge.

## Design notes

- **Not an override.** The marketplace agents are namespaced (`pr-review-toolkit:code-reviewer`), and whether a project agent overrides them is unverified. This is a separate agent, invoked *instead of* them, so the design does not depend on override semantics.
- **The plugin is not edited.** Per the policy page, it is not ours to edit.
- `.claude/agents/` is not gitignored, and `.claude/skills/` is already committed the same way.

## Honest limits

- **It does not guarantee compliance.** It removes one specific, repeatedly-used input. Nothing stops a caller from writing prose on its own initiative.
- **It is not verified end-to-end.** Agent definitions load at **session start**, so `subagent_type: review-findings-only` returns *"agent type not found"* in the session that wrote it — I tried, and that is the failure recorded here rather than a claim of success. Resolution must be confirmed after a restart before anyone relies on it. That is a checklist item on #1298.

This second point is the one that matters: a gate that looks installed and does nothing is worse than none, so it is stated rather than assumed.

## Verification

`lint:okf` and `lint:docs` clean. No code paths touched — one new agent definition and one docs section.

refs #1150, refs #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU