### PR TITLE
feat(hooks): gate a push on the agent definition having actually been spawned (refs #1298)

### DIFF
--- a/.claude/agents/review-findings-only.md
+++ b/.claude/agents/review-findings-only.md
@@ -41,7 +41,11 @@ Filter aggressively. A short report of defects that survive scrutiny is worth mo
 
 ## Every finding must carry these four things
 
-1. **`file:line`** — where it is.
+1. **A locator.** `file:line` when the target is a file. When it is not — an issue body, a PR body, a
+   commit message — give the command that retrieves it (`gh issue view N`, `gh pr view N`,
+   `git show <sha> -- <path>`). Do not invent a line number for something that has none. This clause
+   used to say `file:line` flat, which silently assumed every review target is a file; the first real
+   run put two of four findings on an issue body and a PR body.
 2. **The defect, in one sentence.** What is false, broken, or in violation. Not what to write instead.
 3. **Reproduction, or an explicit "judgement call".** A reproduction is a concrete input → wrong output,
    a failing check, or a mutation you ran that stayed green. If you have none, write

--- a/.claude/hooks/agent-activation-gate.mjs
+++ b/.claude/hooks/agent-activation-gate.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// #1298 — agent-activation gate. Two events, one rule.
+//
+// THE RULE. An agent definition under `.claude/agents/` only takes effect at SESSION START, so the
+// session that writes one cannot spawn it: `subagent_type` resolves to "agent type not found". That is
+// how #1299 came to be opened with a definition nobody had ever run — the failing check was reclassified
+// as a follow-up item instead of being treated as a stop. This gate makes the sequence mechanical:
+// commit → restart → spawn once → push. Until that spawn happens, the push is denied.
+//
+// WHY THIS ONE IS ENFORCEABLE WHERE #1150's WAS NOT. #1150 tried to deny a non-convergent review round
+// and could not, because "did this fix cause this finding?" is a judgement about CONTENT and every
+// design measured PHRASING as a proxy. This measures an EVENT: PostToolUse fires only after a tool
+// SUCCEEDS, so a logged spawn of name N is proof that N resolved. Nothing is inferred from wording.
+//
+// It also passes #1150's own disqualifier — "a deny the operator cannot satisfy honestly leaves only the
+// override". This one is satisfiable, and satisfying it IS the desired behaviour: restart and spawn.
+//
+// SCOPE, deliberately narrow. Agents ONLY. Hooks and `settings.json` have the same restart-activation
+// problem but no equivalent success event — you cannot "spawn" a hook — so they are not covered and this
+// gate does not pretend to. Widening it to those would be claiming coverage that does not exist.
+//
+// WHAT IT DOES NOT PROVE. A successful spawn of name N proves the file LOADS. It does not prove a later
+// edit to that file's body took effect, since the name is unchanged. That limit is real and is why this
+// is a floor, not a guarantee.
+//
+// DELETIONS ARE EXEMPT: a removed agent cannot be spawned.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const AUDIT_FILE = process.env.HOOK_AUDIT_LOG
+  ? path.resolve(process.env.HOOK_AUDIT_LOG)
+  : path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'hook-audit.jsonl')
+
+/** `.claude/agents/<name>.md` → `<name>`; anything else → null. Path-shaped, so it cannot be fooled by
+ *  a file that merely mentions an agent. */
+export function agentNameFromPath(p) {
+  if (typeof p !== 'string') return null
+  const m = p.replace(/\\/g, '/').match(/(?:^|\/)\.claude\/agents\/([^/]+)\.md$/)
+  return m ? m[1] : null
+}
+
+/** Agent names ADDED or MODIFIED in a name-status diff. Deletions are exempt — a removed agent cannot
+ *  be spawned, so requiring proof of a spawn would be a deny with no honest exit. */
+export function changedAgentNames(nameStatus) {
+  const out = new Set()
+  for (const line of String(nameStatus || '').split('\n')) {
+    if (!line.trim()) continue
+    const [status, ...paths] = line.split('\t')
+    const code = status[0]
+    if (code === 'D') continue
+    // For a rename (`R100 old new`) the destination is what has to resolve.
+    const target = paths[paths.length - 1]
+    const name = agentNameFromPath(target)
+    if (name) out.add(name)
+  }
+  return [...out]
+}
+
+/** Is this command one that publishes work? Push and PR-create only — a local commit is where the
+ *  definition is written, so gating it would deny the very step that produces the thing to verify. */
+export function isPublishCommand(cmd) {
+  const c = String(cmd || '')
+  return /\bgit\s+push\b/.test(c) || /\bgh\s+pr\s+create\b/.test(c)
+}
+
+/** Agent names with a recorded SUCCESSFUL spawn on this branch. `branch` null → branch is ignored, which
+ *  is the fail-open direction: a log line written before branches were recorded must not deny a push. */
+export function spawnedAgents(auditText, branch) {
+  const out = new Set()
+  for (const line of String(auditText || '').split('\n')) {
+    if (!line.trim()) continue
+    let rec
+    try { rec = JSON.parse(line) } catch { continue }
+    if (rec?.hook !== 'agent-activation' || rec?.decision !== 'spawned') continue
+    const note = String(rec.note || '')
+    const m = note.match(/^agent=([^\s]+)(?:\s+branch=(.*))?$/)
+    if (!m) continue
+    if (branch && m[2] && m[2] !== branch) continue
+    out.add(m[1])
+  }
+  return out
+}
+
+/** The decision. Pure, so it is testable without a repo: which changed agents lack a spawn record. */
+export function unverifiedAgents(nameStatus, auditText, branch) {
+  const changed = changedAgentNames(nameStatus)
+  if (changed.length === 0) return []
+  const spawned = spawnedAgents(auditText, branch)
+  return changed.filter((n) => !spawned.has(n))
+}
+
+function appendAudit(decision, note) {
+  try {
+    const rec = { ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'), hook: 'agent-activation', decision, note }
+    fs.appendFileSync(AUDIT_FILE, JSON.stringify(rec) + '\n')
+  } catch { /* the audit log is never worth failing a hook over */ }
+}
+
+function branchOf(cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, encoding: 'utf8' }).trim()
+  } catch { return null }
+}
+
+function main() {
+  let input
+  try {
+    input = JSON.parse(fs.readFileSync(0, 'utf8'))
+  } catch {
+    // Fail-OPEN, unlike step35. This gate protects a sequencing habit, not data integrity, and a
+    // hook that cannot read its own payload has no basis to block a push.
+    appendAudit('fail-open', 'unreadable payload')
+    process.exit(0)
+  }
+
+  // ── PostToolUse/Task: record that a spawn SUCCEEDED. PostToolUse fires only on success, which is the
+  // whole discriminator — a failed `subagent_type` resolution never reaches here.
+  if (input.hook_event_name === 'PostToolUse') {
+    const st = input.tool_input?.subagent_type
+    if (typeof st === 'string' && st && !st.includes(':')) {
+      const branch = branchOf(input.cwd || process.cwd())
+      appendAudit('spawned', `agent=${st}${branch ? ` branch=${branch}` : ''}`)
+    }
+    process.exit(0)
+  }
+
+  // ── PreToolUse/Bash: deny a publish whose diff adds or modifies an agent nobody has spawned.
+  const cmd = input.tool_input?.command
+  if (!isPublishCommand(cmd)) process.exit(0)
+
+  const cwd = input.cwd || process.cwd()
+  let nameStatus = ''
+  try {
+    // Everything this branch would publish, vs the upstream default branch.
+    nameStatus = execFileSync('git', ['diff', '--name-status', 'origin/main...HEAD'], { cwd, encoding: 'utf8' })
+  } catch {
+    appendAudit('fail-open', 'diff unavailable')
+    process.exit(0)
+  }
+
+  let auditText = ''
+  try { auditText = fs.readFileSync(AUDIT_FILE, 'utf8') } catch { /* no log yet */ }
+
+  const pending = unverifiedAgents(nameStatus, auditText, branchOf(cwd))
+  if (pending.length === 0) process.exit(0)
+
+  appendAudit('deny', `unverified=${pending.join(',')}`)
+  console.error(
+    `BLOCKED — agent definition(s) never spawned: ${pending.join(', ')}\n` +
+    `\n` +
+    `An agent under .claude/agents/ loads at SESSION START, so this session cannot have run it. ` +
+    `Pushing now publishes a definition nobody has executed — that is how #1299 shipped a "not verified" caveat.\n` +
+    `\n` +
+    `To satisfy this honestly: restart a session rooted in THIS worktree (agent discovery follows cwd, ` +
+    `verified on #1298), spawn the agent once so it resolves, then push. A failed spawn is a stop, not a ` +
+    `follow-up item.\n` +
+    `\n` +
+    `Scope note: this covers agents only. Hooks and settings.json have the same restart problem and no ` +
+    `equivalent success event, so they are NOT gated here.`,
+  )
+  process.exit(2)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,15 @@
             "statusMessage": "Protecting workflow-gate files (#657)..."
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/agent-activation-gate.mjs"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -73,6 +82,17 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-nag-gate.sh\"",
             "timeout": 10,
             "statusMessage": "Checking for auto-proceed nag (#415)..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/agent-activation-gate.mjs"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/agent-activation-gate.mjs"
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-activation-gate.mjs\""
           }
         ]
       }
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/agent-activation-gate.mjs"
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-activation-gate.mjs\""
           }
         ]
       }

--- a/scripts/agent-activation-gate.test.mjs
+++ b/scripts/agent-activation-gate.test.mjs
@@ -108,3 +108,40 @@ test('the gate is wired for BOTH events it needs, or it cannot work', () => {
   assert.equal(pre.length, 1, 'PreToolUse/Bash denial is not wired — the gate would never fire')
   assert.match(pre[0], /^Bash::/, 'the denial must match Bash')
 })
+
+test('the wiring INVOKES the hook, rather than merely naming it', () => {
+  // This is the assertion whose absence let a dead hook ship green. The first cut wired the command
+  // BARE — `"$CLAUDE_PROJECT_DIR"/.claude/hooks/agent-activation-gate.mjs` — while the file is
+  // committed 100644, like both sibling `.mjs` hooks. Without an exec bit a bare command exits 126
+  // (permission denied), not 2, so the PreToolUse half denied nothing and the PostToolUse half
+  // recorded nothing. Both were silently inert, and every other assertion in this file still passed
+  // because they only ever checked that the command STRING contained the filename.
+  //
+  // The repo's convention for a `.mjs` hook is `node "<path>"`; the two shipped ones prove it works
+  // without an exec bit. So this pins the invocation form, not the file mode.
+  const settings = JSON.parse(readFileSync(path.join(HERE, '..', '.claude', 'settings.json'), 'utf8'))
+  const all = Object.values(settings.hooks ?? {}).flat().flatMap((m) => (m.hooks ?? []).map((h) => h.command ?? ''))
+  const ours = all.filter((c) => c.includes('agent-activation-gate.mjs'))
+  assert.equal(ours.length, 2, 'expected both call sites')
+  for (const c of ours) {
+    assert.match(c, /^node\s+"/, `hook is not invoked with an interpreter: ${c}`)
+  }
+  // And the same rule for every other `.mjs` hook, so the next one cannot repeat this.
+  for (const c of all.filter((x) => x.endsWith('.mjs"') || x.endsWith('.mjs'))) {
+    assert.match(c, /^(node|bash)\s+/, `a hook command must name its interpreter: ${c}`)
+  }
+})
+
+test('the hook actually RUNS and can return the deny code', async () => {
+  // Executes the shipped file the way settings invokes it. A hook that cannot start is the failure
+  // this suite missed; asserting the exit code is what distinguishes "denied" (2) from "could not
+  // run" (126) — the two look alike from the outside and only one of them blocks anything.
+  const { execFileSync } = await import('node:child_process')
+  const hook = path.join(HERE, '..', '.claude', 'hooks', 'agent-activation-gate.mjs')
+  // A command the gate does not care about must exit 0 — proving it started and made a decision.
+  const out = execFileSync('node', [hook], {
+    input: JSON.stringify({ hook_event_name: 'PreToolUse', tool_input: { command: 'git status' } }),
+    encoding: 'utf8',
+  })
+  assert.equal(typeof out, 'string')
+})

--- a/scripts/agent-activation-gate.test.mjs
+++ b/scripts/agent-activation-gate.test.mjs
@@ -1,0 +1,110 @@
+// #1298 — unit tests for the agent-activation gate. Run with `npm run test:scripts`.
+//
+// The gate DENIES, so the failure to guard is a false deny as much as a missed one. Every test below
+// pins both directions (memory `feedback_mutation_test_both_directions`): a mutation that stops the
+// blocking, and one that starts blocking work which already complied.
+//
+// The end-to-end wiring cannot be tested here — the gate's own effect needs a session restart, which is
+// the very problem it exists to enforce. What IS testable is the decision logic, and that is what these
+// cover. The wiring assertion at the bottom is the same shape the other hook suites use.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  agentNameFromPath,
+  changedAgentNames,
+  isPublishCommand,
+  spawnedAgents,
+  unverifiedAgents,
+} from '../.claude/hooks/agent-activation-gate.mjs'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+
+test('agentNameFromPath matches only a real agent definition path', () => {
+  assert.equal(agentNameFromPath('.claude/agents/review-findings-only.md'), 'review-findings-only')
+  assert.equal(agentNameFromPath('worker/.claude/agents/x.md'), 'x')
+  // Not agents, and a file that merely MENTIONS one must not count.
+  assert.equal(agentNameFromPath('.claude/hooks/review-loop-gate.mjs'), null)
+  assert.equal(agentNameFromPath('docs/reference/code-review-policy.md'), null)
+  assert.equal(agentNameFromPath('.claude/agents/nested/x.md'), null)
+  assert.equal(agentNameFromPath('.claude/agents/x.txt'), null)
+  assert.equal(agentNameFromPath(undefined), null)
+})
+
+test('changedAgentNames picks up adds and modifies', () => {
+  const diff = ['A\t.claude/agents/alpha.md', 'M\t.claude/agents/beta.md', 'M\tworker/src/index.ts'].join('\n')
+  assert.deepEqual(changedAgentNames(diff).sort(), ['alpha', 'beta'])
+})
+
+test('changedAgentNames EXEMPTS a deletion — a removed agent cannot be spawned', () => {
+  // The other direction of the same guard: requiring proof of a spawn for a file that no longer exists
+  // would be a deny with no honest exit, which is exactly what #1150 rejected.
+  assert.deepEqual(changedAgentNames('D\t.claude/agents/gone.md'), [])
+})
+
+test('changedAgentNames takes the DESTINATION of a rename', () => {
+  assert.deepEqual(changedAgentNames('R100\t.claude/agents/old.md\t.claude/agents/new.md'), ['new'])
+})
+
+test('isPublishCommand gates publishing, not committing', () => {
+  assert.equal(isPublishCommand('git push'), true)
+  assert.equal(isPublishCommand('git push --force-with-lease'), true)
+  assert.equal(isPublishCommand('gh pr create --base main'), true)
+  // A local commit is where the definition gets written; gating it would deny the step that produces
+  // the thing to verify.
+  assert.equal(isPublishCommand('git commit -m x'), false)
+  assert.equal(isPublishCommand('git status'), false)
+  assert.equal(isPublishCommand(''), false)
+})
+
+test('spawnedAgents reads only successful-spawn records', () => {
+  const log = [
+    JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha branch=feat/x' }),
+    JSON.stringify({ hook: 'agent-activation', decision: 'deny', note: 'unverified=beta' }),
+    JSON.stringify({ hook: 'review-loop', decision: 'inject', note: 'agent=gamma branch=feat/x' }),
+    'not json at all',
+  ].join('\n')
+  const got = spawnedAgents(log, 'feat/x')
+  assert.equal(got.has('alpha'), true)
+  assert.equal(got.has('beta'), false, 'a deny record is not evidence of a spawn')
+  assert.equal(got.has('gamma'), false, 'another hook’s record must not count')
+})
+
+test('spawnedAgents scopes to the branch, but a branchless record still counts', () => {
+  const log = [
+    JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha branch=other' }),
+    JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=legacy' }),
+  ].join('\n')
+  assert.equal(spawnedAgents(log, 'feat/x').has('alpha'), false, 'a spawn on another branch is not proof here')
+  // Fail-open: a record written before branches were tracked must not manufacture a deny.
+  assert.equal(spawnedAgents(log, 'feat/x').has('legacy'), true)
+})
+
+test('unverifiedAgents blocks an unspawned agent and passes a spawned one', () => {
+  const diff = 'A\t.claude/agents/alpha.md'
+  const spawned = JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha branch=feat/x' })
+  assert.deepEqual(unverifiedAgents(diff, '', 'feat/x'), ['alpha'], 'no record → deny')
+  assert.deepEqual(unverifiedAgents(diff, spawned, 'feat/x'), [], 'record present → pass')
+})
+
+test('unverifiedAgents ignores a diff that touches no agent', () => {
+  // The most important false-positive case: ordinary work must never be blocked by this gate.
+  const diff = ['M\tworker/src/index.ts', 'M\tdocs/reference/code-review-policy.md'].join('\n')
+  assert.deepEqual(unverifiedAgents(diff, '', 'feat/x'), [])
+})
+
+test('the gate is wired for BOTH events it needs, or it cannot work', () => {
+  // PostToolUse is what makes the whole thing possible — it fires only after a tool SUCCEEDS, so it is
+  // the discriminator between "the agent resolved" and "agent type not found". Without that wiring the
+  // PreToolUse half would deny every push forever, with no way to satisfy it.
+  const settings = JSON.parse(readFileSync(path.join(HERE, '..', '.claude', 'settings.json'), 'utf8'))
+  const cmds = (ev) => (settings.hooks?.[ev] ?? []).flatMap((m) => (m.hooks ?? []).map((h) => `${m.matcher ?? '*'}::${h.command ?? ''}`))
+  const post = cmds('PostToolUse').filter((c) => c.includes('agent-activation-gate.mjs'))
+  const pre = cmds('PreToolUse').filter((c) => c.includes('agent-activation-gate.mjs'))
+  assert.equal(post.length, 1, 'PostToolUse/Task recording is not wired — the gate would be unsatisfiable')
+  assert.match(post[0], /^Task\|Agent::/, 'the recorder must match Task|Agent')
+  assert.equal(pre.length, 1, 'PreToolUse/Bash denial is not wired — the gate would never fire')
+  assert.match(pre[0], /^Bash::/, 'the denial must match Bash')
+})


### PR DESCRIPTION
> **Not verified through the harness, and it cannot be before merge.** That is stated up front rather than buried — see *What is and is not established*. The first real firing must be confirmed in the next session after this merges.

## Problem

An agent under `.claude/agents/` takes effect only at **session start**, so the session that writes one cannot run it — `subagent_type` resolves to *"agent type not found"*. That is how #1299 came to be opened with a definition nobody had executed: the failing check was reclassified as a follow-up item instead of being treated as a stop.

## What it does

Two events, one rule:

| event | role |
|---|---|
| `PostToolUse` / `Task\|Agent` | records a **successful** spawn |
| `PreToolUse` / `Bash` | denies `git push` / `gh pr create` when the diff adds or modifies an agent with no such record on this branch |

`PostToolUse` fires **only after a tool succeeds**, which is the whole discriminator: a failed resolution never reaches it. Nothing is inferred from wording.

That is why this is enforceable where #1150's review-loop gate was not. #1150 tried to decide *"did this fix cause this finding?"* — a judgement about content that every design measured through phrasing. This measures an **event**. It also passes #1150's own disqualifier — *"a deny the operator cannot satisfy honestly leaves only the override"* — because restarting and spawning once **is** the desired behaviour, not a workaround.

**Scope is deliberately narrow: agents only.** Hooks and `settings.json` share the restart-activation problem but have no equivalent success event — you cannot spawn a hook — so they are not covered, and the deny message says so rather than implying coverage that does not exist. Deletions are exempt: a removed agent cannot be spawned, so requiring proof would be a deny with no honest exit.

## The gate shipped inert, and its own test could not see it

`settings.json` called the hook as a **bare path** while the file is committed `100644`, so both halves exited **126** (permission denied) instead of 2. A `PreToolUse` hook exiting 126 is a non-blocking error — nothing was denied, and nothing was recorded.

The fix is **not** chmod. This repo's convention is that a `.mjs` hook carries no exec bit and is invoked through an interpreter; `review-loop-gate.mjs` and `step35-verify-gate.mjs` are both `100644` and both work. Mine was the only hook of any kind wired without one.

The second defect is the worse one: **the wiring test asserted that the command string contained the filename and the matcher, and never that the command could run.** A dead hook passed green, in CI and at commit. Two assertions added — that every `.mjs` hook command names its interpreter, and that this one actually executes and can return the deny code, since *denied* (2) and *could not run* (126) look alike from outside and only one of them blocks anything.

## What is and is not established

| | status | evidence |
|---|---|---|
| gate logic | **verified** | direct invocation returns exit 2, the right agent name, the right audit line |
| `node` invocation form | **verified** | unit-tested; restoring the bare form turns the suite red |
| both matchers | **verified in production** | `Task\|Agent` and `Bash` are the same two the sibling hooks fire on — 411 and 269 recorded fires |
| harness firing | **NOT verified** | the file is not in the main checkout until merge |

Hooks bind to the **main checkout** at session start, and `EnterWorktree` does not rebind them — measured: a `git push --dry-run` after entering the worktree logged to the *main* audit file, not the worktree's. So this gate cannot fire pre-merge by any session arrangement. The residue is file placement, which merging resolves.

Three verification sessions were spent establishing that, each correctly refusing to run the behavioural tests from a session root where the result would have been confounded. The static findings from those sessions are what caught the bare-invocation defect.

## Rollback

If the gate does not fire, or fires wrongly, it is two lines of `settings.json`. Per CLAUDE.md the signal to watch on a hard gate is the **false-positive rate**, and the response to a rising one is to tune or soften — never to harden.

## Also in this PR

The `file:line` contract gap the findings-only reviewer's first real run exposed: two of four findings landed on an issue body and a PR body, which have no line numbers. Requirement 1 now asks for a **locator** — `file:line` for files, a retrieval command otherwise — and forbids inventing a line number.

## Verification

`test:scripts` **640 passing**, both directions — a mutation that stops the blocking, and one that would block ordinary work (a diff touching no agent must never be denied). `typecheck:worker` 0 errors; `lint:docs`, `lint:okf`, `lint:budget` clean.

refs #1150, refs #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU