### PR TITLE
feat(hooks): refuse to push an agent definition nobody has run — as a git pre-push hook (refs #1298)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// #1298 — refuse to push an agent definition nobody has run.
+//
+// THE PROBLEM. A file under `.claude/agents/` takes effect only at SESSION START, so the session that
+// writes one cannot spawn it — `subagent_type` resolves to "agent type not found". #1299 was opened
+// with a definition nobody had executed, because the failing check was filed as a follow-up item
+// instead of treated as a stop.
+//
+// WHY THIS LIVES IN GIT AND NOT IN A CLAUDE HOOK. The first attempt intercepted `PreToolUse`/`Bash`
+// and decided from the COMMAND STRING whether a push was happening. That cannot work:
+// `echo git push` was denied, `git -C /elsewhere push` slipped through, and — the one that mattered —
+// `cd ~/aiwatch-reports && git push` was denied, because the hook read the diff of the SESSION's repo
+// rather than the repo being pushed. Publishing a monthly report is exactly that command, so an
+// unrelated agent edit sitting on an aiwatch branch blocked a different repository, with a message
+// telling the operator to spawn an agent that repo has never heard of.
+//
+// `pre-push` deletes the parsing. Git runs this in the repository actually being pushed and hands it
+// the refs on stdin, so a push from another repo runs THAT repo's hooks and cannot see these agents.
+// The false positives are not narrowed — they become unrepresentable.
+//
+// It is also why this one could be verified the day it was written: `core.hooksPath` is local git
+// config, so the gate is live immediately. The two Claude-hook attempts before it could not be tested
+// without a session restart, and both shipped inert.
+//
+// SCOPE: agents only. Hooks and `settings.json` share the restart-activation problem and have no
+// equivalent "it ran" event, so they are not covered and this does not pretend otherwise.
+//
+// ESCAPE HATCH, on purpose. `AGENT_VERIFIED=1 git push` passes. #1150 rejected earlier gates because
+// "a deny the operator cannot satisfy honestly leaves only the override" — a demand that cannot be met
+// just manufactures the override. This one's demand (restart, spawn once) is usually meetable, but the
+// recorder that writes the evidence is a Claude Code hook and may not be loaded. So the stated escape
+// is part of the design, not a leak. `--no-verify` bypasses it as it does every git hook; the
+// Claude-side `step35-verify-gate` denies that flag separately.
+
+import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+const ZERO = /^0+$/
+
+/** `.claude/agents/<name>.md` → `<name>`. Path-shaped, so a file that merely mentions an agent does
+ *  not count. Nested paths return null: the harness discovers agents at the top level only. */
+export function agentNameFromPath(p) {
+  if (typeof p !== 'string') return null
+  const m = p.replace(/\\/g, '/').match(/(?:^|\/)\.claude\/agents\/([^/]+)\.md$/)
+  return m ? m[1] : null
+}
+
+/** Agent names ADDED or MODIFIED in `git diff --name-status` output. Deletions are exempt: a removed
+ *  agent cannot be spawned, so demanding proof would be a deny with no honest exit. */
+export function changedAgentNames(nameStatus) {
+  const out = new Set()
+  for (const line of String(nameStatus || '').split('\n')) {
+    if (!line.trim()) continue
+    const [status, ...paths] = line.split('\t')
+    if (status[0] === 'D') continue
+    const name = agentNameFromPath(paths[paths.length - 1]) // rename → the destination must resolve
+    if (name) out.add(name)
+  }
+  return [...out]
+}
+
+/** One stdin line → the commit range this push would publish, or null when there is nothing to add.
+ *  Git's format is `<localRef> <localSha> <remoteRef> <remoteSha>`; an all-zero LOCAL sha is a branch
+ *  DELETION (nothing to inspect), an all-zero REMOTE sha is a branch that does not exist yet. */
+export function rangeForLine(line, fallbackBase = 'origin/main') {
+  const [, localSha, , remoteSha] = String(line || '').trim().split(/\s+/)
+  if (!localSha || ZERO.test(localSha)) return null
+  return ZERO.test(remoteSha || '') ? `${fallbackBase}...${localSha}` : `${remoteSha}..${localSha}`
+}
+
+/** Agent names with a recorded successful spawn, written by the Claude-side `PostToolUse` recorder.
+ *  Absent entirely when that hook is not loaded — which is what `AGENT_VERIFIED` exists for. */
+export function spawnedAgents(auditText) {
+  const out = new Set()
+  for (const line of String(auditText || '').split('\n')) {
+    if (!line.trim()) continue
+    let rec
+    try { rec = JSON.parse(line) } catch { continue }
+    if (rec?.hook !== 'agent-activation' || rec?.decision !== 'spawned') continue
+    const m = String(rec.note || '').match(/^agent=([^\s]+)/)
+    if (m) out.add(m[1])
+  }
+  return out
+}
+
+/** The decision. Pure, so it is testable without a repo or a push. */
+export function unverified(nameStatus, auditText, override) {
+  if (override) return []
+  const changed = changedAgentNames(nameStatus)
+  if (changed.length === 0) return []
+  const spawned = spawnedAgents(auditText)
+  return changed.filter((n) => !spawned.has(n))
+}
+
+export function denyMessage(names) {
+  return (
+    `\nBLOCKED — agent definition(s) never spawned: ${names.join(', ')}\n\n` +
+    `A file under .claude/agents/ loads at SESSION START, so the session that wrote it cannot have\n` +
+    `run it. Pushing now publishes a definition nobody has executed.\n\n` +
+    `Either:\n` +
+    `  1. Start a session rooted in this working tree, spawn the agent once so it resolves, push again.\n` +
+    `  2. AGENT_VERIFIED=1 git push   — if you have run it and the recorder was not loaded.\n\n` +
+    `A failed spawn is a stop, not a follow-up item. Scope: agents only; hooks and settings.json are\n` +
+    `not covered by this check.\n\n`
+  )
+}
+
+function main() {
+  const stdin = (() => { try { return fs.readFileSync(0, 'utf8') } catch { return '' } })()
+  // Fail-OPEN on an unreadable payload. This guards a sequencing habit, not data integrity, and a hook
+  // that cannot read its own input has no basis to block a push.
+  if (!stdin.trim()) process.exit(0)
+
+  const pending = new Set()
+  for (const line of stdin.split('\n')) {
+    const range = rangeForLine(line)
+    if (!range) continue
+    let nameStatus = ''
+    try {
+      nameStatus = execFileSync('git', ['diff', '--name-status', range], { encoding: 'utf8' })
+    } catch { continue } // an unresolvable range is not evidence of a violation
+    let audit = ''
+    for (const p of ['.claude/hook-audit.jsonl', `${process.env.HOME}/.claude/hook-audit.jsonl`]) {
+      try { audit += fs.readFileSync(p, 'utf8') } catch { /* absent is normal */ }
+    }
+    for (const n of unverified(nameStatus, audit, process.env.AGENT_VERIFIED)) pending.add(n)
+  }
+
+  if (pending.size === 0) process.exit(0)
+  process.stderr.write(denyMessage([...pending]))
+  process.exit(1)
+}
+
+// Only run when git invoked us, not when a test imports the pure functions above.
+if (process.env.PREPUSH_SELFTEST !== '1' && import.meta.url === `file://${process.argv[1]}`) main()

--- a/docs/reference/workflow-hooks.md
+++ b/docs/reference/workflow-hooks.md
@@ -1,7 +1,7 @@
 ---
 type: reference
 title: "Workflow-gate hooks (#415/#657) — the enforcement layer"
-description: "The seven .claude/hooks workflow hooks: what each fires on, hard vs soft, the audit log, and how to monitor + tune the step-3.5 hard gate."
+description: "The seven .claude/hooks workflow hooks plus the .githooks/pre-push agent gate: what each fires on, hard vs soft, the audit log, and how to monitor + tune the step-3.5 hard gate."
 tags: [workflow, hooks, enforcement, ci]
 ---
 
@@ -64,6 +64,58 @@ already lives in, and count how often it fires and how many of those firings are
 will not tell you that a rule which sounds objective is unreachable, non-discriminating, or inverted.
 Include the worktree session directories (`~/.claude/projects/*--claude-worktrees-*`): issue work happens
 there, and a main-directory-only scan silently drops those sessions.
+
+## A git hook, not a Claude hook — the agent-activation gate (#1298)
+
+`.githooks/pre-push` is the one enforcement point here that is **not** a `.claude/settings.json` hook.
+It refuses a push that adds or modifies a file under `.claude/agents/` unless a successful spawn of
+that agent is on record, or `AGENT_VERIFIED=1` is set. The count above stays SEVEN: this is a
+different mechanism, run by git rather than by the harness.
+
+**Why it is not a Claude hook, having been built as one twice.** An agent definition loads at session
+start, so the session that writes one cannot spawn it — #1299 shipped a definition nobody had run.
+Two `PreToolUse` attempts failed for reasons worth keeping:
+
+1. The first was wired BARE (`"$CLAUDE_PROJECT_DIR"/.claude/hooks/…`) while the file is committed
+   `100644`. A bare command with no exec bit exits **126**, which `PreToolUse` treats as a
+   non-blocking error rather than the deny code **2** — so it blocked nothing and recorded nothing,
+   silently. Every `.mjs` hook in the table above is `100644` and is invoked `node "…"`; that is the
+   convention, and this one broke it. Its own suite could not see the failure: it asserted that the
+   command STRING contained the filename, never that the command could run.
+2. The second, deeper, failure was the interception point. Deciding from the command string whether a
+   push is happening cannot work — `echo git push` denied, `git -C /elsewhere push` bypassed, and
+   `cd ~/aiwatch-reports && git push` **denied**, because the hook read the diff of the SESSION's repo
+   rather than the repo being pushed. That command is how a monthly report is published, so an
+   unrelated agent edit on an aiwatch branch blocked a different repository, naming an agent that repo
+   has never heard of. Per CLAUDE.md the response to a false-positive rate is to tune or soften; there
+   was nothing to tune, because a shell string cannot answer "which repo is being pushed".
+
+`pre-push` deletes that question instead of narrowing it. Git runs the hook **in the repository being
+pushed** and hands it the refs on stdin, so cross-repo false positives are unrepresentable rather than
+filtered.
+
+**It is also the first of the three that could be verified the day it was written.** `core.hooksPath`
+is local git config, so the gate is live immediately — no session restart, which is what neither
+Claude-hook attempt could get past. Both of those shipped inert.
+
+**`AGENT_VERIFIED=1` is a designed exit, not a leak.** The spawn evidence is written by a Claude-side
+recorder that may not be loaded, so without a stated escape the deny would sometimes be unsatisfiable
+— exactly what #1150 rejected ("a deny the operator cannot satisfy honestly leaves only the
+override"). `--no-verify` bypasses it as it does every git hook; `step35-verify-gate` denies that flag
+separately, so the two layers cover each other.
+
+**Two things make it live, and both are pinned by `scripts/prepush-agent-gate.test.mjs`:** the exec
+bit (git invokes the hook directly, unlike a `node`-wired Claude hook) and a `prepare` script pointing
+git at `.githooks`, since `.git/hooks` is not version-controlled and a committed hook is inert on
+every clone without it. **An existing clone needs one `npm install` before the gate is active.**
+
+The suite's shape is deliberate: every test that matters EXECUTES the hook in a throwaway repo and
+asserts its EXIT CODE, because "denied" and "never ran" are indistinguishable from outside otherwise.
+That is the lesson of failure 1 — a structural scan cannot tell a live gate from a dead one.
+
+**Scope: agents only.** Hooks and `settings.json` have the same restart-activation problem and no
+equivalent "it ran" event, so they are not covered, and the deny message says so rather than implying
+coverage that does not exist.
 
 ## The instruction budget — a CI ratchet on always-loaded context (#1285)
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint:graph": "node scripts/lint-decision-graph.mjs",
     "lint:docs": "node scripts/check-doc-symbols.mjs",
     "lint:budget": "node scripts/check-instruction-budget.mjs",
-    "lint:korean": "node scripts/lint-korean-copy.mjs"
+    "lint:korean": "node scripts/lint-korean-copy.mjs",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "chart.js": "^4.4.7",

--- a/scripts/prepush-agent-gate.test.mjs
+++ b/scripts/prepush-agent-gate.test.mjs
@@ -1,0 +1,163 @@
+// #1298 — unit tests for the pre-push agent-activation gate. Run with `npm run test:scripts`.
+//
+// WHY THIS FILE LOOKS THE WAY IT DOES. The previous attempt's suite passed while the hook was
+// completely inert: it asserted that `settings.json` CONTAINED the hook's filename and matcher, and
+// never that the command could run. A later review mutated that gate five ways — deleting the recorder,
+// turning the deny exit into 0, commenting out the `main()` call entirely — and all five stayed green.
+//
+// So every test below that matters EXECUTES the shipped file as a subprocess and asserts its EXIT CODE.
+// A gate that cannot be distinguished from a no-op by its own suite is the defect this whole issue is
+// about, and a structural scan cannot make that distinction: "denied" and "never ran" look identical
+// from outside unless you read the exit status.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  agentNameFromPath, changedAgentNames, rangeForLine, spawnedAgents, unverified,
+} from '../.githooks/pre-push'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const HOOK = path.join(HERE, '..', '.githooks', 'pre-push')
+const ZEROS = '0'.repeat(40)
+
+// ── The decision, as pure functions ──────────────────────────────────────────
+
+test('agentNameFromPath matches only a top-level agent definition', () => {
+  assert.equal(agentNameFromPath('.claude/agents/review-findings-only.md'), 'review-findings-only')
+  assert.equal(agentNameFromPath('worker/.claude/agents/x.md'), 'x')
+  assert.equal(agentNameFromPath('.claude/hooks/review-loop-gate.mjs'), null)
+  assert.equal(agentNameFromPath('docs/reference/code-review-policy.md'), null, 'a file that merely mentions an agent must not count')
+  assert.equal(agentNameFromPath('.claude/agents/nested/x.md'), null)
+  assert.equal(agentNameFromPath(undefined), null)
+})
+
+test('changedAgentNames covers add and modify, exempts delete, follows a rename', () => {
+  assert.deepEqual(changedAgentNames('A\t.claude/agents/a.md\nM\t.claude/agents/b.md\nM\tworker/src/index.ts').sort(), ['a', 'b'])
+  // A removed agent cannot be spawned, so demanding proof would be a deny with no honest exit.
+  assert.deepEqual(changedAgentNames('D\t.claude/agents/gone.md'), [])
+  assert.deepEqual(changedAgentNames('R100\t.claude/agents/old.md\t.claude/agents/new.md'), ['new'])
+})
+
+test('rangeForLine reads git’s stdin format, including both all-zero cases', () => {
+  assert.equal(rangeForLine(`refs/heads/x aaa refs/heads/x bbb`), 'bbb..aaa')
+  assert.equal(rangeForLine(`refs/heads/x aaa refs/heads/x ${ZEROS}`), 'origin/main...aaa', 'a branch the remote does not have yet')
+  assert.equal(rangeForLine(`refs/heads/x ${ZEROS} refs/heads/x bbb`), null, 'a branch DELETION has nothing to inspect')
+  assert.equal(rangeForLine(''), null)
+})
+
+test('spawnedAgents reads only this hook’s successful-spawn records', () => {
+  const log = [
+    JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha branch=feat/x' }),
+    JSON.stringify({ hook: 'agent-activation', decision: 'deny', note: 'unverified=beta' }),
+    JSON.stringify({ hook: 'review-loop', decision: 'inject', note: 'agent=gamma' }),
+    'not json',
+  ].join('\n')
+  const got = spawnedAgents(log)
+  assert.equal(got.has('alpha'), true)
+  assert.equal(got.has('beta'), false, 'a deny record is not evidence of a spawn')
+  assert.equal(got.has('gamma'), false, 'another hook’s record must not count')
+})
+
+test('unverified blocks an unspawned agent, passes a spawned one, and honours the override', () => {
+  const diff = 'A\t.claude/agents/alpha.md'
+  const rec = JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha' })
+  assert.deepEqual(unverified(diff, '', undefined), ['alpha'])
+  assert.deepEqual(unverified(diff, rec, undefined), [])
+  assert.deepEqual(unverified(diff, '', '1'), [], 'AGENT_VERIFIED must be a real exit, or the deny is unsatisfiable')
+})
+
+test('unverified never blocks a diff that touches no agent', () => {
+  // The false positive that matters most: ordinary work must pass untouched.
+  assert.deepEqual(unverified('M\tworker/src/index.ts\nM\tCLAUDE.md', '', undefined), [])
+})
+
+// ── The hook as git actually runs it: exit codes, not string shapes ──────────
+
+/** Run the shipped hook in a throwaway repo, feeding it git's real stdin format. */
+function runHook({ agentChange, audit = '', env = {} }) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'prepush-'))
+  const git = (...a) => execFileSync('git', a, { cwd: dir, encoding: 'utf8' })
+  git('init', '-q', '-b', 'main')
+  git('config', 'user.email', 't@t'); git('config', 'user.name', 't')
+  writeFileSync(path.join(dir, 'seed.txt'), 'seed')
+  git('add', '-A'); git('commit', '-qm', 'seed')
+  const base = git('rev-parse', 'HEAD').trim()
+
+  if (agentChange) {
+    mkdirSync(path.join(dir, '.claude', 'agents'), { recursive: true })
+    writeFileSync(path.join(dir, '.claude/agents/alpha.md'), '---\nname: alpha\n---\nbody\n')
+  } else {
+    writeFileSync(path.join(dir, 'seed.txt'), 'changed')
+  }
+  git('add', '-A'); git('commit', '-qm', 'change')
+  const head = git('rev-parse', 'HEAD').trim()
+  if (audit) {
+    mkdirSync(path.join(dir, '.claude'), { recursive: true })
+    writeFileSync(path.join(dir, '.claude/hook-audit.jsonl'), audit)
+  }
+
+  const r = spawnSync('node', [HOOK], {
+    cwd: dir,
+    input: `refs/heads/main ${head} refs/heads/main ${base}\n`,
+    encoding: 'utf8',
+    // HOME is redirected so a real audit log on this machine cannot make the test pass.
+    env: { ...process.env, HOME: dir, AGENT_VERIFIED: '', ...env },
+  })
+  return { code: r.status, stderr: r.stderr || '' }
+}
+
+test('EXECUTED: a push touching no agent exits 0', () => {
+  const { code } = runHook({ agentChange: false })
+  assert.equal(code, 0)
+})
+
+test('EXECUTED: a push adding an unspawned agent exits NON-ZERO and says which', () => {
+  // This is the assertion whose absence let the previous gate ship inert. `exit 0` here means the hook
+  // ran and decided nothing — indistinguishable from a hook that was never wired, unless the code is
+  // read. Deleting the deny, or the `main()` call, turns this red.
+  const { code, stderr } = runHook({ agentChange: true })
+  assert.notEqual(code, 0, 'the gate did not block — it is inert')
+  assert.match(stderr, /BLOCKED/)
+  assert.match(stderr, /alpha/, 'the deny must name the agent it is about')
+  assert.match(stderr, /AGENT_VERIFIED=1/, 'the deny must state its own escape, or it is unsatisfiable')
+})
+
+test('EXECUTED: a recorded spawn lets the same push through', () => {
+  const { code } = runHook({
+    agentChange: true,
+    audit: JSON.stringify({ hook: 'agent-activation', decision: 'spawned', note: 'agent=alpha branch=main' }) + '\n',
+  })
+  assert.equal(code, 0)
+})
+
+test('EXECUTED: AGENT_VERIFIED=1 is a real exit', () => {
+  const { code } = runHook({ agentChange: true, env: { AGENT_VERIFIED: '1' } })
+  assert.equal(code, 0)
+})
+
+test('EXECUTED: empty stdin fails OPEN rather than blocking a push it cannot judge', () => {
+  const r = spawnSync('node', [HOOK], { input: '', encoding: 'utf8' })
+  assert.equal(r.status, 0)
+})
+
+test('the hook is executable and shebanged — git runs it directly, unlike a Claude hook', () => {
+  // The previous gate died on exactly this: a `.mjs` committed 100644 and invoked bare exits 126, which
+  // is a non-blocking error rather than a deny. Claude hooks are wired with an explicit `node`; git is
+  // not, so here the mode bit is load-bearing.
+  assert.ok(statSync(HOOK).mode & 0o111, 'pre-push has no exec bit — git will not run it')
+  const first = execFileSync('head', ['-1', HOOK], { encoding: 'utf8' })
+  assert.match(first, /^#!.*\bnode\b/)
+})
+
+test('the repo ships the core.hooksPath wiring, or the hook is dead on every clone', () => {
+  // `.git/hooks` is not version-controlled, so a committed hook does nothing until git is pointed at
+  // `.githooks`. Without this the gate is present in the tree and inert everywhere — the same failure
+  // mode as before, one layer over.
+  const pkg = JSON.parse(execFileSync('cat', [path.join(HERE, '..', 'package.json')], { encoding: 'utf8' }))
+  const prepare = pkg.scripts?.prepare ?? ''
+  assert.match(prepare, /core\.hooksPath\s+\.githooks/, 'no prepare script points git at .githooks')
+})


### PR DESCRIPTION
Third attempt, and **the first whose behaviour was measured the day it was written**. Replaces #1304, which is being closed.

## The problem

A file under `.claude/agents/` takes effect only at **session start**, so the session that writes one cannot spawn it. #1299 was opened with a definition nobody had executed — the failing check was filed as a follow-up item instead of treated as a stop.

## Why this moved out of a Claude hook

#1304 intercepted `PreToolUse`/`Bash` and decided from the **command string** whether a push was happening. Review found that cannot work:

| command | #1304 | correct |
|---|---|---|
| `echo git push` | denied | should pass |
| `git -C /elsewhere push` | passed | — |
| `cd ~/aiwatch-reports && git push` | **denied** | should pass |

The third is not hypothetical: publishing a monthly report is exactly that command. An unrelated agent edit sitting on an aiwatch branch blocked **a different repository**, with a message naming an agent that repo has never heard of — and there was no override. That is CLAUDE.md's stated disqualifier for a hard gate, and #1150's: *"a deny the operator cannot satisfy honestly leaves only the override."*

`pre-push` **deletes the parsing** rather than patching it. Git runs the hook in the repository actually being pushed and hands it the refs on stdin. Those false positives are not narrowed — they become unrepresentable.

## Measured, in the session that wrote it

`core.hooksPath` is local git config, so the gate is live immediately. This is what stopped the two previous attempts, both of which shipped inert and could not be tested without a session restart.

| case | result |
|---|---|
| commit touching no agent → `git push` | **exit 0**, proceeds |
| agent definition modified → `git push` | **BLOCKED**, refused |
| `AGENT_VERIFIED=1 git push` | **exit 0** |
| `git push` from `aiwatch-reports` | **unaffected** — no `core.hooksPath` there |

`AGENT_VERIFIED` is a **designed exit, not a leak**. The evidence this gate reads is written by a Claude-side recorder that may not be loaded; without a stated escape the deny would sometimes be unsatisfiable, which is precisely what #1150 rejected.

## The test suite is the other half of the fix

#1304's suite passed while its hook was **completely inert**. Five mutations — including commenting out the `main()` call — all stayed green, because it only asserted that a command *string* contained a filename.

Every test here that matters **executes the shipped hook** in a throwaway repo, feeds it git's real stdin format, and asserts the **exit code**, because *denied* and *never ran* are otherwise indistinguishable from outside.

Same five mutations, re-run:

| mutation | #1304 | here |
|---|---|---|
| deny exit → 0 | green | **red** |
| `main()` call removed | green | **red** (whole file dies) |
| override always true | — | **red** |
| delete-exemption removed | — | **red** |
| exec bit removed | — | **red** |

One honest note on that last row: my first measurement said green, because the harness re-applied `chmod +x` after mutating. Re-measured in isolation. Same instrument failure this issue keeps producing.

## Also pinned — the two things that made #1304 dead on arrival

- **The exec bit.** Git invokes the hook directly, unlike a Claude hook wired with `node`, so the mode is load-bearing. Staged `100755`, asserted by a test.
- **`core.hooksPath`.** `.git/hooks` is not version-controlled, so a committed hook is inert on every clone. A `prepare` script points git at `.githooks`, and a test fails if it is missing.

## Scope and limits

Agents only. Hooks and `settings.json` share the restart-activation problem but have no equivalent "it ran" event, and the deny message says so rather than implying coverage that does not exist. `--no-verify` bypasses this as it does every git hook; `step35-verify-gate` denies that flag separately.

## Verification

`test:scripts` **641 passing**; `lint:docs`, `lint:okf`, `lint:budget` clean.

refs #1150, refs #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU