### PR TITLE
fix(hooks): say what the agent gate actually is — the override is the mechanism, not a fallback (refs #1298)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,12 +25,17 @@
 // SCOPE: agents only. Hooks and `settings.json` share the restart-activation problem and have no
 // equivalent "it ran" event, so they are not covered and this does not pretend otherwise.
 //
-// ESCAPE HATCH, on purpose. `AGENT_VERIFIED=1 git push` passes. #1150 rejected earlier gates because
-// "a deny the operator cannot satisfy honestly leaves only the override" — a demand that cannot be met
-// just manufactures the override. This one's demand (restart, spawn once) is usually meetable, but the
-// recorder that writes the evidence is a Claude Code hook and may not be loaded. So the stated escape
-// is part of the design, not a leak. `--no-verify` bypasses it as it does every git hook; the
-// Claude-side `step35-verify-gate` denies that flag separately.
+// WHAT THIS ACTUALLY IS TODAY: a conscious-confirmation gate, not an evidence-based one. The recorder
+// that would write spawn evidence was part of the `PreToolUse` design that got withdrawn (#1304), so
+// NOTHING currently writes a `spawned` record and `AGENT_VERIFIED=1` is the ONLY way through. Reading
+// the audit log is kept because the recorder may return; it finds nothing today.
+//
+// That makes the override honest rather than a leak — it is the mechanism, not a bypass of it. The
+// gate's value is that it stops you at the moment you would otherwise publish an unrun definition and
+// makes you assert, out loud, that you ran it. #1150 rejected earlier gates because "a deny the
+// operator cannot satisfy honestly leaves only the override"; here the override IS the honest
+// satisfaction. `--no-verify` bypasses the whole hook as it does every git hook; the Claude-side
+// `step35-verify-gate` denies that flag separately.
 
 import fs from 'node:fs'
 import { execFileSync } from 'node:child_process'
@@ -68,8 +73,10 @@ export function rangeForLine(line, fallbackBase = 'origin/main') {
   return ZERO.test(remoteSha || '') ? `${fallbackBase}...${localSha}` : `${remoteSha}..${localSha}`
 }
 
-/** Agent names with a recorded successful spawn, written by the Claude-side `PostToolUse` recorder.
- *  Absent entirely when that hook is not loaded — which is what `AGENT_VERIFIED` exists for. */
+/** Agent names with a recorded successful spawn. NO recorder currently ships — the one that would
+ *  write these records was withdrawn with #1304 — so this returns empty in practice. Kept because the
+ *  format is what a future recorder would emit, and because an empty result is the correct answer
+ *  either way. */
 export function spawnedAgents(auditText) {
   const out = new Set()
   for (const line of String(auditText || '').split('\n')) {
@@ -97,11 +104,14 @@ export function denyMessage(names) {
     `\nBLOCKED — agent definition(s) never spawned: ${names.join(', ')}\n\n` +
     `A file under .claude/agents/ loads at SESSION START, so the session that wrote it cannot have\n` +
     `run it. Pushing now publishes a definition nobody has executed.\n\n` +
-    `Either:\n` +
-    `  1. Start a session rooted in this working tree, spawn the agent once so it resolves, push again.\n` +
-    `  2. AGENT_VERIFIED=1 git push   — if you have run it and the recorder was not loaded.\n\n` +
-    `A failed spawn is a stop, not a follow-up item. Scope: agents only; hooks and settings.json are\n` +
-    `not covered by this check.\n\n`
+    `Run it first, then say so:\n` +
+    `  1. Start a session rooted in this working tree and spawn the agent, so you know it resolves\n` +
+    `     and that your edit is what loads.\n` +
+    `  2. AGENT_VERIFIED=1 git push\n\n` +
+    `Step 2 is the only way through: no spawn RECORDER ships today, so spawning alone will not clear\n` +
+    `this. That is deliberate — the gate stops you here so the assertion is a conscious one. Do not\n` +
+    `set AGENT_VERIFIED without having run the agent; a failed spawn is a stop, not a follow-up item.\n\n` +
+    `Scope: agents only; hooks and settings.json are not covered by this check.\n\n`
   )
 }
 

--- a/docs/reference/doc-symbols-allow.txt
+++ b/docs/reference/doc-symbols-allow.txt
@@ -37,3 +37,4 @@ _templates          # Jekyll dir in the sibling aiwatch-reports repo, not this t
 kv_limit_alert      # KV key name in the kv-schema table (data key column, not a code identifier)
 workers_kv          # Cloudflare wrangler OAuth token scope name (whoami output), not ours
 page_location       # GA4 auto-collected event parameter, not a symbol in this tree (#1243)
+PostToolUse         # Claude Code hook event name; no code cites it since the #1304 recorder was withdrawn (#1298)

--- a/docs/reference/workflow-hooks.md
+++ b/docs/reference/workflow-hooks.md
@@ -98,11 +98,23 @@ filtered.
 is local git config, so the gate is live immediately — no session restart, which is what neither
 Claude-hook attempt could get past. Both of those shipped inert.
 
-**`AGENT_VERIFIED=1` is a designed exit, not a leak.** The spawn evidence is written by a Claude-side
-recorder that may not be loaded, so without a stated escape the deny would sometimes be unsatisfiable
-— exactly what #1150 rejected ("a deny the operator cannot satisfy honestly leaves only the
-override"). `--no-verify` bypasses it as it does every git hook; `step35-verify-gate` denies that flag
-separately, so the two layers cover each other.
+**What it is today: a conscious-confirmation gate, not an evidence-based one.** The recorder that
+would write spawn evidence belonged to the withdrawn `PreToolUse` design (#1304), so **nothing
+currently writes a `spawned` record and `AGENT_VERIFIED=1` is the only way through** — spawning the
+agent alone will not clear the deny. The hook still reads the audit log, because the recorder may
+return and an empty result is the right answer either way.
+
+That makes the override the mechanism rather than a bypass of it: the gate stops you at the moment you
+would otherwise publish an unrun definition and makes you assert, out loud, that you ran it. #1150
+rejected earlier gates because "a deny the operator cannot satisfy honestly leaves only the override";
+here the override IS the honest satisfaction. The deny message says so plainly, so nobody reads step 1
+as sufficient. `--no-verify` bypasses the whole hook as it does every git hook; `step35-verify-gate`
+denies that flag separately, so the two layers cover each other.
+
+**Whether to add the recorder is open.** It would be a Claude `PostToolUse` hook, which reintroduces
+the binding problem that sank both earlier attempts — and its load-bearing premise, that `PostToolUse`
+fires only on SUCCESS, has never been observed. Until someone measures that, the honest design is the
+one shipped.
 
 **Two things make it live, and both are pinned by `scripts/prepush-agent-gate.test.mjs`:** the exec
 bit (git invokes the hook directly, unlike a `node`-wired Claude hook) and a `prepare` script pointing


### PR DESCRIPTION
The gate merged in #1305 describes an evidence path that does not exist.

## What was wrong

Its comments, the docs section, and — worst — **the deny message the operator reads** all implied that a spawn *recorder* writes proof, and that `AGENT_VERIFIED=1` is a fallback for when that recorder is not loaded.

**There is no recorder.** It belonged to the `PreToolUse` design withdrawn as #1304; #1305 brought over only the git hook. The audit log holds **zero** `spawned` records and always has. `AGENT_VERIFIED=1` is the only way through.

The deny text was the real defect. Step 1 told the operator to start a session and spawn the agent — which clears nothing, because nothing records it. **Following the instructions as written left you exactly where you started.**

## What it says now

```
Run it first, then say so:
  1. Start a session rooted in this working tree and spawn the agent, so you know it resolves
     and that your edit is what loads.
  2. AGENT_VERIFIED=1 git push

Step 2 is the only way through: no spawn RECORDER ships today, so spawning alone will not clear
this. That is deliberate — the gate stops you here so the assertion is a conscious one. Do not
set AGENT_VERIFIED without having run the agent; a failed spawn is a stop, not a follow-up item.
```

Step 1 is still worth doing — it is how you learn the definition resolves and that *your* edit is what loads — but it is no longer presented as something that satisfies the gate.

## What the gate actually is

A **conscious-confirmation** gate, not an evidence-based one. It stops you at the moment you would otherwise publish an unrun definition and makes you assert, out loud, that you ran it.

That makes the override the **mechanism** rather than a bypass of it. #1150 rejected earlier gates because *"a deny the operator cannot satisfy honestly leaves only the override"* — here the override **is** the honest satisfaction, and the message says not to set it without having run the agent.

The audit reader is kept: the format is what a future recorder would emit, and an empty result is the correct answer either way.

## Left open, with the reason

Whether to add the recorder. It would be a `PostToolUse` hook, which reintroduces the binding problem that sank both earlier attempts — and its load-bearing premise, that it fires only on **success**, has never been observed by anyone. Until someone measures that, the shipped design is the honest one.

## Note

`lint:docs` caught `PostToolUse` as a cited symbol with no source reference — exactly right now that the recorder is gone. Allowlisted as an external harness event name with that reason.

## Verification

Deny message re-rendered from the shipped hook in a throwaway repo. `test:scripts` 13/13 on this suite; `lint:docs`, `lint:okf`, `lint:budget` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU