### PR TITLE
fix(review): give the findings-only reviewer a locator, not a file:line (#1298)

### DIFF
--- a/.claude/agents/review-findings-only.md
+++ b/.claude/agents/review-findings-only.md
@@ -81,8 +81,10 @@ than silently mixing two states.
 
 ## Report shape
 
-Open with what you reviewed — the exact diff range and file list — so the caller can tell whether you
-saw what they meant. Then group by severity (**Critical 91-100**, **Important 80-89**), each finding
+Open with what you reviewed, precisely enough that the caller can tell whether you saw what they meant
+— the diff range and file list when the target is a diff, otherwise whatever identifies it (an issue
+number, a PR number, a commit). The same rule as the locator above: do not describe a non-file target
+as if it were a file list. Then group by severity (**Critical 91-100**, **Important 80-89**), each finding
 carrying the four things above.
 
 Close with a plain verdict: **is there a Critical or Important a reasonable reviewer would block the

--- a/.claude/agents/review-findings-only.md
+++ b/.claude/agents/review-findings-only.md
@@ -6,7 +6,7 @@ model: opus
 color: yellow
 ---
 
-You are a code reviewer for this repository. You review a diff against the project's own rules in
+You are a code reviewer for this repository. You review against the project's own rules in
 `CLAUDE.md` and `docs/reference/*`, and you report **findings**. You do not write the fix.
 
 ## The one rule that makes this agent different
@@ -81,12 +81,10 @@ than silently mixing two states.
 
 ## Report shape
 
-Open with what you reviewed, precisely enough that the caller can tell whether you saw what they meant
-— the diff range and file list when the target is a diff, otherwise whatever identifies it (an issue
-number, a PR number, a commit). The same rule as the locator above: do not describe a non-file target
-as if it were a file list. Then group by severity (**Critical 91-100**, **Important 80-89**), each finding
-carrying the four things above.
+Open with what you reviewed, precisely enough that the caller can tell whether you saw what they meant.
+Then group by severity (**Critical 91-100**, **Important 80-89**), each finding carrying the four things
+above.
 
 Close with a plain verdict: **is there a Critical or Important a reasonable reviewer would block the
-merge on?** If there is nothing at or above 80, say the diff is clean and say what you checked to
+merge on?** If there is nothing at or above 80, say so and say what you checked to
 conclude that.

--- a/.claude/agents/review-findings-only.md
+++ b/.claude/agents/review-findings-only.md
@@ -41,7 +41,11 @@ Filter aggressively. A short report of defects that survive scrutiny is worth mo
 
 ## Every finding must carry these four things
 
-1. **`file:line`** — where it is.
+1. **A locator.** `file:line` when the target is a file. When it is not — an issue body, a PR body, a
+   commit message — give the command that retrieves it (`gh issue view N`, `gh pr view N`,
+   `git show <sha> -- <path>`). Do not invent a line number for something that has none. This clause
+   used to say `file:line` flat, which silently assumed every review target is a file; the first real
+   run put two of four findings on an issue body and a PR body.
 2. **The defect, in one sentence.** What is false, broken, or in violation. Not what to write instead.
 3. **Reproduction, or an explicit "judgement call".** A reproduction is a concrete input → wrong output,
    a failing check, or a mutation you ran that stayed green. If you have none, write

--- a/docs/reference/code-review-policy.md
+++ b/docs/reference/code-review-policy.md
@@ -80,7 +80,8 @@ subagent prompts without being read), but reading it would not have been suffici
 remaining lever is not a better reminder.
 
 **`.claude/agents/review-findings-only.md`** is that lever. It is a project-defined reviewer whose system
-prompt forbids replacement prose outright — findings, `file:line`, reproduction-or-judgement-call, and
+prompt forbids replacement prose outright — findings, a locator (`file:line` for a file, a retrieval
+command for an issue or PR body), reproduction-or-judgement-call, and
 round attribution, with no "change it to this". Where the answer is a deletion it says so as a finding
 and lets the caller delete. It keeps the ≥80 floor, since that is the plugin reviewer's one real quality
 signal. Use it for the step 5-6 loop from round 2 onward, when the previous round's fix is itself part of

--- a/docs/reference/code-review-policy.md
+++ b/docs/reference/code-review-policy.md
@@ -80,8 +80,7 @@ subagent prompts without being read), but reading it would not have been suffici
 remaining lever is not a better reminder.
 
 **`.claude/agents/review-findings-only.md`** is that lever. It is a project-defined reviewer whose system
-prompt forbids replacement prose outright — findings, a locator (`file:line` for a file, a retrieval
-command for an issue or PR body), reproduction-or-judgement-call, and
+prompt forbids replacement prose outright — findings, a locator, reproduction-or-judgement-call, and
 round attribution, with no "change it to this". Where the answer is a deletion it says so as a finding
 and lets the caller delete. It keeps the ≥80 floor, since that is the plugin reviewer's one real quality
 signal. Use it for the step 5-6 loop from round 2 onward, when the previous round's fix is itself part of


### PR DESCRIPTION
## What

`.claude/agents/review-findings-only.md` told the reviewer that every finding carries a `file:line`. The first real run put two of four findings on an issue body and a PR body, which have no line numbers. Requirement 1 now asks for a locator: `file:line` for a file, a retrieval command (`gh issue view N`, `gh pr view N`, `git show <sha> -- <path>`) for anything else.

- `4174dc0` — requirement 1: a locator, not a flat `file:line`
- `259df3d` — the same assumption in `## Report shape` and in `docs/reference/code-review-policy.md`
- `0e6039c` — deletion-only: `You review a diff` → `You review`; `say the diff is clean` → `say so`; and **the clause `259df3d` had just added to `## Report shape` is deleted outright**, because it was a second statement of the rule requirement 1 already makes
- `e99fcb2` — the policy page's copy of the locator FORMAT is deleted too; it now says "a locator" and leaves the format to the agent's own instructions

refs #1298

## Four rounds on one class, and what ended it

Rounds 1-3 each fixed the flagged sentence and left a sibling standing. Round 3 deleted one copy and its message asserted "the rule now lives in exactly one place" — true of the file it had edited, false of the branch, since the copy round 2 put in the policy page was still there. `e99fcb2` retracts that and removes the copy.

The two copies had already drifted, which is the argument against keeping them: the agent file named three non-file targets, the policy page named two, and the policy page had dropped the "do not invent a line number" clause. Nothing pins them together.

Two mentions of "diff" remain in the agent file on purpose — the frontmatter `description` (when a CALLER should reach for this agent) and line 79 (narrating a past incident on this repo). Neither tells the agent what it is looking at.

## Verification

Each definition edit was exercised by starting a session rooted in this worktree and spawning `review-findings-only` — the agent's own first customer under the `a81d71c` pre-push gate, which blocked every push of an unspawned definition and was overridden with `AGENT_VERIFIED=1` only after a spawn.

**The obvious discriminator does not work.** Asking whether the returned report's locators *look* right is a false positive: a session running the pre-edit definition still produced `Locator: gh issue view 1298`, because the prompt described the target as a non-file one and the model complied without being told to. What separates the versions is making the agent quote its own instructions VERBATIM with reading its definition file forbidden. Round 3 was confirmed that way on requirement 1; round 4 on `## Report shape`, since requirement 1 was unchanged by it and would not have discriminated.

`e99fcb2` touches no agent definition, so the gate passed it with no override.

## Standing gap, not fixed here

No lint reads `.claude/agents/*`. `lint:okf` (22 pages), `lint:docs` (23 docs) and `lint:budget` are green and none of them measure that directory, so every finding in these four rounds came from a human-triggered review rather than CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU
