### PR TITLE
fix(worker): name the mixed row by a rule that holds, and retire two stale WAE claims (#1293)

### DIFF
--- a/worker/src/api-traffic.ts
+++ b/worker/src/api-traffic.ts
@@ -4,12 +4,12 @@
 // counter, Workers analytics don't break down by URL path, and the worker runs on a
 // workers.dev subdomain (no zone-level HTTP analytics). This records one Analytics Engine
 // data point per served (non-429) v1 request, mirroring the #494 statusline pattern, so the
-// call volume becomes queryable via the Cloudflare GraphQL Analytics API.
+// call volume becomes queryable.
 //
 // Schema (dataset: aiwatch_statusline, binding env.ANALYTICS):
 //   index1  = constant 'v1-status'           → total v1 traffic via one index filter (≤32 bytes)
 //   blob1   = 'v1-status-all'|'v1-status-service' → optional all-vs-per-service split
-//   double1 = 1                              → request counter (SUM in GraphQL queries)
+//   double1 = 1                              → request counter
 
 // AnalyticsEngineDataset is a global ambient type from @cloudflare/workers-types.
 
@@ -64,7 +64,7 @@ export interface V1TrafficCounts {
 //   blob1   = 'feed-all' | 'feed-service'     → /feed.xml vs /feed/:slug split
 //   blob2   = feed target (#1273)             → service id | FEED_ALL_TARGET | FEED_UNKNOWN_TARGET
 //   blob3   = client class (#1273)            → a `FeedClientClass` (the union owns the list)
-//   double1 = 1                               → request counter (SUM in AE SQL)
+//   double1 = 1                               → request counter
 //
 // #1273 — WHY blob2/blob3 exist. blob1 alone answers "how many polls", which nobody reading it later
 // can turn into "how many subscriptions": every poller shares one anonymous URL. blob2 says WHICH
@@ -518,7 +518,7 @@ export async function queryFeedTraffic(
 // so per-service embed counts are directly queryable via GROUP BY blob1.
 //   index1  = 'badge-request'                                  → total badge traffic, one index filter
 //   blob1   = serviceId, or BADGE_UNKNOWN_SERVICE on a miss     → per-service breakdown
-//   double1 = 1                                                 → request counter (SUM in AE SQL)
+//   double1 = 1                                                 → request counter
 // blob1 is NOT restricted to known service ids by the handler's `^[a-z0-9_-]+$` validation — that
 // regex only constrains the character set, and the badge handler deliberately still records a
 // not-found id (a stale/retired-service embed is itself a signal worth surfacing). Recording the
@@ -1241,7 +1241,7 @@ export async function countNewFeedItems(kv: KVNamespace, now: Date = new Date())
 // Schema (dataset: aiwatch_statusline, binding env.ANALYTICS):
 //   index1  = constant 'cache-read'   → all snapshot-read failures behind one index filter
 //   blob1   = the outcome            → which failure it was
-//   double1 = 1                       → counter (SUM)
+//   double1 = 1                       → counter
 export const CACHE_READ_INDEX = 'cache-read' as const
 
 /** The mutually-exclusive ways a status-snapshot read fails to yield a usable snapshot. Every one

--- a/worker/src/growth-series.ts
+++ b/worker/src/growth-series.ts
@@ -96,9 +96,10 @@ export interface GrowthDailyRow {
   //   absent → the row predates #1273. NOT zero, and not a failure either: nothing was instrumented.
   // Reading `absent` as 0 would manufacture a step-up on the deploy date out of nothing.
   //
-  // The day of deploy is a mixed row: its 24h AE window straddles the deploy, so it stores a map
-  // covering only the instrumented part, indistinguishable from a complete one. Which row that is
-  // cannot be recovered from the series — the deploy date goes in docs/reference/kv-schema.md's
+  // The FIRST row carrying this field is a mixed row: its 24h AE window straddles the deploy, so it
+  // stores a map covering only the instrumented part, indistinguishable from a complete one. It is not
+  // always the deploy-day row — #1275 landed after that day's 09:00 run, so `2026-08-24` predates the
+  // field and `2026-08-25` is the mixed one. The deploy date goes in docs/reference/kv-schema.md's
   // `growth:daily` cell, as `audienceBySource` already does for #1055.
   //
   // The window is the AE query's rolling `NOW() - INTERVAL '1' DAY`, i.e. the same 24h span the
@@ -144,9 +145,10 @@ export interface GrowthDailyRow {
   // exclusion and its start date belongs in the kv-schema `growth:daily` cell beside the deploy
   // boundaries. Read all three as CHANGE, never as a population.
   //
-  // Deploy day is a mixed row here too (the AE window straddles it) and which row that is cannot be
-  // recovered from the series — the boundary goes in docs/reference/kv-schema.md's `growth:daily`
-  // cell, beside the `feedPolls` (#1273) and `audienceByScreen` (#1280) boundaries.
+  // The first row carrying these fields has a 24h window that straddles the deploy — here that IS the
+  // deploy-day row, #1297 having landed before the run — but its counts are NOT mixed: the row covers
+  // a fully recorded window. The boundary goes in docs/reference/kv-schema.md's `growth:daily` cell,
+  // beside the `feedPolls` (#1273) and `audienceByScreen` (#1280) boundaries.
   extPolls?: number | null
   extPollsRead?: PollsVerdict
   // The plugin's two indexes stay SEPARATE (`aiwatch-monitor` background polls vs `aiwatch-brief`

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5222,7 +5222,7 @@ export default {
             const safeSrc = src.slice(0, 32)
             env.ANALYTICS.writeDataPoint({
               blobs: [safeSrc],   // blob1: full src tag (preset slug)
-              doubles: [1],       // double1: request counter (sum in GraphQL queries)
+              doubles: [1],       // double1: request counter
               indexes: [safeSrc], // fast dimension filter (max 32 bytes)
             })
           } catch (err) {

--- a/worker/src/outage-audience.ts
+++ b/worker/src/outage-audience.ts
@@ -27,7 +27,7 @@
 //                                                     AudienceSurfaceKey — a hand-written AE SQL
 //                                                     filter of `IN ('service','group')` silently
 //                                                     drops every deploy-window row.
-//   double1 = 1                                     → view counter (SUM in AE SQL)
+//   double1 = 1                                     → view counter
 //
 // #1280 — why blob3 alone could not be read. Two surfaces write it. A per-service page sends its own
 // id, but a provider-family GROUP page (`/is-claude-down`, #1164) has a slug that is not a service id,

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -19,7 +19,9 @@ binding = "AI"
 
 [[analytics_engine_datasets]]
 binding = "ANALYTICS"
-dataset = "aiwatch_statusline" # #494: statusline per-preset traffic counts (queried via CF GraphQL)
+# Named for its first use (#494, statusline presets); it now carries every WAE counter in the worker,
+# this being the only dataset. Read via the SQL REST API, not GraphQL.
+dataset = "aiwatch_statusline"
 
 # #955 — without this, `console.error`/`console.warn` are emitted and immediately lost, so a
 # silently-failing AI path (a retired model id 404ing for weeks) is undiagnosable after the


### PR DESCRIPTION
Comment-only, five files. Two unrelated-looking corrections that turned out to be the same shape: a claim that stopped being true, left standing in every place it was copied to.

refs #1293

## 1. The mixed row was named by the wrong rule

Two blocks in `worker/src/growth-series.ts` tell a future reader which rows of a permanent, un-backfillable series are comparable.

`main`, for `feedPolls`: *"The day of deploy is a mixed row"*. #1275 merged `2026-08-24T12:13:59Z`, **after** that day's 09:00 UTC run — so the `2026-08-24` row was written by pre-#1273 code and carries the field ABSENT. The mixed row is `2026-08-25`. A reader following the comment would treat an empty row as mixed and a 508-of-586-poll row as complete: the exact misreading the block exists to prevent.

Both blocks now identify the row as **the first one carrying the field** — a rule that holds whichever side of the run the deploy lands on, which is why the old phrasing gave opposite answers (#1297 merged `03:29:14Z`, *before* its run, so there the deploy-day row genuinely is the straddling one).

Also deleted from both blocks: *"which row that is cannot be recovered from the series"*. False — the ABSENT→PRESENT transition names it exactly, which the same block already implied 29 lines up by warning that reading ABSENT as zero *"would manufacture a step-up on the deploy date out of nothing"*.

**The split this turns on**, verified from the deploy commits and the raw dataset rather than the comments: #1275 changed the WAE write payload (added `blob2`/`blob3`) so its row is genuinely partial; #1297 substituted three value-identical consts and touched no statusline write site, so its row is not. `ext-claude` appears in **24 of 24 hours** of the `2026-09-01` window summing to **1924** — the stored `extPolls` exactly, no discontinuity at the deploy.

## 2. Two stale claims about the WAE dataset

**Read path.** `wrangler.toml` said *"queried via CF GraphQL"*. No GraphQL reader exists — all seven AE reads POST to `/accounts/{id}/analytics_engine/sql`. Its description was also frozen at first use: named for #494's statusline presets, it now carries every WAE counter in the worker, this being the only dataset. The same GraphQL claim survived in three more `worker/src` comments, so the first fix de-staled one copy of four.

**Aggregation.** Six comments annotated `double1 = 1` as the field to SUM. Every `doubles` payload is the constant `1`, so `SUM(double1)` is exactly the `COUNT(*)` that `api-traffic.ts:1277` forbids in as many words — *"NOT COUNT(\*), which would undercount"*. Measured on seven days of `v1-status`: **8187 rows against a sample-corrected 14100, a 41.9% undercount.** No query reads `double1` at all.

Deleted with no correct-mechanism note in their place: a note beside a field nothing reads would be a fresh claim about dead weight, and the rule already sits in `buildV1TrafficSql`'s docblock.

`utils.ts:142` keeps its GraphQL mention deliberately — its subject is KV-namespace read volume (#1224), a different Cloudflare API the AE SQL endpoint cannot answer.

## Verification

**Eight rounds, 8 findings, 2 Critical.** Rounds 2-8 ran `review-findings-only`, each told to inherit nothing and re-derive unbounded.

The loop's own stop trigger fired twice. Round 6 found three sibling copies I had left standing; round 7 found four more of the other axis — two consecutive rounds on unswept siblings — so the last fix was a **sweep across every `double1` line** rather than another hand-edit of the instances named. Round 8 enumerated the result independently with positive controls, searched three other vocabularies for the same claim in a form no regex of mine would have matched, re-derived the 41.9% figure from production, and came back clean. It also found a candidate at `index.ts:84`, rated it ~72 and said explicitly not to touch it — editing it would have been a fourth consecutive round on comment prose adjacent to the previous fix.

Findings that were mine to own: round 1's was a claim I had disproved with my own hands and then wrote anyway; round 3's Critical was the false row name above, which I preserved without checking; round 4's was a closed-set assumption over `index1 LIKE 'statusline-%'` — an open predicate whose write side takes `?src=` through a 32-byte truncation and no allowlist, which `docs/reference/kv-schema.md` calls *"an unbounded, externally-controlled key space"*. And I misread my own sweep check once: `grep -ci "sum\|count"` returned 6, which I read as six survivors before noticing `count` matches inside `counter`.

`wrangler deploy --dry-run` clean, `typecheck:worker` 0 errors, `test:worker` 152 files / 4972 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU
