### PR TITLE
fix(lint): judge a doc citation on a window, not on 16.6k characters of line (#1312)

### DIFF
--- a/scripts/check-doc-symbols.mjs
+++ b/scripts/check-doc-symbols.mjs
@@ -85,28 +85,61 @@ export function isCodeShaped(tok) {
 /**
  * A line/sentence that documents a symbol's REMOVAL, RENAME, or absence. The hardest false positive is
  * a doc CORRECTLY saying "#713 removed `estimateUptimeFromIncidents`" — shape-identical to #1076's
- * invented `violationsOf`, distinguishable only by the surrounding prose. If a removal/rename/absence
- * verb sits on the same line, the cited symbol is deliberately absent, not a dangler.
+ * invented `violationsOf`, distinguishable only by the surrounding prose.
  *
- * Deliberately line-scoped, not whole-doc: these docs use paragraph-length lines, so "same line" ≈
- * "same thought". Residual risk — a NEW invented symbol added to a paragraph that also says "removed"
- * would be masked — is accepted as rare; the allowlist covers anything this misses.
+ * `delet` carries `\w*` because it never matched anything (#1312). The group's trailing `\b` demands a
+ * non-word character after the alternative, and "deleted" continues with "e" — so the stem was dead
+ * from #1100. Nothing noticed: the exemption used to be judged on the WHOLE line, and a 16.6k-character
+ * line needs only ONE trigger anywhere in it, which the full-word alternatives always supplied. The two
+ * defects hid each other — narrowing the scope without this fix surfaces three legitimate removal
+ * citations in product-constraints.md as false positives.
+ *
+ * `dropp` and `deprecat` were dead the same way and stay dead, deliberately. The corpus does not
+ * implicate them — in these docs "dropped" is the ordinary word for a runtime discard and "deprecation"
+ * appears as a data value, not as a note that a symbol is gone. Reviving a stem the corpus does not
+ * force is a new exemption rule, not a bug fix. Both directions are pinned by tests.
  */
 export function isRemovalContext(line) {
-  return /\b(removed?|delet|dropp|retired?|deprecat|no longer|renamed?|replaced by|was `|used to|former|gone\b|absent)\b/i.test(line)
+  return /\b(removed?|delet\w*|retired?|no longer|renamed?|replaced by|was `|used to|former|gone\b|absent)\b/i.test(line)
     || /삭제|제거|없앴|없어졌|폐기|이전 이름|옛/.test(line)
+}
+
+/** How far from a citation a removal verb still governs it. DERIVED, not picked: the furthest citation
+ *  in CLAUDE.md and docs/reference that needs the exemption sits 151 characters from its verb
+ *  (`estimateUptimeFromIncidents` in product-constraints.md), and 200 clears it with margin. The lower
+ *  bound is pinned by the real-corpus test, which reddens once the window stops covering that citation.
+ *  A removal note further than this from its symbol fails loudly and takes an allowlist entry — the
+ *  designed exit. */
+export const REMOVAL_WINDOW_CHARS = 200
+
+/** The text a citation's exemption is judged on: itself plus `REMOVAL_WINDOW_CHARS` either side.
+ *
+ *  Judging the whole line is what #1312 was: kv-schema.md's `growth:daily` cell is ONE line of 16.6k
+ *  characters carrying "used to", "ABSENT" and "removed", so every symbol in it was exempt and a
+ *  fabricated name planted there survived.
+ *
+ *  A window, not a splitter. Splitting the line at table pipes and sentence ends was tried and is wrong
+ *  in both directions: it cuts INSIDE inline code spans — `string | null` in backticks becomes two
+ *  fragments with unbalanced backticks, and every identifier after the cut stops being extracted at all
+ *  — and it cuts too finely the other way, so on the canonical
+ *  removal row `| oldFn | removed in #713 |` the verb and the symbol land in different cells and a
+ *  correct doc becomes a false positive. A window needs no notion of a boundary and has neither. */
+export function removalWindow(line, start, end) {
+  return line.slice(Math.max(0, start - REMOVAL_WINDOW_CHARS), end + REMOVAL_WINDOW_CHARS)
 }
 
 /** Extract inline-backtick identifier tokens from prose (fenced blocks already stripped). */
 export function extractInlineTokens(prose) {
   const out = new Set()
   for (const line of prose.split('\n')) {
-    if (isRemovalContext(line)) continue // a line documenting removal/rename cites absent symbols on purpose
     // single-backtick spans; skip double+ (rare). Token = the identifier at the head of the span
     // (`foo`, `foo.bar`→foo, `foo()`→foo).
     for (const m of line.matchAll(/(?<!`)`([^`\n]+)`(?!`)/g)) {
       const head = m[1].trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/)
-      if (head && isCodeShaped(head[1]) && !STOPLIST.has(head[1]) && !isMemoryPageName(head[1])) out.add(head[1])
+      if (!head || !isCodeShaped(head[1]) || STOPLIST.has(head[1]) || isMemoryPageName(head[1])) continue
+      // a removal/rename verb NEAR this citation means the symbol is absent on purpose
+      if (isRemovalContext(removalWindow(line, m.index, m.index + m[0].length))) continue
+      out.add(head[1])
     }
   }
   return out

--- a/scripts/check-doc-symbols.test.mjs
+++ b/scripts/check-doc-symbols.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
-  stripFencedBlocks, isCodeShaped, isMemoryPageName, isRemovalContext,
+  stripFencedBlocks, isCodeShaped, isMemoryPageName, isRemovalContext, REMOVAL_WINDOW_CHARS,
   extractInlineTokens, parseAllowlist, auditDocSymbols,
   docFiles, collectSourceBlob,
 } from './check-doc-symbols.mjs'
@@ -130,4 +130,87 @@ test('a doc re-introducing the #1076 headline example IS flagged against the rea
   const docs = [{ file: 'z.md', content: 'This line justifies itself with `violationsOf`.' }]
   const findings = auditDocSymbols({ docs, sourceBlob: collectSourceBlob(ROOT), allow: new Map() })
   assert.deepEqual(findings.map((f) => f.token), ['violationsOf'])
+})
+
+// ── #1312: the window, and the dead stem it was hiding ───────────────────────
+
+test('#1312: `delet` fires on its inflections — the trailing word-boundary made it match NOTHING', () => {
+  for (const w of ['deleted', 'deleting', 'delete', 'deletion']) {
+    assert.ok(isRemovalContext(`#713 ${w} the helper`), `stem does not match "${w}"`)
+  }
+})
+
+test('#1312: `dropped`/`deprecated` are NOT removal contexts — reviving those stems is a new rule', () => {
+  // Both were dead the same way as `delet` and stay dead: in these docs "dropped" is a runtime discard
+  // and "deprecation" is a data value, not a note that a symbol is gone. Without these negatives the
+  // suite is green while that coverage silently disappears.
+  assert.ok(!isRemovalContext('an untagged incident is dropped before scoring'))
+  assert.ok(!isRemovalContext('the poll is dropping under load'))
+  assert.ok(!isRemovalContext('keywords: compliance/access-revocation-or-deprecation'))
+})
+
+test('#1312: the window governs a nearby verb and not a distant one', () => {
+  const near = `#713 removed it. ${'x'.repeat(50)} \`fabricatedHelperName\``
+  const far = `#713 removed it. ${'x'.repeat(REMOVAL_WINDOW_CHARS + 50)} \`fabricatedHelperName\``
+  assert.ok(!extractInlineTokens(near).has('fabricatedHelperName'), 'a verb this close must exempt')
+  assert.ok(extractInlineTokens(far).has('fabricatedHelperName'), 'a verb this far must not')
+})
+
+test('#1312: a pipe inside an inline code span does not blind the rest of the line', () => {
+  // The splitter tried first cut at table pipes, including pipes INSIDE `` `string | null` ``. That left
+  // two fragments with unbalanced backticks and every identifier after the cut stopped being extracted —
+  // a coverage LOSS versus the line-scoped original, in real spans in this corpus.
+  const line = 'the field is `string | null`, produced by `fabricatedHelperName`'
+  assert.ok(extractInlineTokens(line).has('fabricatedHelperName'))
+})
+
+test('#1312: the canonical removal ROW stays exempt — verb and symbol in different cells', () => {
+  // The other direction the splitter got wrong: cell-scoping severs `| \`oldFn\` | removed in #713 |`,
+  // turning the most likely way a doc records a removal into a false positive.
+  const row = '| `estimateUptimeFromIncidents` | removed in #713 | gone |'
+  assert.equal(extractInlineTokens(row).size, 0)
+})
+
+test('#1312: one removal citation no longer immunises a whole 16k-character row', () => {
+  const row = '| `growth:daily` | #713 removed `estimateUptimeFromIncidents` entirely |'
+    + ` ${'filler. '.repeat(60)} it calls \`fabricatedHelperName\` daily |`
+  const toks = extractInlineTokens(row)
+  assert.ok(toks.has('fabricatedHelperName'), 'a citation far from the verb must still be checked')
+  assert.ok(!toks.has('estimateUptimeFromIncidents'), 'the citation beside the verb stays exempt')
+})
+
+test('#1312 MUTATION: judging the whole line re-hides the fabricated symbol', () => {
+  // Guards the fix itself: with a line-wide skip this row yields nothing, because the removal note far
+  // to the left covers the fabricated name. That was the defect.
+  const row = '| `growth:daily` | #713 removed `estimateUptimeFromIncidents` entirely |'
+    + ` ${'filler. '.repeat(60)} it calls \`fabricatedHelperName\` daily |`
+  const lineScoped = (prose) => {
+    const out = new Set()
+    for (const line of prose.split('\n')) {
+      if (isRemovalContext(line)) continue
+      for (const m of line.matchAll(/(?<!`)`([^`\n]+)`(?!`)/g)) {
+        const head = m[1].trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/)
+        if (head && isCodeShaped(head[1])) out.add(head[1])
+      }
+    }
+    return out
+  }
+  assert.equal(lineScoped(row).size, 0, 'the old scope saw nothing here — that was the defect')
+  assert.ok(extractInlineTokens(row).has('fabricatedHelperName'), 'the shipped window sees it')
+})
+
+test('#1312 REAL DOCS: a fabricated symbol planted in the longest table row is caught', () => {
+  // A pure-function test cannot prove the blind spot is closed in the corpus this gate actually reads.
+  // Plant a name in kv-schema.md's real `growth:daily` cell — the 16.6k-character line — and require the
+  // audit to flag it. This assertion fails on the pre-#1312 script.
+  const file = join(ROOT, 'docs/reference/kv-schema.md')
+  const raw = readFileSync(file, 'utf8')
+  assert.ok(raw.includes('`readPluginPolls`'), 'anchor symbol missing — re-anchor this test, do not delete it')
+  const mutated = raw.replace('`readPluginPolls`', '`readPluginPollsFabricated1312`')
+  assert.notEqual(mutated, raw, 'mutation did not apply')
+  const findings = auditDocSymbols({ docs: [{ file, content: mutated }], sourceBlob: 'nothing here', allow: new Map() })
+  assert.ok(
+    findings.some((f) => f.token === 'readPluginPollsFabricated1312'),
+    'a fabricated symbol in the longest row went unflagged — the #1312 blind spot is back',
+  )
 })


### PR DESCRIPTION
## The blind spot

`check-doc-symbols` fails a docs PR that cites a symbol absent from source, and CLAUDE.md names it as a gate on docs PRs. It could not fail on `docs/reference/kv-schema.md:71` — the `growth:daily` cell, **one line of 16,625 characters**, the longest in the corpus. `isRemovalContext` was asked about the whole line; that line carries "used to", "ABSENT" and "removed"; so every symbol in it was exempt. A fabricated name planted there passed while the same name on a short line failed.

closes #1312

## Two defects, hiding each other

The second surfaced only while fixing the first. `delet`, `dropp` and `deprecat` are written as stems, but the alternation closes with `\b`, which demands a non-word character after them — so **none of the three ever matched** `deleted`, `dropped` or `deprecated`. Dead since #1100, unnoticed because a 16.6k-character line needs only ONE trigger anywhere in it and the full-word alternatives always supplied one.

Measured: narrowing the scope *without* reviving `delet` surfaces three legitimate removal citations in `product-constraints.md` as false positives. `dropp` and `deprecat` stay dead deliberately — the corpus does not implicate them, and reviving a stem it does not force is a new exemption rule, not a bug fix. Both directions are pinned by tests, including negatives.

## A window, not a splitter

The first attempt split each line at table pipes and sentence ends. Review found it **wrong in both directions**:

- It cut INSIDE inline code spans — `` `string | null` `` became two fragments with unbalanced backticks, and every identifier after the cut stopped being extracted. **A coverage LOSS, shipped while I claimed a gain**, in 32 real spans.
- It cut too finely the other way: on the canonical removal row `| oldFn | removed in #713 |` the verb and symbol land in different cells, turning a correct doc into a false positive.

`removalWindow` has no notion of a boundary, so neither failure is expressible.

`REMOVAL_WINDOW_CHARS = 200` is **derived, not picked**: the furthest citation needing the exemption sits 151 characters from its verb, and the real-corpus test reddens at 156 and passes at 157 — the lower bound is pinned by a test rather than asserted.

| | citation sites checked |
|---|---|
| `main` | 1393 |
| the rejected splitter | 1643 |
| **shipped window** | **1803** |

8 tokens are newly masked; all are present in source.

## Verification

Four rounds, 9 findings, 2 Critical. Rounds 2-4 ran `review-findings-only`, each told to inherit nothing.

**The same pattern three times: I fixed one copy of a claim and left its sibling.** Round 3 caught a figure round 2 had deleted from the `.mjs` docstring and left verbatim in the test file. Round 4 found a fourth count my own summary of survivors had omitted.

**Two of my numbers did not reproduce and are deleted rather than corrected** — "38 further citation sites" (really 84) and "34 spans" (32 fence-stripped). Comment prose carries no automated check, which `docs/reference/code-review-policy.md` says in as many words, so the counts had to go rather than be repaired. What survives, every round re-derived to the digit.

Eight tests; seven redden under a mutation verified to have applied, and the eighth pins the rejected splitter design. Round 2 deleted one that guarded nothing — `String.slice` already clamps a negative start, so the test named for the `Math.max(0, …)` clamp stayed green when the clamp was removed.

Round 4 caught **its own** instrument first: its initial window sweep wrote the mutated module into `scripts/`, which `collectSourceBlob` walks, so a symbol named in that docstring registered as "exists" and the sweep reported the wrong furthest citation. Re-run outside the scanned roots, `151` held.

`npm run test:scripts` 653/653; `lint:docs` and `lint:okf` green. Both workflows gate this change — `test.yml` has no `paths-ignore` for `scripts/`, and `docs-lint.yml` lists `check-doc-symbols.mjs`.

## No docs page updated

Nothing in `CLAUDE.md` or `docs/reference/*` describes this predicate's scope, so nothing went stale. Adding a description would be a prose mirror with no test behind it. All four rounds agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nKfwXXDPuowGwpEL3ByDU
