### PR TITLE
chore: migrate Claude Code skills to Codex

### DIFF
--- a/.codex/skills/issue-triage/SKILL.md
+++ b/.codex/skills/issue-triage/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-triage
+description: Review the AIWatch open-issue board for stale, shipped, superseded, or invalid issues and derive the next work priority.
+metadata:
+  short-description: Triage and prioritize the AIWatch issue board
+---
+
+# Codex issue triage
+
+Use this skill for a board-wide staleness sweep and prioritization. Run `git fetch origin`, record
+`git rev-list --count HEAD..origin/main`, and inspect both AIWatch and the sibling reports repository
+when it exists. List open issues, open PRs, and recently merged PRs with `gh`. For each open issue,
+check whether it shipped, was superseded, or has an invalid premise; verify checklist items against
+the code before recommending closure or work. Inspect every worktree with `git worktree list --porcelain`
+and treat locks, non-empty status, or commits ahead of `origin/main` as in-flight work.
+
+Classify live issues with one `area:` label (`dev`, `design`, `ops`, `biz`, or `marketing`) and one
+urgency label (`U0-now` through `U3-someday`), then derive P0–P3 from impact, urgency, and effort.
+Impact ranks wrong user-visible values highest, then silent failures, degraded experiences, and
+internal-only cost. Exclude merged or `verify-after` work from the do-next list as P1*. Balance the
+recommended pick across areas, state every deadline, and never print a bare issue number.
+
+Use `exec_command` for git, `gh`, `rg`, and focused file reads. Do not mutate issues, labels, or bodies
+until the user confirms. When applying a confirmed update, synchronize body checkboxes and retain
+English factual comments as the repository convention requires.

--- a/.codex/skills/issue-triage/agents/openai.yaml
+++ b/.codex/skills/issue-triage/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Issue Triage"
+  short_description: "Triage and prioritize the AIWatch issue board"
+  default_prompt: "Use $issue-triage to review and prioritize the AIWatch open issues."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/memory-ingest/SKILL.md
+++ b/.codex/skills/memory-ingest/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: memory-ingest
+description: Capture durable session knowledge in the Codex project memory bundle when the user asks to remember it or a durable finding emerges.
+metadata:
+  short-description: Save durable project memory
+---
+
+# Codex memory ingest
+
+Use this skill for an explicit “remember this” request or a durable correction, root-cause finding,
+project constraint, or external reference. Resolve the Codex memory root from the current Codex
+configuration; never assume a Claude-specific path. Do not ingest ephemeral task state, TODOs,
+repository facts already recorded in code/docs, secrets, or unconfirmed guesses.
+
+Deduplicate against the index and existing pages first. Store one concept per
+`memory/<type>_<kebab-slug>.md`, where type is `feedback`, `debugging`, `project`, or `reference`.
+Use frontmatter with `name`, `description`, and `type`; quote descriptions or titles containing a
+bare `#`. Feedback pages must include `Why:` and `How to apply:`. Link related pages with filename
+stems such as `[[feedback_local_verify]]`, add exactly one index line to `MEMORY.md`, and append
+`YYYY-MM-DD ingest: <slug> (<reason>)` to `memory/log.md`. Use `apply_patch`, then verify the index,
+wikilinks, frontmatter, and changed files. If a fact is disproved, remove its page and index entry
+only after user confirmation.

--- a/.codex/skills/memory-ingest/agents/openai.yaml
+++ b/.codex/skills/memory-ingest/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Memory Ingest"
+  short_description: "Save durable project memory"
+  default_prompt: "Use $memory-ingest to save the durable knowledge from this session."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/memory-lint/SKILL.md
+++ b/.codex/skills/memory-lint/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: memory-lint
+description: Audit the Codex project memory bundle for index drift, broken links, stale claims, contradictions, and redundant pages.
+metadata:
+  short-description: Lint project memory health
+---
+
+# Codex memory lint
+
+Use this skill every one to two weeks, after a batch of memory writes, or when recall feels stale.
+Resolve the Codex memory root from the current Codex configuration. Check index↔file drift, broken
+wikilinks, required frontmatter, unquoted `#` truncation, contradictions, stale claims, and redundant
+clusters. Run the repository decision-graph lint with `npm run lint:graph -- --github` when the memory
+bundle supports it; treat structural findings as defects and unclaimed candidates as judgement input.
+
+Write one dated findings line to `memory/log.md`. Auto-fix only mechanical issues such as missing
+index lines, safe link repairs, or quoting truncated YAML. Report proposed merges, deletions, or
+stale-claim changes without applying them until the user confirms. Use `exec_command` for inspection,
+`apply_patch` for safe edits, and verify the final index and links.

--- a/.codex/skills/memory-lint/agents/openai.yaml
+++ b/.codex/skills/memory-lint/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Memory Lint"
+  short_description: "Lint project memory health"
+  default_prompt: "Use $memory-lint to audit the project memory bundle."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/ship-issue/SKILL.md
+++ b/.codex/skills/ship-issue/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ship-issue
+description: Apply the AIWatch issue-to-release workflow when starting, implementing, verifying, reviewing, or closing an issue.
+metadata:
+  short-description: Ship an AIWatch issue safely
+---
+
+# Codex issue delivery
+
+Use this skill at the start of, during, and before closing per-issue work. Read the issue checklist,
+check for an existing PR, inspect all worktrees, and branch from `origin/main` in an isolated worktree.
+For UI work compare the design draft before coding. Use `apply_patch` for edits and add a regression
+test for every bug fix.
+
+Verify locally before committing: use the local Worker with real data for dashboard work, the correct
+Edge/Vercel surface for landing pages, and a real generated artifact for UI-less backend work. Tests
+and automated browser checks do not replace the user's explicit in-browser confirmation. Run the
+scope-appropriate lint, build, unit, E2E, worker typecheck, and dry-run deployment checks.
+
+Review the complete diff against `AGENTS.md`, the development workflow, and relevant references.
+Report only Critical or Important findings with a file/line locator plus reproduction or judgement
+call; re-test after fixes until no such findings remain. Do not adopt unverified replacement prose.
+Before commit, status must contain only intended files. Commit, push, PR, merge, deploy, and issue
+close operations require explicit user approval. Keep production-gated checklist items open with a
+dated `verify-after` plus `assert:` or `durable:` evidence when applicable.

--- a/.codex/skills/ship-issue/agents/openai.yaml
+++ b/.codex/skills/ship-issue/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Ship Issue"
+  short_description: "Ship an AIWatch issue safely"
+  default_prompt: "Use $ship-issue to implement and verify this AIWatch issue."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/strategy-review/SKILL.md
+++ b/.codex/skills/strategy-review/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: strategy-review
+description: Reconstruct AIWatch business and marketing strategy state from durable initiative and decision memory, then identify the next strategic actions.
+metadata:
+  short-description: Review AIWatch strategy state
+---
+
+# Codex strategy review
+
+Use this skill for AIWatch business, growth, marketing, and monetization reviews. Read all
+`type:initiative` memory pages first: their status, evidence, delivered edges, advances edges, next
+action, and exit criterion are the state of record. Traverse decision-graph relations and inspect
+the current decision pages before using discovery artifacts or GitHub issues as evidence. Distinguish
+30-day thread cadence from repo attention measured over a named day window; do not reconstruct
+initiative state from issue checkboxes.
+
+Produce a plain-language brief with active initiatives first, one executable next action per live
+thread, per-initiative shipped/remaining detail, and decisions past their current trigger. Read issue
+gates and open PRs before calling an action startable. Keep board-wide P0–P3 ranking in `issue-triage`.
+Use `exec_command` and direct file reads instead of Claude agent calls. Do not mutate issues, labels,
+memory pages, or production KV while producing the brief unless the user explicitly confirms.

--- a/.codex/skills/strategy-review/agents/openai.yaml
+++ b/.codex/skills/strategy-review/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Strategy Review"
+  short_description: "Review AIWatch strategy state"
+  default_prompt: "Use $strategy-review to reconstruct the current AIWatch strategy and next actions."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/write-monthly-report/SKILL.md
+++ b/.codex/skills/write-monthly-report/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: write-monthly-report
+description: Author and locally verify an AIWatch monthly reliability report using its data, recurrence checks, bilingual content rules, and publication gates.
+metadata:
+  short-description: Write an AIWatch monthly report
+---
+
+# Codex monthly report authoring
+
+Use this skill when editing the sibling `aiwatch-reports` Jekyll report. Work on a
+`report/YYYY-MM` branch, keep `published: false`, and read the target archive plus the previous two
+or three reports. Fill Summary, Korean mirror, Recommendations, Key Insight, Notable Incidents,
+Observations, and the manual NVD attribution check from the report's own data; do not invent numbers.
+Use the generated service count/category header as the source of truth, include specialized
+recommendation rows only for ranked services in buckets present that month, and avoid repeating the
+same story or timeless framing across sections. Keep Score notation bare and Korean prose native.
+
+Delete every AUTO-DRAFT and RECURRENCE CHECK fence before publishing. Run the report's lint and test
+checks, serve drafts with Jekyll using `--unpublished`, and obtain the user's explicit in-browser
+confirmation. Only then may the user-approved commit, PR, merge, or publication happen. Use
+`exec_command` for commands and `apply_patch` for edits; never flip `published` or publish on your
+own authority.

--- a/.codex/skills/write-monthly-report/agents/openai.yaml
+++ b/.codex/skills/write-monthly-report/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Write Monthly Report"
+  short_description: "Write an AIWatch monthly report"
+  default_prompt: "Use $write-monthly-report to draft and verify the AIWatch monthly report."
+policy:
+  allow_implicit_invocation: true

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint:docs": "node scripts/check-doc-symbols.mjs",
     "lint:budget": "node scripts/check-instruction-budget.mjs",
     "lint:korean": "node scripts/lint-korean-copy.mjs",
+    "skills:install": "node scripts/install-codex-skills.mjs",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {

--- a/scripts/install-codex-skills.mjs
+++ b/scripts/install-codex-skills.mjs
@@ -1,0 +1,22 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.dirname(scriptDir)
+const sourceRoot = path.join(repoRoot, '.codex', 'skills')
+const codexRoot = process.env.CODEX_HOME || path.join(process.env.HOME || process.env.USERPROFILE, '.codex')
+const targetRoot = path.join(codexRoot, 'skills')
+
+if (!fs.existsSync(sourceRoot)) {
+  throw new Error(`Codex skill source directory not found: ${sourceRoot}`)
+}
+
+for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue
+  const source = path.join(sourceRoot, entry.name)
+  const target = path.join(targetRoot, entry.name)
+  fs.mkdirSync(targetRoot, { recursive: true })
+  fs.cpSync(source, target, { recursive: true, force: true })
+  console.log(`Installed ${entry.name} -> ${target}`)
+}


### PR DESCRIPTION
## Summary
- add Codex-native adapters for all six repository-local Claude Code skills
- add `agents/openai.yaml` metadata for automatic skill selection
- add `npm run skills:install` to install the skills into `$CODEX_HOME/skills` or `~/.codex/skills`
- preserve the original `.claude/skills` files

## Validation
- `quick_validate.py` passed for all six skills
- `node --check scripts/install-codex-skills.mjs` passed
- `git diff --check` passed
- `npm run lint` passed with 0 errors and 20 pre-existing warnings

Refs #1342

🤖 Generated with [Codex](https://openai.com/codex/)
