### PR TITLE
fix(worker): census live status KV reads

### DIFF
--- a/worker/src/__tests__/kv-read-census.test.ts
+++ b/worker/src/__tests__/kv-read-census.test.ts
@@ -444,3 +444,57 @@ describe('cron wiring (#1224 Phase 2)', () => {
     expect(line).toContain('uninstrumented')
   }, 30_000)
 })
+
+// The account-level remainder is the live `/api/status` path, not the cron path. This test drives
+// the real fetch handler so a census added only around a helper, or skipped on the fallback return,
+// cannot claim to measure the request that pays the reads.
+describe('live status wiring (#1224 Phase 2)', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('emits a conserved census line for the real /api/status handler', async () => {
+    const { kv, calls } = fakeKv()
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network disabled in test'))
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => { logs.push(args.map(String).join(' ')) })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const response = await workerModule.fetch(
+      new Request('https://example.com/api/status'),
+      { ALLOWED_ORIGIN: '*', STATUS_CACHE: kv } as never,
+      { waitUntil: (promise: Promise<unknown>) => { void promise.catch(() => {}) }, passThroughOnException: () => {} } as never,
+    )
+
+    expect([200, 500]).toContain(response.status)
+    const line = logs.find(l => l.includes('[fetch] #1224 kv read census'))
+    expect(line, 'no live fetch census line was emitted').toBeDefined()
+    const total = Number(/total=(\d+)/.exec(line as string)?.[1])
+    expect(total).toBe(calls.get.length + calls.getWithMetadata.length)
+    expect(total).toBeGreaterThan(0)
+    expect(line).toContain('path=/api/status')
+  }, 60_000)
+
+  it('emits the census when the status handler falls back after an internal error', async () => {
+    const { kv, calls } = fakeKv()
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network disabled in test'))
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => { logs.push(args.map(String).join(' ')) })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const env = { ALLOWED_ORIGIN: '*', STATUS_CACHE: kv } as Record<string, unknown>
+    Object.defineProperty(env, 'DISCORD_WEBHOOK_URL', {
+      get: () => { throw new Error('forced status-handler error') },
+    })
+    const response = await workerModule.fetch(
+      new Request('https://example.com/api/status'),
+      env as never,
+      { waitUntil: (promise: Promise<unknown>) => { void promise.catch(() => {}) }, passThroughOnException: () => {} } as never,
+    )
+
+    expect(response.status).toBe(500)
+    const line = logs.find(l => l.includes('[fetch] #1224 kv read census'))
+    expect(line).toBeDefined()
+    expect(Number(/total=(\d+)/.exec(line as string)?.[1])).toBe(calls.get.length + calls.getWithMetadata.length)
+  }, 60_000)
+})

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5652,6 +5652,16 @@ export default {
       })
     }
 
+    // #1224 Phase 2 — the cron census already attributes its own STATUS_CACHE reads. The remaining
+    // account volume is on this live fetch path, so wrap the binding once after all non-status routes
+    // have returned. This keeps admin/report/ingest traffic out of the series and covers every existing
+    // read in the status response without a per-call-site edit.
+    const kvCensus = createReadCensus()
+    const censusedKv = env.STATUS_CACHE ? kvCensus.wrapKv(env.STATUS_CACHE) : undefined
+    env = new Proxy(env, {
+      get: (target, prop) => (prop === 'STATUS_CACHE' && censusedKv) ? censusedKv : Reflect.get(target, prop),
+    })
+
     try {
       // Read probe data BEFORE fetchAllServices — needed for cross-validation of status page failures
       let latency24h: Array<{ t: string; data: Record<string, number> }> = []
@@ -5833,6 +5843,18 @@ export default {
         status: 500,
         headers: { ...cors, 'Content-Type': 'application/json' },
       })
+    } finally {
+      // One line per live status request, including fallback/error responses. The census is a scoped
+      // lower bound on account reads: other endpoints and concurrent requests share the namespace.
+      // Keep diagnostics fail-soft; a census failure must never replace the response or the original
+      // request exception.
+      try {
+        const snapshot = kvCensus.snapshot()
+        console.log('[fetch] #1224 kv read census —', `path=${url.pathname}`, `total=${snapshot.total}`, `distinct=${snapshot.distinct}`,
+          censusedKv ? `| family: ${formatCensus(snapshot.families)} | detail: ${formatCensus(snapshot.detail, 8)}` : '| uninstrumented (no STATUS_CACHE binding)')
+      } catch (censusErr) {
+        console.error('[fetch] #1224 kv read census FAILED', censusErr instanceof Error ? censusErr.message : censusErr)
+      }
     }
   },
 }


### PR DESCRIPTION
## Summary
- Attribute STATUS_CACHE reads on the live /api/status path with the existing createReadCensus wrapper.
- Emit a fail-soft census line for normal, fallback, and error responses without instrumenting other routes.
- Add real fetch-handler regression coverage for conservation and error-path logging.

## Verification
- npm run test:worker — 5,106 tests passed
- npm run typecheck:worker — 0 type errors
- npx wrangler deploy --config worker/wrangler.toml --dry-run — passed
- git diff --check — passed
- Read-only review using review-agent and docs/reference/code-review-policy.md — no findings

Refs #1224


## Post-merge operational verification
- [ ] After merge, run `npm run deploy:worker` — confirm the output includes `Uploaded aiwatch-worker`
- [ ] Wait at least 6 minutes after deployment for Cloudflare Analytics ingestion lag
- [ ] In `npx wrangler tail --config worker/wrangler.toml --format json`, confirm `[fetch] #1224 kv read census` entries appear
- [ ] Observe production `/api/status` requests for at least 20 minutes and record `total/distinct/family/detail`
- [ ] Compare the result with the `kvOperationsAdaptiveGroups` read total for the same time window
- [ ] Record the result in a comment on this PR and synchronize the Issue `verify-after` checkbox

🤖 Generated with [Codex](https://openai.com/codex/)