### PR TITLE
chore: gitignore .claude/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ mempalace.yaml
 .claude/mcp.json
 .claude/scheduled_tasks.lock
 .claude/hook-audit.jsonl
+.claude/launch.json
 
 # Parallel-agent worktrees (see docs/reference/parallel-agents.md)
 .claude/worktrees/


### PR DESCRIPTION
## What

Adds `.claude/launch.json` to `.gitignore`, in the local-config block beside `.claude/mcp.json`.

## Why

`.claude/launch.json` is the preview/dev-server launch config the `preview_start` tool reads. When it is absent that tool fails with `No .claude/launch.json found` and prints the exact schema to create — so the file is functional, not a stray artifact, and it is **not** being deleted here.

It was sitting untracked and un-ignored, so every `git status` in this repo carried a permanent `??` line. That is noise against the workflow rule that a pre-commit `git status` must show only the intended files (CLAUDE.md step 1) — a standing stray entry is exactly what makes that check stop being read.

## Why ignored rather than committed

It looks shareable at first glance (`npm run dev` on 5173 is the documented dashboard command), but two things make it a local convenience rather than a project contract:

- **The port is pinned to 5173.** `docs/reference/parallel-agents.md` offsets dev-server ports by `+100·N` per worktree slot, so a committed 5173 would be wrong in every worktree but the first.
- **It covers only the Vite dashboard.** The landing / is-down / methodology pages need `vercel dev` (3333) and the Worker needs `wrangler dev` (8788) — neither is in the file, so committing it would publish a config that silently handles one of three surfaces.

## Verification

- `git check-ignore -v .claude/launch.json` → `.gitignore:58`, rule resolves.
- `git ls-files -i -c --exclude-standard` → **empty**: no already-tracked file becomes ignored by this pattern.
- The pattern contains a slash, so it is anchored to the `.gitignore` directory and matches only the repo-root file.

## Notes

No issue number — the operator asked for this to be handled without one, and the commit body records that so a later reader does not read it as an omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc5ubC7XPxNU5ZafU4JgZc
